### PR TITLE
Remove findbugs-annotation dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,11 +136,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/src/findbugs/findbugs-exclude.xml
+++ b/src/findbugs/findbugs-exclude.xml
@@ -23,4 +23,9 @@
     <Match>
         <Class name="org.skife.jdbi.rewriter.printf.FormatterStatementLexer" />
     </Match>
+    <Match>
+        <Class name="org.skife.jdbi.v2.sqlobject.BatchHandler$InfiniteIterator"/>
+        <Method name="next"/>
+        <Bug pattern="IT_NO_SUCH_ELEMENT"/>
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
@@ -34,8 +34,6 @@ import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 
 import com.fasterxml.classmate.members.ResolvedMethod;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 class BatchHandler extends CustomizingStatementHandler
 {
     private final String  sql;
@@ -97,7 +95,7 @@ class BatchHandler extends CustomizingStatementHandler
         Handle handle = h.getHandle();
 
         List<Iterator> extras = new ArrayList<Iterator>();
-        for (final Object arg : args) {
+        for (Object arg : args) {
             if (arg instanceof Iterable) {
                 extras.add(((Iterable) arg).iterator());
             }
@@ -108,25 +106,7 @@ class BatchHandler extends CustomizingStatementHandler
                 extras.add(Arrays.asList((Object[])arg).iterator());
             }
             else {
-                extras.add(new Iterator()
-                {
-                    public boolean hasNext()
-                    {
-                        return true;
-                    }
-
-                    @SuppressFBWarnings("IT_NO_SUCH_ELEMENT")
-                    public Object next()
-                    {
-                        return arg;
-                    }
-
-                    public void remove()
-                    {
-                        // NOOP
-                    }
-                }
-                );
+                extras.add(new InfiniteIterator(arg));
             }
         }
 
@@ -233,6 +213,26 @@ class BatchHandler extends CustomizingStatementHandler
         public int call(Object[] args)
         {
             return (Integer)args[index];
+        }
+    }
+
+    private static class InfiniteIterator implements Iterator<Object> {
+        private Object arg;
+
+        private InfiniteIterator(Object arg) {
+            this.arg = arg;
+        }
+
+        public boolean hasNext() {
+            return true;
+        }
+
+        public Object next() {
+            return arg;
+        }
+
+        public void remove() {
+            // NOOP
         }
     }
 }


### PR DESCRIPTION
Fix #106
Findbugs-annotations is used only in one place and could be replaced by a rule in the XML annotator.
