### PR TITLE
Use actual class for generic object bind

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/SQLStatement.java
+++ b/src/main/java/org/skife/jdbi/v2/SQLStatement.java
@@ -1117,7 +1117,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
      */
     public final SelfType bind(int position, Object value)
     {
-        return bind(position, getForeman().waffle(Object.class, value, getContext()));
+        return bind(position, getForeman().waffle(value != null ? value.getClass() : Object.class, value, getContext()));
     }
 
     /**
@@ -1130,7 +1130,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
      */
     public final SelfType bind(String name, Object value)
     {
-        return bind(name, getForeman().waffle(Object.class, value, getContext()));
+        return bind(name, getForeman().waffle(value != null ? value.getClass() : Object.class, value, getContext()));
     }
 
     /**


### PR DESCRIPTION
If the generic objects value is not null, bind method should use the actual class of the object. This enables foreman to use custom argument factories registered by the user.

This is currently possible via the dynamicBind method of SQLStatement, but I think it is a bit verbose
