### PR TITLE
fix masked exception in on-demand sqlobject

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
@@ -169,12 +169,24 @@ class SqlObject
             return mp.invokeSuper(proxy, args);
         }
 
+        Throwable doNotMask = null;
         try {
             ding.retain(method.toString());
             return handler.invoke(ding, proxy, args, mp);
         }
+        catch (Throwable e) {
+            doNotMask = e;
+            throw e;
+        }
         finally {
-            ding.release(method.toString());
+            try {
+                ding.release(method.toString());
+            }
+            catch (Throwable e) {
+                if (doNotMask==null) {
+                    throw e;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
When using on-demand sqlobject, two exceptions may be thrown:
- the first one during the execution of the SQL
- the second one when the connection is closed

When this happens, the first exception is lost.

I discovered this problem because of network errors. During the SQL execution, I get (for example) a socket read timeout. Afterwards, closing the connection will also throws an exception. In this case, the exception is misleading, and I did not immediately understood the underlying problem.

It would be simple to fix with Java7. Here with Java6, the code is dreadful. If you can think of a more elegant solution, I would be happy to fix my code!
