### PR TITLE
Support for fluent map queries

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/BaseQuery.java
+++ b/src/main/java/org/skife/jdbi/v2/BaseQuery.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2;
+
+
+import org.skife.jdbi.v2.tweak.SQLLog;
+import org.skife.jdbi.v2.tweak.StatementBuilder;
+import org.skife.jdbi.v2.tweak.StatementLocator;
+import org.skife.jdbi.v2.tweak.StatementRewriter;
+import org.skife.jdbi.v2.tweak.StatementCustomizer;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.util.Collection;
+
+/**
+ * Base class for statements providing convenience result handling for SQL queries
+ *
+ * @param <SelfType> concrete query type
+ */
+@SuppressWarnings("unchecked")
+public class BaseQuery<SelfType extends BaseQuery<SelfType>> extends SQLStatement<SelfType> {
+
+    protected final MappingRegistry mappingRegistry;
+
+    BaseQuery(Binding params,
+              StatementLocator locator,
+              StatementRewriter statementRewriter,
+              Handle handle,
+              StatementBuilder cache,
+              String sql,
+              ConcreteStatementContext ctx,
+              SQLLog log,
+              TimingCollector timingCollector,
+              Collection<StatementCustomizer> customizers,
+              MappingRegistry mappingRegistry,
+              Foreman foreman,
+              ContainerFactoryRegistry containerFactoryRegistry) {
+        super(params, locator, statementRewriter, handle, cache, sql, ctx, log,
+                timingCollector, customizers, foreman, containerFactoryRegistry);
+        this.mappingRegistry = new MappingRegistry(mappingRegistry);
+    }
+
+    /**
+     * Specify the fetch size for the query. This should cause the results to be
+     * fetched from the underlying RDBMS in groups of rows equal to the number passed.
+     * This is useful for doing chunked streaming of results when exhausting memory
+     * could be a problem.
+     *
+     * @param fetchSize the number of rows to fetch in a bunch
+     * @return the modified query
+     */
+    public SelfType setFetchSize(final int fetchSize) {
+        this.addStatementCustomizer(new StatementCustomizers.FetchSizeCustomizer(fetchSize));
+        return (SelfType) this;
+    }
+
+    /**
+     * Specify the maimum number of rows the query is to return. This uses the underlying JDBC
+     * {@link java.sql.Statement#setMaxRows(int)}}.
+     *
+     * @param maxRows maximum number of rows to return
+     * @return modified query
+     */
+    public SelfType setMaxRows(final int maxRows) {
+        this.addStatementCustomizer(new StatementCustomizers.MaxRowsCustomizer(maxRows));
+        return (SelfType) this;
+    }
+
+    /**
+     * Specify the maimum field size in the result set. This uses the underlying JDBC
+     * {@link java.sql.Statement#setMaxFieldSize(int)}
+     *
+     * @param maxFields maximum field size
+     * @return modified query
+     */
+    public SelfType setMaxFieldSize(final int maxFields) {
+        this.addStatementCustomizer(new StatementCustomizers.MaxFieldSizeCustomizer(maxFields));
+        return (SelfType) this;
+    }
+
+    /**
+     * Specify that the fetch order should be reversed, uses the underlying
+     * {@link java.sql.Statement#setFetchDirection(int)}
+     *
+     * @return the modified query
+     */
+    public SelfType fetchReverse() {
+        setFetchDirection(ResultSet.FETCH_REVERSE);
+        return (SelfType) this;
+    }
+
+    /**
+     * Specify that the fetch order should be forward, uses the underlying
+     * {@link java.sql.Statement#setFetchDirection(int)}
+     *
+     * @return the modified query
+     */
+    public BaseQuery<SelfType> fetchForward() {
+        setFetchDirection(ResultSet.FETCH_FORWARD);
+        return this;
+    }
+
+    public void registerMapper(ResultSetMapper m) {
+        this.mappingRegistry.add(new InferredMapperFactory(m));
+    }
+
+    public void registerMapper(ResultSetMapperFactory m) {
+        this.mappingRegistry.add(m);
+    }
+}

