### PR TITLE
Bind collection

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
@@ -31,30 +31,33 @@ class BindBeanFactory implements BinderFactory
         {
             public void bind(SQLStatement q, BindBean bind, Object arg)
             {
-                final String prefix;
-                if ("___jdbi_bare___".equals(bind.value())) {
-                    prefix = "";
-                }
-                else {
-                    prefix = bind.value() + ".";
-                }
-
-                try {
-                    BeanInfo infos = Introspector.getBeanInfo(arg.getClass());
-                    PropertyDescriptor[] props = infos.getPropertyDescriptors();
-                    for (PropertyDescriptor prop : props) {
-                        Method readMethod = prop.getReadMethod();
-                        if (readMethod != null) {
-                            q.dynamicBind(readMethod.getReturnType(), prefix + prop.getName(), readMethod.invoke(arg));
-                        }
-                    }
-                }
-                catch (Exception e) {
-                    throw new IllegalStateException("unable to bind bean properties", e);
-                }
-
-
+                bindBeanProperties(q, bind.value(), arg);
             }
         };
+    }
+
+    static void bindBeanProperties(SQLStatement q, String placeholder, Object arg)
+    {
+        final String prefix;
+        if ("___jdbi_bare___".equals(placeholder)) {
+            prefix = "";
+        }
+        else {
+            prefix = placeholder + ".";
+        }
+
+        try {
+            BeanInfo infos = Introspector.getBeanInfo(arg.getClass());
+            PropertyDescriptor[] props = infos.getPropertyDescriptors();
+            for (PropertyDescriptor prop : props) {
+                Method readMethod = prop.getReadMethod();
+                if (readMethod != null) {
+                    q.dynamicBind(readMethod.getReturnType(), prefix + prop.getName(), readMethod.invoke(arg));
+                }
+            }
+        }
+        catch (Exception e) {
+            throw new IllegalStateException("unable to bind bean properties", e);
+        }
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindCollection.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindCollection.java
@@ -1,11 +1,7 @@
-package org.skife.jdbi.v2.unstable;
+package org.skife.jdbi.v2.sqlobject;
 
 import org.skife.jdbi.v2.SQLStatement;
-import org.skife.jdbi.v2.sqlobject.*;
 
-import java.beans.BeanInfo;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -68,33 +64,6 @@ public @interface BindCollection
     public static class BindingFactory implements BinderFactory
     {
 
-        /*
-         * Copied from org.skife.jdbi.v2.sqlobject.BindBeanFactory:bind
-         * This logic should be unified
-         */
-        private void bindBeanProperties(SQLStatement q, String placeholder, Object arg)
-        {
-            final String prefix;
-
-            if ("___jdbi_bare___".equals(placeholder)) {
-                prefix = "";
-            }
-            else {
-                prefix = placeholder + ".";
-            }
-
-            try {
-                BeanInfo infos = Introspector.getBeanInfo(arg.getClass());
-                PropertyDescriptor[] props = infos.getPropertyDescriptors();
-                for (PropertyDescriptor prop : props) {
-                    q.bind(prefix + prop.getName(), prop.getReadMethod().invoke(arg));
-                }
-            }
-            catch (Exception e) {
-                throw new IllegalStateException("unable to bind bean properties", e);
-            }
-        }
-
         public Binder build(Annotation annotation)
         {
             final BindCollection in = (BindCollection) annotation;
@@ -116,7 +85,7 @@ public @interface BindCollection
                 private void bindBothRawValueAndBeanProperties(SQLStatement q, String placeholder, Object value)
                 {
                     q.bind(placeholder, value);
-                    bindBeanProperties(q, placeholder, value);
+                    BindBeanFactory.bindBeanProperties(q, placeholder, value);
                 }
             };
         }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindCollection.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindCollection.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.skife.jdbi.v2.sqlobject;
 
 import org.skife.jdbi.v2.SQLStatement;

--- a/src/main/java/org/skife/jdbi/v2/unstable/BindCollection.java
+++ b/src/main/java/org/skife/jdbi/v2/unstable/BindCollection.java
@@ -1,0 +1,124 @@
+package org.skife.jdbi.v2.unstable;
+
+import org.skife.jdbi.v2.SQLStatement;
+import org.skife.jdbi.v2.sqlobject.*;
+
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Retention(RetentionPolicy.RUNTIME)
+@SqlStatementCustomizingAnnotation(BindCollection.CustomizerFactory.class)
+@BindingAnnotation(BindCollection.BindingFactory.class)
+public @interface BindCollection
+{
+    String value();
+
+    public static final class CustomizerFactory implements SqlStatementCustomizerFactory
+    {
+
+        public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
+        {
+            throw new UnsupportedOperationException("Not supported on method!");
+        }
+
+        public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
+        {
+            throw new UnsupportedOperationException("Not supported on type");
+        }
+
+        public SqlStatementCustomizer createForParameter(Annotation annotation,
+                                                         Class sqlObjectType,
+                                                         Method method,
+                                                         Object arg)
+        {
+            final Collection<?> coll = (Collection<?>) arg;
+
+            BindCollection in = (BindCollection) annotation;
+            final String key = in.value();
+
+            final List<String> placeholdersToBeBoundByJdbi = new ArrayList<String>();
+            for (int idx = 0; idx < coll.size(); idx++) {
+                placeholdersToBeBoundByJdbi.add(":" + placeholderFor(key, idx));
+            }
+
+            return new SqlStatementCustomizer()
+            {
+                public void apply(SQLStatement q) throws SQLException
+                {
+                    q.define(key, placeholdersToBeBoundByJdbi);
+                }
+            };
+        }
+
+        static String placeholderFor(String key, Integer index)
+        {
+            return "__" + key + "_" + index;
+        }
+    }
+
+    public static class BindingFactory implements BinderFactory
+    {
+
+        /*
+         * Copied from org.skife.jdbi.v2.sqlobject.BindBeanFactory:bind
+         * This logic should be unified
+         */
+        private void bindBeanProperties(SQLStatement q, String placeholder, Object arg)
+        {
+            final String prefix;
+
+            if ("___jdbi_bare___".equals(placeholder)) {
+                prefix = "";
+            }
+            else {
+                prefix = placeholder + ".";
+            }
+
+            try {
+                BeanInfo infos = Introspector.getBeanInfo(arg.getClass());
+                PropertyDescriptor[] props = infos.getPropertyDescriptors();
+                for (PropertyDescriptor prop : props) {
+                    q.bind(prefix + prop.getName(), prop.getReadMethod().invoke(arg));
+                }
+            }
+            catch (Exception e) {
+                throw new IllegalStateException("unable to bind bean properties", e);
+            }
+        }
+
+        public Binder build(Annotation annotation)
+        {
+            final BindCollection in = (BindCollection) annotation;
+            final String key = in.value();
+
+            return new Binder()
+            {
+
+                public void bind(SQLStatement q, Annotation bind, Object arg)
+                {
+                    Iterable<?> coll = (Iterable<?>) arg;
+                    int idx = 0;
+                    for (Object value : coll) {
+                        String placeholder = CustomizerFactory.placeholderFor(key, idx++);
+                        bindBothRawValueAndBeanProperties(q, placeholder, value);
+                    }
+                }
+
+                private void bindBothRawValueAndBeanProperties(SQLStatement q, String placeholder, Object value)
+                {
+                    q.bind(placeholder, value);
+                    bindBeanProperties(q, placeholder, value);
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
+++ b/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
@@ -38,7 +38,21 @@ public class TestBindCollection
     }
 
     @Test
-    public void testCollectionBinding() throws Exception
+    public void testCollectionValueBinding() throws Exception
+    {
+        handle.execute("insert into keyvalues (id, key, value) values (1, 'k1', 'v1'), (2, 'k1', 'blah'), (3, 'k2', 'v2')");
+
+        DAO dao = handle.attach(DAO.class);
+
+        Collection<String> values = asList("%1%", "%2");
+
+        List<Integer> results = dao.findValuesLikeAnyOf(values);
+
+        assertThat(results, equalTo(asList(1, 3)));
+    }
+
+    @Test
+    public void testCollectionBeanBinding() throws Exception
     {
         handle.execute("insert into keyvalues (id, key, value) values (1, 'k1', 'v1'), (2, 'k1', 'blah'), (3, 'k2', 'v2')");
 
@@ -56,6 +70,10 @@ public class TestBindCollection
     {
         @SqlQuery
         public List<Integer> findAnyWithAKeyAndValue(@BindCollection("keyValues") Collection<KeyValue> keyValues);
+
+
+        @SqlQuery
+        public List<Integer> findValuesLikeAnyOf(@BindCollection("values") Collection<String> values);
     }
 
     public static class KeyValue {

--- a/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
+++ b/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
@@ -1,0 +1,99 @@
+package org.skife.jdbi.v2.docs;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.logging.PrintStreamLog;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+import org.skife.jdbi.v2.unstable.BindCollection;
+
+import java.util.*;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestBindCollection
+{
+    private DBI    dbi;
+    private Handle handle;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        dbi = new DBI("jdbc:h2:mem:" + UUID.randomUUID());
+
+        dbi.setSQLLog(new PrintStreamLog(System.out));
+        handle = dbi.open();
+        handle.execute("create table keyvalues (id integer primary key, key varchar(100), value varchar(100))");
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        handle.close();
+    }
+
+    @Test
+    public void testCollectionBinding() throws Exception
+    {
+        handle.execute("insert into keyvalues (id, key, value) values (1, 'k1', 'v1'), (2, 'k1', 'blah'), (3, 'k2', 'v2')");
+
+        DAO dao = handle.attach(DAO.class);
+
+        Collection<KeyValue> keyValuePairs = asList(new KeyValue("k1", "v1"), new KeyValue("k2", "v2"));
+
+        List<Integer> results = dao.findAnyWithAKeyAndValue(keyValuePairs);
+
+        assertThat(results, equalTo(asList(1, 3)));
+    }
+
+    @Test
+    public void testCollectionBindingWithEmptyCollection() throws Exception
+    {
+        handle.execute("insert into keyvalues (id, key, value) values (1, 'k1', 'v1'), (2, 'k1', 'blah'), (3, 'k2', 'v2')");
+
+        DAO dao = handle.attach(DAO.class);
+
+        List<Integer> results = dao.findAnyWithAKeyAndValue(new ArrayList<KeyValue>());
+
+        assertThat(results, equalTo(asList(1, 2, 3)));
+    }
+
+
+    @UseStringTemplate3StatementLocator
+    public static interface DAO
+    {
+        @SqlQuery
+        public List<Integer> findAnyWithAKeyAndValue(@BindCollection("keyValues") Collection<KeyValue> keyValues);
+    }
+
+    public static class KeyValue {
+        private String key;
+        private String value;
+
+        public KeyValue(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
+++ b/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
@@ -8,7 +8,7 @@ import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.logging.PrintStreamLog;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
-import org.skife.jdbi.v2.unstable.BindCollection;
+import org.skife.jdbi.v2.sqlobject.BindCollection;
 
 import java.util.*;
 

--- a/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
+++ b/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.skife.jdbi.v2.docs;
 
 import org.junit.After;

--- a/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
+++ b/src/test/java/org/skife/jdbi/v2/docs/TestBindCollection.java
@@ -51,19 +51,6 @@ public class TestBindCollection
         assertThat(results, equalTo(asList(1, 3)));
     }
 
-    @Test
-    public void testCollectionBindingWithEmptyCollection() throws Exception
-    {
-        handle.execute("insert into keyvalues (id, key, value) values (1, 'k1', 'v1'), (2, 'k1', 'blah'), (3, 'k2', 'v2')");
-
-        DAO dao = handle.attach(DAO.class);
-
-        List<Integer> results = dao.findAnyWithAKeyAndValue(new ArrayList<KeyValue>());
-
-        assertThat(results, equalTo(asList(1, 2, 3)));
-    }
-
-
     @UseStringTemplate3StatementLocator
     public static interface DAO
     {

--- a/src/test/resources/org/skife/jdbi/v2/docs/TestBindCollection$DAO.sql.stg
+++ b/src/test/resources/org/skife/jdbi/v2/docs/TestBindCollection$DAO.sql.stg
@@ -7,3 +7,11 @@ findAnyWithAKeyAndValue(keyValues) ::= <<
       (key = <first(keyValues)>.key AND value = <first(keyValues)>.value)
       <rest(keyValues):{ kv | OR (key = <kv>.key AND value = <kv>.value) }>
 >>
+
+findValuesLikeAnyOf(values) ::= <<
+  select id
+  from keyvalues
+  where
+    value like <first(values)>
+    <rest(values):{ v | OR value like <v> }>
+>>

--- a/src/test/resources/org/skife/jdbi/v2/docs/TestBindCollection$DAO.sql.stg
+++ b/src/test/resources/org/skife/jdbi/v2/docs/TestBindCollection$DAO.sql.stg
@@ -3,9 +3,7 @@ group DAO;
 findAnyWithAKeyAndValue(keyValues) ::= <<
     select id
     from keyvalues
-    <if(first(keyValues))>
     where
       (key = <first(keyValues)>.key AND value = <first(keyValues)>.value)
       <rest(keyValues):{ kv | OR (key = <kv>.key AND value = <kv>.value) }>
-    <endif>
 >>

--- a/src/test/resources/org/skife/jdbi/v2/docs/TestBindCollection$DAO.sql.stg
+++ b/src/test/resources/org/skife/jdbi/v2/docs/TestBindCollection$DAO.sql.stg
@@ -1,0 +1,11 @@
+group DAO;
+
+findAnyWithAKeyAndValue(keyValues) ::= <<
+    select id
+    from keyvalues
+    <if(first(keyValues))>
+    where
+      (key = <first(keyValues)>.key AND value = <first(keyValues)>.value)
+      <rest(keyValues):{ kv | OR (key = <kv>.key AND value = <kv>.value) }>
+    <endif>
+>>


### PR DESCRIPTION
The current @BindIn annotation is useful for when you want to use a collection of values in an IN statement, but does not allow us to further customize a complicated query.

This hit us when we tried to query for entities matching one or more of a set of free form tags (joined from an 'entity_tags' table)

This pr adds a @BindCollection annotation that makes these complicated queries possible.

You can use StringTemplate to iterate though collection items any way you want:

```
where
  value like <first(values)>
  <rest(values):{ v | OR value like <v> }>
```

translates roughly into:

``` sql
where
  value like :v1
  OR value like :v2
  OR value like :v3
```
