### PR TITLE
Restore Connection Auto-Commit on Exception

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/exceptions/UnableToRestoreAutoCommitStateException.java
+++ b/src/main/java/org/skife/jdbi/v2/exceptions/UnableToRestoreAutoCommitStateException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.skife.jdbi.v2.exceptions;
 
 public class UnableToRestoreAutoCommitStateException  extends DBIException {

--- a/src/main/java/org/skife/jdbi/v2/exceptions/UnableToRestoreAutoCommitStateException.java
+++ b/src/main/java/org/skife/jdbi/v2/exceptions/UnableToRestoreAutoCommitStateException.java
@@ -1,0 +1,8 @@
+package org.skife.jdbi.v2.exceptions;
+
+public class UnableToRestoreAutoCommitStateException  extends DBIException {
+
+    public UnableToRestoreAutoCommitStateException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/src/main/java/org/skife/jdbi/v2/exceptions/UnableToRestoreAutoCommitStateException.java
+++ b/src/main/java/org/skife/jdbi/v2/exceptions/UnableToRestoreAutoCommitStateException.java
@@ -15,7 +15,9 @@
  */
 package org.skife.jdbi.v2.exceptions;
 
-public class UnableToRestoreAutoCommitStateException  extends DBIException {
+public class UnableToRestoreAutoCommitStateException extends DBIException {
+
+    private static final long serialVersionUID = 2433069110223543423L;
 
     public UnableToRestoreAutoCommitStateException(Throwable throwable) {
         super(throwable);

--- a/src/main/java/org/skife/jdbi/v2/tweak/transactions/LocalTransactionHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/transactions/LocalTransactionHandler.java
@@ -21,6 +21,7 @@ import org.skife.jdbi.v2.TransactionIsolationLevel;
 import org.skife.jdbi.v2.TransactionStatus;
 import org.skife.jdbi.v2.exceptions.TransactionException;
 import org.skife.jdbi.v2.exceptions.TransactionFailedException;
+import org.skife.jdbi.v2.exceptions.UnableToRestoreAutoCommitStateException;
 import org.skife.jdbi.v2.tweak.TransactionHandler;
 
 import java.sql.Connection;
@@ -64,20 +65,12 @@ public class LocalTransactionHandler implements TransactionHandler
     {
         try {
             handle.getConnection().commit();
-            final LocalStuff stuff = localStuff.remove(handle);
-            if (stuff != null) {
-                handle.getConnection().setAutoCommit(stuff.getInitialAutocommit());
-                stuff.getCheckpoints().clear();
-            }
         }
         catch (SQLException e) {
             throw new TransactionException("Failed to commit transaction", e);
         }
         finally {
-            // prevent memory leak if commit throws an exception
-            if (localStuff.containsKey(handle)) {
-                localStuff.remove(handle);
-            }
+            restoreAutoCommitState(handle);
         }
     }
 
@@ -88,20 +81,12 @@ public class LocalTransactionHandler implements TransactionHandler
     {
         try {
             handle.getConnection().rollback();
-            final LocalStuff stuff = localStuff.remove(handle);
-            if (stuff != null) {
-                handle.getConnection().setAutoCommit(stuff.getInitialAutocommit());
-                stuff.getCheckpoints().clear();
-            }
         }
         catch (SQLException e) {
             throw new TransactionException("Failed to rollback transaction", e);
         }
         finally {
-            // prevent memory leak if rollback throws an exception
-            if (localStuff.containsKey(handle)) {
-                localStuff.remove(handle);
-            }
+            restoreAutoCommitState(handle);
         }
     }
 
@@ -227,6 +212,24 @@ public class LocalTransactionHandler implements TransactionHandler
             handle.setTransactionIsolation(initial);
         }
     }
+
+    private void restoreAutoCommitState(final Handle handle) {
+        try {
+            final LocalStuff stuff = localStuff.remove(handle);
+            if (stuff != null) {
+                handle.getConnection().setAutoCommit(stuff.getInitialAutocommit());
+                stuff.getCheckpoints().clear();
+            }
+        } catch (SQLException e) {
+            throw new UnableToRestoreAutoCommitStateException(e);
+        } finally {
+            // prevent memory leak if rollback throws an exception
+            if (localStuff.containsKey(handle)) {
+                localStuff.remove(handle);
+            }
+        }
+    }
+
 
     private static class LocalStuff
     {

--- a/src/main/java/org/skife/jdbi/v2/tweak/transactions/LocalTransactionHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/transactions/LocalTransactionHandler.java
@@ -224,9 +224,7 @@ public class LocalTransactionHandler implements TransactionHandler
             throw new UnableToRestoreAutoCommitStateException(e);
         } finally {
             // prevent memory leak if rollback throws an exception
-            if (localStuff.containsKey(handle)) {
-                localStuff.remove(handle);
-            }
+            localStuff.remove(handle);
         }
     }
 

--- a/src/test/java/org/skife/jdbi/v2/DBITestCase.java
+++ b/src/test/java/org/skife/jdbi/v2/DBITestCase.java
@@ -95,20 +95,19 @@ public abstract class DBITestCase
     protected BasicHandle openHandle(Connection connection) throws SQLException
     {
         BasicHandle h = new BasicHandle(getTransactionHandler(),
-                getStatementLocator(),
-                new CachingStatementBuilder(new DefaultStatementBuilder()),
-                new ColonPrefixNamedParamStatementRewriter(),
-                connection,
-                new HashMap<String, Object>(),
-                new NoOpLog(),
-                TimingCollector.NOP_TIMING_COLLECTOR,
-                new MappingRegistry(),
-                new Foreman(),
-                new ContainerFactoryRegistry());
+                                        getStatementLocator(),
+                                        new CachingStatementBuilder(new DefaultStatementBuilder()),
+                                        new ColonPrefixNamedParamStatementRewriter(),
+                                        connection,
+                                        new HashMap<String, Object>(),
+                                        new NoOpLog(),
+                                        TimingCollector.NOP_TIMING_COLLECTOR,
+                                        new MappingRegistry(),
+                                        new Foreman(),
+                                        new ContainerFactoryRegistry());
         HANDLES.add(h);
         return h;
     }
-
 
     protected TransactionHandler getTransactionHandler()
     {

--- a/src/test/java/org/skife/jdbi/v2/DBITestCase.java
+++ b/src/test/java/org/skife/jdbi/v2/DBITestCase.java
@@ -89,21 +89,26 @@ public abstract class DBITestCase
 
     protected BasicHandle openHandle() throws SQLException
     {
-        Connection conn = DERBY_HELPER.getConnection();
+        return openHandle(DERBY_HELPER.getConnection());
+    }
+
+    protected BasicHandle openHandle(Connection connection) throws SQLException
+    {
         BasicHandle h = new BasicHandle(getTransactionHandler(),
-                                        getStatementLocator(),
-                                        new CachingStatementBuilder(new DefaultStatementBuilder()),
-                                        new ColonPrefixNamedParamStatementRewriter(),
-                                        conn,
-                                        new HashMap<String, Object>(),
-                                        new NoOpLog(),
-                                        TimingCollector.NOP_TIMING_COLLECTOR,
-                                        new MappingRegistry(),
-                                        new Foreman(),
-                                        new ContainerFactoryRegistry());
+                getStatementLocator(),
+                new CachingStatementBuilder(new DefaultStatementBuilder()),
+                new ColonPrefixNamedParamStatementRewriter(),
+                connection,
+                new HashMap<String, Object>(),
+                new NoOpLog(),
+                TimingCollector.NOP_TIMING_COLLECTOR,
+                new MappingRegistry(),
+                new Foreman(),
+                new ContainerFactoryRegistry());
         HANDLES.add(h);
         return h;
     }
+
 
     protected TransactionHandler getTransactionHandler()
     {

--- a/src/test/java/org/skife/jdbi/v2/TestTransactionsAutoCommit.java
+++ b/src/test/java/org/skife/jdbi/v2/TestTransactionsAutoCommit.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+public class TestTransactionsAutoCommit extends DBITestCase
+{
+    @Test
+    public void restoreAutoCommitInitialStateOnUnexpectedError() throws Exception
+    {
+
+        final Connection connection = createNiceMock(Connection.class);
+        final PreparedStatement statement = createNiceMock(PreparedStatement.class);
+
+        Handle h = openHandle(connection);
+
+        // expected behaviour chain:
+        // 1. store initial auto-commit state
+        expect(connection.getAutoCommit()).andReturn(true);
+
+        // 2. turn off auto-commit
+        connection.setAutoCommit(false);
+        expectLastCall().once();
+
+        // 3. execute statement (without commit)
+        expect(connection.prepareStatement("insert into something (id, name) values (?, ?)")).andReturn(statement);
+        expect(statement.execute()).andReturn(true);
+        expect(statement.getUpdateCount()).andReturn(1);
+
+        // 4. commit transaction (throw e.g some underlying database error)
+        connection.commit();
+        expectLastCall().andThrow(new SQLException("infrastructure error"));
+
+        // 5. set auto-commit back to initial state
+        connection.setAutoCommit(true);
+        expectLastCall().once();
+
+        replay(connection, statement);
+
+        h.begin();
+        try {
+            h.insert("insert into something (id, name) values (?, ?)", 1L, "Tom");
+
+            // throws exception on commit
+            h.commit();
+        } catch (final Exception exception) {
+            // ignore
+        }
+
+        verify(connection);
+    }
+
+}


### PR DESCRIPTION
These changes addresses the problem when the underlying database driver throws error on commit in transactional mode. Previously the auto-commit state was not restored when throwing, thus creating inconsistent connections in the pool which then typically caused connections to hang when used non-transactional. This behaviour is especially sneaky in systems with large database pools where connection auto-commit state might be compromised over a longer period, creating hanging connections which might be hard to explain. 