### PR TITLE
Stop caching inline SQL statments in ClasspathStatementLocator

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
@@ -15,6 +15,9 @@
  */
 package org.skife.jdbi.v2;
 
+import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
+import org.skife.jdbi.v2.tweak.StatementLocator;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,9 +26,6 @@ import java.nio.charset.Charset;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
-
-import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
-import org.skife.jdbi.v2.tweak.StatementLocator;
 
 /**
  * looks for [name], then [name].sql on the classpath
@@ -83,7 +83,7 @@ public class ClasspathStatementLocator implements StatementLocator
         }
 
         if (looksLikeSql(name)) {
-            found.putIfAbsent(cache_key, name);
+            // No need to cache individual SQL statements that don't cause us to search the classpath
             return name;
         }
         final ClassLoader loader = selectClassLoader();


### PR DESCRIPTION
We've been experiencing an issue in our production environment where 90% of our heap was getting filled up by the ConcurrentMap cache in ClasspathStatementLocator. 

I can see the need to cache named SQL statements that cause us to search the classpath, but for inline SQL, I don't see the benefit of caching the string. 

There is one performance hit to this, in that every inline SQL statement will get passed through the "looksLikeSQL" method.  Personally, I think this is acceptable given the light-weight nature of that method. An alternative implementation (which I'm happy to provide if you don't like the implementation in this pull request), is to use an LRU cache (from Guava) instead of a ConcurrentMap so that the entries can expire after some configurable amount of time. 
