### PR TITLE
Scala compatibility for Binder interface

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/Binder.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/Binder.java
@@ -22,5 +22,5 @@ import java.lang.annotation.Annotation;
 
 public interface Binder<AnnotationType extends Annotation, ArgType>
 {
-    public void bind(SQLStatement q, AnnotationType bind, ArgType arg);
+    public void bind(SQLStatement<?> q, AnnotationType bind, ArgType arg);
 }


### PR DESCRIPTION
As it currently stands, I can't implement a Binder in Scala.  The scala compiler gets quite unhappy on account of the missing type parameter.  I haven't been able to find any workaround; adding the missing type parameter to the interface definition seems to be the only solution.