--- a/src/main/java/org/skife/jdbi/v2/BasicHandle.java
+++ b/src/main/java/org/skife/jdbi/v2/BasicHandle.java
@@ -99,6 +99,30 @@ class BasicHandle implements Handle
     }
 
     /**
+     * Creates a builder for queries whose results are transformed to {@link java.util.Map} in some way
+     * @param sql sql query
+     * @return a map query builder
+     */
+    @Override
+    public MapQuery<Map<String, Object>, Map<String, Object>> createMapQuery(String sql) {
+        return new MapQuery<Map<String, Object>, Map<String, Object>>(new Binding(),
+                new DefaultMapper(),
+                new DefaultMapper(),
+                statementLocator,
+                statementRewriter,
+                this,
+                statementBuilder,
+                sql,
+                new ConcreteStatementContext(globalStatementAttributes),
+                log,
+                timingCollector,
+                Collections.<StatementCustomizer>emptyList(),
+                new MappingRegistry(mappingRegistry),
+                foreman.createChild(),
+                containerFactoryRegistry.createChild());
+    }
+
+    /**
      * Get the JDBC Connection this Handle uses
      *
      * @return the JDBC Connection this Handle uses

--- a/src/main/java/org/skife/jdbi/v2/Handle.java
+++ b/src/main/java/org/skife/jdbi/v2/Handle.java
@@ -89,6 +89,8 @@ public interface Handle extends Closeable
      */
     Query<Map<String, Object>> createQuery(String sql);
 
