### PR TITLE
Compile with Java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>


### PR DESCRIPTION
After an import of the project into Eclipse, I noticed that one class uses the `@Override` annotation for implementing a method and produces an error, specifically:

```
The method add(Object) of type ListContainerBuilder must override a superclass method   
ListContainerBuilder.java   /jdbi/src/main/java/org/skife/jdbi/v2   line 16
```

First it was a mystery for me why maven would still compile the sources but then I realized that the only JDK I had installed was JDK6, so I installed JDK5 and tried building the project and failed (amongst other) with the following error:

```
[ERROR] /jdbi/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java:[3,-1] cannot access com.fasterxml.classmate.MemberResolver
bad class file: /Users/Shared/Local/Development/data/maven/repository/com/fasterxml/classmate/0.5.3/classmate-0.5.3.jar(com/fasterxml/classmate/MemberResolver.class)
class file has wrong version 50.0, should be 49.0
```

I don't know when @cowtowncoder introduced 1.6 compilation but the [0.5.3](https://github.com/cowtowncoder/java-classmate/blob/06de2c82001de6a396f3eb4b38e38957e028989b/pom.xml) release at least is compiled with Java 1.6

I suggest bumping source and target level to 1.6. I attached this in the pull request for convenience.
