### PR TITLE
Locate resources when using JUnit

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
@@ -74,6 +74,14 @@ public class ClasspathStatementLocator implements StatementLocator
                 in_stream = loader.getResourceAsStream(name + ".sql");
             }
 
+      			if (in_stream == null) {
+      				in_stream = this.getClass().getResourceAsStream(name);
+      			}
+
+      			if (in_stream == null) {
+      				in_stream = this.getClass().getResourceAsStream(name + ".sql");
+      			}
+            
             if ((in_stream == null) && (ctx.getSqlObjectType() != null)) {
                 String filename = '/' + mungify(ctx.getSqlObjectType().getName() + '.' + name) + ".sql";
                 in_stream = getClass().getResourceAsStream(filename);


### PR DESCRIPTION
I had some problems writing Unit tests when using the `ClasspathStatementLocator`

```
public interface AttributeDaoJdbi extends AttributeDao {

    @Override
    @SqlQuery("/sql/base/attribute/select-all")
    @RegisterMapper(AttributeSetMapper.class)
    public Set<Attribute> all();
```

When I ran the follwing test

```
    @Test
    public void test() {
        final DBI dbi=new DBI(dataSource);
        final Handle h=dbi.open();
        h.attach(AttributeDaoJdbi.class);

        final AttributeDaoJdbi dao=dbi.open(AttributeDaoJdbi.class);

        final Set<Attribute> attributes=dao.all();

        assertNotNull(attributes);
        assertTrue(attributes.size()>0);

        dao.close();
    }
```

the statement locator wouldn't find the sql file `/src/main/resources/sql/base/attribute/select-all`. I'm not that familiar with the ClassLoader in Java but my guess is that the JUnit tests are run from a different thread, so that `Thread.currentThread().getContextClassLoader()` (which is used) fails to find the files via `loader.getResourceAsStream(name)` or `loader.getResourceAsStream(name +".sql")`

I added the attached code as a workaround. I don't really like it as it seems to correct behavior that no one uses in production code. As I said I'm not an expert on ClassLoader issues so maybe somebody else else with more knowledge can have a go at this.