+    MapQuery<Map<String, Object>, Map<String, Object>> createMapQuery(String sql);
+
     /**
      * Create an Insert or Update statement which returns the number of rows modified.
      * @param sql The statement sql

--- a/src/main/java/org/skife/jdbi/v2/MapFolder.java
+++ b/src/main/java/org/skife/jdbi/v2/MapFolder.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2;
+
+public interface MapFolder<A, K, V> {
+
+     void fold(A accumulator, K key, V value);
+}

--- a/src/main/java/org/skife/jdbi/v2/MapQuery.java
+++ b/src/main/java/org/skife/jdbi/v2/MapQuery.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2;
+
+import org.skife.jdbi.v2.tweak.SQLLog;
+import org.skife.jdbi.v2.tweak.StatementBuilder;
+import org.skife.jdbi.v2.tweak.StatementLocator;
+import org.skife.jdbi.v2.tweak.StatementRewriter;
+import org.skife.jdbi.v2.tweak.StatementCustomizer;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.AbstractMap;
+
+/**
+ * Statement providing convenience result handling for SQL queries transformed to a {@link java.util.Map}.
+ */
+public class MapQuery<KeyType, ValueType> extends BaseQuery<MapQuery<KeyType, ValueType>> {
+
+    /**
+     * Functional interface for managing a result set iteration cycle
+     */
+    private interface Condition {
+        boolean check(ResultSet rs, int index) throws SQLException;
+    }
+
+    private static final Condition GET_ALL = new Condition() {
+        @Override
+        public boolean check(ResultSet rs, int index) throws SQLException {
+            return rs.next();
+        }
+    };
+
+    private final ResultSetMapper<KeyType> keyMapper;
+    private final ResultSetMapper<ValueType> valueMapper;
+    private Map<KeyType, ValueType> accumulator = null;
+
+    MapQuery(Binding params,
+             ResultSetMapper<KeyType> keyMapper,
+             ResultSetMapper<ValueType> valueMapper,
+             StatementLocator locator,
+             StatementRewriter statementRewriter,
+             Handle handle,
+             StatementBuilder cache,
+             String sql,
+             ConcreteStatementContext ctx,
+             SQLLog log,
+             TimingCollector timingCollector,
+             Collection<StatementCustomizer> customizers,
+             MappingRegistry mappingRegistry,
+             Foreman foreman,
+             ContainerFactoryRegistry containerFactoryRegistry) {
+        super(params, locator, statementRewriter, handle, cache, sql, ctx, log, timingCollector, customizers,
+                mappingRegistry, foreman, containerFactoryRegistry);
+        this.valueMapper = valueMapper;
+        this.keyMapper = keyMapper;
+    }
+
+    /**
+     * Executes the select
+     * <p/>
+     * Will eagerly load all results
+     *
+     * @throws org.skife.jdbi.v2.exceptions.UnableToCreateStatementException
+     *          if there is an error creating the statement
+     * @throws org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException
+     *          if there is an error executing the statement
+     * @throws org.skife.jdbi.v2.exceptions.ResultSetException
+     *          if there is an error dealing with the result set
+     */
+    public Map<KeyType, ValueType> get() {
+        return innerGet(GET_ALL);
+    }
+
+    /**
+     * Executes the select
+     * <p/>
+     * Will eagerly load all results up to a maximum of <code>maxRows</code>
+     *
+     * @param maxRows The maximum number of results to include in the result, any
+     *                rows in the result set beyond this number will be ignored.
+     * @throws org.skife.jdbi.v2.exceptions.UnableToCreateStatementException
+     *          if there is an error creating the statement
+     * @throws org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException
+     *          if there is an error executing the statement
+     * @throws org.skife.jdbi.v2.exceptions.ResultSetException
+     *          if there is an error dealing with the result set
+     */
+    public Map<KeyType, ValueType> get(final int maxRows) {
+        return innerGet(new Condition() {
+            @Override
+            public boolean check(ResultSet rs, int index) throws SQLException {
+                return rs.next() && index < maxRows;
+            }
+        });
+    }
+
+    private Map<KeyType, ValueType> innerGet(final Condition continueCondition) {
+        try {
+            return this.internalExecute(new QueryResultSetMunger<Map<KeyType, ValueType>>(this) {
+                public Map<KeyType, ValueType> munge(ResultSet rs) throws SQLException {
+                    // Traverse a result set and fill the map with keys and values
+                    Map<KeyType, ValueType> resultMap =
+                            accumulator != null ? accumulator : new HashMap<KeyType, ValueType>();
+                    int index = 0;
+                    while (continueCondition.check(rs, index)) {
+                        KeyType key = keyMapper.map(index, rs, getContext());
+                        ValueType value = valueMapper.map(index, rs, getContext());
+                        resultMap.put(key, value);
+                        index++;
+                    }
+                    return resultMap;
+                }
+            });
+        } finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * Provide basic JavaBean mapping capabilities for keys. Will instantiate an instance of keyType
+     * for each row and set the JavaBean properties which match fields in the result set.
+     *
+     * @param keyType JavaBean class to map result set fields into the properties
+     * @return a Query which provides the bean property mapping for keys
+     */
+    public <T> MapQuery<T, ValueType> mapKey(Class<T> keyType) {
+        return this.mapKey(new BeanMapper<T>(keyType));
+    }
+
+    /**
+     * Makes use of registered mappers to map the result set to the desired key type.
+     *
+     * @param keyType the key type of map the query results to
+     * @return a new query instance which will map keys to the desired type
+     * @see DBI#registerMapper(org.skife.jdbi.v2.tweak.ResultSetMapper)
+     * @see DBI#registerMapper(ResultSetMapperFactory)
+     * @see Handle#registerMapper(ResultSetMapperFactory)
+     * @see Handle#registerMapper(org.skife.jdbi.v2.tweak.ResultSetMapper)
+     */
+    public <T> MapQuery<T, ValueType> mapKeyTo(Class<T> keyType) {
+        return this.mapKey(new RegisteredMapper<T>(keyType, mappingRegistry));
+    }
+
+    /**
+     * Provide basic JavaBean mapping capabilities for values. Will instantiate an instance of valueType
+     * for each row and set the JavaBean properties which match fields in the result set.
+     *
+     * @param valueType JavaBean class to map result set fields into the properties
+     * @return a Query which provides the bean property mapping for values
+     */
+    public <T> MapQuery<KeyType, T> mapValue(Class<T> valueType) {
+        return this.mapValue(new BeanMapper<T>(valueType));
+    }
+
+    /**
+     * Makes use of registered mappers to map the result set to the desired value type.
+     *
+     * @param valueType the value type of map the query results to
+     * @return a new query instance which will map values to the desired type
+     * @see DBI#registerMapper(org.skife.jdbi.v2.tweak.ResultSetMapper)
+     * @see DBI#registerMapper(ResultSetMapperFactory)
+     * @see Handle#registerMapper(ResultSetMapperFactory)
+     * @see Handle#registerMapper(org.skife.jdbi.v2.tweak.ResultSetMapper)
+     */
+    public <T> MapQuery<KeyType, T> mapValueTo(Class<T> valueType) {
+        return this.mapValue(new RegisteredMapper<T>(valueType, mappingRegistry));
+    }
+
+
+    /**
+     * Makes use of the mapper to map the result set to the desired key type.
+     *
+     * @param keyMapper the mapper to keys of map the query results to
+     * @return a new query instance which will map keys to the desired type
+     */
+    public <T> MapQuery<T, ValueType> mapKey(ResultSetMapper<T> keyMapper) {
+        return new MapQuery<T, ValueType>(getParameters(),
+                keyMapper,
+                valueMapper,
+                getStatementLocator(),
+                getRewriter(),
+                getHandle(),
+                getStatementBuilder(),
+                getSql(),
+                getConcreteContext(),
+                getLog(),
+                getTimingCollector(),
+                getStatementCustomizers(),
+                new MappingRegistry(mappingRegistry),
+                getForeman().createChild(),
+                getContainerMapperRegistry().createChild());
+    }
+
+    /**
+     * Makes use of the mapper to map the result set to the desired value type.
+     *
+     * @param valueMapper the mapper to values of map the query results to
+     * @return a new query instance which will map values to the desired type
+     */
+    public <V> MapQuery<KeyType, V> mapValue(ResultSetMapper<V> valueMapper) {
+        return new MapQuery<KeyType, V>(getParameters(),
+                keyMapper,
+                valueMapper,
+                getStatementLocator(),
+                getRewriter(),
+                getHandle(),
+                getStatementBuilder(),
+                getSql(),
+                getConcreteContext(),
+                getLog(),
+                getTimingCollector(),
+                getStatementCustomizers(),
+                new MappingRegistry(mappingRegistry),
+                getForeman().createChild(),
+                getContainerMapperRegistry().createChild());
+    }
+
+    /**
+     * Obtain a forward-only result set iterator. Note that you must explicitely close
+     * the iterator to close the underlying resources.
+     */
+    public ResultIterator<Map.Entry<KeyType, ValueType>> iterator() {
+        return this.internalExecute(new QueryResultMunger<ResultIterator<Map.Entry<KeyType, ValueType>>>() {
+            public ResultIterator<Map.Entry<KeyType, ValueType>> munge(Statement stmt) throws SQLException {
+                return new ResultSetResultIterator<Map.Entry<KeyType, ValueType>>(new ResultSetMapper<Map.Entry<KeyType, ValueType>>() {
+                    @Override
+                    public Map.Entry<KeyType, ValueType> map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+                        return new AbstractMap.SimpleEntry<KeyType, ValueType>(keyMapper.map(index, r, ctx),
+                                valueMapper.map(index, r, ctx));
+                    }
+                }, MapQuery.this, stmt, getContext());
+            }
+        });
+    }
+
+    /**
+     * Used to execute the query and traverse the result with gathering data to the accumulator.
+     * The link to the accumulator doesn't change. So the return object is the same object as passed as an argument,
+     * but with a changed state. Callback is used to change a state of the accumulator.
+     *
+     * @param accumulator Empty accumulator object
+     * @param folder      Defines the function which will fold over the result set.
+     * @return The return value from the last invocation of {@link MapFolder#fold(Object, Object, Object)}}
+     */
+    public <AccumulatorType> AccumulatorType fold(final AccumulatorType accumulator,
+                                                  final MapFolder<AccumulatorType, KeyType, ValueType> folder) {
+        try {
+            this.internalExecute(new QueryResultSetMunger<Void>(this) {
+                public Void munge(ResultSet rs) throws SQLException {
+                    int index = 0;
+                    while (rs.next()) {
+                        folder.fold(accumulator, keyMapper.map(index, rs, getContext()),
+                                valueMapper.map(index, rs, getContext()));
+                        index++;
+                    }
+                    return null;
+                }
+            });
+            return accumulator;
+        } finally {
+            cleanup();
+        }
+
+    }
+
+    /**
+     * Accumulator (empty {@link java.util.Map} implementation) to which keys and values would be placed.
+     * If it's not specified, it would be a plain {@link java.util.HashMap}
+     * <p/>
+     * This method should be called after key and value mappers are set, otherwise the accumulator will be overridden
+     * by another builder because type safety reasons.
+     *
+     * @param accumulator Empty accumulator map
+     * @return The same builder
+     */
+    public MapQuery<KeyType, ValueType> accumulator(Map<KeyType, ValueType> accumulator) {
+        this.accumulator = accumulator;
+        return this;
+    }
+}

