### PR TITLE
Fix race condition when creating DAO objects

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
@@ -77,7 +77,10 @@ class SqlObject
             });
             T t = (T) e.create();
             T actual = (T) factories.putIfAbsent(sqlObjectType, (Factory) t);
-            return actual != null ? actual : t;
+            if (actual == null) {
+                return t;
+            }
+            f = (Factory) actual;
         }
 
         final SqlObject so = new SqlObject(buildHandlersFor(sqlObjectType), handle);


### PR DESCRIPTION
There is a race condition in SqlObject.buildSqlObject that can return an instance of the desired DAO associated with the wrong database handle.  This occurs only when there are multiple concurrent requests to create a DAO which has not previously been created.

This pull-request fixes the race condition and adds a test to verify the fix.
