### PR TITLE
Another try for Snake_case 

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/helpers/MapResultAsBean.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/helpers/MapResultAsBean.java
@@ -6,6 +6,7 @@ import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizer;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizerFactory;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizingAnnotation;
 import org.skife.jdbi.v2.tweak.BeanMapperFactory;
+import org.skife.jdbi.v2.util.NamingStrategy;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
@@ -20,20 +21,24 @@ import java.sql.SQLException;
 @Target(ElementType.METHOD)
 public @interface MapResultAsBean
 {
+    NamingStrategy dbFormattingStrategy() default NamingStrategy.LOWER;
+
+    NamingStrategy propertyFormattingStrategy() default NamingStrategy.LOWER;
 
     public static class MapAsBeanFactory implements SqlStatementCustomizerFactory
     {
 
         @Override
-        public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
+        public SqlStatementCustomizer createForMethod(final Annotation annotation, Class sqlObjectType, Method method)
         {
             return new SqlStatementCustomizer()
             {
                 @Override
                 public void apply(SQLStatement s) throws SQLException
                 {
-                    Query q = (Query) s;
-                    q.registerMapper(new BeanMapperFactory());
+                   Query q = (Query) s;
+                   MapResultAsBean asBean = (MapResultAsBean) annotation;
+                   q.registerMapper(new BeanMapperFactory(asBean.dbFormattingStrategy(),asBean.propertyFormattingStrategy()));
                 }
             };
         }

--- a/src/main/java/org/skife/jdbi/v2/tweak/BeanMapperFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/BeanMapperFactory.java
@@ -3,10 +3,19 @@ package org.skife.jdbi.v2.tweak;
 import org.skife.jdbi.v2.BeanMapper;
 import org.skife.jdbi.v2.ResultSetMapperFactory;
 import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.util.NamingStrategy;
 
 public class BeanMapperFactory implements ResultSetMapperFactory
 {
-    @Override
+   private final NamingStrategy dbFormattingStrategy;
+   private final NamingStrategy propertyFormattingStrategy;
+
+   public BeanMapperFactory(NamingStrategy dbFormattingStrategy, NamingStrategy propertyFormattingStrategy) {
+      this.dbFormattingStrategy = dbFormattingStrategy;
+      this.propertyFormattingStrategy = propertyFormattingStrategy;
+   }
+
+   @Override
     public boolean accepts(Class type, StatementContext ctx)
     {
         return true;
@@ -15,6 +24,6 @@ public class BeanMapperFactory implements ResultSetMapperFactory
     @Override
     public ResultSetMapper mapperFor(Class type, StatementContext ctx)
     {
-        return new BeanMapper(type);
+        return new BeanMapper(type, dbFormattingStrategy, propertyFormattingStrategy);
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/util/NamingStrategy.java
+++ b/src/main/java/org/skife/jdbi/v2/util/NamingStrategy.java
@@ -1,0 +1,143 @@
+package org.skife.jdbi.v2.util;
+
+/**
+ * LOWER_UNDERSCORE implementation is borrowed from org.codehaus.jackson.map.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy
+ */
+public enum NamingStrategy {
+
+   IDENTICAL {
+      @Override
+      public String translate(String input) {
+         return input;
+      }
+   },
+   UPPER {
+      @Override
+      public String translate(String input) {
+         return input.toUpperCase();
+      }
+   },
+   LOWER {
+      @Override
+      public String translate(String input) {
+         return input.toLowerCase();
+      }
+   },
+   LOWER_UNDERSCORE {
+      @Override
+      public String translate(String input) {
+         if(input == null) return input;
+         int length = input.length();
+         StringBuilder result = new StringBuilder(length * 2);
+         int resultLength = 0;
+         boolean wasPrevTranslated = false;
+         for(int i = 0; i < length; i++) {
+            char c = input.charAt(i);
+            if(i > 0 || c != '_') {
+               if(Character.isUpperCase(c)) {
+                  if(!wasPrevTranslated && resultLength > 0 && result.charAt(resultLength - 1) != '_') {
+                     result.append('_');
+                     resultLength++;
+                  }
+                  c = Character.toLowerCase(c);
+                  wasPrevTranslated = true;
+               } else {
+                  wasPrevTranslated = false;
+               }
+               result.append(c);
+               resultLength++;
+            }
+         }
+         return resultLength > 0 ? result.toString() : input;
+      }
+   },
+   UPPER_UNDERSCORE {
+      @Override
+      public String translate(String input) {
+         if(input == null) return input;
+         int length = input.length();
+         StringBuilder result = new StringBuilder(length * 2);
+         int resultLength = 0;
+         boolean wasPrevTranslated = false;
+         for(int i = 0; i < length; i++) {
+            char c = input.charAt(i);
+            if(i > 0 || c != '_') {
+               if(Character.isUpperCase(c)) {
+                  if(!wasPrevTranslated && resultLength > 0 && result.charAt(resultLength - 1) != '_') {
+                     result.append('_');
+                     resultLength++;
+                  }
+                  c = Character.toUpperCase(c);
+                  wasPrevTranslated = true;
+               } else {
+                  wasPrevTranslated = false;
+               }
+               result.append(Character.toUpperCase(c));
+               resultLength++;
+            }
+         }
+         return resultLength > 0 ? result.toString() : input;
+      }
+   },
+   LOWER_CAMEL {
+      @Override
+      public String translate(String input) {
+         if(input == null) return input;
+         int length = input.length();
+         StringBuilder result = new StringBuilder(length);
+         int resultLength = 0;
+         boolean capitalizeNextChar = false;
+         for(int i = 0; i < length; i++) {
+            char c = input.charAt(i);
+            if(c == '_') {
+               capitalizeNextChar = true;
+               continue;
+            }
+            if(capitalizeNextChar) {
+               result.append(Character.toUpperCase(c));
+               capitalizeNextChar = false;
+            } else {
+               result.append(Character.toLowerCase(c));
+            }
+            resultLength++;
+         }
+
+         if(resultLength > 0 && input.charAt(0) != '_') {
+            result.setCharAt(0, Character.toLowerCase(result.charAt(0)));
+         }
+         return resultLength > 0 ? result.toString() : input;
+      }
+   },
+   UPPER_CAMEL {
+      @Override
+      public String translate(String input) {
+         if(input == null) return input;
+         int length = input.length();
+         StringBuilder result = new StringBuilder(length);
+         int resultLength = 0;
+         boolean capitalizeNextChar = false;
+         for(int i = 0; i < length; i++) {
+            char c = input.charAt(i);
+            if(c == '_') {
+               capitalizeNextChar = true;
+               continue;
+            }
+            if(capitalizeNextChar) {
+               result.append(Character.toUpperCase(c));
+               capitalizeNextChar = false;
+            } else {
+               result.append(Character.toLowerCase(c));
+            }
+            resultLength++;
+         }
+
+         if(resultLength > 0 && input.charAt(0) != '_') {
+            result.setCharAt(0, Character.toUpperCase(result.charAt(0)));
+         }
+         return resultLength > 0 ? result.toString() : input;
+      }
+   };
+
+   public abstract String translate(String input);
+
+}

--- a/src/test/java/org/skife/jdbi/v2/util/NamingStrategyTest.java
+++ b/src/test/java/org/skife/jdbi/v2/util/NamingStrategyTest.java
@@ -1,0 +1,61 @@
+package org.skife.jdbi.v2.util;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class NamingStrategyTest {
+
+   @Test
+   public void testLowerUnderscore() {
+      assertEquals("user_name",NamingStrategy.LOWER_UNDERSCORE.translate("userName"));
+      assertEquals("user_name",NamingStrategy.LOWER_UNDERSCORE.translate("UserName"));
+      assertEquals("user_name",NamingStrategy.LOWER_UNDERSCORE.translate("USER_NAME"));
+      assertEquals("user_name",NamingStrategy.LOWER_UNDERSCORE.translate("user_name"));
+      assertEquals("user__name",NamingStrategy.LOWER_UNDERSCORE.translate("user__name"));
+      assertEquals("user",NamingStrategy.LOWER_UNDERSCORE.translate("user"));
+      assertEquals("user",NamingStrategy.LOWER_UNDERSCORE.translate("User"));
+      assertEquals("user",NamingStrategy.LOWER_UNDERSCORE.translate("_user"));
+      assertEquals("user",NamingStrategy.LOWER_UNDERSCORE.translate("_User"));
+      assertEquals("_user",NamingStrategy.LOWER_UNDERSCORE.translate("__user"));
+      assertEquals("__user",NamingStrategy.LOWER_UNDERSCORE.translate("___user"));
+      assertEquals("___user",NamingStrategy.LOWER_UNDERSCORE.translate("____user"));
+   }
+
+   @Test
+   public void testUpperUnderscore() {
+     assertEquals("USER_NAME",NamingStrategy.UPPER_UNDERSCORE.translate("userName"));
+     assertEquals("USER_NAME",NamingStrategy.UPPER_UNDERSCORE.translate("UserName"));
+     assertEquals("USER_NAME",NamingStrategy.UPPER_UNDERSCORE.translate("USER_NAME"));
+     assertEquals("USER_NAME",NamingStrategy.UPPER_UNDERSCORE.translate("user_name"));
+     assertEquals("USER",NamingStrategy.UPPER_UNDERSCORE.translate("user"));
+     assertEquals("USER",NamingStrategy.UPPER_UNDERSCORE.translate("User"));
+     assertEquals("USER",NamingStrategy.UPPER_UNDERSCORE.translate("_user"));
+     assertEquals("USER",NamingStrategy.UPPER_UNDERSCORE.translate("_User"));
+     assertEquals("_USER",NamingStrategy.UPPER_UNDERSCORE.translate("__user"));
+   }
+
+   @Test
+   public void testLowerCamelCase() {
+      assertEquals("userName", NamingStrategy.LOWER_CAMEL.translate("user_name"));
+      assertEquals("Username", NamingStrategy.LOWER_CAMEL.translate("_username"));
+      assertEquals("UserName", NamingStrategy.LOWER_CAMEL.translate("_user_name"));
+      assertEquals("UserName", NamingStrategy.LOWER_CAMEL.translate("__user_name"));
+      assertEquals("UserName", NamingStrategy.LOWER_CAMEL.translate("_user__name"));
+      assertEquals("USERNAME", NamingStrategy.LOWER_CAMEL.translate("_u_s_e_r_n_a_m_e"));
+      assertEquals("uSERNAME", NamingStrategy.LOWER_CAMEL.translate("u_s_e_r_n_a_m_e"));
+      assertEquals("userName", NamingStrategy.LOWER_CAMEL.translate("user__Name"));
+   }
+
+   @Test
+   public void testUpperCamelCase() {
+      assertEquals("UserName", NamingStrategy.UPPER_CAMEL.translate("user_name"));
+      assertEquals("Username", NamingStrategy.UPPER_CAMEL.translate("_username"));
+      assertEquals("UserName", NamingStrategy.UPPER_CAMEL.translate("_user_name"));
+      assertEquals("UserName", NamingStrategy.UPPER_CAMEL.translate("__user_name"));
+      assertEquals("UserName", NamingStrategy.UPPER_CAMEL.translate("_user__name"));
+      assertEquals("USERNAME", NamingStrategy.UPPER_CAMEL.translate("_u_s_e_r_n_a_m_e"));
+      assertEquals("USERNAME", NamingStrategy.UPPER_CAMEL.translate("u_s_e_r_n_a_m_e"));
+      assertEquals("UserName", NamingStrategy.UPPER_CAMEL.translate("user__Name"));
+   }
+}


### PR DESCRIPTION
This is another try for snake_case support. This time it is based on strategies as suggested before. This implementation is backward compatible and might need some modifications, especially naming. 

Also providing a better way for  corresponding between db and property names.  Currently JDBI is based on lowering both db column names and property names. However for `snake_case`, one can provide property db formatting strategy `IDENTICAL` and db formatting `LOWER_CAMEL` thus it reduces the cost for each request.