--- a/src/main/java/org/skife/jdbi/v2/Query.java
+++ b/src/main/java/org/skife/jdbi/v2/Query.java
@@ -33,10 +33,9 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Statement providing convenience result handling for SQL queries.
  */
-public class Query<ResultType> extends SQLStatement<Query<ResultType>> implements ResultBearing<ResultType>
+public class Query<ResultType> extends BaseQuery<Query<ResultType>> implements ResultBearing<ResultType>
 {
     private final ResultSetMapper<ResultType> mapper;
-    private final MappingRegistry             mappingRegistry;
 
     Query(Binding params,
           ResultSetMapper<ResultType> mapper,
@@ -53,9 +52,9 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
           Foreman foreman,
           ContainerFactoryRegistry containerFactoryRegistry)
     {
-        super(params, locator, statementRewriter, handle, cache, sql, ctx, log, timingCollector, customizers, foreman, containerFactoryRegistry);
+        super(params, locator, statementRewriter, handle, cache, sql, ctx, log, timingCollector, customizers,
+                mappingRegistry, foreman, containerFactoryRegistry);
         this.mapper = mapper;
-        this.mappingRegistry = new MappingRegistry(mappingRegistry);
     }
 
     /**
@@ -316,83 +315,5 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
                             new MappingRegistry(mappingRegistry),
                             getForeman().createChild(),
                             getContainerMapperRegistry().createChild());
-    }
-
-    /**
-     * Specify the fetch size for the query. This should cause the results to be
-     * fetched from the underlying RDBMS in groups of rows equal to the number passed.
-     * This is useful for doing chunked streaming of results when exhausting memory
-     * could be a problem.
-     *
-     * @param fetchSize the number of rows to fetch in a bunch
-     *
-     * @return the modified query
-     */
-    public Query<ResultType> setFetchSize(final int fetchSize)
-    {
-        this.addStatementCustomizer(new StatementCustomizers.FetchSizeCustomizer(fetchSize));
-        return this;
-    }
-
-    /**
-     * Specify the maimum number of rows the query is to return. This uses the underlying JDBC
-     * {@link Statement#setMaxRows(int)}}.
-     *
-     * @param maxRows maximum number of rows to return
-     *
-     * @return modified query
-     */
-    public Query<ResultType> setMaxRows(final int maxRows)
-    {
-        this.addStatementCustomizer(new StatementCustomizers.MaxRowsCustomizer(maxRows));
-        return this;
-    }
-
-    /**
-     * Specify the maimum field size in the result set. This uses the underlying JDBC
-     * {@link Statement#setMaxFieldSize(int)}
-     *
-     * @param maxFields maximum field size
-     *
-     * @return modified query
-     */
-    public Query<ResultType> setMaxFieldSize(final int maxFields)
-    {
-        this.addStatementCustomizer(new StatementCustomizers.MaxFieldSizeCustomizer(maxFields));
-        return this;
-    }
-
-    /**
-     * Specify that the fetch order should be reversed, uses the underlying
-     * {@link Statement#setFetchDirection(int)}
-     *
-     * @return the modified query
-     */
-    public Query<ResultType> fetchReverse()
-    {
-        setFetchDirection(ResultSet.FETCH_REVERSE);
-        return this;
-    }
-
-    /**
-     * Specify that the fetch order should be forward, uses the underlying
-     * {@link Statement#setFetchDirection(int)}
-     *
-     * @return the modified query
-     */
-    public Query<ResultType> fetchForward()
-    {
-        setFetchDirection(ResultSet.FETCH_FORWARD);
-        return this;
-    }
-
-    public void registerMapper(ResultSetMapper m)
-    {
-        this.mappingRegistry.add(new InferredMapperFactory(m));
-    }
-
-    public void registerMapper(ResultSetMapperFactory m)
-    {
-        this.mappingRegistry.add(m);
     }
 }

