### PR TITLE
Support for returning generated keys (auto_increment/identity) in Update

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilder.java
+++ b/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilder.java
@@ -25,7 +25,7 @@ public class DefaultStatementBuilder implements StatementBuilder
      */
     public PreparedStatement create(Connection conn, String sql, StatementContext ctx) throws SQLException
     {
-		return conn.prepareStatement(sql);
+		return conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
     }
 
     /**

--- a/src/main/java/org/skife/jdbi/v2/GeneratedKeys.java
+++ b/src/main/java/org/skife/jdbi/v2/GeneratedKeys.java
@@ -1,0 +1,134 @@
+package org.skife.jdbi.v2;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import org.skife.jdbi.v2.exceptions.ResultSetException;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+public class GeneratedKeys<Type>
+{
+    private final ResultSetMapper<Type> mapper;
+    private final SQLStatement<?> jdbiStatement;
+    private final Statement stmt;
+    private final ResultSet results;
+    private final StatementContext context;
+
+    /**
+     * Creates a new wrapper object for generated keys as returned by the {@link Statement#getGeneratedKeys()}
+     * method for update and insert statement for drivers that support this function.
+     *
+     * @param mapper Maps the generated keys result set to an object
+     * @param jdbiStatement The original jDBI statement
+     * @param stmt The corresponding sql statement
+     * @param context The statement context
+     */
+    public GeneratedKeys(ResultSetMapper<Type> mapper,
+                         SQLStatement<?> jdbiStatement,
+                         Statement stmt,
+                         StatementContext context) throws SQLException
+    {
+        this.mapper = mapper;
+        this.jdbiStatement = jdbiStatement;
+        this.stmt = stmt;
+        this.results = stmt.getGeneratedKeys();
+        this.context = context;
+    }
+
+    /**
+     * Returns the first generated key.
+     *
+     * @return The key or null if no keys were returned
+     */
+    public Type first() {
+        try {
+            if ((results != null) && results.next()) {
+                return mapper.map(0, results, context);
+            }
+            else {
+                // no result matches
+                return null;
+            }
+        }
+        catch (SQLException e) {
+            throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, context);
+        }
+        finally {
+            QueryPostMungeCleanup.CLOSE_RESOURCES_QUIETLY.cleanup(jdbiStatement, null, results);
+        }
+    }
+
+    /**
+     * Returns a list of all generated keys.
+     *
+     * @return The list of keys or an empty list if no keys were returned
+     */
+    public List<Type> list() {
+        try {
+            List<Type> resultList = new ArrayList<Type>();
+
+            if ((results != null) && !results.isClosed()) {
+                int index = 0;
+                while (results.next()) {
+                    resultList.add(mapper.map(index++, results, context));
+                }
+            }
+            return resultList;
+        }
+        catch (SQLException e) {
+            throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, context);
+        }
+        finally {
+            QueryPostMungeCleanup.CLOSE_RESOURCES_QUIETLY.cleanup(jdbiStatement, null, results);
+        }
+    }
+
+    /**
+     * Returns a iterator over all generated keys.
+     *
+     * @return The key iterator
+     */
+    public ResultIterator<Type> iterator() {
+        try {
+            return new ResultSetResultIterator<Type>(mapper, jdbiStatement, stmt, context);
+        }
+        catch (SQLException e) {
+            throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, context);
+        }
+    }
+
+    /**
+     * Used to execute the query and traverse the generated keys with a accumulator.
+     * <a href="http://en.wikipedia.org/wiki/Fold_(higher-order_function)">Folding</a> over the
+     * keys involves invoking a callback for each row, passing into the callback the return value
+     * from the previous function invocation.
+     *
+     * @param accumulator The initial accumulator value
+     * @param folder      Defines the function which will fold over the result set.
+     *
+     * @return The return value from the last invocation of {@link Folder#fold(Object, java.sql.ResultSet)}
+     *
+     * @see org.skife.jdbi.v2.Folder
+     */
+    public <AccumulatorType> AccumulatorType fold(AccumulatorType accumulator, final Folder2<AccumulatorType> folder)
+    {
+        try {
+            AccumulatorType value = accumulator;
+
+            if ((results != null) && !results.isClosed()) {
+                while (results.next()) {
+                    value = folder.fold(value, results, context);
+                }
+            }
+            return value;
+        }
+        catch (SQLException e) {
+            throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, context);
+        }
+        finally {
+            QueryPostMungeCleanup.CLOSE_RESOURCES_QUIETLY.cleanup(jdbiStatement, null, results);
+        }
+    }
+}

