### PR TITLE
Fix potential NPE in BeanMapper

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/BeanMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/BeanMapper.java
@@ -143,7 +143,7 @@ public class BeanMapper<T> implements ResultSetMapper<T>
                 }
                 catch (NullPointerException e) {
                     throw new IllegalArgumentException(String.format("No appropriate method to " +
-                                                                     "write value %s ", value.toString()), e);
+                                                                     "write property %s", name), e);
                 }
 
             }


### PR DESCRIPTION
When handle the NullPointerException issued by the `pd.getWriteMethod`, it logs the property value, but not check the weather the value is null, and when people forget to write the setter, providing the property value is useless, what we want is the property name for the missing property.