--- a/src/test/java/org/skife/jdbi/v2/TestMapQueries.java
+++ b/src/test/java/org/skife/jdbi/v2/TestMapQueries.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.*;
+import com.google.common.net.HostAndPort;
+import org.junit.Test;
+import org.skife.jdbi.v2.logging.PrintStreamLog;
+import org.skife.jdbi.v2.sqlobject.SomethingMapper;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.skife.jdbi.v2.util.IntegerMapper;
+import org.skife.jdbi.v2.util.StringMapper;
+import org.skife.jdbi.v2.util.TimestampMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class TestMapQueries extends DBITestCase {
+
+    private BasicHandle h;
+
+    @Override
+    public void doSetUp() throws Exception {
+        h = openHandle();
+        h.setSQLLog(new PrintStreamLog());
+    }
+
+    @Override
+    public void doTearDown() throws Exception {
+        if (h != null) h.close();
+    }
+
+
+    @Test
+    public void testPrimitiveMappers() {
+        insertDefaultData();
+
+        Map<Integer, String> map = h.createMapQuery("select id, name from something")
+                .mapKey(new IntegerMapper("id"))
+                .mapValue(new StringMapper("name"))
+                .get();
+        Map<Integer, String> expected = ImmutableMap.of(1, "eric", 2, "brian");
+        assertThat(map, equalTo(expected));
+    }
+
+    private void insertDefaultData() {
+        h.insert("insert into something (id, name) values (1, 'eric')");
+        h.insert("insert into something (id, name) values (2, 'brian')");
+    }
+
+    private void insertExtendedData() {
+        h.insert("insert into something (id, name) values (1, 'eric')");
+        h.insert("insert into something (id, name) values (2, 'brian')");
+        h.insert("insert into something (id, name) values (3, 'david')");
+        h.insert("insert into something (id, name) values (4, 'michael')");
+        h.insert("insert into something (id, name) values (5, 'scott')");
+        h.insert("insert into something (id, name) values (6, 'fred')");
+    }
+
+    @Test
+    public void testPrimitiveKeyComplexValue() {
+        insertDefaultData();
+
+        Map<Integer, Something> map = h.createMapQuery("select id, name from something")
+                .mapKey(new IntegerMapper("id"))
+                .mapValue(new SomethingMapper())
+                .get();
+
+        Map<Integer, Something> expected = ImmutableMap.of(1, new Something(1, "eric"), 2, new Something(2, "brian"));
+        assertThat(map, equalTo(expected));
+    }
+
+    @Test
+    public void testComplexKeyPrimitiveValue() {
+        h.createStatement("create table user_updates(id integer, name varchar(50), update_date timestamp)").execute();
+        h.insert("insert into user_updates (id, name, update_date) values (1, 'eric', '2014-05-01 12:00:00')");
+        h.insert("insert into user_updates (id, name, update_date) values (2, 'brian', '2014-05-06 13:00:00')");
+
+        try {
+            Map<Something, Timestamp> map = h.createMapQuery("select id, name, update_date from user_updates")
+                    .mapKey(new SomethingMapper())
+                    .mapValue(new TimestampMapper("update_date"))
+                    .get();
+            Map<Something, Timestamp> expected =
+                    ImmutableMap.of(new Something(1, "eric"), timestamp("2014-05-01 12:00:00"),
+                            new Something(2, "brian"), timestamp("2014-05-06 13:00:00"));
+            assertThat(map, equalTo(expected));
+        } finally {
+            h.createStatement("drop table user_updates").execute();
+        }
+    }
+
+    private static Timestamp timestamp(String textDate) {
+        try {
+            return new Timestamp(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(textDate).getTime());
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+
+    @Test
+    public void testComplexKeyComplexValue() {
+        h.createStatement("create table user_servers(id integer, name varchar(50), ip varchar(15), port integer)").execute();
+        h.insert("insert into user_servers (id, name, ip, port) values (1, 'eric', '192.168.52.15', 8080)");
+        h.insert("insert into user_servers (id, name, ip, port) values (2, 'brian', '192.168.52.88', 9091)");
+
+        try {
+            Map<Something, HostAndPort> map = h.createMapQuery("select id, name, ip, port from user_servers")
+                    .mapKey(new SomethingMapper())
+                    .mapValue(new ResultSetMapper<HostAndPort>() {
+                        @Override
+                        public HostAndPort map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+                            return HostAndPort.fromParts(r.getString("ip"), r.getInt("port"));
+                        }
+                    }).get();
+            Map<Something, HostAndPort> expected = ImmutableMap.of(
+                    new Something(1, "eric"), HostAndPort.fromString("192.168.52.15:8080"),
+                    new Something(2, "brian"), HostAndPort.fromString("192.168.52.88:9091"));
+            assertThat(map, equalTo(expected));
+        } finally {
+            h.createStatement("drop table user_servers").execute();
+        }
+    }
+
+    @Test
+    public void testBeanKey() {
+        insertDefaultData();
+
+        Map<Something, Integer> map = h.createMapQuery("select id, name from something")
+                .mapKey(Something.class)
+                .mapValue(IntegerMapper.FIRST)
+                .get();
+
+        Map<Something, Integer> expected = ImmutableMap.of(new Something(1, "eric"), 1, new Something(2, "brian"), 2);
+        assertThat(map, equalTo(expected));
+    }
+
+    @Test
+    public void testBeanValue() {
+        insertDefaultData();
+
+        Map<Integer, Something> map = h.createMapQuery("select id, name from something")
+                .mapKey(new IntegerMapper("id"))
+                .mapValue(Something.class)
+                .get();
+
+        Map<Integer, Something> expected = ImmutableMap.of(1, new Something(1, "eric"), 2, new Something(2, "brian"));
+        assertThat(map, equalTo(expected));
+    }
+
+    @Test
+    public void testRegisteredMappers() {
+        h.createStatement("create table user_servers(id integer, name varchar(50), ip varchar(15), port integer)").execute();
+        h.insert("insert into user_servers (id, name, ip, port) values (1, 'eric', '192.168.52.15', 8080)");
+        h.insert("insert into user_servers (id, name, ip, port) values (2, 'brian', '192.168.52.88', 9091)");
+
+        try {
+            h.registerMapper(new SomethingMapper());
+            h.registerMapper(new ResultSetMapper<HostAndPort>() {
+                @Override
+                public HostAndPort map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+                    return HostAndPort.fromParts(r.getString("ip"), r.getInt("port"));
+                }
+            });
+            Map<Something, HostAndPort> map = h.createMapQuery("select id, name, ip, port from user_servers")
+                    .mapKeyTo(Something.class)
+                    .mapValueTo(HostAndPort.class)
+                    .get();
+            Map<Something, HostAndPort> expected = ImmutableMap.of(
+                    new Something(1, "eric"), HostAndPort.fromString("192.168.52.15:8080"),
+                    new Something(2, "brian"), HostAndPort.fromString("192.168.52.88:9091"));
+            assertThat(map, equalTo(expected));
+        } finally {
+            h.createStatement("drop table user_servers").execute();
+        }
+    }
+
+    @Test
+    public void testJoinedTables() {
+        h.createScript("user-cities").execute();
+
+        try {
+
+            h.registerMapper(new SomethingMapper());
+            h.registerMapper(new ResultSetMapper<City>() {
+                @Override
+                public City map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+                    return new City(r.getInt("city_id"), r.getString("city_name"), r.getString("state"));
+                }
+            });
+            Map<Something, City> map = h.createMapQuery("select u.id, u.name, u.city_id, c.name city_name, c.state " +
+                    "from users u " +
+                    "inner join cities c on u.city_id = c.id")
+                    .mapKeyTo(Something.class)
+                    .mapValueTo(City.class)
+                    .get();
+            Map<Something, City> expected = ImmutableMap.<Something, City>builder()
+                    .put(new Something(1, "eric"), new City(1, "Los Angeles", "CA"))
+                    .put(new Something(2, "brian"), new City(1, "Los Angeles", "CA"))
+                    .put(new Something(3, "david"), new City(2, "St. Louis", "MO"))
+                    .put(new Something(4, "michael"), new City(3, "Boston", "MA"))
+                    .put(new Something(5, "scott"), new City(3, "Boston", "MA"))
+                    .put(new Something(6, "fred"), new City(1, "Los Angeles", "CA"))
+                    .build();
+            assertThat(map, equalTo(expected));
+        } finally {
+            h.createStatement("drop table users").execute();
+            h.createStatement("drop table cities").execute();
+        }
+    }
+
+    @Test
+    public void testFolder() {
+        h.createScript("user-cities").execute();
+
+        try {
+            h.registerMapper(new SomethingMapper());
+            h.registerMapper(new ResultSetMapper<City>() {
+                @Override
+                public City map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+                    return new City(r.getInt("city_id"), r.getString("city_name"), r.getString("state"));
+                }
+            });
+
+            Multimap<City, Something> multimap = h.createMapQuery("select u.id, u.name, u.city_id, c.name city_name, c.state " +
+                    "from users u " +
+                    "inner join cities c on u.city_id = c.id")
+                    .mapKeyTo(Something.class)
+                    .mapValueTo(City.class)
+                    .fold(ArrayListMultimap.<City, Something>create(), new MapFolder<ArrayListMultimap<City, Something>, Something, City>() {
+                        @Override
+                        public void fold(ArrayListMultimap<City, Something> accumulator, Something key, City value) {
+                            accumulator.put(value, key);
+                        }
+                    });
+
+            Multimap<City, Something> expected = ImmutableMultimap.<City, Something>builder()
+                    .putAll(new City(1, "Los Angeles", "CA"), new Something(1, "eric"), new Something(2, "brian"), new Something(6, "fred"))
+                    .putAll(new City(2, "St. Louis", "MO"), new Something(3, "david"))
+                    .putAll(new City(3, "Boston", "MA"), new Something(4, "michael"), new Something(5, "scott"))
+                    .build();
+            assertThat(multimap, equalTo(expected));
+        } finally {
+            h.createStatement("drop table users").execute();
+            h.createStatement("drop table cities").execute();
+        }
+    }
+
+    @Test
+    public void testIterator() {
+        insertExtendedData();
+
+        ResultIterator<Map.Entry<Integer, String>> iterator = h.createMapQuery("select id, name from something")
+                .mapKey(new IntegerMapper(1))
+                .mapValue(new StringMapper(2))
+                .iterator();
+        try {
+            int count = 0;
+            List<Integer> shortNameIds = new ArrayList<Integer>(3);
+            while (iterator.hasNext()) {
+                Map.Entry<Integer, String> entry = iterator.next();
+                if (entry.getValue().length() == 5) {
+                    shortNameIds.add(entry.getKey());
+                    if (++count >= 3) {
+                        break;
+                    }
+                }
+            }
+            assertTrue(shortNameIds.size() == 3);
+        } finally {
+            iterator.close();
+        }
+    }
+
+    @Test
+    public void testMaxRows() {
+        insertExtendedData();
+
+        Map<Integer, String> map = h.createMapQuery("select id, name from something")
+                .mapKey(new IntegerMapper(1))
+                .mapValue(new StringMapper(2))
+                .get(3);
+        assertThat(map.size(), equalTo(3));
+    }
+
+    @Test
+    public void testAccumulator() {
+        insertExtendedData();
+
+        Map<Integer, String> map = h.createMapQuery("select id, name from something")
+                .mapKey(new IntegerMapper(1))
+                .mapValue(new StringMapper(2))
+                .accumulator(new TreeMap<Integer, String>(Ordering.natural().reverse()))
+                .get();
+        assertTrue(map.getClass().equals(TreeMap.class));
+        assertTrue(map.keySet().equals(ImmutableSet.of(6, 5, 4, 3, 2, 1)));
+    }
+
+
+    private static class City {
+        int id;
+        String name;
+        String state;
+
+        City(int id, String name, String state) {
+            this.id = id;
+            this.name = name;
+            this.state = state;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            City that = (City) o;
+
+            return Objects.equal(id, that.id) && Objects.equal(name, that.name) &&
+                    Objects.equal(state, that.state);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(id, name, state);
+        }
+
+        @Override
+        public String toString() {
+            return Objects.toStringHelper(this)
+                    .add("id", id)
+                    .add("name", name)
+                    .add("state", state)
+                    .toString();
+        }
+    }
+
+
+}

