### PR TITLE
use getColumnLabel instead of getColumnName

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/BeanMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/BeanMapper.java
@@ -78,7 +78,7 @@ public class BeanMapper<T> implements ResultSetMapper<T>
 		ResultSetMetaData metadata = rs.getMetaData();
 
 		for (int i = 1; i <= metadata.getColumnCount(); ++i) {
-			String name = metadata.getColumnName(i).toLowerCase();
+			String name = metadata.getColumnLabel(i).toLowerCase();
 
 			PropertyDescriptor descriptor = properties.get(name);
 


### PR DESCRIPTION
So we can override db field names
