### PR TITLE
Modified BeanMapper to use Reflection to set fields instead of depending...

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/ReflectionBeanMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/ReflectionBeanMapper.java
@@ -32,7 +32,7 @@ import java.util.Date;
 
 /**
  * A result set mapper which maps the fields in a statement into a JavaBean. This uses
- * the reflection to set the fields, it does not support nested properties.
+ * the reflection to set the fields on the bean including its super class fields, it does not support nested properties.
  */
 public class ReflectionBeanMapper<T> implements ResultSetMapper<T>
 {
@@ -42,10 +42,17 @@ public class ReflectionBeanMapper<T> implements ResultSetMapper<T>
     public ReflectionBeanMapper(Class<T> type)
     {
         this.type = type;
-        for (Field field : type.getDeclaredFields()) {
-            properties.put(field.getName().toLowerCase(), field);
-        }
+        cacheAllFieldsIncludingSuperClass(type);
+    }
 
+    private void cacheAllFieldsIncludingSuperClass(Class<T> type) {
+        Class aClass = type;
+        while(aClass != null) {
+            for (Field field : aClass.getDeclaredFields()) {
+                properties.put(field.getName().toLowerCase(), field);
+            }
+            aClass = aClass.getSuperclass();
+        }
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/org/skife/jdbi/v2/ReflectionBeanMapperTest.java
+++ b/src/test/java/org/skife/jdbi/v2/ReflectionBeanMapperTest.java
@@ -27,9 +27,7 @@ import java.sql.ResultSetMetaData;
 
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 
 
 @RunWith(EasyMockRunner.class)
@@ -140,6 +138,31 @@ public class ReflectionBeanMapperTest {
         assertSame(aIntVal, sampleBean.getIntField());
         assertSame(aStringVal, sampleBean.getStringField());
     }
+
+    @Test
+    public void shouldSetValuesInSuperClassFields() throws Exception {
+
+        expect(resultSetMetaData.getColumnCount()).andReturn(2).anyTimes();
+        expect(resultSetMetaData.getColumnLabel(1)).andReturn("longField");
+        expect(resultSetMetaData.getColumnLabel(2)).andReturn("blongField");
+        replay(resultSetMetaData);
+
+        expect(resultSet.getMetaData()).andReturn(resultSetMetaData);
+        Long aLongVal = 100l;
+        Long bLongVal = 200l;
+
+        expect(resultSet.getLong(1)).andReturn(aLongVal);
+        expect(resultSet.getLong(2)).andReturn(bLongVal);
+        expect(resultSet.wasNull()).andReturn(false).anyTimes();
+        replay(resultSet);
+
+        ReflectionBeanMapper<DerivedBean> mapper = new ReflectionBeanMapper<DerivedBean>(DerivedBean.class);
+
+        DerivedBean derivedBean = mapper.map(0, resultSet, ctx);
+
+        assertEquals(aLongVal, derivedBean.getLongField());
+        assertEquals(bLongVal, derivedBean.getBlongField());
+    }
 }
 
 
@@ -163,5 +186,13 @@ class SampleBean {
 
     public BigDecimal getBigDecimalField() {
         return bigDecimalField;
+    }
+}
+
+class DerivedBean extends SampleBean {
+    private Long blongField;
+
+    public Long getBlongField() {
+        return blongField;
     }
 }


### PR DESCRIPTION
Modified BeanMapper to use Reflection to set fields instead of depending on existence of setters in Beans. This helps in client code base to be cleaner without setters. I have also noticed a small performance improvement(~20%) on setting data using reflection vs beanutils.