--- a/src/test/resources/user-cities.sql
+++ b/src/test/resources/user-cities.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright (C) 2004 - 2014 Brian McCallister
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE TABLE cities (id INTEGER PRIMARY KEY, name VARCHAR(100), state VARCHAR(100));
+CREATE TABLE users (id INTEGER, name VARCHAR(50), city_id INTEGER REFERENCES cities (id));
+
+INSERT INTO cities (id, name, state) VALUES (1, 'Los Angeles', 'CA');
+INSERT INTO cities (id, name, state) VALUES (2, 'St. Louis', 'MO');
+INSERT INTO cities (id, name, state) VALUES (3, 'Boston', 'MA');
+
+INSERT INTO users (id, name, city_id) VALUES (1, 'eric', 1);
+INSERT INTO users (id, name, city_id) VALUES (2, 'brian', 1);
+INSERT INTO users (id, name, city_id) VALUES (3, 'david', 2);
+INSERT INTO users (id, name, city_id) VALUES (4, 'michael', 3);
+INSERT INTO users (id, name, city_id) VALUES (5, 'scott', 3);
+INSERT INTO users (id, name, city_id) VALUES (6, 'fred', 1);


### PR DESCRIPTION
Maybe it's a quite a big change to add, but I will give a shot.

The problem this PR addresses is a complexity to perform map queries in JDBI. I think JDBI can do a lot better in this field.

