### PR TITLE
Supply name of column that generates key.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,12 +199,7 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>oracle</groupId>
-            <artifactId>ojdbc6</artifactId>
-            <version>11.2.0.4</version>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,13 @@
             <version>9.1-901-1.jdbc4</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>oracle</groupId>
+            <artifactId>ojdbc6</artifactId>
+            <version>11.2.0.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
+++ b/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
@@ -18,11 +18,13 @@ package org.skife.jdbi.v2;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+
 
 public final class ConcreteStatementContext implements StatementContext
 {
@@ -38,6 +40,7 @@ public final class ConcreteStatementContext implements StatementContext
     private Class<?>          sqlObjectType;
     private Method            sqlObjectMethod;
     private boolean           returningGeneratedKeys;
+    private String[]          generatedKeysColumnNames;
 
     ConcreteStatementContext(Map<String, Object> globalAttributes)
     {
@@ -198,7 +201,20 @@ public final class ConcreteStatementContext implements StatementContext
 
     public boolean isReturningGeneratedKeys()
     {
-        return returningGeneratedKeys;
+        return returningGeneratedKeys || generatedKeysColumnNames != null && generatedKeysColumnNames.length > 0;
+    }
+
+    public String[] getGeneratedKeysColumnNames()
+    {
+        if (generatedKeysColumnNames == null) {
+            return new String[0];
+        }
+        return Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
+    }
+
+    public void setGeneratedKeysColumnNames(String[] generatedKeysColumnNames)
+    {
+        this.generatedKeysColumnNames = Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
     }
 
     public void addCleanable(Cleanable cleanable)

--- a/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilder.java
+++ b/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilder.java
@@ -41,6 +41,10 @@ public class DefaultStatementBuilder implements StatementBuilder
     public PreparedStatement create(Connection conn, String sql, StatementContext ctx) throws SQLException
     {
         if (ctx.isReturningGeneratedKeys()) {
+            String[] columnNames = ctx.getGeneratedKeysColumnNames();
+            if (columnNames != null && columnNames.length > 0) {
+                return conn.prepareStatement(sql, columnNames);
+            }
             return conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
         }
         else {

--- a/src/main/java/org/skife/jdbi/v2/StatementContext.java
+++ b/src/main/java/org/skife/jdbi/v2/StatementContext.java
@@ -108,6 +108,8 @@ public interface StatementContext
      */
     boolean isReturningGeneratedKeys();
 
+    String[] getGeneratedKeysColumnNames();
+
     void addCleanable(Cleanable cleanable);
 
 }

--- a/src/main/java/org/skife/jdbi/v2/Update.java
+++ b/src/main/java/org/skife/jdbi/v2/Update.java
@@ -69,11 +69,15 @@ public class Update extends SQLStatement<Update>
      * Execute the statement and returns any auto-generated keys. This requires the JDBC driver to support
      * the {@link Statement#getGeneratedKeys()} method.
      * @param mapper the mapper to generate the resulting key object
+     * @param columnName name of the column that generates the key
      * @return the generated key or null if none was returned
      */
-    public <GeneratedKeyType> GeneratedKeys<GeneratedKeyType> executeAndReturnGeneratedKeys(final ResultSetMapper<GeneratedKeyType> mapper)
+    public <GeneratedKeyType> GeneratedKeys<GeneratedKeyType> executeAndReturnGeneratedKeys(final ResultSetMapper<GeneratedKeyType> mapper, String columnName)
     {
         getConcreteContext().setReturningGeneratedKeys(true);
+        if (columnName != null) {
+            getConcreteContext().setGeneratedKeysColumnNames(new String[] { columnName } );
+        }
         return this.internalExecute(new QueryResultMunger<GeneratedKeys<GeneratedKeyType>>() {
             public GeneratedKeys<GeneratedKeyType> munge(Statement results) throws SQLException
             {
@@ -84,6 +88,10 @@ public class Update extends SQLStatement<Update>
                                                            getContainerMapperRegistry());
             }
         });
+    }
+
+    public <GeneratedKeyType> GeneratedKeys<GeneratedKeyType> executeAndReturnGeneratedKeys(final ResultSetMapper<GeneratedKeyType> mapper) {
+        return executeAndReturnGeneratedKeys(mapper, null);
     }
 
     public GeneratedKeys<Map<String, Object>> executeAndReturnGeneratedKeys()

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
@@ -47,7 +47,7 @@ class UpdateHandler extends CustomizingStatementHandler
             {
                 public Object value(Update update, HandleDing baton)
                 {
-                    GeneratedKeys o = update.executeAndReturnGeneratedKeys(mapper);
+                    GeneratedKeys o = update.executeAndReturnGeneratedKeys(mapper, ggk.columnName());
                     return magic.result(o, baton);
                 }
             };

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysOracle.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysOracle.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.sqlobject.mixins.CloseMe;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This test assumes an instance of Oracle database called 'test' is
+ * running on localhost port 1521.
+ *
+ * @author Ricco Førgaard mailto:ricco@vimond.com
+ * @since 2014-10-18
+ */
+public class TestGetGeneratedKeysOracle {
+
+    private DBI dbi;
+
+    @Before
+    public void setUp() throws Exception {
+        dbi = new DBI("jdbc:oracle:thin:@localhost:test", "oracle", "oracle");
+        dbi.withHandle(new HandleCallback<Object>() {
+            public Object withHandle(Handle handle) throws Exception
+            {
+                handle.execute("create sequence something_id_sequence INCREMENT BY 1 START WITH 100");
+                handle.execute("create table something (name varchar(200), id int, constraint something_id primary key (id))");
+                return null;
+            }
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        dbi.withHandle(new HandleCallback<Object>() {
+            public Object withHandle(Handle handle) throws Exception
+            {
+                handle.execute("drop table something");
+                handle.execute("drop sequence something_id_sequence");
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Oracle needs to be queried by index and not id (like
+     * {@link org.skife.jdbi.v2.sqlobject.FigureItOutResultSetMapper} does).
+     */
+    public static class OracleGeneratedKeyMapper implements ResultSetMapper<Long> {
+
+        @Override
+        public Long map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+            return r.getLong(1);
+        }
+    }
+
+    public static interface DAO extends CloseMe {
+        @SqlUpdate("insert into something (name, id) values (:name, something_id_sequence.nextval)")
+        @GetGeneratedKeys(columnName = "id", value = OracleGeneratedKeyMapper.class)
+        public long insert(@Bind("name") String name);
+
+        @SqlQuery("select name from something where id = :it")
+        public String findNameById(@Bind long id);
+    }
+
+    @Ignore
+    @Test
+    public void testGetGeneratedKeys() throws Exception {
+        DAO dao = dbi.open(DAO.class);
+
+        Long fooId = dao.insert("Foo");
+        long barId = dao.insert("Bar");
+
+        assertThat(dao.findNameById(fooId), equalTo("Foo"));
+        assertThat(dao.findNameById(barId), equalTo("Bar"));
+    }
+}

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/stringtemplate/TestingStatementContext.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/stringtemplate/TestingStatementContext.java
@@ -107,6 +107,11 @@ public class TestingStatementContext implements StatementContext
     }
 
     @Override
+    public String[] getGeneratedKeysColumnNames() {
+        return new String[0];
+    }
+
+    @Override
     public void addCleanable(final Cleanable cleanable)
     {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
Oracle needs the name of the column that generates a key in order for `@GetGeneratedKeys` to work.

This PR makes it possible to add a `columnName` to the `@GetGeneratedKeys` annotation which will be passed on to the `PreparedStatement`.