### PR TITLE
Add VoidTransactionCallback and VoidHandleCallback

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/VoidTransactionCallback.java
+++ b/src/main/java/org/skife/jdbi/v2/VoidTransactionCallback.java
@@ -1,0 +1,31 @@
+package org.skife.jdbi.v2;
+
+/**
+ * Abstract {@link TransactionCallback} that doesn't return a result.
+ */
+public abstract class VoidTransactionCallback implements TransactionCallback<Void>
+{
+    /**
+     * This implementation delegates to {@link #execute}.
+     *
+     * @param handle {@inheritDoc}
+     * @return nothing
+     * @throws Exception {@inheritDoc}
+     */
+    @Override
+    public final Void inTransaction(Handle handle, TransactionStatus status) throws Exception
+    {
+        execute(handle, status);
+        return null;
+    }
+
+    /**
+     * {@link #inTransaction} will delegate to this method.
+     *
+     * @param handle Handle to be used only within scope of this callback
+     * @param status Allows rolling back the transaction
+     * @throws Exception will result in a {@link org.skife.jdbi.v2.exceptions.CallbackFailedException} wrapping
+     *                   the exception being thrown
+     */
+    protected abstract void execute(Handle handle, TransactionStatus status) throws Exception;
+}

--- a/src/main/java/org/skife/jdbi/v2/tweak/VoidHandleCallback.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/VoidHandleCallback.java
@@ -1,0 +1,32 @@
+package org.skife.jdbi.v2.tweak;
+
+import org.skife.jdbi.v2.Handle;
+
+/**
+ * Abstract {@link HandleCallback} that doesn't return a result.
+ */
+public abstract class VoidHandleCallback implements HandleCallback<Void>
+{
+    /**
+     * This implementation delegates to {@link #execute}.
+     *
+     * @param handle {@inheritDoc}
+     * @return nothing
+     * @throws Exception {@inheritDoc}
+     */
+    @Override
+    public final Void withHandle(Handle handle) throws Exception
+    {
+        execute(handle);
+        return null;
+    }
+
+    /**
+     * {@link #withHandle} will delegate to this method.
+     *
+     * @param handle Handle to be used only within scope of this callback
+     * @throws Exception will result in a {@link org.skife.jdbi.v2.exceptions.CallbackFailedException} wrapping
+     *                   the exception being thrown
+     */
+    protected abstract void execute(Handle handle) throws Exception;
+}


### PR DESCRIPTION
I often use `withHandle` or `inTransaction` to perform work that doesn't return a result. These abstract classes make that code cleaner. (I have copies of them in various projects.)