Let's have a simple table in a database
```sql
insert into something(id, name) values (1, 'keith');
insert into something(id, name) values (2, 'brian');
```

Let's imagine we want to load data from this table to **Map**. *Canonical* way to make such queries is using *fold*. Something like that:
```java
h.createQuery("select id, name from something")
                .fold(new HashMap<String, Integer>(), new Folder2<Map<String, Integer>>() {
                    public Map<String, Integer> fold(Map<String, Integer> a, ResultSet rs, StatementContext context) throws SQLException {
                        a.put(rs.getString("name"), rs.getInt("id"));
                        return a;
                    }
                });
```
Quite cumbersome. A little better with *Guava* and *Java 8*:
```java
 h.createQuery("select id, name from something")
                .fold(Maps.newHashMap(), (a, rs, context) -> {
                    a.put(rs.getString("name"), rs.getInt("id"));
                    return a;
                });
```

Another problem is that we don't have a strict mapping between keys and values. So, in case if we already have some mappers for complex types it's quite not natural to use it the *fold* method.

This change proposes a fluent interface to work with map queries. Basic structure like that:
 ```java
h.createMapQuery("select id, name from something")
                .mapKey(new StringMapper("name"))
                .mapValue(new IntegerMapper("id"))
                .get();
```
I believe it's more concise and more focused on the real task. 

