### PR TITLE
fix connection leak for iterator in on-demand sqlobject

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
@@ -160,8 +160,8 @@ abstract class ResultReturnThing
         @Override
         protected Object result(ResultBearing q, final HandleDing baton)
         {
-            baton.retain("iterator");
             final ResultIterator itty = q.iterator();
+            baton.retain("iterator");
 
             return new ResultIterator()
             {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
@@ -165,16 +165,25 @@ abstract class ResultReturnThing
 
             return new ResultIterator()
             {
+                private boolean closed = false;
+
                 public void close()
                 {
-                    itty.close();
+                    if (!closed) {
+                        closed = true;
+                        try {
+                            itty.close();
+                        } finally {
+                            baton.release("iterator");
+                        }
+                    }
                 }
 
                 public boolean hasNext()
                 {
                     boolean has_next = itty.hasNext();
                     if (!has_next) {
-                        baton.release("iterator");
+                        close();
                     }
                     return itty.hasNext();
                 }
@@ -184,7 +193,7 @@ abstract class ResultReturnThing
                     Object rs = itty.next();
                     boolean has_next = itty.hasNext();
                     if (!has_next) {
-                        baton.release("iterator");
+                        close();
                     }
                     return rs;
                 }


### PR DESCRIPTION
I noticed that on-demand sqlobject was leaking connections when a SQL statement fails to execute. This can happen for example when there is a syntax error, a bad parameter, or an unavailable resource on the database.

While fixing, I noticed two other potential problems. I fixed them on two separate commits.

