### PR TITLE
Add class nesting for ClasspathStatementLocator

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.regex.Matcher;
 
 /**
  * looks for [name], then [name].sql on the classpath
@@ -72,6 +73,12 @@ public class ClasspathStatementLocator implements StatementLocator
             if (in_stream == null) {
                 in_stream = loader.getResourceAsStream(name + ".sql");
             }
+
+            if ((in_stream == null) && (ctx.getSqlObjectType() != null)) {
+                String filename = '/' + mungify(ctx.getSqlObjectType().getName() + '.' + name) + ".sql";
+                in_stream = getClass().getResourceAsStream(filename);
+            }
+
             if (in_stream == null) {
                 return name;
             }
@@ -122,5 +129,11 @@ public class ClasspathStatementLocator implements StatementLocator
 
     private static boolean isComment(final String line) {
         return line.startsWith("#") || line.startsWith("--") || line.startsWith("//");
+    }
+
+    private final static String sep = "/"; // *Not* System.getProperty("file.separator"), which breaks in jars
+
+    private static String mungify(String path) {
+        return path.replaceAll("\\.", Matcher.quoteReplacement(sep));
     }
 }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator.java
@@ -1,0 +1,47 @@
+package org.skife.jdbi.v2.sqlobject;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.Something;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestClasspathStatementLocator {
+    private Handle handle;
+
+    @Before
+    public void setUp() throws Exception {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:test");
+        DBI dbi = new DBI(ds);
+        handle = dbi.open();
+
+        handle.execute("create table something (id int primary key, name varchar(100))");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        handle.execute("drop table something");
+        handle.close();
+    }
+
+    @Test
+    public void testBam() throws Exception {
+        handle.execute("insert into something (id, name) values (6, 'Martin')");
+
+        Something s = handle.attach(Cromulence.class).findById(6L);
+        assertThat(s.getName(), equalTo("Martin"));
+    }
+
+    @RegisterMapper(SomethingMapper.class)
+    static interface Cromulence {
+        @SqlQuery
+        public Something findById(@Bind("id") Long id);
+    }
+}

--- a/src/test/resources/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator$Cromulence/findById.sql
+++ b/src/test/resources/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator$Cromulence/findById.sql
@@ -1,0 +1,1 @@
+select something.id, something.name from something where id = :id;


### PR DESCRIPTION
This allows `.sql` files for SQL objects which use the default `ClasspathStatementLocator` to be nested under the full class name (e.g., `src/main/resources/com/example/db/SqlObj/methodName.sql`).

This adds a new test for SQL object-specific behavior of `ClasspathStatementLocator`, and all other tests pass.

It definitely shares some behavior with `StringTemplate3StatementLocator` (i.e., `mungify` and the class-relative resource loading), but I'm not sure how you'd like to handle that.
