### PR TITLE
Remove unnecessary synchronization on a PrintStream instance

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/logging/PrintStreamLog.java
+++ b/src/main/java/org/skife/jdbi/v2/logging/PrintStreamLog.java
@@ -50,8 +50,6 @@ public class PrintStreamLog extends FormattedLog
     @Override
     protected void log(String msg)
     {
-        synchronized(out) {
-            out.println(msg);
-        }
+        out.println(msg);
     }
 }


### PR DESCRIPTION
I believe **PrintSteam** already has an inner lock, that guards I/O operations

``` java
public void println(String x) {
       synchronized (this) {
           print(x);
           newLine();
       }
 }
```

So an outer lock seems unnecessary. 
