### PR TITLE
Error messaging for API misuse

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/QueryResultSetMunger.java
+++ b/src/main/java/org/skife/jdbi/v2/QueryResultSetMunger.java
@@ -16,6 +16,8 @@
 
 package org.skife.jdbi.v2;
 
+import org.skife.jdbi.v2.exceptions.NoResultsException;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -34,6 +36,9 @@ abstract class QueryResultSetMunger<T>
             throws SQLException
     {
         ResultSet rs = results.getResultSet();
+        if (rs == null)
+            throw new NoResultsException("Query did not have a result set, perhaps you meant update?", stmt.getContext());
+
         stmt.addCleanable(Cleanables.forResultSet(rs));
         return munge(rs);
     }

--- a/src/main/java/org/skife/jdbi/v2/exceptions/NoResultsException.java
+++ b/src/main/java/org/skife/jdbi/v2/exceptions/NoResultsException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2004 - 2011 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.skife.jdbi.v2.exceptions;
+
+import org.skife.jdbi.v2.StatementContext;
+
+public class NoResultsException extends StatementException
+{
+    public NoResultsException(String msg, Throwable e, StatementContext ctx) {
+        super(msg, e, ctx);
+    }
+
+    public NoResultsException(Throwable e, StatementContext ctx) {
+        super(e, ctx);
+    }
+
+    public NoResultsException(String msg, StatementContext ctx) {
+        super(msg, ctx);
+    }
+}

--- a/src/test/java/org/skife/jdbi/v2/TestQueries.java
+++ b/src/test/java/org/skife/jdbi/v2/TestQueries.java
@@ -16,6 +16,7 @@
 package org.skife.jdbi.v2;
 
 import org.skife.jdbi.derby.Tools;
+import org.skife.jdbi.v2.exceptions.NoResultsException;
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.exceptions.StatementException;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
@@ -320,5 +321,16 @@ public class TestQueries extends DBITestCase
             .list();
 
         assertEquals(1, rs.size());
+    }
+
+    public void testQueriesWithNullResultSets() throws Exception
+    {
+        try {
+            h.select("insert into something (id, name) values (?, ?)", 1, "hello");
+        }
+        catch (NoResultsException e) {
+            return;
+        }
+        fail("expected NoResultsException");
     }
 }


### PR DESCRIPTION
Since I've now been bit by this twice, here's a patch. When using the SqlObject API, it's easy to be careless and write @SqlQuery when one means @SqlUpdate. This manifests as an NPE from Query.java, and it's not obvious when looking at the call site what you've done wrong since the error is a bad annotation.

Adding a more descriptive error message will help SqlObject API users know what the root problem is and possibly where to look.