Registered mappers can be reused:
 ```java
h.registerMapper(new SomethingMapper());
h.registerMapper((index, r, ctx) -> 
        new City(r.getInt("city_id"), r.getString("city_name"), r.getString("state")));
h.createMapQuery("select u.id, u.name, u.city_id, c.name city_name, c.state " +
        "from users u inner join cities c on u.city_id = c.id")
        .mapKeyTo(Something.class)
        .mapValueTo(City.class)
        .get();
 ```

We can set the needed implementation of **Map** if the default **HashMap** is not sufficient.
 ```java
h.createMapQuery("select id, name from something")
                .mapKey(new StringMapper("name"))
                .mapValue(new IntegerMapper("id"))
                .accumulator(Maps.newHashMapWithExpectedSize(128))
                .get();
 ```

If we want some not standard structure with keys and values, we can use *fold* (I use more simple fold version without changing an accumulator, because it more handy for typical cases).
 ```java
h.createMapQuery("select u.id, u.name, u.city_id, c.name city_name, c.state " +
        "from users u inner join cities c on u.city_id = c.id")
        .mapKeyTo(Something.class)
        .mapValueTo(City.class)
        .fold(ArrayListMultimap.create(), (accumulator, key, value) -> 
                {accumulator.put(value, key);});
 ```  

I've tried to make everything backward compatible, but could make mistakes. Fell free to correct me.
Thanks in advance. 