### PR TITLE
add a logBinding method to SQLLog interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,6 @@
                 <version>2.8.1</version>
                 <configuration>
                     <source>1.6</source>
-                    <target>1.6</target>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <links>

--- a/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
@@ -23,6 +23,7 @@ import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.RewrittenStatement;
+import org.skife.jdbi.v2.tweak.SQLLog;
 import org.skife.jdbi.v2.tweak.StatementRewriter;
 
 import java.sql.PreparedStatement;
@@ -108,7 +109,7 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
             this.stmt = stmt;
         }
 
-        public void bind(Binding params, PreparedStatement statement) throws SQLException
+        public void bind(Binding params, PreparedStatement statement, SQLLog log) throws SQLException
         {
             if (stmt.positionalOnly) {
                 // no named params, is easy
@@ -117,7 +118,8 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
                     final Argument a = params.forPosition(i);
                     if (a != null) {
                         try {
-                        a.apply(i + 1, statement, this.context);
+                            a.apply(i + 1, statement, this.context);
+                            log.logBinding(i + 1, null, a.toString());
                         }
                         catch (SQLException e) {
                             throw new UnableToExecuteStatementException(
@@ -150,6 +152,7 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
 
                     try {
                         a.apply(i + 1, statement, this.context);
+                        log.logBinding(i + 1, named_param, a.toString());
                     }
                     catch (SQLException e) {
                         throw new UnableToCreateStatementException(String.format("Exception while binding '%s'",

--- a/src/main/java/org/skife/jdbi/v2/HashPrefixStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/HashPrefixStatementRewriter.java
@@ -23,6 +23,7 @@ import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.RewrittenStatement;
+import org.skife.jdbi.v2.tweak.SQLLog;
 import org.skife.jdbi.v2.tweak.StatementRewriter;
 
 import java.sql.PreparedStatement;
@@ -107,7 +108,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter
             this.stmt = stmt;
         }
 
-        public void bind(Binding params, PreparedStatement statement) throws SQLException
+        public void bind(Binding params, PreparedStatement statement, SQLLog log) throws SQLException
         {
             if (stmt.positionalOnly) {
                 // no named params, is easy
@@ -117,6 +118,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter
                     if (a != null) {
                         try {
                             a.apply(i + 1, statement, this.context);
+                            log.logBinding(i + 1, null, a.toString());
                         }
                         catch (SQLException e) {
                             throw new UnableToExecuteStatementException(
@@ -149,6 +151,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter
 
                     try {
                         a.apply(i + 1, statement, this.context);
+                        log.logBinding(i + 1, named_param, a.toString());
                     }
                     catch (SQLException e) {
                         throw new UnableToCreateStatementException(String.format("Exception while binding '%s'",

--- a/src/main/java/org/skife/jdbi/v2/NoOpStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/NoOpStatementRewriter.java
@@ -18,6 +18,7 @@ package org.skife.jdbi.v2;
 
 import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.RewrittenStatement;
+import org.skife.jdbi.v2.tweak.SQLLog;
 import org.skife.jdbi.v2.tweak.StatementRewriter;
 
 import java.sql.PreparedStatement;
@@ -46,12 +47,13 @@ public class NoOpStatementRewriter implements StatementRewriter
             this.sql = sql;
         }
 
-        public void bind(Binding params, PreparedStatement statement) throws SQLException
+        public void bind(Binding params, PreparedStatement statement, SQLLog log) throws SQLException
         {
             for (int i = 0; ; i++) {
-                final Argument s = params.forPosition(i);
-                if (s == null) { break; }
-                s.apply(i + 1, statement, this.context);
+                final Argument argument = params.forPosition(i);
+                if (argument == null) { break; }
+                argument.apply(i + 1, statement, this.context);
+                log.logBinding(i + 1, null, argument.toString());
             }
         }
 

--- a/src/main/java/org/skife/jdbi/v2/PreparedBatch.java
+++ b/src/main/java/org/skife/jdbi/v2/PreparedBatch.java
@@ -120,7 +120,7 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
 
             try {
                 for (PreparedBatchPart part : parts) {
-                    rewritten.bind(part.getParameters(), stmt);
+                    rewritten.bind(part.getParameters(), stmt, this.log);
                     stmt.addBatch();
                 }
             }

--- a/src/main/java/org/skife/jdbi/v2/SQLStatement.java
+++ b/src/main/java/org/skife/jdbi/v2/SQLStatement.java
@@ -66,7 +66,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
      */
     private       RewrittenStatement rewritten;
     private       PreparedStatement  stmt;
-    private final SQLLog             log;
+    protected final SQLLog             log;
     private final TimingCollector    timingCollector;
     private final ContainerFactoryRegistry containerMapperRegistry;
 
@@ -1287,7 +1287,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
         getConcreteContext().setStatement(stmt);
 
         try {
-            rewritten.bind(getParameters(), stmt);
+            rewritten.bind(getParameters(), stmt, log);
         }
         catch (SQLException e) {
             throw new UnableToExecuteStatementException("Unable to bind parameters to query", e, getContext());

--- a/src/main/java/org/skife/jdbi/v2/logging/FormattedLog.java
+++ b/src/main/java/org/skife/jdbi/v2/logging/FormattedLog.java
@@ -127,4 +127,10 @@ public abstract class FormattedLog implements SQLLog
             log(String.format("checkpoint [%s] on [%s] rolled back in %d millis", checkpointName, h, time));
         }
     }
+
+    public void logBinding(int offset, String name, String value) {
+        if (isEnabled()) {
+            log(String.format("binding argument offset %d [%s] to %s", offset, name, value));
+        }
+    }
 }

--- a/src/main/java/org/skife/jdbi/v2/logging/NoOpLog.java
+++ b/src/main/java/org/skife/jdbi/v2/logging/NoOpLog.java
@@ -60,6 +60,9 @@ public final class NoOpLog implements SQLLog
     {
     }
 
+    public void logBinding(int offset, String name, String value) {
+    }
+
     public void logPreparedBatch(long time, String sql, int count)
     {
     }

--- a/src/main/java/org/skife/jdbi/v2/tweak/RewrittenStatement.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/RewrittenStatement.java
@@ -32,9 +32,10 @@ public interface RewrittenStatement
      * getSql() return result
      * @param params
      * @param statement
+     * @param log the logging instance
      * @throws SQLException
      */
-    public void bind(Binding params, PreparedStatement statement) throws SQLException;
+    public void bind(Binding params, PreparedStatement statement, SQLLog log) throws SQLException;
 
     /**
      * Obtain the SQL in valid (rewritten) form to be used to prepare a statement

--- a/src/main/java/org/skife/jdbi/v2/tweak/SQLLog.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/SQLLog.java
@@ -55,6 +55,14 @@ public interface SQLLog
     public void logSQL(long time, String sql);
 
     /**
+     * Called when an argument is bound to the query
+     * @param offset position of the argument in query
+     * @param name place holder name (can be null)
+     * @param value argument value
+     */
+    public void logBinding(int offset, String name, String value);
+
+    /**
      * Called to log a prepared batch execution
      * @param sql The sql for the prepared batch
      * @param count the number of elements in the prepared batch

--- a/src/test/java/org/skife/jdbi/v2/DelegatingConnection.java
+++ b/src/test/java/org/skife/jdbi/v2/DelegatingConnection.java
@@ -32,6 +32,7 @@ import java.sql.Statement;
 import java.sql.Struct;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.Executor;
 
 public class DelegatingConnection implements Connection
 {
@@ -277,7 +278,29 @@ public class DelegatingConnection implements Connection
 		return null;
 	}
 
-	public <T> T unwrap(Class<T> iface) throws SQLException
+    //needed for java 7
+    public void setSchema(String schema) throws SQLException {
+    }
+
+    //needed for java 7
+    public String getSchema() throws SQLException {
+        return null;
+    }
+
+    //needed for java 7
+    public void abort(Executor executor) throws SQLException {
+    }
+
+    //needed for java 7
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+    }
+
+    //needed for java 7
+    public int getNetworkTimeout() throws SQLException {
+        return 0;
+    }
+
+    public <T> T unwrap(Class<T> iface) throws SQLException
 	{
 		return null;
 	}

--- a/src/test/java/org/skife/jdbi/v2/TestTooManyCursors.java
+++ b/src/test/java/org/skife/jdbi/v2/TestTooManyCursors.java
@@ -12,10 +12,12 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * Oracle was getting angry about too many open cursors because of the large number
@@ -88,7 +90,12 @@ public class TestTooManyCursors extends DBITestCase
             return target.getLoginTimeout();
         }
 
-	    public <T> T unwrap(Class<T> iface) throws SQLException
+        //necessary for java 7
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return null;
+        }
+
+        public <T> T unwrap(Class<T> iface) throws SQLException
 	    {
 		    return null;
 	    }


### PR DESCRIPTION
the idea is to be able to rebuild the query from the logs.
arguments needing binding appear as ? in the logs. 
That change simply display the offset and/or the binding name plus its associated value.