--- a/src/test/java/org/skife/jdbi/v2/TestPreparedStatementCache.java
+++ b/src/test/java/org/skife/jdbi/v2/TestPreparedStatementCache.java
@@ -33,10 +33,10 @@ public class TestPreparedStatementCache extends DBITestCase
         Connection c = new DelegatingConnection(Tools.getConnection())
         {
             @Override
-            public PreparedStatement prepareStatement(String s) throws SQLException
+            public PreparedStatement prepareStatement(String s, int flag) throws SQLException
             {
                 prep_count[0]++;
-                return super.prepareStatement(s);
+                return super.prepareStatement(s, flag);
             }
         };
         CachingStatementBuilder builder = new CachingStatementBuilder(new DefaultStatementBuilder());

--- a/src/test/java/org/skife/jdbi/v2/TestUpdateGeneratedKeys.java
+++ b/src/test/java/org/skife/jdbi/v2/TestUpdateGeneratedKeys.java
@@ -1,0 +1,83 @@
+package org.skife.jdbi.v2;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import org.skife.jdbi.derby.Tools;
+import org.skife.jdbi.v2.util.LongMapper;
+
+public class TestUpdateGeneratedKeys extends DBITestCase
+{
+    @Override
+    public void setUp() throws Exception
+    {
+        super.setUp();
+
+        final Connection conn = Tools.getConnection();
+
+        final Statement create = conn.createStatement();
+        try
+        {
+            create.execute("create table something_else ( id integer not null generated always as identity, name varchar(50) )");
+        }
+        catch (Exception e)
+        {
+            // probably still exists because of previous failed test, just delete then
+            create.execute("delete from something_else");
+        }
+        create.close();
+        conn.close();
+    }
+
+    public void testInsert() throws Exception
+    {
+        Handle h = openHandle();
+
+        Update insert1 = h.createStatement("insert into something_else (name) values (:name)");
+        insert1.bind("name", "Brian");
+        Long id1 = insert1.executeAndReturnGeneratedKeys(LongMapper.FIRST).first();
+
+        assertNotNull(id1);
+
+        Update insert2 = h.createStatement("insert into something_else (name) values (:name)");
+        insert2.bind("name", "Tom");
+        Long id2 = insert2.executeAndReturnGeneratedKeys(LongMapper.FIRST).first();
+
+        assertNotNull(id2);
+        assertTrue(id2 > id1);
+    }
+
+    public void testUpdate() throws Exception
+    {
+        Handle h = openHandle();
+
+        Update insert = h.createStatement("insert into something_else (name) values (:name)");
+        insert.bind("name", "Brian");
+        Long id1 = insert.executeAndReturnGeneratedKeys(LongMapper.FIRST).first();
+
+        assertNotNull(id1);
+
+        Update update = h.createStatement("update something_else set name = :name where id = :id");
+        update.bind("id", id1);
+        update.bind("name", "Tom");
+        Long id2 = update.executeAndReturnGeneratedKeys(LongMapper.FIRST).first();
+
+        assertNull(id2);
+    }
+
+    public void testDelete() throws Exception
+    {
+        Handle h = openHandle();
+
+        Update insert = h.createStatement("insert into something_else (name) values (:name)");
+        insert.bind("name", "Brian");
+        Long id1 = insert.executeAndReturnGeneratedKeys(LongMapper.FIRST).first();
+
+        assertNotNull(id1);
+
+        Update delete = h.createStatement("delete from something_else where id = :id");
+        delete.bind("id", id1);
+        Long id2 = delete.executeAndReturnGeneratedKeys(LongMapper.FIRST).first();
+
+        assertNull(id2);
+    }
+}


### PR DESCRIPTION
This uses the Statement#getGeneratedKeys method which exists since JDBC 3.0 and seems to be supported in most current JDBC drivers (I checked Oracle since 10.1.x, Mysql, Derby).
