### PR TITLE
Snake_Case support

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/BeanMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/BeanMapper.java
@@ -79,11 +79,10 @@ public class BeanMapper<T> implements ResultSetMapper<T>
 
 		for (int i = 1; i <= metadata.getColumnCount(); ++i) {
 			String name = metadata.getColumnLabel(i).toLowerCase();
-         if(properties.get(name) == null){
-            name = name.replace("_","");
+         PropertyDescriptor descriptor = properties.get(name);
+         if(descriptor == null) {
+            descriptor = properties.get(name.replace("_", ""));
          }
-			PropertyDescriptor descriptor = properties.get(name);
-
 			if (descriptor != null) {
 				Class<?> type = descriptor.getPropertyType();
 

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestRegisteredMappersWork.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestRegisteredMappersWork.java
@@ -115,6 +115,62 @@ public class TestRegisteredMappersWork
         assertThat(another_lima.getColor(), equalTo(lima.getColor()));
     }
 
+    public static class User
+    {
+        private Integer userId;
+        private String username;
+
+        public Integer getUserId()
+        {
+           return userId;
+        }
+
+        public void setUserId(Integer userId)
+        {
+           this.userId = userId;
+        }
+
+        public String getUsername()
+        {
+           return username;
+        }
+
+        public void setUsername(String username)
+        {
+           this.username = username;
+        }
+    }
+
+    public static interface UserBeanMappingDao
+    {
+        @SqlUpdate("create table users ( user_id int primary key, username varchar )")
+        public void createUserTable();
+
+        @SqlUpdate("insert into users (user_id, username) values (:userId, :username)")
+        public void insertUser(@BindBean User user);
+
+        @SqlQuery("select user_id, username from users where username = :username")
+        @MapResultAsBean
+        public User findByName(@Bind("username") String username);
+    }
+
+    @Test
+    public void testSnakeCaseUserMapperFactory() throws Exception
+    {
+        UserBeanMappingDao db = handle.attach(UserBeanMappingDao.class);
+        db.createUserTable();
+
+        User user = new User();
+        user.setUserId(1);
+        user.setUsername("Galatasaray");
+
+        db.insertUser(user);
+
+        User another_user = db.findByName("Galatasaray");
+        assertThat(another_user.getUsername(), equalTo("Galatasaray"));
+        assertThat(another_user.getUserId(), equalTo(1));
+    }
+
     @Test
     public void testRegistered() throws Exception
     {


### PR DESCRIPTION
Current BeanMapper implementation is using lowercase property descriptor names for corresponding. This check lets BeanMapper to support camel_case without breaking existing implementations.
