### PR TITLE
Introduce @BindMap, binds Map entries as statement parameters

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/Binding.java
+++ b/src/main/java/org/skife/jdbi/v2/Binding.java
@@ -63,7 +63,7 @@ public class Binding
      *
      * @param position starts at 0, not 1
      *
-     * @return arfument bound to that position
+     * @return argument bound to that position
      */
     public Argument forPosition(int position) {
         return positionals.get(position);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindBean.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindBean.java
@@ -25,6 +25,6 @@ import java.lang.annotation.Target;
 @BindingAnnotation(BindBeanFactory.class)
 public @interface BindBean
 {
-    String value() default "___jdbi_bare___";
-
+    static final String BARE_BINDING = "___jdbi_bare___";
+    String value() default BARE_BINDING;
 }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
@@ -34,7 +34,7 @@ class BindBeanFactory implements BinderFactory
             public void bind(SQLStatement q, BindBean bind, Object arg)
             {
                 final String prefix;
-                if ("___jdbi_bare___".equals(bind.value())) {
+                if (BindBean.BARE_BINDING.equals(bind.value())) {
                     prefix = "";
                 }
                 else {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindMap.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindMap.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Bind a {@code Map<String, Object>}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@BindingAnnotation(BindMapFactory.class)
+public @interface BindMap
+{
+    /**
+     * The list of allowed map keys to bind.
+     * If not specified, to binds all provided {@code Map} entries.  Any missing parameters will cause an exception.
+     * If specified, binds all provided keys.  Missing entries are bound with a SQL {@code NULL}.
+     */
+    String[] value() default {};
+
+    /**
+     * If specified, key {@code key} will be bound as {@code prefix.key}.
+     */
+    String prefix() default BindBean.BARE_BINDING;
+
+    /**
+     * Specify key handling.
+     * If false, {@code Map} keys must be strings, or an exception is thrown.
+     * If true, any object may be the key, and it will be converted with {@link Object#toString()}.
+     */
+    boolean implicitKeyStringConversion() default false;
+}

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindMapFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindMapFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.skife.jdbi.v2.SQLStatement;
+
+class BindMapFactory implements BinderFactory
+{
+    @Override
+    public Binder build(Annotation annotation)
+    {
+        return new Binder<BindMap, Object>()
+        {
+            @SuppressWarnings("unchecked")
+            @Override
+            public void bind(SQLStatement q, BindMap bind, Object arg)
+            {
+                final String prefix;
+                if (BindBean.BARE_BINDING.equals(bind.prefix())) {
+                    prefix = "";
+                }
+                else {
+                    prefix = bind.prefix() + ".";
+                }
+
+                final Set<String> allowedKeys = new HashSet<String>(Arrays.asList(bind.value()));
+                final Map<String, Object> map = (Map<String, Object>) arg;
+
+                for (Entry e : map.entrySet()) {
+                    final Object keyObj = e.getKey();
+                    final String key;
+                    if (bind.implicitKeyStringConversion() || (keyObj instanceof String)) {
+                        key = keyObj.toString();
+                    } else {
+                        throw new IllegalArgumentException("Key " + keyObj + " (of " + keyObj.getClass() + ") must be a String");
+                    }
+
+                    if (allowedKeys.isEmpty() || allowedKeys.remove(key)) {
+                        q.bind(prefix + key, e.getValue());
+                    }
+                }
+
+                // Any leftover keys were specified but not found in the map, so bind as null
+                for (String key : allowedKeys) {
+                    final Object val = map.get(key);
+                    if (val != null) {
+                        throw new IllegalStateException("Internal error: map iteration missed key " + key);
+                    }
+                    q.bind(prefix + key, (Object) null);
+                }
+            }
+        };
+    }
+}

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestMapBinder.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestMapBinder.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.sqlobject.customizers.Mapper;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import junit.framework.TestCase;
+
+public class TestMapBinder extends TestCase
+{
+    private DBI    dbi;
+    private Handle handle;
+
+    @Override
+    public void setUp() throws Exception
+    {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:test");
+        dbi = new DBI(ds);
+        handle = dbi.open();
+
+        handle.execute("create table something (id int primary key, name varchar(100), a varchar(100), b int, c varchar(100))");
+    }
+
+    @Override
+    public void tearDown() throws Exception
+    {
+        handle.execute("drop table something");
+        handle.close();
+    }
+
+
+    public void testInsert() throws Exception
+    {
+        Spiffy s = handle.attach(Spiffy.class);
+        s.insert(allMap(5, "woo", 3, "too"));
+
+        Result elem = s.load(5);
+        assertEquals("too", elem.c);
+        assertEquals(3, elem.b);
+    }
+
+
+    public void testUpdate() throws Exception
+    {
+        Spiffy s = handle.attach(Spiffy.class);
+        s.insert(allMap(4, "woo", 1, "too"));
+        Map<String, Object> update = new HashMap<String, Object>();
+
+        update.put("a", "goo");
+        update.put("b", 2);
+        update.put("c", null);
+
+        assertEquals(1, s.update(4, update));
+
+        Result elem = s.load(4);
+        assertEquals("goo", elem.a);
+        assertEquals(2, elem.b);
+        assertEquals("too", elem.c);
+    }
+
+    public void testUpdatePrefix() throws Exception
+    {
+        Spiffy s = handle.attach(Spiffy.class);
+        s.insert(allMap(4, "woo", 1, "too"));
+        Map<Object, Object> update = new HashMap<Object, Object>();
+
+        update.put("b", 2);
+        update.put(new A(), "goo");
+
+        assertEquals(1, s.updatePrefix(4, update));
+
+        Result elem = s.load(4);
+        assertEquals("goo", elem.a);
+        assertEquals(1, elem.b); // filtered out by annotation value
+        assertEquals("too", elem.c);
+    }
+
+    private Map<String, Object> allMap(int id, Object a, int b, Object c)
+    {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("id", id);
+        map.put("a", a);
+        map.put("b", b);
+        map.put("c", c);
+        return map;
+    }
+
+    interface Spiffy
+    {
+        @SqlUpdate("insert into something (id, a, b, c) values (:id, :a, :b, :c)")
+        int insert(@BindMap Map<String, Object> bindings);
+
+        @SqlUpdate("update something set a=coalesce(:a, a), b=coalesce(:b, b), c=coalesce(:c, c) where id=:id")
+        int update(@Bind("id") int id, @BindMap Map<String, Object> updates);
+
+        @SqlUpdate("update something set a=coalesce(:asdf.a, a), c=coalesce(:asdf.c, c) where id=:id")
+        int updatePrefix(@Bind("id") int id, @BindMap(prefix="asdf", value={"a","c"}, implicitKeyStringConversion=true) Map<Object, Object> updates);
+
+        @SqlQuery("select * from something where id = :id")
+        @Mapper(ResultMapper.class)
+        Result load(@Bind("id") int id);
+    }
+
+    static class ResultMapper implements ResultSetMapper<Result>
+    {
+        @Override
+        public Result map(int index, ResultSet r, StatementContext ctx)
+        throws SQLException
+        {
+            Result ret = new Result();
+            ret.id = r.getInt("id");
+            ret.a = r.getString("a");
+            ret.b = r.getInt("b");
+            ret.c = r.getString("c");
+            return ret;
+        }
+    }
+
+    static class Result
+    {
+        String a, c;
+        int id, b;
+    }
+
+    static class A
+    {
+        @Override
+        public String toString()
+        {
+            return "a";
+        }
+    }
+}


### PR DESCRIPTION
Feature request from [D. Reinert on the mailing list](https://groups.google.com/d/topic/jdbi/nuJFiFnpMgo/discussion)

Introduce a new binding method, where ```Map``` entries are bound as parameters.  Has a couple of tweaks on the annotation for its behavior.