### PR TITLE
Improve transaction handling to prevent exception swallowing

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/BasicHandle.java
+++ b/src/main/java/org/skife/jdbi/v2/BasicHandle.java
@@ -346,12 +346,26 @@ class BasicHandle implements Handle
                                                  TransactionCallback<ReturnType> callback)
     {
         final TransactionIsolationLevel initial = getTransactionIsolationLevel();
+        boolean failed = true;
         try {
             setTransactionIsolation(level);
-            return inTransaction(callback);
+
+            ReturnType result = inTransaction(callback);
+            failed = false;
+
+            return result;
         }
         finally {
-            setTransactionIsolation(initial);
+            try {
+                setTransactionIsolation(initial);
+            }
+            catch (RuntimeException e) {
+                if (! failed) {
+                    throw e;
+                }
+
+                // Ignore, there was already an exceptional condition and we don't want to clobber it.
+            }
         }
     }
 


### PR DESCRIPTION
If a transaction fails spectacularly, it's quite possible that
resetting the isolation level fails as well.  The previous
behavior is to swallow the "real" cause and report the latter
failure, which makes diagnosing the cause rather difficult.
