### PR TITLE
Java6 missing overrides.

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/BaseResultSetMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/BaseResultSetMapper.java
@@ -31,6 +31,7 @@ public abstract class BaseResultSetMapper<ResultType> implements ResultSetMapper
     /**
      * Defers to mapInternal
      */
+    @Override
     public final ResultType map(int index, ResultSet r, StatementContext ctx)
     {
         return this.mapInternal(index, mapper.map(index, r, ctx));

--- a/src/main/java/org/skife/jdbi/v2/BasicHandle.java
+++ b/src/main/java/org/skife/jdbi/v2/BasicHandle.java
@@ -80,6 +80,7 @@ class BasicHandle implements Handle
         this.containerFactoryRegistry = containerFactoryRegistry.createChild();
     }
 
+    @Override
     public Query<Map<String, Object>> createQuery(String sql)
     {
         return new Query<Map<String, Object>>(new Binding(),
@@ -103,11 +104,13 @@ class BasicHandle implements Handle
      *
      * @return the JDBC Connection this Handle uses
      */
+    @Override
     public Connection getConnection()
     {
         return this.connection;
     }
 
+    @Override
     public void close()
     {
         if (!closed) {
@@ -130,6 +133,7 @@ class BasicHandle implements Handle
         return closed;
     }
 
+    @Override
     public void define(String key, Object value)
     {
         this.globalStatementAttributes.put(key, value);
@@ -138,6 +142,7 @@ class BasicHandle implements Handle
     /**
      * Start a transaction
      */
+    @Override
     public Handle begin()
     {
         transactions.begin(this);
@@ -148,6 +153,7 @@ class BasicHandle implements Handle
     /**
      * Commit a transaction
      */
+    @Override
     public Handle commit()
     {
         final long start = System.nanoTime();
@@ -159,6 +165,7 @@ class BasicHandle implements Handle
     /**
      * Rollback a transaction
      */
+    @Override
     public Handle rollback()
     {
         final long start = System.nanoTime();
@@ -174,6 +181,7 @@ class BasicHandle implements Handle
      *
      * @return The same handle
      */
+    @Override
     public Handle checkpoint(String name)
     {
         transactions.checkpoint(this, name);
@@ -186,6 +194,7 @@ class BasicHandle implements Handle
      *
      * @return The same handle
      */
+    @Override
     public Handle release(String checkpointName)
     {
         transactions.release(this, checkpointName);
@@ -193,16 +202,19 @@ class BasicHandle implements Handle
         return this;
     }
 
+    @Override
     public void setStatementBuilder(StatementBuilder builder)
     {
         this.statementBuilder = builder;
     }
 
+    @Override
     public void setSQLLog(SQLLog log)
     {
         this.log = log;
     }
 
+    @Override
     public void setTimingCollector(final TimingCollector timingCollector)
     {
         if (timingCollector == null) {
@@ -219,6 +231,7 @@ class BasicHandle implements Handle
      *
      * @param checkpointName the name of the checkpoint, previously declared with {@see Handle#checkpoint}
      */
+    @Override
     public Handle rollback(String checkpointName)
     {
         final long start = System.nanoTime();
@@ -227,11 +240,13 @@ class BasicHandle implements Handle
         return this;
     }
 
+    @Override
     public boolean isInTransaction()
     {
         return transactions.isInTransaction(this);
     }
 
+    @Override
     public Update createStatement(String sql)
     {
         return new Update(this,
@@ -246,6 +261,7 @@ class BasicHandle implements Handle
                           containerFactoryRegistry);
     }
 
+    @Override
     public Call createCall(String sql)
     {
         return new Call(this,
@@ -261,11 +277,13 @@ class BasicHandle implements Handle
                         containerFactoryRegistry);
     }
 
+    @Override
     public int insert(String sql, Object... args)
     {
         return update(sql, args);
     }
 
+    @Override
     public int update(String sql, Object... args)
     {
         Update stmt = createStatement(sql);
@@ -276,6 +294,7 @@ class BasicHandle implements Handle
         return stmt.execute();
     }
 
+    @Override
     public PreparedBatch prepareBatch(String sql)
     {
         return new PreparedBatch(statementLocator,
@@ -291,6 +310,7 @@ class BasicHandle implements Handle
                                  containerFactoryRegistry);
     }
 
+    @Override
     public Batch createBatch()
     {
         return new Batch(this.statementRewriter,
@@ -301,11 +321,13 @@ class BasicHandle implements Handle
                          foreman.createChild());
     }
 
+    @Override
     public <ReturnType> ReturnType inTransaction(TransactionCallback<ReturnType> callback)
     {
         return transactions.inTransaction(this, callback);
     }
 
+    @Override
     public <ReturnType> ReturnType inTransaction(TransactionIsolationLevel level,
                                                  TransactionCallback<ReturnType> callback)
     {
@@ -333,6 +355,7 @@ class BasicHandle implements Handle
         }
     }
 
+    @Override
     public List<Map<String, Object>> select(String sql, Object... args)
     {
         Query<Map<String, Object>> query = this.createQuery(sql);
@@ -343,46 +366,55 @@ class BasicHandle implements Handle
         return query.list();
     }
 
+    @Override
     public void setStatementLocator(StatementLocator locator)
     {
         this.statementLocator = locator;
     }
 
+    @Override
     public void setStatementRewriter(StatementRewriter rewriter)
     {
         this.statementRewriter = rewriter;
     }
 
+    @Override
     public Script createScript(String name)
     {
         return new Script(this, statementLocator, name, globalStatementAttributes);
     }
 
+    @Override
     public void execute(String sql, Object... args)
     {
         this.update(sql, args);
     }
 
+    @Override
     public void registerMapper(ResultSetMapper mapper)
     {
         mappingRegistry.add(mapper);
     }
 
+    @Override
     public void registerMapper(ResultSetMapperFactory factory)
     {
         mappingRegistry.add(factory);
     }
 
+    @Override
     public <SqlObjectType> SqlObjectType attach(Class<SqlObjectType> sqlObjectType)
     {
         return SqlObjectBuilder.attach(this, sqlObjectType);
     }
 
+    @Override
     public void setTransactionIsolation(TransactionIsolationLevel level)
     {
         setTransactionIsolation(level.intValue());
     }
 
+    @Override
     public void setTransactionIsolation(int level)
     {
         try {
@@ -397,6 +429,7 @@ class BasicHandle implements Handle
         }
     }
 
+    @Override
     public TransactionIsolationLevel getTransactionIsolationLevel()
     {
         try {
@@ -407,11 +440,13 @@ class BasicHandle implements Handle
         }
     }
 
+    @Override
     public void registerArgumentFactory(ArgumentFactory argumentFactory)
     {
         this.foreman.register(argumentFactory);
     }
 
+    @Override
     public void registerContainerFactory(ContainerFactory<?> factory)
     {
         this.containerFactoryRegistry.register(factory);

--- a/src/main/java/org/skife/jdbi/v2/BeanMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/BeanMapper.java
@@ -56,6 +56,7 @@ public class BeanMapper<T> implements ResultSetMapper<T>
         }
     }
 
+    @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     public T map(int row, ResultSet rs, StatementContext ctx)
         throws SQLException

--- a/src/main/java/org/skife/jdbi/v2/BeanPropertyArguments.java
+++ b/src/main/java/org/skife/jdbi/v2/BeanPropertyArguments.java
@@ -52,6 +52,7 @@ class BeanPropertyArguments implements NamedArgumentFinder
 
     }
 
+    @Override
     public Argument find(String name)
     {
         for (PropertyDescriptor descriptor : info.getPropertyDescriptors())

--- a/src/main/java/org/skife/jdbi/v2/BigDecimalArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/BigDecimalArgument.java
@@ -34,6 +34,7 @@ class BigDecimalArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/BlobArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/BlobArgument.java
@@ -34,6 +34,7 @@ class BlobArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/BooleanArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/BooleanArgument.java
@@ -30,6 +30,7 @@ class BooleanArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value == null) {

--- a/src/main/java/org/skife/jdbi/v2/BooleanIntegerArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/BooleanIntegerArgument.java
@@ -33,6 +33,7 @@ class BooleanIntegerArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(final int position, final PreparedStatement statement, final StatementContext ctx) throws SQLException
     {
         statement.setInt(position, value ? 1 : 0);

--- a/src/main/java/org/skife/jdbi/v2/BuiltInArgumentFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/BuiltInArgumentFactory.java
@@ -70,11 +70,13 @@ public final class BuiltInArgumentFactory implements ArgumentFactory
 
     BuiltInArgumentFactory(){}
 
+    @Override
     public boolean accepts(Class expectedType, Object value, StatementContext ctx)
     {
         return canAccept(expectedType);
     }
 
+    @Override
     public Argument build(Class expectedType, Object value, StatementContext ctx)
     {
         P p;

--- a/src/main/java/org/skife/jdbi/v2/ByteArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/ByteArgument.java
@@ -33,6 +33,7 @@ class ByteArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value == null) {

--- a/src/main/java/org/skife/jdbi/v2/ByteArrayArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/ByteArrayArgument.java
@@ -34,6 +34,7 @@ class ByteArrayArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/CachingStatementBuilder.java
+++ b/src/main/java/org/skife/jdbi/v2/CachingStatementBuilder.java
@@ -48,6 +48,7 @@ public class CachingStatementBuilder implements StatementBuilder
      * Return either a cached PreparedStatement or a new one which has just been added to the cache
      * @return A new, or cached, PreparedStatement
      */
+    @Override
     public PreparedStatement create(Connection conn, String sql, StatementContext ctx) throws SQLException
     {
         if (cache.containsKey(sql)) {
@@ -64,6 +65,7 @@ public class CachingStatementBuilder implements StatementBuilder
     /**
      * NOOP, statements will be closed when the handle is closed
      */
+    @Override
     public void close(Connection conn, String sql, Statement stmt) throws SQLException
     {
     }
@@ -72,6 +74,7 @@ public class CachingStatementBuilder implements StatementBuilder
      * Iterate over all cached statements and ask the wrapped StatementBuilder to close
      * each one.
      */
+    @Override
     @SuppressWarnings("PMD.EmptyCatchBlock")
     public void close(Connection conn)
     {
@@ -85,6 +88,7 @@ public class CachingStatementBuilder implements StatementBuilder
         }
     }
 
+    @Override
     public CallableStatement createCall(Connection conn, String sql, StatementContext ctx) throws SQLException
     {
         if (cache.containsKey(sql)) {

--- a/src/main/java/org/skife/jdbi/v2/CachingStatementBuilderFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/CachingStatementBuilderFactory.java
@@ -30,6 +30,7 @@ public class CachingStatementBuilderFactory implements StatementBuilderFactory
     /**
      * Return a new, or cached, prepared statement
      */
+    @Override
     public StatementBuilder createStatementBuilder(Connection conn) {
         return new CachingStatementBuilder(new DefaultStatementBuilder());
     }

--- a/src/main/java/org/skife/jdbi/v2/Call.java
+++ b/src/main/java/org/skife/jdbi/v2/Call.java
@@ -88,6 +88,7 @@ public class Call extends SQLStatement<Call>
     {
         try {
             return this.internalExecute(new QueryResultMunger<OutParameters>() {
+                @Override
                 public OutParameters munge(Statement results) throws SQLException
                 {
                     OutParameters out = new OutParameters();
@@ -122,6 +123,7 @@ public class Call extends SQLStatement<Call>
             params.add(this);
         }
 
+        @Override
         public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
         {
             ((CallableStatement)statement).registerOutParameter(position, sqlType);

--- a/src/main/java/org/skife/jdbi/v2/CharacterArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/CharacterArgument.java
@@ -30,6 +30,7 @@ class CharacterArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/CharacterStreamArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/CharacterStreamArgument.java
@@ -35,6 +35,7 @@ class CharacterStreamArgument implements Argument
         this.length = length;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         statement.setCharacterStream(position, value, length);

--- a/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
@@ -71,6 +71,7 @@ public class ClasspathStatementLocator implements StatementLocator
      * @throws UnableToCreateStatementException
      *          if an IOException occurs reading a found resource
      */
+    @Override
     @SuppressWarnings("PMD.EmptyCatchBlock")
     @SuppressFBWarnings("DM_STRING_CTOR")
     public String locate(String name, StatementContext ctx)

--- a/src/main/java/org/skife/jdbi/v2/Cleanables.java
+++ b/src/main/java/org/skife/jdbi/v2/Cleanables.java
@@ -211,6 +211,7 @@ class Cleanables
             this.stmt = stmt;
         }
 
+        @Override
         public void cleanup()
             throws SQLException
         {

--- a/src/main/java/org/skife/jdbi/v2/ClobArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/ClobArgument.java
@@ -34,6 +34,7 @@ class ClobArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
@@ -53,6 +53,7 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
      * @return somethign which can provde the actual SQL to prepare a statement from
      *         and which can bind the correct arguments to that prepared statement
      */
+    @Override
     public RewrittenStatement rewrite(String sql, Binding params, StatementContext ctx)
     {
         final ParsedStatement stmt = new ParsedStatement();
@@ -114,6 +115,7 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
             this.stmt = stmt;
         }
 
+        @Override
         public void bind(Binding params, PreparedStatement statement) throws SQLException
         {
             if (stmt.positionalOnly) {
@@ -168,6 +170,7 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
             }
         }
 
+        @Override
         public String getSql()
         {
             return sql;

--- a/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
+++ b/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
@@ -52,6 +52,7 @@ public final class ConcreteStatementContext implements StatementContext
      *
      * @return previous value of this attribute
      */
+    @Override
     public Object setAttribute(String key, Object value)
     {
         return attributes.put(key, value);
@@ -64,6 +65,7 @@ public final class ConcreteStatementContext implements StatementContext
      *
      * @return the value of the attribute
      */
+    @Override
     public Object getAttribute(String key)
     {
         return this.attributes.get(key);
@@ -75,6 +77,7 @@ public final class ConcreteStatementContext implements StatementContext
      *
      * @return a map f attributes
      */
+    @Override
     public Map<String, Object> getAttributes()
     {
         return attributes;
@@ -90,6 +93,7 @@ public final class ConcreteStatementContext implements StatementContext
      *
      * @return the initial sql
      */
+    @Override
     public String getRawSql()
     {
         return rawSql;
@@ -112,6 +116,7 @@ public final class ConcreteStatementContext implements StatementContext
      *
      * @return the sql as it will be executed against the database
      */
+    @Override
     public String getRewrittenSql()
     {
         return rewrittenSql;
@@ -124,6 +129,7 @@ public final class ConcreteStatementContext implements StatementContext
      *
      * @return the sql which will be passed to the statement rewriter
      */
+    @Override
     public String getLocatedSql()
     {
         return locatedSql;
@@ -141,6 +147,7 @@ public final class ConcreteStatementContext implements StatementContext
      *
      * @return Obtain the actual prepared statement being used.
      */
+    @Override
     public PreparedStatement getStatement()
     {
         return statement;
@@ -156,6 +163,7 @@ public final class ConcreteStatementContext implements StatementContext
      *
      * @return the JDBC connection
      */
+    @Override
     public Connection getConnection()
     {
         return connection;
@@ -166,6 +174,7 @@ public final class ConcreteStatementContext implements StatementContext
         this.binding = b;
     }
 
+    @Override
     public Binding getBinding()
     {
         return binding;
@@ -176,6 +185,7 @@ public final class ConcreteStatementContext implements StatementContext
         this.sqlObjectType = sqlObjectType;
     }
 
+    @Override
     public Class<?> getSqlObjectType()
     {
         return sqlObjectType;
@@ -186,6 +196,7 @@ public final class ConcreteStatementContext implements StatementContext
         this.sqlObjectMethod = sqlObjectMethod;
     }
 
+    @Override
     public Method getSqlObjectMethod()
     {
         return sqlObjectMethod;
@@ -196,11 +207,13 @@ public final class ConcreteStatementContext implements StatementContext
         this.returningGeneratedKeys = b;
     }
 
+    @Override
     public boolean isReturningGeneratedKeys()
     {
         return returningGeneratedKeys;
     }
 
+    @Override
     public void addCleanable(Cleanable cleanable)
     {
         this.cleanables.add(cleanable);

--- a/src/main/java/org/skife/jdbi/v2/ContainerFactoryRegistry.java
+++ b/src/main/java/org/skife/jdbi/v2/ContainerFactoryRegistry.java
@@ -77,23 +77,27 @@ class ContainerFactoryRegistry
 
     static class SortedSetContainerFactory implements ContainerFactory<SortedSet<?>> {
 
+        @Override
         public boolean accepts(Class<?> type)
         {
             return type.equals(SortedSet.class);
         }
 
+        @Override
         public ContainerBuilder<SortedSet<?>> newContainerBuilderFor(Class<?> type)
         {
             return new ContainerBuilder<SortedSet<?>>()
             {
                 private SortedSet<Object> s = new TreeSet<Object>();
 
+                @Override
                 public ContainerBuilder<SortedSet<?>> add(Object it)
                 {
                     s.add(it);
                     return this;
                 }
 
+                @Override
                 public SortedSet<?> build()
                 {
                     return s;
@@ -105,23 +109,27 @@ class ContainerFactoryRegistry
     static class SetContainerFactory implements ContainerFactory<Set<?>>
     {
 
+        @Override
         public boolean accepts(Class<?> type)
         {
             return Set.class.equals(type) || LinkedHashSet.class.equals(type);
         }
 
+        @Override
         public ContainerBuilder<Set<?>> newContainerBuilderFor(Class<?> type)
         {
             return new ContainerBuilder<Set<?>>()
             {
                 private Set<Object> s = new LinkedHashSet<Object>();
 
+                @Override
                 public ContainerBuilder<Set<?>> add(Object it)
                 {
                     s.add(it);
                     return this;
                 }
 
+                @Override
                 public Set<?> build()
                 {
                     return s;
@@ -133,11 +141,13 @@ class ContainerFactoryRegistry
     static class ListContainerFactory implements ContainerFactory<List<?>>
     {
 
+        @Override
         public boolean accepts(Class<?> type)
         {
             return type.equals(List.class) || type.equals(Collection.class) || type.equals(Iterable.class);
         }
 
+        @Override
         public ContainerBuilder<List<?>> newContainerBuilderFor(Class<?> type)
         {
             return new ListContainerBuilder();

--- a/src/main/java/org/skife/jdbi/v2/DBI.java
+++ b/src/main/java/org/skife/jdbi/v2/DBI.java
@@ -95,6 +95,7 @@ public class DBI implements IDBI
     {
         this(new ConnectionFactory()
         {
+            @Override
             public Connection openConnection() throws SQLException
             {
                 return DriverManager.getConnection(url);
@@ -112,6 +113,7 @@ public class DBI implements IDBI
     {
         this(new ConnectionFactory()
         {
+            @Override
             public Connection openConnection() throws SQLException
             {
                 return DriverManager.getConnection(url, props);
@@ -130,6 +132,7 @@ public class DBI implements IDBI
     {
         this(new ConnectionFactory()
         {
+            @Override
             public Connection openConnection() throws SQLException
             {
                 return DriverManager.getConnection(url, username, password);
@@ -199,6 +202,7 @@ public class DBI implements IDBI
      *
      * @return an open Handle instance
      */
+    @Override
     public Handle open()
     {
         try {
@@ -250,6 +254,7 @@ public class DBI implements IDBI
      * @param key   The key for the attribute
      * @param value the value for the attribute
      */
+    @Override
     public void define(String key, Object value)
     {
         this.globalStatementAttributes.put(key, value);
@@ -266,6 +271,7 @@ public class DBI implements IDBI
      * @throws CallbackFailedException Will be thrown if callback raises an exception. This exception will
      *                                 wrap the exception thrown by the callback.
      */
+    @Override
     public <ReturnType> ReturnType withHandle(HandleCallback<ReturnType> callback) throws CallbackFailedException
     {
         final Handle h = this.open();
@@ -293,9 +299,11 @@ public class DBI implements IDBI
      * @throws CallbackFailedException Will be thrown if callback raises an exception. This exception will
      *                                 wrap the exception thrown by the callback.
      */
+    @Override
     public <ReturnType> ReturnType inTransaction(final TransactionCallback<ReturnType> callback) throws CallbackFailedException
     {
         return withHandle(new HandleCallback<ReturnType>() {
+            @Override
             public ReturnType withHandle(Handle handle) throws Exception
             {
                 return handle.inTransaction(callback);
@@ -303,9 +311,11 @@ public class DBI implements IDBI
         });
     }
 
+    @Override
     public <ReturnType> ReturnType inTransaction(final TransactionIsolationLevel isolation, final TransactionCallback<ReturnType> callback) throws CallbackFailedException
     {
         return withHandle(new HandleCallback<ReturnType>() {
+            @Override
             public ReturnType withHandle(Handle handle) throws Exception
             {
                 return handle.inTransaction(isolation, callback);
@@ -320,6 +330,7 @@ public class DBI implements IDBI
      * @param <SqlObjectType>
      * @return a new sql object of the specified type, with a dedicated handle
      */
+    @Override
     public <SqlObjectType> SqlObjectType open(Class<SqlObjectType> sqlObjectType)
     {
         return SqlObjectBuilder.open(this, sqlObjectType);
@@ -333,6 +344,7 @@ public class DBI implements IDBI
      * @param <SqlObjectType>
      * @return a new sql object of the specified type, with a dedicated handle
      */
+    @Override
     public <SqlObjectType> SqlObjectType onDemand(Class<SqlObjectType> sqlObjectType)
     {
         return SqlObjectBuilder.onDemand(this, sqlObjectType);
@@ -342,6 +354,7 @@ public class DBI implements IDBI
      * Used to close a sql object which lacks a close() method.
      * @param sqlObject the sql object to close
      */
+    @Override
     public void close(Object sqlObject)
     {
         if (sqlObject instanceof Handle) {
@@ -379,6 +392,7 @@ public class DBI implements IDBI
         assert connection != null;
         return new DBI(new ConnectionFactory()
         {
+            @Override
             public Connection openConnection()
             {
                 return connection;

--- a/src/main/java/org/skife/jdbi/v2/DataSourceConnectionFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/DataSourceConnectionFactory.java
@@ -30,6 +30,7 @@ class DataSourceConnectionFactory implements ConnectionFactory
         this.dataSource = dataSource;
     }
 
+    @Override
     public Connection openConnection() throws SQLException
     {
         return dataSource.getConnection();

--- a/src/main/java/org/skife/jdbi/v2/DefaultMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/DefaultMapper.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 public class DefaultMapper implements ResultSetMapper<Map<String, Object>>
 {
+    @Override
     public Map<String, Object> map(int index, ResultSet r, StatementContext ctx)
     {
         Map<String, Object> row = new DefaultResultMap();

--- a/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilder.java
+++ b/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilder.java
@@ -38,6 +38,7 @@ public class DefaultStatementBuilder implements StatementBuilder
      *
      * @return a new PreparedStatement
      */
+    @Override
     public PreparedStatement create(Connection conn, String sql, StatementContext ctx) throws SQLException
     {
         if (ctx.isReturningGeneratedKeys()) {
@@ -57,6 +58,7 @@ public class DefaultStatementBuilder implements StatementBuilder
      *
      * @throws java.sql.SQLException if anything goes wrong closing the statement
      */
+    @Override
     public void close(Connection conn, String sql, Statement stmt) throws SQLException
     {
         if (stmt != null) {
@@ -67,6 +69,7 @@ public class DefaultStatementBuilder implements StatementBuilder
     /**
      * In this case, a NOOP
      */
+    @Override
     public void close(Connection conn)
     {
     }
@@ -78,6 +81,7 @@ public class DefaultStatementBuilder implements StatementBuilder
      * @param sql the translated SQL which should be prepared
      * @param ctx Statement context associated with the SQLStatement this is building for
      */
+    @Override
     public CallableStatement createCall(Connection conn, String sql, StatementContext ctx) throws SQLException
     {
         return conn.prepareCall(sql);

--- a/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilderFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilderFactory.java
@@ -28,6 +28,7 @@ public class DefaultStatementBuilderFactory implements StatementBuilderFactory
     /**
      * Obtain a StatementBuilder, called when a new handle is opened
      */
+    @Override
     public StatementBuilder createStatementBuilder(Connection conn)
     {
         return new DefaultStatementBuilder();

--- a/src/main/java/org/skife/jdbi/v2/DelegatingConnection.java
+++ b/src/main/java/org/skife/jdbi/v2/DelegatingConnection.java
@@ -48,246 +48,295 @@ public class DelegatingConnection implements Connection
         this.connection = delegate;
     }
 
+    @Override
     public Statement createStatement() throws SQLException
     {
         return connection.createStatement();
     }
 
+    @Override
     public PreparedStatement prepareStatement(String s) throws SQLException
     {
         return connection.prepareStatement(s);
     }
 
+    @Override
     public CallableStatement prepareCall(String s) throws SQLException
     {
         return connection.prepareCall(s);
     }
 
+    @Override
     public String nativeSQL(String s) throws SQLException
     {
         return connection.nativeSQL(s);
     }
 
+    @Override
     public boolean getAutoCommit() throws SQLException
     {
         return connection.getAutoCommit();
     }
 
+    @Override
     public void setAutoCommit(boolean b) throws SQLException
     {
         connection.setAutoCommit(b);
     }
 
+    @Override
     public void commit() throws SQLException
     {
         connection.commit();
     }
 
+    @Override
     public void rollback() throws SQLException
     {
         connection.rollback();
     }
 
+    @Override
     public void close() throws SQLException
     {
         connection.close();
     }
 
+    @Override
     public boolean isClosed() throws SQLException
     {
         return connection.isClosed();
     }
 
+    @Override
     public DatabaseMetaData getMetaData() throws SQLException
     {
         return connection.getMetaData();
     }
 
+    @Override
     public boolean isReadOnly() throws SQLException
     {
         return connection.isReadOnly();
     }
 
+    @Override
     public void setReadOnly(boolean b) throws SQLException
     {
         connection.setReadOnly(b);
     }
 
+    @Override
     public String getCatalog() throws SQLException
     {
         return connection.getCatalog();
     }
 
+    @Override
     public void setCatalog(String s) throws SQLException
     {
         connection.setCatalog(s);
     }
 
+    @Override
     public int getTransactionIsolation() throws SQLException
     {
         return connection.getTransactionIsolation();
     }
 
+    @Override
     public void setTransactionIsolation(int i) throws SQLException
     {
         connection.setTransactionIsolation(i);
     }
 
+    @Override
     public SQLWarning getWarnings() throws SQLException
     {
         return connection.getWarnings();
     }
 
+    @Override
     public void clearWarnings() throws SQLException
     {
         connection.clearWarnings();
     }
 
+    @Override
     public Statement createStatement(int i, int i1) throws SQLException
     {
         return connection.createStatement(i, i1);
     }
 
+    @Override
     public PreparedStatement prepareStatement(String s, int i, int i1) throws SQLException
     {
         return connection.prepareStatement(s, i, i1);
     }
 
+    @Override
     public CallableStatement prepareCall(String s, int i, int i1) throws SQLException
     {
         return connection.prepareCall(s, i, i1);
     }
 
+    @Override
     public Map<String, Class<?>> getTypeMap() throws SQLException
     {
         return connection.getTypeMap();
     }
 
+    @Override
     public void setTypeMap(Map<String, Class<?>> map) throws SQLException
     {
         connection.setTypeMap(map);
     }
 
+    @Override
     public int getHoldability() throws SQLException
     {
         return connection.getHoldability();
     }
 
+    @Override
     public void setHoldability(int i) throws SQLException
     {
         connection.setHoldability(i);
     }
 
+    @Override
     public Savepoint setSavepoint() throws SQLException
     {
         return connection.setSavepoint();
     }
 
+    @Override
     public Savepoint setSavepoint(String s) throws SQLException
     {
         return connection.setSavepoint(s);
     }
 
+    @Override
     public void rollback(Savepoint savepoint) throws SQLException
     {
         connection.rollback(savepoint);
     }
 
+    @Override
     public void releaseSavepoint(Savepoint savepoint) throws SQLException
     {
         connection.releaseSavepoint(savepoint);
     }
 
+    @Override
     public Statement createStatement(int i, int i1, int i2) throws SQLException
     {
         return connection.createStatement(i, i1, i2);
     }
 
+    @Override
     public PreparedStatement prepareStatement(String s, int i, int i1, int i2) throws SQLException
     {
         return connection.prepareStatement(s, i, i1, i2);
     }
 
+    @Override
     public CallableStatement prepareCall(String s, int i, int i1, int i2) throws SQLException
     {
         return connection.prepareCall(s, i, i1, i2);
     }
 
+    @Override
     public PreparedStatement prepareStatement(String s, int i) throws SQLException
     {
         return connection.prepareStatement(s, i);
     }
 
+    @Override
     public PreparedStatement prepareStatement(String s, int[] ints) throws SQLException
     {
         return connection.prepareStatement(s, ints);
     }
 
+    @Override
     public PreparedStatement prepareStatement(String s, String[] strings) throws SQLException
     {
         return connection.prepareStatement(s, strings);
     }
 
+    @Override
     public Clob createClob() throws SQLException
     {
         return connection.createClob();
     }
 
+    @Override
     public Blob createBlob() throws SQLException
     {
         return connection.createBlob();
     }
 
+    @Override
     public NClob createNClob() throws SQLException
     {
         return connection.createNClob();
     }
 
+    @Override
     public SQLXML createSQLXML() throws SQLException
     {
         return connection.createSQLXML();
     }
 
+    @Override
     public boolean isValid(int timeout) throws SQLException
     {
         return connection.isValid(timeout);
     }
 
+    @Override
     public void setClientInfo(String name, String value) throws SQLClientInfoException
     {
         connection.setClientInfo(name, value);
     }
 
+    @Override
     public String getClientInfo(String name) throws SQLException
     {
         return connection.getClientInfo(name);
     }
 
+    @Override
     public Properties getClientInfo() throws SQLException
     {
         return connection.getClientInfo();
     }
 
+    @Override
     public void setClientInfo(Properties properties) throws SQLClientInfoException
     {
         connection.setClientInfo(properties);
     }
 
+    @Override
     public Array createArrayOf(String typeName, Object[] elements) throws SQLException
     {
         return connection.createArrayOf(typeName, elements);
     }
 
+    @Override
     public Struct createStruct(String typeName, Object[] attributes) throws SQLException
     {
         return connection.createStruct(typeName, attributes);
     }
 
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException
     {
         return connection.unwrap(iface);
     }
 
+    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException
     {
         return connection.isWrapperFor(iface);

--- a/src/main/java/org/skife/jdbi/v2/DoubleArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/DoubleArgument.java
@@ -33,6 +33,7 @@ class DoubleArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/EnumArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/EnumArgument.java
@@ -30,6 +30,7 @@ class EnumArgument<T extends Enum<T>> implements Argument {
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException {
         if (value == null) {
             statement.setNull(position, Types.VARCHAR);

--- a/src/main/java/org/skife/jdbi/v2/FloatArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/FloatArgument.java
@@ -33,6 +33,7 @@ class FloatArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/GeneratedKeys.java
+++ b/src/main/java/org/skife/jdbi/v2/GeneratedKeys.java
@@ -67,6 +67,7 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
      *
      * @return The key or null if no keys were returned
      */
+    @Override
     public Type first()
     {
         try {
@@ -86,18 +87,21 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
         }
     }
 
+    @Override
     public <T> T first(Class<T> containerType)
     {
 //        return containerFactoryRegistry.lookup(containerType).create(Arrays.asList(first()));
         throw new UnsupportedOperationException("Not Yet Implemented!");
     }
 
+    @Override
     public <ContainerType> ContainerType list(Class<ContainerType> containerType)
     {
 //        return containerFactoryRegistry.lookup(containerType).create(Arrays.asList(list()));
         throw new UnsupportedOperationException("Not Yet Implemented!");
     }
 
+    @Override
     public List<Type> list(int maxRows)
     {
         try {
@@ -125,6 +129,7 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
      *
      * @return The list of keys or an empty list if no keys were returned
      */
+    @Override
     public List<Type> list()
     {
         return list(Integer.MAX_VALUE);
@@ -135,6 +140,7 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
      *
      * @return The key iterator
      */
+    @Override
     public ResultIterator<Type> iterator()
     {
         try {

--- a/src/main/java/org/skife/jdbi/v2/Handle.java
+++ b/src/main/java/org/skife/jdbi/v2/Handle.java
@@ -42,6 +42,7 @@ public interface Handle extends Closeable
      */
     Connection getConnection();
 
+    @Override
     /**
      * @throws org.skife.jdbi.v2.exceptions.UnableToCloseResourceException if any
      * resources throw exception while closing

--- a/src/main/java/org/skife/jdbi/v2/HashPrefixStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/HashPrefixStatementRewriter.java
@@ -52,6 +52,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter
      * @return somethign which can provde the actual SQL to prepare a statement from
      *         and which can bind the correct arguments to that prepared statement
      */
+    @Override
     public RewrittenStatement rewrite(String sql, Binding params, StatementContext ctx)
     {
         final ParsedStatement stmt = new ParsedStatement();
@@ -113,6 +114,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter
             this.stmt = stmt;
         }
 
+        @Override
         public void bind(Binding params, PreparedStatement statement) throws SQLException
         {
             if (stmt.positionalOnly) {
@@ -167,6 +169,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter
             }
         }
 
+        @Override
         public String getSql()
         {
             return sql;

--- a/src/main/java/org/skife/jdbi/v2/InferredMapperFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/InferredMapperFactory.java
@@ -39,11 +39,13 @@ class InferredMapperFactory implements ResultSetMapperFactory
         maps = rs.get(0).getErasedType();
     }
 
+    @Override
     public boolean accepts(Class type, StatementContext ctx)
     {
         return maps.equals(type);
     }
 
+    @Override
     public ResultSetMapper mapperFor(Class type, StatementContext ctx)
     {
         return mapper;

--- a/src/main/java/org/skife/jdbi/v2/InputStreamArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/InputStreamArgument.java
@@ -38,6 +38,7 @@ class InputStreamArgument implements Argument
         this.ascii = ascii;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (ascii)

--- a/src/main/java/org/skife/jdbi/v2/IntegerArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/IntegerArgument.java
@@ -33,6 +33,7 @@ class IntegerArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value == null) {

--- a/src/main/java/org/skife/jdbi/v2/JavaDateArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/JavaDateArgument.java
@@ -37,6 +37,7 @@ class JavaDateArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/LongArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/LongArgument.java
@@ -33,6 +33,7 @@ class LongArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/NoOpStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/NoOpStatementRewriter.java
@@ -29,6 +29,7 @@ import java.sql.SQLException;
  */
 public class NoOpStatementRewriter implements StatementRewriter
 {
+    @Override
     public RewrittenStatement rewrite(String sql, Binding params, StatementContext ctx)
     {
         return new NoOpRewrittenStatement(sql, ctx);
@@ -45,6 +46,7 @@ public class NoOpStatementRewriter implements StatementRewriter
             this.sql = sql;
         }
 
+        @Override
         public void bind(Binding params, PreparedStatement statement) throws SQLException
         {
             for (int i = 0; ; i++) {
@@ -54,6 +56,7 @@ public class NoOpStatementRewriter implements StatementRewriter
             }
         }
 
+        @Override
         public String getSql()
         {
             return sql;

--- a/src/main/java/org/skife/jdbi/v2/NullArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/NullArgument.java
@@ -28,6 +28,7 @@ class NullArgument implements Argument
         this.sqlType = sqlType;
     }
 
+    @Override
     public void apply(final int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         statement.setNull(position, sqlType);

--- a/src/main/java/org/skife/jdbi/v2/ObjectArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/ObjectArgument.java
@@ -33,6 +33,7 @@ class ObjectArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/PreparedBatch.java
+++ b/src/main/java/org/skife/jdbi/v2/PreparedBatch.java
@@ -63,6 +63,7 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
      *
      * @return self
      */
+    @Override
     public PreparedBatch define(String key, Object value)
     {
         getContext().setAttribute(key, value);
@@ -75,6 +76,7 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
      * @param values containing key/value pairs.
      * @return this
      */
+    @Override
     public PreparedBatch define(final Map<String, ? extends Object> values)
     {
         if (values != null) {

--- a/src/main/java/org/skife/jdbi/v2/PrimitivesMapperFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/PrimitivesMapperFactory.java
@@ -76,11 +76,13 @@ public class PrimitivesMapperFactory implements ResultSetMapperFactory
         mappers.put(String.class, StringMapper.FIRST);
     }
 
+    @Override
     public boolean accepts(Class type, StatementContext ctx)
     {
         return mappers.containsKey(type);
     }
 
+    @Override
     public ResultSetMapper mapperFor(Class type, StatementContext ctx)
     {
         return mappers.get(type);

--- a/src/main/java/org/skife/jdbi/v2/Query.java
+++ b/src/main/java/org/skife/jdbi/v2/Query.java
@@ -69,16 +69,19 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
      *                            if there is an error executing the statement
      * @throws org.skife.jdbi.v2.exceptions.ResultSetException if there is an error dealing with the result set
      */
+    @Override
     public List<ResultType> list()
     {
         return list(List.class);
     }
 
+    @Override
     public <ContainerType> ContainerType list(Class<ContainerType> containerType)
     {
         ContainerBuilder<ContainerType> builder = getContainerMapperRegistry().createBuilderFor(containerType);
         return fold(builder, new Folder3<ContainerBuilder<ContainerType>, ResultType>()
         {
+            @Override
             public ContainerBuilder<ContainerType> fold(ContainerBuilder<ContainerType> accumulator,
                                                         ResultType rs,
                                                         FoldController ctl,
@@ -104,11 +107,13 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
      *                            if there is an error executing the statement
      * @throws org.skife.jdbi.v2.exceptions.ResultSetException if there is an error dealing with the result set
      */
+    @Override
     public List<ResultType> list(final int maxRows)
     {
         try {
             return this.internalExecute(new QueryResultSetMunger<List<ResultType>>(this)
             {
+                @Override
                 public List<ResultType> munge(ResultSet rs) throws SQLException
                 {
                     List<ResultType> result_list = new ArrayList<ResultType>();
@@ -145,6 +150,7 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
         try {
             this.internalExecute(new QueryResultSetMunger<Void>(this)
             {
+                @Override
                 public Void munge(ResultSet rs) throws SQLException
                 {
                     while (rs.next()) {
@@ -208,6 +214,7 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
         try {
             this.internalExecute(new QueryResultSetMunger<Void>(this)
             {
+                @Override
                 public Void munge(ResultSet rs) throws SQLException
                 {
                     while (rs.next()) {
@@ -227,10 +234,12 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
      * Obtain a forward-only result set iterator. Note that you must explicitely close
      * the iterator to close the underlying resources.
      */
+    @Override
     public ResultIterator<ResultType> iterator()
     {
         return this.internalExecute(new QueryResultMunger<ResultIterator<ResultType>>()
         {
+            @Override
             public ResultIterator<ResultType> munge(Statement stmt) throws SQLException
             {
                 return new ResultSetResultIterator<ResultType>(mapper,
@@ -249,11 +258,13 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
      *
      * @return first result, mapped, or null if there is no first result
      */
+    @Override
     public ResultType first()
     {
         return (ResultType) first(UnwrappedSingleValue.class);
     }
 
+    @Override
     public <T> T first(Class<T> containerType)
     {
         addStatementCustomizer(StatementCustomizers.MAX_ROW_ONE);
@@ -261,6 +272,7 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
 
         return (T) this.fold(builder, new Folder3<ContainerBuilder, ResultType>()
         {
+            @Override
             public ContainerBuilder fold(ContainerBuilder accumulator, ResultType rs, FoldController control, StatementContext ctx) throws SQLException
             {
                 accumulator.add(rs);

--- a/src/main/java/org/skife/jdbi/v2/QueryResultSetMunger.java
+++ b/src/main/java/org/skife/jdbi/v2/QueryResultSetMunger.java
@@ -30,6 +30,7 @@ abstract class QueryResultSetMunger<T> implements QueryResultMunger<T>
         this.stmt = stmt;
     }
 
+    @Override
     public final T munge(Statement results)
             throws SQLException
     {

--- a/src/main/java/org/skife/jdbi/v2/ReflectionBeanMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/ReflectionBeanMapper.java
@@ -55,6 +55,7 @@ public class ReflectionBeanMapper<T> implements ResultSetMapper<T>
         }
     }
 
+    @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     public T map(int row, ResultSet rs, StatementContext ctx)
             throws SQLException

--- a/src/main/java/org/skife/jdbi/v2/RegisteredMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/RegisteredMapper.java
@@ -31,6 +31,7 @@ class RegisteredMapper<T> implements ResultSetMapper<T>
         this.registry = registry;
     }
 
+    @Override
     public T map(int index, ResultSet r, StatementContext ctx) throws SQLException
     {
         return (T) registry.mapperFor(type, ctx).map(index, r, ctx);

--- a/src/main/java/org/skife/jdbi/v2/ResultBearing.java
+++ b/src/main/java/org/skife/jdbi/v2/ResultBearing.java
@@ -22,6 +22,7 @@ public interface ResultBearing<ResultType> extends Iterable<ResultType>
     <ContainerType> ContainerType list(Class<ContainerType> containerType);
     List<ResultType> list(final int maxRows);
     List<ResultType> list();
+    @Override
     ResultIterator<ResultType> iterator();
     ResultType first();
     <T> T first(Class<T> containerType);

--- a/src/main/java/org/skife/jdbi/v2/ResultIterator.java
+++ b/src/main/java/org/skife/jdbi/v2/ResultIterator.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
  */
 public interface ResultIterator<Type> extends Iterator<Type>, Closeable
 {
+    @Override
     /**
      * Close the underlying result set.
      */

--- a/src/main/java/org/skife/jdbi/v2/ResultSetResultIterator.java
+++ b/src/main/java/org/skife/jdbi/v2/ResultSetResultIterator.java
@@ -48,6 +48,7 @@ class ResultSetResultIterator<Type> implements ResultIterator<Type>
         this.jdbiStatement.addCleanable(Cleanables.forResultSet(results));
     }
 
+    @Override
     public void close()
     {
         if (closed) {
@@ -57,6 +58,7 @@ class ResultSetResultIterator<Type> implements ResultIterator<Type>
         jdbiStatement.cleanup();
     }
 
+    @Override
     public boolean hasNext()
     {
         if (closed) {
@@ -79,6 +81,7 @@ class ResultSetResultIterator<Type> implements ResultIterator<Type>
         return hasNext;
     }
 
+    @Override
     public Type next()
     {
         if (closed) {
@@ -104,6 +107,7 @@ class ResultSetResultIterator<Type> implements ResultIterator<Type>
         }
     }
 
+    @Override
     public void remove()
     {
         throw new UnsupportedOperationException("Deleting from a result set iterator is not yet supported");

--- a/src/main/java/org/skife/jdbi/v2/ShortArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/ShortArgument.java
@@ -33,6 +33,7 @@ class ShortArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/SqlDateArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/SqlDateArgument.java
@@ -34,6 +34,7 @@ class SqlDateArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/SqlTypeArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/SqlTypeArgument.java
@@ -34,6 +34,7 @@ class SqlTypeArgument implements Argument
         this.sqlType = sqlType;
     }
 
+    @Override
     public void apply(final int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         statement.setObject(position, value, sqlType);

--- a/src/main/java/org/skife/jdbi/v2/StringArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/StringArgument.java
@@ -33,6 +33,7 @@ class StringArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/TimeArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/TimeArgument.java
@@ -34,6 +34,7 @@ class TimeArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/TimestampArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/TimestampArgument.java
@@ -34,6 +34,7 @@ class TimestampArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/TimingCollector.java
+++ b/src/main/java/org/skife/jdbi/v2/TimingCollector.java
@@ -38,6 +38,7 @@ public interface TimingCollector
 
     public static final class NopTimingCollector implements TimingCollector
     {
+        @Override
         public void collect(final long elapsedTime, final StatementContext ctx)
         {
             // GNDN

--- a/src/main/java/org/skife/jdbi/v2/URLArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/URLArgument.java
@@ -34,6 +34,7 @@ class URLArgument implements Argument
         this.value = value;
     }
 
+    @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
     {
         if (value != null) {

--- a/src/main/java/org/skife/jdbi/v2/UnwrappedSingleValueFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/UnwrappedSingleValueFactory.java
@@ -19,23 +19,27 @@ import org.skife.jdbi.v2.tweak.ContainerFactory;
 
 class UnwrappedSingleValueFactory implements ContainerFactory<Object>
 {
+    @Override
     public boolean accepts(Class<?> type)
     {
         return UnwrappedSingleValue.class.equals(type);
     }
 
+    @Override
     public ContainerBuilder newContainerBuilderFor(Class<?> type)
     {
         return new ContainerBuilder<Object>()
         {
             private Object it;
 
+            @Override
             public ContainerBuilder add(Object it)
             {
                 this.it = it;
                 return this;
             }
 
+            @Override
             public Object build()
             {
                 return it;

--- a/src/main/java/org/skife/jdbi/v2/Update.java
+++ b/src/main/java/org/skife/jdbi/v2/Update.java
@@ -54,6 +54,7 @@ public class Update extends SQLStatement<Update>
     {
         try {
             return this.internalExecute(new QueryResultMunger<Integer>() {
+                @Override
                 public Integer munge(Statement results) throws SQLException
                 {
                     return results.getUpdateCount();
@@ -75,6 +76,7 @@ public class Update extends SQLStatement<Update>
     {
         getConcreteContext().setReturningGeneratedKeys(true);
         return this.internalExecute(new QueryResultMunger<GeneratedKeys<GeneratedKeyType>>() {
+            @Override
             public GeneratedKeys<GeneratedKeyType> munge(Statement results) throws SQLException
             {
                 return new GeneratedKeys<GeneratedKeyType>(mapper,

--- a/src/main/java/org/skife/jdbi/v2/logging/FormattedLog.java
+++ b/src/main/java/org/skife/jdbi/v2/logging/FormattedLog.java
@@ -23,6 +23,7 @@ import org.skife.jdbi.v2.tweak.SQLLog;
  */
 public abstract class FormattedLog implements SQLLog
 {
+    @Override
     public final void logSQL(long time, String sql)
     {
         if (isEnabled()) {
@@ -44,6 +45,7 @@ public abstract class FormattedLog implements SQLLog
     protected abstract void log(String msg);
 
 
+    @Override
     public final void logPreparedBatch(long time, String sql, int count)
     {
         if (isEnabled()) {
@@ -51,6 +53,7 @@ public abstract class FormattedLog implements SQLLog
         }
     }
 
+    @Override
     public final BatchLogger logBatch()
     {
         if (isEnabled()) {
@@ -60,12 +63,14 @@ public abstract class FormattedLog implements SQLLog
             {
                 private boolean added = false;
 
+                @Override
                 public final void add(String sql)
                 {
                     added = true;
                     builder.append("[").append(sql).append("], ");
                 }
 
+                @Override
                 public final void log(long time)
                 {
                     if (added) {
@@ -81,6 +86,7 @@ public abstract class FormattedLog implements SQLLog
         }
     }
 
+    @Override
     public void logBeginTransaction(Handle h)
     {
         if (isEnabled()) {
@@ -88,6 +94,7 @@ public abstract class FormattedLog implements SQLLog
         }
     }
 
+    @Override
     public void logCommitTransaction(long time, Handle h)
     {
         if (isEnabled()) {
@@ -95,6 +102,7 @@ public abstract class FormattedLog implements SQLLog
         }
     }
 
+    @Override
     public void logRollbackTransaction(long time, Handle h)
     {
         if (isEnabled()) {
@@ -102,6 +110,7 @@ public abstract class FormattedLog implements SQLLog
         }
     }
 
+    @Override
     public void logObtainHandle(long time, Handle h)
     {
         if (this.isEnabled()) {
@@ -109,6 +118,7 @@ public abstract class FormattedLog implements SQLLog
         }
     }
 
+    @Override
     public void logReleaseHandle(Handle h)
     {
         if (this.isEnabled()) {
@@ -116,6 +126,7 @@ public abstract class FormattedLog implements SQLLog
         }
     }
 
+    @Override
     public void logCheckpointTransaction(Handle h, String name)
     {
         if (this.isEnabled()) {
@@ -123,6 +134,7 @@ public abstract class FormattedLog implements SQLLog
         }
     }
 
+    @Override
     public void logReleaseCheckpointTransaction(Handle h, String name)
     {
         if (this.isEnabled()) {
@@ -130,6 +142,7 @@ public abstract class FormattedLog implements SQLLog
         }
     }
 
+    @Override
     public void logRollbackToCheckpoint(long time, Handle h, String checkpointName)
     {
         if (this.isEnabled()) {

--- a/src/main/java/org/skife/jdbi/v2/logging/NoOpLog.java
+++ b/src/main/java/org/skife/jdbi/v2/logging/NoOpLog.java
@@ -26,56 +26,69 @@ public final class NoOpLog implements SQLLog
 
     static final BatchLogger batch = new BatchLogger() {
 
+        @Override
         public void add(String sql)
         {
         }
 
+        @Override
         public void log(long time)
         {
         }
     };
 
+    @Override
     public void logBeginTransaction(Handle h)
     {
     }
 
+    @Override
     public void logCommitTransaction(long time, Handle h)
     {
     }
 
+    @Override
     public void logRollbackTransaction(long time, Handle h)
     {
     }
 
+    @Override
     public void logObtainHandle(long time, Handle h)
     {
     }
 
+    @Override
     public void logReleaseHandle(Handle h)
     {
     }
 
+    @Override
     public void logSQL(long time, String sql)
     {
     }
 
+    @Override
     public void logPreparedBatch(long time, String sql, int count)
     {
     }
 
+    @Override
     public BatchLogger logBatch()
     {
         return batch;
     }
 
+    @Override
     public void logCheckpointTransaction(Handle h, String name)
     {
     }
 
+    @Override
     public void logReleaseCheckpointTransaction(Handle h, String name)
     {
     }
 
+    @Override
     public void logRollbackToCheckpoint(long time, Handle h, String checkpointName)
     {
     }

--- a/src/main/java/org/skife/jdbi/v2/spring/DBIFactoryBean.java
+++ b/src/main/java/org/skife/jdbi/v2/spring/DBIFactoryBean.java
@@ -38,6 +38,7 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
     /**
      * See org.springframework.beans.factory.FactoryBean#getObject
      */
+    @Override
     public Object getObject() throws Exception
     {
         final DBI dbi = new DBI(new SpringDataSourceConnectionFactory(dataSource));
@@ -55,6 +56,7 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
     /**
      * See org.springframework.beans.factory.FactoryBean#getObjectType
      */
+    @Override
     public Class<?> getObjectType()
     {
         return IDBI.class;
@@ -65,6 +67,7 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
      *
      * @return false
      */
+    @Override
     public boolean isSingleton()
     {
         return true;
@@ -91,6 +94,7 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
     /**
      * Verifies that a dataSource has been set
      */
+    @Override
     public void afterPropertiesSet() throws Exception
     {
         if (dataSource == null) {

--- a/src/main/java/org/skife/jdbi/v2/spring/SpringDataSourceConnectionFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/spring/SpringDataSourceConnectionFactory.java
@@ -34,6 +34,7 @@ class SpringDataSourceConnectionFactory implements ConnectionFactory
         this.dataSource = dataSource;
     }
 
+    @Override
     public Connection openConnection() throws SQLException
     {
         return DataSourceUtils.getConnection(dataSource);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
@@ -92,6 +92,7 @@ class BatchHandler extends CustomizingStatementHandler
         return -1;
     }
 
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         Handle handle = h.getHandle();
@@ -110,17 +111,20 @@ class BatchHandler extends CustomizingStatementHandler
             else {
                 extras.add(new Iterator()
                 {
+                    @Override
                     public boolean hasNext()
                     {
                         return true;
                     }
 
+                    @Override
                     @SuppressFBWarnings("IT_NO_SUCH_ELEMENT")
                     public Object next()
                     {
                         return arg;
                     }
 
+                    @Override
                     public void remove()
                     {
                         // NOOP
@@ -178,6 +182,7 @@ class BatchHandler extends CustomizingStatementHandler
             // Handle instance.
             return handle.inTransaction(new TransactionCallback<int[]>()
             {
+                @Override
                 public int[] inTransaction(Handle conn, TransactionStatus status) throws Exception
                 {
                     return batch.execute();
@@ -216,6 +221,7 @@ class BatchHandler extends CustomizingStatementHandler
             this.value = value;
         }
 
+        @Override
         public int call(Object[] args)
         {
             return value;
@@ -230,6 +236,7 @@ class BatchHandler extends CustomizingStatementHandler
             this.index = index;
         }
 
+        @Override
         public int call(Object[] args)
         {
             return (Integer)args[index];

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BeginHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BeginHandler.java
@@ -19,6 +19,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 class BeginHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         h.retain("transaction#explicit");

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
@@ -25,10 +25,12 @@ import java.lang.reflect.Method;
 
 class BindBeanFactory implements BinderFactory
 {
+    @Override
     public Binder build(Annotation annotation)
     {
         return new Binder<BindBean, Object>()
         {
+            @Override
             public void bind(SQLStatement q, BindBean bind, Object arg)
             {
                 final String prefix;

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindFactory.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Annotation;
 
 class BindFactory implements BinderFactory
 {
+    @Override
     public Binder build(Annotation annotation)
     {
         Bind bind = (Bind) annotation;

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/CheckpointHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/CheckpointHandler.java
@@ -19,6 +19,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 class CheckpointHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         h.getHandle().checkpoint(String.valueOf(args[0]));

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/CloseHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/CloseHandler.java
@@ -19,6 +19,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 class CloseHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         h.getHandle().close();

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/CloseInternalDoNotUseThisClass.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/CloseInternalDoNotUseThisClass.java
@@ -31,6 +31,7 @@ public interface CloseInternalDoNotUseThisClass
 
     static class CloseHandler implements Handler
     {
+        @Override
         public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
         {
             h.getHandle().close();

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/CommitHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/CommitHandler.java
@@ -19,6 +19,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 class CommitHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         h.release("transaction#explicit");

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ConstantHandleDing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ConstantHandleDing.java
@@ -26,15 +26,18 @@ class ConstantHandleDing implements HandleDing
         this.handle = handle;
     }
 
+    @Override
     public Handle getHandle()
     {
         return handle;
     }
 
+    @Override
     public void release(String name)
     {
     }
 
+    @Override
     public void retain(String name)
     {
     }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/DefaultObjectBinder.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/DefaultObjectBinder.java
@@ -19,6 +19,7 @@ import org.skife.jdbi.v2.SQLStatement;
 
 class DefaultObjectBinder implements Binder<Bind, Object>
 {
+    @Override
     public void bind(SQLStatement q, Bind b, Object arg)
     {
         q.bind(b.value(), arg);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/EqualsHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/EqualsHandler.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 class EqualsHandler implements Handler
 {
+    @Override
     public Object invoke(final HandleDing h, final Object target, final Object[] args, MethodProxy mp)
     {
         // basic reference equals for now.

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/FigureItOutResultSetMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/FigureItOutResultSetMapper.java
@@ -43,6 +43,7 @@ class FigureItOutResultSetMapper implements ResultSetMapper<Object>
 {
     private static final PrimitivesMapperFactory factory = new PrimitivesMapperFactory();
 
+    @Override
     public Object map(int index, ResultSet r, StatementContext ctx) throws SQLException
     {
         Method m = ctx.getSqlObjectMethod();

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/GetHandleHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/GetHandleHandler.java
@@ -19,6 +19,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 class GetHandleHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         return h.getHandle();

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/InTransactionHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/InTransactionHandler.java
@@ -23,6 +23,7 @@ import org.skife.jdbi.v2.TransactionStatus;
 
 class InTransactionHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, final Object target, Object[] args, MethodProxy mp)
     {
         h.retain("transaction#implicit");
@@ -30,6 +31,7 @@ class InTransactionHandler implements Handler
             final Transaction t = (Transaction) args[0];
             return h.getHandle().inTransaction(new TransactionCallback()
             {
+                @Override
                 public Object inTransaction(Handle conn, TransactionStatus status) throws Exception
                 {
                     return t.inTransaction(target, status);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/InTransactionWithIsolationLevelHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/InTransactionWithIsolationLevelHandler.java
@@ -24,6 +24,7 @@ import org.skife.jdbi.v2.TransactionStatus;
 
 class InTransactionWithIsolationLevelHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, final Object target, Object[] args, MethodProxy mp)
     {
         h.retain("transaction#withlevel");
@@ -32,6 +33,7 @@ class InTransactionWithIsolationLevelHandler implements Handler
             final Transaction t = (Transaction) args[1];
             return h.getHandle().inTransaction(level, new TransactionCallback()
             {
+                @Override
                 public Object inTransaction(Handle conn, TransactionStatus status) throws Exception
                 {
                     return t.inTransaction(target, status);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/OnDemandHandleDing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/OnDemandHandleDing.java
@@ -31,6 +31,7 @@ class OnDemandHandleDing implements HandleDing
         this.dbi = dbi;
     }
 
+    @Override
     public Handle getHandle()
     {
         if (threadDing.get() == null) {
@@ -39,12 +40,14 @@ class OnDemandHandleDing implements HandleDing
         return threadDing.get().getHandle();
     }
 
+    @Override
     public void retain(String name)
     {
         getHandle(); // need to ensure the local ding has been created as this is called before getHandle sometimes.
         threadDing.get().retain(name);
     }
 
+    @Override
     public void release(String name)
     {
         LocalDing ding = threadDing.get();
@@ -65,11 +68,13 @@ class OnDemandHandleDing implements HandleDing
             this.handle = handle;
         }
 
+        @Override
         public Handle getHandle()
         {
             return handle;
         }
 
+        @Override
         public void release(String name)
         {
             retentions.remove(name);
@@ -79,6 +84,7 @@ class OnDemandHandleDing implements HandleDing
             }
         }
 
+        @Override
         public void retain(String name)
         {
             retentions.add(name);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/QueryHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/QueryHandler.java
@@ -34,6 +34,7 @@ class QueryHandler extends CustomizingStatementHandler
         this.sql = SqlObject.getSql(method.getRawMember().getAnnotation(SqlQuery.class), method.getRawMember());
     }
 
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         Query q = h.getHandle().createQuery(sql);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ReleaseCheckpointHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ReleaseCheckpointHandler.java
@@ -19,6 +19,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 class ReleaseCheckpointHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         h.getHandle().release(String.valueOf(args[0]));

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
@@ -169,6 +169,7 @@ abstract class ResultReturnThing
                 private boolean closed = false;
                 private boolean hasNext = itty.hasNext();
 
+                @Override
                 public void close()
                 {
                     if (!closed) {
@@ -182,11 +183,13 @@ abstract class ResultReturnThing
                     }
                 }
 
+                @Override
                 public boolean hasNext()
                 {
                     return hasNext;
                 }
 
+                @Override
                 public Object next()
                 {
                     Object rs;
@@ -211,6 +214,7 @@ abstract class ResultReturnThing
                     } catch (RuntimeException ex) {}
                 }
 
+                @Override
                 public void remove()
                 {
                     itty.remove();

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/RollbackCheckpointHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/RollbackCheckpointHandler.java
@@ -19,6 +19,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 class RollbackCheckpointHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         h.getHandle().rollback(String.valueOf(args[0]));

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/RollbackHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/RollbackHandler.java
@@ -19,6 +19,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 class RollbackHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         h.release("transaction#explicit");

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ToStringHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ToStringHandler.java
@@ -30,6 +30,7 @@ class ToStringHandler implements Handler
         this.className = className;
     }
 
+    @Override
     public Object invoke(final HandleDing h, final Object target, final Object[] args, MethodProxy mp)
     {
         return className + '@' + Integer.toHexString(target.hashCode());

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/TransformHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/TransformHandler.java
@@ -19,6 +19,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 class TransformHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, final Object target, Object[] args, MethodProxy mp)
     {
         Class t = (Class) args[0];

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
@@ -45,6 +45,7 @@ class UpdateHandler extends CustomizingStatementHandler
             }
             this.returner = new Returner()
             {
+                @Override
                 public Object value(Update update, HandleDing baton)
                 {
                     GeneratedKeys o = update.executeAndReturnGeneratedKeys(mapper);
@@ -55,6 +56,7 @@ class UpdateHandler extends CustomizingStatementHandler
         else {
             this.returner = new Returner()
             {
+                @Override
                 public Object value(Update update, HandleDing baton)
                 {
                     return update.execute();
@@ -63,6 +65,7 @@ class UpdateHandler extends CustomizingStatementHandler
         }
     }
 
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         Update q = h.getHandle().createStatement(sql);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/WithHandleHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/WithHandleHandler.java
@@ -22,6 +22,7 @@ import org.skife.jdbi.v2.tweak.HandleCallback;
 
 class WithHandleHandler implements Handler
 {
+    @Override
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         final Handle handle = h.getHandle();

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/Define.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/Define.java
@@ -43,22 +43,26 @@ public @interface Define
 
     static class Factory implements SqlStatementCustomizerFactory
     {
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             throw new UnsupportedOperationException("Not allowed on Type");
         }
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             throw new UnsupportedOperationException("Not allowed on Method");
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, final Object arg)
         {
             Define d = (Define) annotation;
             final String key = d.value();
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q)
                 {
                     q.define(key, arg);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchDirection.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchDirection.java
@@ -49,18 +49,21 @@ public @interface FetchDirection
             return new FetchDirectionSqlStatementCustomizer((Integer) arg);
         }
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             final FetchDirection fs = (FetchDirection) annotation;
             return new FetchDirectionSqlStatementCustomizer(fs.value());
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             final FetchDirection fs = (FetchDirection) annotation;
             return new FetchDirectionSqlStatementCustomizer(fs.value());
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation,
                                                          Class sqlObjectType,
                                                          Method method,
@@ -79,6 +82,7 @@ public @interface FetchDirection
             this.direction = direction;
         }
 
+        @Override
         public void apply(SQLStatement q) throws SQLException
         {
             q.addStatementCustomizer(new StatementCustomizers.FetchDirectionStatementCustomizer(direction));

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchSize.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchSize.java
@@ -38,11 +38,13 @@ public @interface FetchSize
 
     static class Factory implements SqlStatementCustomizerFactory
     {
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             final FetchSize fs = (FetchSize) annotation;
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     assert q instanceof Query;
@@ -51,11 +53,13 @@ public @interface FetchSize
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             final FetchSize fs = (FetchSize) annotation;
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     assert q instanceof Query;
@@ -64,11 +68,13 @@ public @interface FetchSize
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, Object arg)
         {
             final Integer va = (Integer) arg;
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     assert q instanceof Query;

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/MaxRows.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/MaxRows.java
@@ -45,11 +45,13 @@ public @interface MaxRows
 
     static class Factory implements SqlStatementCustomizerFactory
     {
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             final int va = ((MaxRows)annotation).value();
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     assert q instanceof Query;
@@ -58,11 +60,13 @@ public @interface MaxRows
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             final int va = ((MaxRows)annotation).value();
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     assert q instanceof Query;
@@ -71,11 +75,13 @@ public @interface MaxRows
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, Object arg)
         {
             final Integer va = (Integer) arg;
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     assert q instanceof Query;

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/OverrideStatementLocatorWith.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/OverrideStatementLocatorWith.java
@@ -46,6 +46,7 @@ public @interface OverrideStatementLocatorWith
     static class Factory implements SqlStatementCustomizerFactory
     {
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             OverrideStatementLocatorWith sl = (OverrideStatementLocatorWith) annotation;
@@ -58,6 +59,7 @@ public @interface OverrideStatementLocatorWith
             }
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q)
                 {
                     q.setStatementLocator(f);
@@ -65,6 +67,7 @@ public @interface OverrideStatementLocatorWith
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             OverrideStatementLocatorWith sl = (OverrideStatementLocatorWith) annotation;
@@ -77,6 +80,7 @@ public @interface OverrideStatementLocatorWith
             }
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q)
                 {
                     q.setStatementLocator(f);
@@ -110,6 +114,7 @@ public @interface OverrideStatementLocatorWith
 
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, Object arg)
         {
             throw new UnsupportedOperationException("Not applicable to parameter");

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/OverrideStatementRewriterWith.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/OverrideStatementRewriterWith.java
@@ -45,6 +45,7 @@ public @interface OverrideStatementRewriterWith
 
     public static class Factory implements SqlStatementCustomizerFactory
     {
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             OverrideStatementRewriterWith anno = (OverrideStatementRewriterWith) annotation;
@@ -52,6 +53,7 @@ public @interface OverrideStatementRewriterWith
                 final StatementRewriter rw = instantiate(anno.value(), sqlObjectType, method);
                 return new SqlStatementCustomizer()
                 {
+                    @Override
                     public void apply(SQLStatement q)
                     {
                         q.setStatementRewriter(rw);
@@ -63,6 +65,7 @@ public @interface OverrideStatementRewriterWith
             }
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             OverrideStatementRewriterWith anno = (OverrideStatementRewriterWith) annotation;
@@ -70,6 +73,7 @@ public @interface OverrideStatementRewriterWith
                 final StatementRewriter rw = instantiate(anno.value(), sqlObjectType, null);
                 return new SqlStatementCustomizer()
                 {
+                    @Override
                     public void apply(SQLStatement q)
                     {
                         q.setStatementRewriter(rw);
@@ -81,6 +85,7 @@ public @interface OverrideStatementRewriterWith
             }
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, Object arg)
         {
             throw new IllegalStateException("Not defined on parameters!");

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/QueryTimeOut.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/QueryTimeOut.java
@@ -40,11 +40,13 @@ public @interface QueryTimeOut
 
     static class Factory implements SqlStatementCustomizerFactory
     {
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             final QueryTimeOut fs = (QueryTimeOut) annotation;
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     q.setQueryTimeout(fs.value());
@@ -52,11 +54,13 @@ public @interface QueryTimeOut
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             final QueryTimeOut fs = (QueryTimeOut) annotation;
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     q.setQueryTimeout(fs.value());
@@ -64,6 +68,7 @@ public @interface QueryTimeOut
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation,
                                                          Class sqlObjectType,
                                                          Method method,
@@ -72,6 +77,7 @@ public @interface QueryTimeOut
             final Integer va = (Integer) arg;
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     q.setQueryTimeout(va);

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/RegisterArgumentFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/RegisterArgumentFactory.java
@@ -47,16 +47,19 @@ public @interface RegisterArgumentFactory
 
     static class Factory implements SqlStatementCustomizerFactory
     {
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             return create(annotation);
         }
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             return create(annotation);
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, final Object arg)
         {
             throw new IllegalStateException("not allowed on parameter");
@@ -76,6 +79,7 @@ public @interface RegisterArgumentFactory
             }
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     for (ArgumentFactory argumentFactory : ary) {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/RegisterContainerMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/RegisterContainerMapper.java
@@ -42,16 +42,19 @@ public @interface RegisterContainerMapper
     public static class Factory implements SqlStatementCustomizerFactory
     {
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             return new MyCustomizer((RegisterContainerMapper) annotation);
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             return new MyCustomizer((RegisterContainerMapper) annotation);
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, Object arg)
         {
             throw new UnsupportedOperationException("Not Yet Implemented!");
@@ -76,6 +79,7 @@ public @interface RegisterContainerMapper
             this.factory = ls;
         }
 
+        @Override
         public void apply(SQLStatement q) throws SQLException
         {
             if (q instanceof Query) {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/RegisterMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/RegisterMapper.java
@@ -44,6 +44,7 @@ public @interface RegisterMapper
 
     static class Factory implements SqlStatementCustomizerFactory
     {
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             final RegisterMapper ma = (RegisterMapper) annotation;
@@ -60,6 +61,7 @@ public @interface RegisterMapper
             }
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement statement)
                 {
                     if (statement instanceof Query) {
@@ -73,6 +75,7 @@ public @interface RegisterMapper
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             final RegisterMapper ma = (RegisterMapper) annotation;
@@ -88,6 +91,7 @@ public @interface RegisterMapper
             }
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement statement)
                 {
                     if (statement instanceof Query) {
@@ -100,6 +104,7 @@ public @interface RegisterMapper
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, Object arg)
         {
             throw new UnsupportedOperationException("Not defined for parameter");

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/RegisterMapperFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/RegisterMapperFactory.java
@@ -42,6 +42,7 @@ public @interface RegisterMapperFactory
     public static class Factory implements SqlStatementCustomizerFactory
     {
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             final RegisterMapperFactory ma = (RegisterMapperFactory) annotation;
@@ -58,6 +59,7 @@ public @interface RegisterMapperFactory
             }
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement statement)
                 {
                     if (statement instanceof Query) {
@@ -71,6 +73,7 @@ public @interface RegisterMapperFactory
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             final RegisterMapperFactory ma = (RegisterMapperFactory) annotation;
@@ -87,6 +90,7 @@ public @interface RegisterMapperFactory
             }
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement statement)
                 {
                     if (statement instanceof Query) {
@@ -100,6 +104,7 @@ public @interface RegisterMapperFactory
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, Object arg)
         {
             throw new UnsupportedOperationException("Not defined for parameter");

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/TransactionIsolation.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/TransactionIsolation.java
@@ -49,16 +49,19 @@ public @interface TransactionIsolation
     static class Factory implements SqlStatementCustomizerFactory
     {
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             return new MyCustomizer(((TransactionIsolation) annotation).value());
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             return new MyCustomizer(((TransactionIsolation) annotation).value());
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, Object arg)
         {
             assert arg instanceof TransactionIsolationLevel;
@@ -73,6 +76,7 @@ public @interface TransactionIsolation
 
         public MyCustomizer(TransactionIsolationLevel level) {this.level = level;}
 
+        @Override
         public void apply(SQLStatement q) throws SQLException
         {
             final int initial_level = q.getContext().getConnection().getTransactionIsolation();

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/ExternalizedSqlViaStringTemplate3.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/ExternalizedSqlViaStringTemplate3.java
@@ -43,6 +43,7 @@ public @interface ExternalizedSqlViaStringTemplate3
 
     public static class LocatorFactory implements SqlStatementCustomizerFactory
     {
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             final ExternalizedSqlViaStringTemplate3 a = (ExternalizedSqlViaStringTemplate3) annotation;
@@ -58,6 +59,7 @@ public @interface ExternalizedSqlViaStringTemplate3
 
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q)
                 {
                     q.setStatementLocator(l);
@@ -65,6 +67,7 @@ public @interface ExternalizedSqlViaStringTemplate3
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation,
                                                       Class sqlObjectType,
                                                       Method method)
@@ -72,6 +75,7 @@ public @interface ExternalizedSqlViaStringTemplate3
             throw new UnsupportedOperationException("Not Defined on Method");
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation,
                                                          Class sqlObjectType,
                                                          Method method, Object arg)

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/StringTemplate3StatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/StringTemplate3StatementLocator.java
@@ -243,6 +243,7 @@ public class StringTemplate3StatementLocator implements StatementLocator
         }
     }
 
+    @Override
     public String locate(String name, StatementContext ctx) throws Exception
     {
         if (group.isDefined(name)) {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/UseStringTemplate3StatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/UseStringTemplate3StatementLocator.java
@@ -42,6 +42,7 @@ public @interface UseStringTemplate3StatementLocator
 
     public static class LocatorFactory implements SqlStatementCustomizerFactory
     {
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             final UseStringTemplate3StatementLocator a = (UseStringTemplate3StatementLocator) annotation;
@@ -68,6 +69,7 @@ public @interface UseStringTemplate3StatementLocator
 
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q)
                 {
                     q.setStatementLocator(l);
@@ -75,6 +77,7 @@ public @interface UseStringTemplate3StatementLocator
             };
         }
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation,
                                                       Class sqlObjectType,
                                                       Method method)
@@ -82,6 +85,7 @@ public @interface UseStringTemplate3StatementLocator
             throw new UnsupportedOperationException("Not Defined on Method");
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation,
                                                          Class sqlObjectType,
                                                          Method method, Object arg)

--- a/src/main/java/org/skife/jdbi/v2/tweak/BaseStatementCustomizer.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/BaseStatementCustomizer.java
@@ -34,6 +34,7 @@ public class BaseStatementCustomizer implements StatementCustomizer
      *
      * @throws java.sql.SQLException go ahead and percolate it for jDBI to handle
      */
+    @Override
     public void beforeExecution(PreparedStatement stmt, StatementContext ctx) throws SQLException
     {
     }
@@ -47,6 +48,7 @@ public class BaseStatementCustomizer implements StatementCustomizer
      *
      * @throws java.sql.SQLException go ahead and percolate it for jDBI to handle
      */
+    @Override
     public void afterExecution(PreparedStatement stmt, StatementContext ctx) throws SQLException
     {
     }
@@ -58,6 +60,7 @@ public class BaseStatementCustomizer implements StatementCustomizer
      * @param ctx Statement context associated with the statement being customized
      * @throws SQLException go ahead and percolate it for jDBI to handle
      */
+    @Override
     public void cleanup(final StatementContext ctx) throws SQLException
     {
     }

--- a/src/main/java/org/skife/jdbi/v2/tweak/transactions/CMTTransactionHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/transactions/CMTTransactionHandler.java
@@ -34,6 +34,7 @@ public class CMTTransactionHandler implements TransactionHandler
     /**
      * Called when a transaction is started
      */
+    @Override
     public void begin(Handle handle)
     {
         // noop
@@ -42,6 +43,7 @@ public class CMTTransactionHandler implements TransactionHandler
     /**
      * Called when a transaction is committed
      */
+    @Override
     public void commit(Handle handle)
     {
         // noop
@@ -51,6 +53,7 @@ public class CMTTransactionHandler implements TransactionHandler
      * Called when a transaction is rolled back
      * Will throw a RuntimeException to force transactional rollback
      */
+    @Override
     public void rollback(Handle handle)
     {
         throw new TransactionException("Rollback called, this runtime exception thrown to halt the transaction");
@@ -62,6 +65,7 @@ public class CMTTransactionHandler implements TransactionHandler
      * @param handle the handle the rollback is being performed on
      * @param name   the name of the checkpoint to rollback to
      */
+    @Override
     public void rollback(Handle handle, String name)
     {
         throw new UnsupportedOperationException("Checkpoints not implemented");
@@ -70,6 +74,7 @@ public class CMTTransactionHandler implements TransactionHandler
     /**
      * Called to test if a handle is in a transaction
      */
+    @Override
     public boolean isInTransaction(Handle handle)
     {
         try
@@ -88,6 +93,7 @@ public class CMTTransactionHandler implements TransactionHandler
      * @param handle the handle on which the transaction is being checkpointed
      * @param name   The name of the chckpoint, used to rollback to or release late
      */
+    @Override
     public void checkpoint(Handle handle, String name)
     {
         throw new UnsupportedOperationException("Checkpoints not implemented");
@@ -99,6 +105,7 @@ public class CMTTransactionHandler implements TransactionHandler
      * @param handle         the handle on which the checkpoint is being released
      * @param checkpointName the checkpoint to release
      */
+    @Override
     public void release(Handle handle, String checkpointName)
     {
         throw new TransactionException("Rollback called, this runtime exception thrown to halt the transaction");

--- a/src/main/java/org/skife/jdbi/v2/tweak/transactions/LocalTransactionHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/transactions/LocalTransactionHandler.java
@@ -44,6 +44,7 @@ public class LocalTransactionHandler implements TransactionHandler
     /**
      * Called when a transaction is started
      */
+    @Override
     public void begin(Handle handle)
     {
         try {
@@ -61,6 +62,7 @@ public class LocalTransactionHandler implements TransactionHandler
     /**
      * Called when a transaction is committed
      */
+    @Override
     public void commit(Handle handle)
     {
         try {
@@ -77,6 +79,7 @@ public class LocalTransactionHandler implements TransactionHandler
     /**
      * Called when a transaction is rolled back
      */
+    @Override
     public void rollback(Handle handle)
     {
         try {
@@ -96,6 +99,7 @@ public class LocalTransactionHandler implements TransactionHandler
      * @param handle the handle on which the transaction is being checkpointed
      * @param name   The name of the chckpoint, used to rollback to or release late
      */
+    @Override
     public void checkpoint(Handle handle, String name)
     {
         final Connection conn = handle.getConnection();
@@ -108,6 +112,7 @@ public class LocalTransactionHandler implements TransactionHandler
         }
     }
 
+    @Override
     public void release(Handle handle, String name)
     {
         final Connection conn = handle.getConnection();
@@ -130,6 +135,7 @@ public class LocalTransactionHandler implements TransactionHandler
      * @param handle the handle the rollback is being performed on
      * @param name   the name of the checkpoint to rollback to
      */
+    @Override
     public void rollback(Handle handle, String name)
     {
         final Connection conn = handle.getConnection();
@@ -149,6 +155,7 @@ public class LocalTransactionHandler implements TransactionHandler
     /**
      * Called to test if a handle is in a transaction
      */
+    @Override
     public boolean isInTransaction(Handle handle)
     {
         try {

--- a/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
+++ b/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
@@ -43,16 +43,19 @@ public @interface BindIn
     public static final class CustomizerFactory implements SqlStatementCustomizerFactory
     {
 
+        @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
             throw new UnsupportedOperationException("Not supported on method!");
         }
 
+        @Override
         public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType)
         {
             throw new UnsupportedOperationException("Not supported on type");
         }
 
+        @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation,
                                                          Class sqlObjectType,
                                                          Method method,
@@ -77,6 +80,7 @@ public @interface BindIn
 
             return new SqlStatementCustomizer()
             {
+                @Override
                 public void apply(SQLStatement q) throws SQLException
                 {
                     q.define(key, ns);
@@ -87,6 +91,7 @@ public @interface BindIn
 
     public static class BindingFactory implements BinderFactory
     {
+        @Override
         public Binder build(Annotation annotation)
         {
             final BindIn in = (BindIn) annotation;
@@ -95,6 +100,7 @@ public @interface BindIn
             return new Binder()
             {
 
+                @Override
                 public void bind(SQLStatement q, Annotation bind, Object arg)
                 {
                     Iterable<?> coll = (Iterable<?>) arg;

--- a/src/main/java/org/skife/jdbi/v2/util/TypedMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/util/TypedMapper.java
@@ -58,6 +58,7 @@ public abstract class TypedMapper<T> implements ResultSetMapper<T>
         internal = new StringMapper(name);
     }
 
+    @Override
     public final T map(int index, ResultSet r, StatementContext ctx) throws SQLException
     {
         return internal.map(index, r, ctx);
@@ -77,6 +78,7 @@ public abstract class TypedMapper<T> implements ResultSetMapper<T>
             this.name = name;
         }
 
+        @Override
         public T map(int index, ResultSet r, StatementContext ctx) throws SQLException
         {
             return extractByName(r, name);
@@ -92,6 +94,7 @@ public abstract class TypedMapper<T> implements ResultSetMapper<T>
             this.index = index;
         }
 
+        @Override
         public T map(int index, ResultSet r, StatementContext ctx) throws SQLException
         {
             return extractByIndex(r, this.index);

--- a/src/test/java/org/skife/jdbi/v2/ExtraMatchers.java
+++ b/src/test/java/org/skife/jdbi/v2/ExtraMatchers.java
@@ -35,6 +35,7 @@ public class ExtraMatchers
         final List opts = Arrays.asList(options);
         return new BaseMatcher<T>()
         {
+            @Override
             public boolean matches(Object item)
             {
                 for (Object opt : opts) {
@@ -45,6 +46,7 @@ public class ExtraMatchers
                 return false;
             }
 
+            @Override
             public void describeTo(Description d)
             {
                 d.appendText("one of " + opts);

--- a/src/test/java/org/skife/jdbi/v2/TestArgumentFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/TestArgumentFactory.java
@@ -113,11 +113,13 @@ public class TestArgumentFactory
 
     public static class NameAF implements ArgumentFactory<Name>
     {
+        @Override
         public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx)
         {
             return expectedType == Object.class && value instanceof Name;
         }
 
+        @Override
         public Argument build(Class<?> expectedType, Name value, StatementContext ctx)
         {
             return new StringArgument(value.getFullName());
@@ -140,6 +142,7 @@ public class TestArgumentFactory
             return first + " " + last;
         }
 
+        @Override
         public String toString()
         {
             return "<Name first=" + first + " last=" + last + " >";

--- a/src/test/java/org/skife/jdbi/v2/TestContainerFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/TestContainerFactory.java
@@ -172,23 +172,27 @@ public class TestContainerFactory
     public static class SetContainerFactory implements ContainerFactory<Set<?>>
     {
 
+        @Override
         public boolean accepts(Class<?> type)
         {
             return Set.class.equals(type);
         }
 
+        @Override
         public ContainerBuilder<Set<?>> newContainerBuilderFor(Class<?> type)
         {
             return new ContainerBuilder<Set<?>>()
             {
                 private Set<Object> rs = new LinkedHashSet<Object>();
 
+                @Override
                 public ContainerBuilder<Set<?>> add(Object it)
                 {
                     rs.add(it);
                     return this;
                 }
 
+                @Override
                 public Set<?> build()
                 {
                     return rs;
@@ -200,23 +204,27 @@ public class TestContainerFactory
     public static class ImmutableListContainerFactory implements ContainerFactory<ImmutableList<?>>
     {
 
+        @Override
         public boolean accepts(Class<?> type)
         {
             return ImmutableList.class.equals(type);
         }
 
+        @Override
         public ContainerBuilder<ImmutableList<?>> newContainerBuilderFor(Class<?> type)
         {
             return new ContainerBuilder<ImmutableList<?>>()
             {
                 private final ImmutableList.Builder<Object> b = ImmutableList.builder();
 
+                @Override
                 public ContainerBuilder<ImmutableList<?>> add(Object it)
                 {
                     b.add(it);
                     return this;
                 }
 
+                @Override
                 public ImmutableList<?> build()
                 {
                     return b.build();
@@ -228,23 +236,27 @@ public class TestContainerFactory
     public static class MaybeContainerFactory implements ContainerFactory<Maybe<?>>
     {
 
+        @Override
         public boolean accepts(Class<?> type)
         {
             return type.equals(Maybe.class);
         }
 
+        @Override
         public ContainerBuilder<Maybe<?>> newContainerBuilderFor(Class<?> type)
         {
             return new ContainerBuilder<Maybe<?>>()
             {
                 private Maybe<Object> value = Maybe.unknown();
 
+                @Override
                 public ContainerBuilder<Maybe<?>> add(Object it)
                 {
                     value = value.otherwise(Maybe.definitely(it));
                     return this;
                 }
 
+                @Override
                 public Maybe<?> build()
                 {
                     return value;

--- a/src/test/java/org/skife/jdbi/v2/TestDBI.java
+++ b/src/test/java/org/skife/jdbi/v2/TestDBI.java
@@ -44,6 +44,7 @@ public class TestDBI extends DBITestCase
     {
         DBI dbi = new DBI(new ConnectionFactory()
         {
+            @Override
             public Connection openConnection()
             {
                 try
@@ -66,6 +67,7 @@ public class TestDBI extends DBITestCase
     {
         DBI dbi = new DBI(new ConnectionFactory()
         {
+            @Override
             public Connection openConnection() throws SQLException
             {
                 throw new SQLException();
@@ -96,6 +98,7 @@ public class TestDBI extends DBITestCase
     {
         DBI dbi = new DBI(DERBY_HELPER.getDataSource());
         String value = dbi.withHandle(new HandleCallback<String>() {
+            @Override
             public String withHandle(Handle handle) throws Exception
             {
                 handle.insert("insert into something (id, name) values (1, 'Brian')");

--- a/src/test/java/org/skife/jdbi/v2/TestHandle.java
+++ b/src/test/java/org/skife/jdbi/v2/TestHandle.java
@@ -36,6 +36,7 @@ public class TestHandle extends DBITestCase
 
         String value = h.inTransaction(new TransactionCallback<String>()
         {
+            @Override
             public String inTransaction(Handle handle, TransactionStatus status) throws Exception
             {
                 handle.insert("insert into something (id, name) values (1, 'Brian')");
@@ -55,14 +56,17 @@ public class TestHandle extends DBITestCase
 
         String value = new DBI(DERBY_HELPER.getJdbcConnectionString()).withHandle(new HandleCallback<String>()
         {
+            @Override
             public String withHandle(Handle handle) throws Exception
             {
                 return handle.inTransaction(new TransactionCallback<String>()
                 {
+                    @Override
                     public String inTransaction(Handle handle, TransactionStatus status) throws Exception
                     {
                         return handle.createQuery("select name from something where id = 1").map(new ResultSetMapper<String>()
                         {
+                            @Override
                             public String map(int index, ResultSet r, StatementContext ctx) throws SQLException
                             {
                                 return r.getString(1);

--- a/src/test/java/org/skife/jdbi/v2/TestPreparedBatch.java
+++ b/src/test/java/org/skife/jdbi/v2/TestPreparedBatch.java
@@ -63,6 +63,7 @@ public class TestPreparedBatch extends DBITestCase
 
         int row_count = h.createQuery("select count(id) from something").map(new ResultSetMapper<Integer>()
         {
+            @Override
             public Integer map(int index, ResultSet r, StatementContext ctx) throws SQLException
             {
                 return r.getInt(1);

--- a/src/test/java/org/skife/jdbi/v2/TestQueries.java
+++ b/src/test/java/org/skife/jdbi/v2/TestQueries.java
@@ -116,6 +116,7 @@ public class TestQueries extends DBITestCase
 
         Query<String> query = h.createQuery("select name from something order by id").map(new ResultSetMapper<String>()
         {
+            @Override
             public String map(int index, ResultSet r, StatementContext ctx) throws SQLException
             {
                 return r.getString(1);
@@ -335,7 +336,8 @@ public class TestQueries extends DBITestCase
         Map<String, Integer> rs = h.createQuery("select id, name from something")
                                    .fold(new HashMap<String, Integer>(), new Folder2<Map<String, Integer>>()
                                    {
-                                       public Map<String, Integer> fold(Map<String, Integer> a, ResultSet rs, StatementContext context) throws SQLException
+                                       @Override
+                                    public Map<String, Integer> fold(Map<String, Integer> a, ResultSet rs, StatementContext context) throws SQLException
                                        {
                                            a.put(rs.getString("name"), rs.getInt("id"));
                                            return a;
@@ -358,7 +360,8 @@ public class TestQueries extends DBITestCase
                            .map(StringMapper.FIRST)
                            .fold(new ArrayList<String>(), new Folder3<List<String>, String>()
                            {
-                               public List<String> fold(List<String> a, String rs, FoldController ctl, StatementContext ctx) throws SQLException
+                               @Override
+                            public List<String> fold(List<String> a, String rs, FoldController ctl, StatementContext ctx) throws SQLException
                                {
                                    a.add(rs);
                                    return a;

--- a/src/test/java/org/skife/jdbi/v2/TestRegisteredMappers.java
+++ b/src/test/java/org/skife/jdbi/v2/TestRegisteredMappers.java
@@ -55,6 +55,7 @@ public class TestRegisteredMappers
         Something sam = dbi.withHandle(new HandleCallback<Something>()
         {
 
+            @Override
             public Something withHandle(Handle handle) throws Exception
             {
                 handle.insert("insert into something (id, name) values (18, 'Sam')");

--- a/src/test/java/org/skife/jdbi/v2/TestSqlLogging.java
+++ b/src/test/java/org/skife/jdbi/v2/TestSqlLogging.java
@@ -52,67 +52,80 @@ public class TestSqlLogging extends DBITestCase
         logged = new ArrayList<String>();
         log = new SQLLog()
         {
+            @Override
             public void logBeginTransaction(Handle h)
             {
                 logged.add("begin");
             }
 
+            @Override
             public void logCommitTransaction(long time, Handle h)
             {
                 logged.add("commit");
             }
 
+            @Override
             public void logRollbackTransaction(long time, Handle h)
             {
                 logged.add("rollback");
             }
 
+            @Override
             public void logObtainHandle(long time, Handle h)
             {
                 logged.add("open");
             }
 
+            @Override
             public void logReleaseHandle(Handle h)
             {
                 logged.add("close");
             }
 
+            @Override
             public void logSQL(long time, String sql)
             {
                 logged.add(sql);
             }
 
+            @Override
             public void logPreparedBatch(long time, String sql, int count)
             {
                 logged.add(String.format("%d:%s", count, sql));
             }
 
+            @Override
             public BatchLogger logBatch()
             {
                 return new SQLLog.BatchLogger()
                 {
 
+                    @Override
                     public void add(String sql)
                     {
                         logged.add(sql);
                     }
 
+                    @Override
                     public void log(long time)
                     {
                     }
                 };
             }
 
+            @Override
             public void logCheckpointTransaction(Handle h, String name)
             {
                 logged.add(String.format("checkpoint %s created", name));
             }
 
+            @Override
             public void logReleaseCheckpointTransaction(Handle h, String name)
             {
                 logged.add(String.format("checkpoint %s released", name));
             }
 
+            @Override
             public void logRollbackToCheckpoint(long time, Handle h, String name)
             {
                 logged.add(String.format("checkpoint %s rolled back to", name));
@@ -231,6 +244,7 @@ public class TestSqlLogging extends DBITestCase
     {
         h.inTransaction(new TransactionCallback<Object>()
         {
+            @Override
             public Object inTransaction(Handle handle, TransactionStatus status) throws Exception
             {
                 assertTrue(logged.contains("begin"));
@@ -246,6 +260,7 @@ public class TestSqlLogging extends DBITestCase
         try {
             h.inTransaction(new TransactionCallback<Object>()
             {
+                @Override
                 public Object inTransaction(Handle handle, TransactionStatus status) throws Exception
                 {
                     assertTrue(logged.contains("begin"));

--- a/src/test/java/org/skife/jdbi/v2/TestStatementContext.java
+++ b/src/test/java/org/skife/jdbi/v2/TestStatementContext.java
@@ -31,6 +31,7 @@ public class TestStatementContext extends DBITestCase
         Handle h = openHandle();
         h.setStatementLocator(new StatementLocator() {
 
+            @Override
             public String locate(String name, StatementContext ctx) throws Exception
             {
                 return name.replaceAll("<table>", String.valueOf(ctx.getAttribute("table")));

--- a/src/test/java/org/skife/jdbi/v2/TestTimingCollector.java
+++ b/src/test/java/org/skife/jdbi/v2/TestTimingCollector.java
@@ -130,6 +130,7 @@ public class TestTimingCollector extends DBITestCase
     {
         private List<String> statements = new ArrayList<String>();
 
+        @Override
         public synchronized void collect(final long elapsedTime, final StatementContext ctx)
         {
             statements.add(ctx.getRawSql());

--- a/src/test/java/org/skife/jdbi/v2/TestTooManyCursors.java
+++ b/src/test/java/org/skife/jdbi/v2/TestTooManyCursors.java
@@ -53,6 +53,7 @@ public class TestTooManyCursors extends DBITestCase
         try {
             dbi.withHandle(new HandleCallback<Object>()
             {
+                @Override
                 public Void withHandle(Handle handle) throws Exception
                 {
                     handle.setStatementBuilder(new DefaultStatementBuilder());
@@ -79,41 +80,49 @@ public class TestTooManyCursors extends DBITestCase
             connCount = i;
         }
 
+        @Override
         public Connection getConnection() throws SQLException
         {
             return ConnectionInvocationHandler.newInstance(target.getConnection(), connCount);
         }
 
+        @Override
         public Connection getConnection(String string, String string1) throws SQLException
         {
             return ConnectionInvocationHandler.newInstance(target.getConnection(string, string1), connCount);
         }
 
+        @Override
         public PrintWriter getLogWriter() throws SQLException
         {
             return target.getLogWriter();
         }
 
+        @Override
         public void setLogWriter(PrintWriter printWriter) throws SQLException
         {
             target.setLogWriter(printWriter);
         }
 
+        @Override
         public void setLoginTimeout(int i) throws SQLException
         {
             target.setLoginTimeout(i);
         }
 
+        @Override
         public int getLoginTimeout() throws SQLException
         {
             return target.getLoginTimeout();
         }
 
+        @Override
         public <T> T unwrap(Class<T> iface) throws SQLException
         {
             return null;
         }
 
+        @Override
         public boolean isWrapperFor(Class<?> iface) throws SQLException
         {
             return false;
@@ -145,6 +154,7 @@ public class TestTooManyCursors extends DBITestCase
             this.numSuccessfulStatements = numSuccessfulStatements;
         }
 
+        @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
         {
             try {
@@ -197,6 +207,7 @@ public class TestTooManyCursors extends DBITestCase
             this.connectionHandler = connectionHandler;
         }
 
+        @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
         {
             if ("close".equals(method.getName())) {

--- a/src/test/java/org/skife/jdbi/v2/TestTransactions.java
+++ b/src/test/java/org/skife/jdbi/v2/TestTransactions.java
@@ -38,6 +38,7 @@ public class TestTransactions extends DBITestCase
 
         String woot = h.inTransaction(new TransactionCallback<String>()
         {
+            @Override
             public String inTransaction(Handle handle, TransactionStatus status) throws Exception
             {
                 return "Woot!";
@@ -78,6 +79,7 @@ public class TestTransactions extends DBITestCase
         {
             h.inTransaction(new TransactionCallback<Object>()
             {
+                @Override
                 public Object inTransaction(Handle handle, TransactionStatus status) throws Exception
                 {
                     handle.insert("insert into something (id, name) values (:id, :name)", 0, "Keith");
@@ -105,6 +107,7 @@ public class TestTransactions extends DBITestCase
         {
             h.inTransaction(new TransactionCallback<Object>()
             {
+                @Override
                 public Object inTransaction(Handle handle, TransactionStatus status) throws Exception
                 {
                     handle.insert("insert into something (id, name) values (:id, :name)", 0, "Keith");
@@ -165,6 +168,7 @@ public class TestTransactions extends DBITestCase
         Handle h = openHandle();
         try {
             h.inTransaction(new TransactionCallback<Object>() {
+                @Override
                 public Object inTransaction(Handle handle, TransactionStatus status) throws Exception
                 {
                     throw new IllegalArgumentException();

--- a/src/test/java/org/skife/jdbi/v2/docs/TestDocumentation.java
+++ b/src/test/java/org/skife/jdbi/v2/docs/TestDocumentation.java
@@ -134,6 +134,7 @@ public class TestDocumentation
         DBI dbi = new DBI("jdbc:h2:mem:" + UUID.randomUUID());
         dbi.withHandle(new HandleCallback<Void>()
         {
+            @Override
             public Void withHandle(Handle handle) throws Exception
             {
                 handle.execute("create table silly (id int)");
@@ -190,6 +191,7 @@ public class TestDocumentation
             .map(StringMapper.FIRST)
             .fold(new StringBuilder(), new Folder2<StringBuilder>()
             {
+                @Override
                 public StringBuilder fold(StringBuilder acc, ResultSet rs, StatementContext ctx) throws SQLException
                 {
                     acc.append(rs.getString(1)).append(", ");

--- a/src/test/java/org/skife/jdbi/v2/docs/TestInClauseExpansion.java
+++ b/src/test/java/org/skife/jdbi/v2/docs/TestInClauseExpansion.java
@@ -80,23 +80,27 @@ public class TestInClauseExpansion
     public static class ImmutableSetContainerFactory implements ContainerFactory<ImmutableSet>
     {
 
+        @Override
         public boolean accepts(Class<?> type)
         {
             return ImmutableSet.class.isAssignableFrom(type);
         }
 
+        @Override
         public ContainerBuilder<ImmutableSet> newContainerBuilderFor(Class<?> type)
         {
             return new ContainerBuilder<ImmutableSet>()
             {
                 final ImmutableSet.Builder<Object> builder = ImmutableSet.builder();
 
+                @Override
                 public ContainerBuilder<ImmutableSet> add(Object it)
                 {
                     builder.add(it);
                     return this;
                 }
 
+                @Override
                 public ImmutableSet build()
                 {
                     return builder.build();

--- a/src/test/java/org/skife/jdbi/v2/spring/DummyService.java
+++ b/src/test/java/org/skife/jdbi/v2/spring/DummyService.java
@@ -32,24 +32,28 @@ public class DummyService implements Service
         this.dbi = dbi;
     }
 
+    @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public void inPropagationRequired(Callback c)
     {
         c.call(dbi);
     }
 
+    @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void inRequiresNew(Callback c)
     {
         c.call(dbi);
     }
 
+    @Override
     @Transactional(propagation = Propagation.NESTED)
     public void inNested(Callback c)
     {
         c.call(dbi);
     }
 
+    @Override
     @Transactional(propagation=Propagation.REQUIRES_NEW, isolation = Isolation.READ_UNCOMMITTED)
     public void inRequiresNewReadUncommitted(Callback c)
     {

--- a/src/test/java/org/skife/jdbi/v2/spring/TestDBIFactoryBean.java
+++ b/src/test/java/org/skife/jdbi/v2/spring/TestDBIFactoryBean.java
@@ -96,6 +96,7 @@ public class TestDBIFactoryBean extends AbstractDependencyInjectionSpringContext
         try {
             service.inPropagationRequired(new Callback()
             {
+                @Override
                 public void call(IDBI dbi)
                 {
                     Handle h = DBIUtil.getHandle(dbi);
@@ -130,6 +131,7 @@ public class TestDBIFactoryBean extends AbstractDependencyInjectionSpringContext
         try {
             service.inPropagationRequired(new Callback()
             {
+                @Override
                 public void call(IDBI outer)
                 {
                     final Handle h = DBIUtil.getHandle(outer);
@@ -138,6 +140,7 @@ public class TestDBIFactoryBean extends AbstractDependencyInjectionSpringContext
                     try {
                         service.inNested(new Callback()
                         {
+                            @Override
                             public void call(IDBI inner)
                             {
                                 final Handle h = DBIUtil.getHandle(inner);
@@ -166,6 +169,7 @@ public class TestDBIFactoryBean extends AbstractDependencyInjectionSpringContext
 
         service.inPropagationRequired(new Callback()
         {
+            @Override
             public void call(IDBI dbi)
             {
                 final Handle h = DBIUtil.getHandle(dbi);
@@ -179,6 +183,7 @@ public class TestDBIFactoryBean extends AbstractDependencyInjectionSpringContext
     {
         service.inPropagationRequired(new Callback()
         {
+            @Override
             public void call(IDBI outer)
             {
                 final Handle h = DBIUtil.getHandle(outer);
@@ -187,6 +192,7 @@ public class TestDBIFactoryBean extends AbstractDependencyInjectionSpringContext
                 try {
                     service.inRequiresNewReadUncommitted(new Callback()
                     {
+                        @Override
                         public void call(IDBI inner)
                         {
                             final Handle h = DBIUtil.getHandle(inner);

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/BindSomething.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/BindSomething.java
@@ -34,10 +34,12 @@ public @interface BindSomething
 
     static class Factory implements BinderFactory
     {
+        @Override
         public Binder build(Annotation annotation)
         {
             return new Binder()
             {
+                @Override
                 public void bind(SQLStatement q, Annotation bind, Object arg)
                 {
                     BindSomething bs = (BindSomething) bind;

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/SomethingBinderAgainstBind.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/SomethingBinderAgainstBind.java
@@ -20,6 +20,7 @@ import org.skife.jdbi.v2.Something;
 
 public class SomethingBinderAgainstBind implements Binder<Bind, Something>
 {
+    @Override
     public void bind(SQLStatement q, Bind bind, Something it)
     {
         q.bind(bind.value() + ".id", it.getId());

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/SomethingMapper.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/SomethingMapper.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
 
 public class SomethingMapper implements ResultSetMapper<Something>
 {
+    @Override
     public Something map(int index, ResultSet r, StatementContext ctx) throws SQLException
     {
         return new Something(r.getInt("id"), r.getString("name"));

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeys.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeys.java
@@ -43,6 +43,7 @@ public class TestGetGeneratedKeys
         dbi = new DBI(ds);
         dbi.withHandle(new HandleCallback<Object>()
         {
+            @Override
             public Object withHandle(Handle handle) throws Exception
             {
                 handle.execute("create table something (id identity primary key, name varchar(32))");

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysPostgres.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysPostgres.java
@@ -37,6 +37,7 @@ public class TestGetGeneratedKeysPostgres
     public void setUp() throws Exception {
         dbi = new DBI("jdbc:postgresql:test", "postgres", "postgres");
         dbi.withHandle(new HandleCallback<Object>() {
+            @Override
             public Object withHandle(Handle handle) throws Exception
             {
                 handle.execute("create sequence id_sequence INCREMENT 1 START WITH 100");
@@ -49,6 +50,7 @@ public class TestGetGeneratedKeysPostgres
     @After
     public void tearDown() throws Exception {
         dbi.withHandle(new HandleCallback<Object>() {
+            @Override
             public Object withHandle(Handle handle) throws Exception
             {
                 handle.execute("drop table something");

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestMixinInterfaces.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestMixinInterfaces.java
@@ -111,6 +111,7 @@ public class TestMixinInterfaces
         txl.insert(7, "Keith");
 
         Something s = txl.inTransaction(new Transaction<Something, TransactionStuff>() {
+            @Override
             public Something inTransaction(TransactionStuff conn, TransactionStatus status) throws Exception
             {
                 return conn.byId(7);
@@ -127,6 +128,7 @@ public class TestMixinInterfaces
         txl.insert(7, "Keith");
 
         Something s = txl.inTransaction(TransactionIsolationLevel.SERIALIZABLE, new Transaction<Something, TransactionStuff>() {
+            @Override
             public Something inTransaction(TransactionStuff conn, TransactionStatus status) throws Exception
             {
                 Assert.assertEquals(TransactionIsolationLevel.SERIALIZABLE, conn.getHandle().getTransactionIsolationLevel());

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestOnDemandSqlObject.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestOnDemandSqlObject.java
@@ -254,6 +254,7 @@ public class TestOnDemandSqlObject
 
     static class CrashingMapper implements ResultSetMapper<Something>
     {
+        @Override
         public Something map(int index, ResultSet r, StatementContext ctx) throws SQLException
         {
             throw new SQLException("protocol error");

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestRegisterArgumentFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestRegisterArgumentFactory.java
@@ -82,15 +82,18 @@ public class TestRegisterArgumentFactory
 
     public static class NameAF implements ArgumentFactory<Name>
     {
+        @Override
         public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx)
         {
             return expectedType == Object.class && value instanceof Name;
         }
 
+        @Override
         public Argument build(Class<?> expectedType, final Name value, StatementContext ctx)
         {
             return new Argument()
             {
+                @Override
                 public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException
                 {
                     statement.setString(position, value.getFullName());
@@ -116,6 +119,7 @@ public class TestRegisterArgumentFactory
             return first + " " + last;
         }
 
+        @Override
         public String toString()
         {
             return "<Name first=" + first + " last=" + last + " >";

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestRegisterMapperFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestRegisterMapperFactory.java
@@ -89,11 +89,13 @@ public class TestRegisterMapperFactory
     public static class MyFactory implements ResultSetMapperFactory
     {
 
+        @Override
         public boolean accepts(Class type, StatementContext ctx)
         {
             return type.isAnnotationPresent(MapWith.class);
         }
 
+        @Override
         public ResultSetMapper mapperFor(Class type, StatementContext ctx)
         {
 
@@ -131,6 +133,7 @@ public class TestRegisterMapperFactory
 
         public static class FooMapper implements ResultSetMapper<Foo>
         {
+            @Override
             public Foo map(final int index, final ResultSet r, final StatementContext ctx) throws SQLException
             {
                 return new Foo(r.getInt("id"), r.getString("name"));

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestRegisteredMappersWork.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestRegisteredMappersWork.java
@@ -232,6 +232,7 @@ public class TestRegisteredMappersWork
 
     public static class MySomethingMapper implements ResultSetMapper<Something>
     {
+        @Override
         public Something map(int index, ResultSet r, StatementContext ctx) throws SQLException
         {
             return new Something(r.getInt("id"), r.getString("name"));


### PR DESCRIPTION
Now that we left Java5 behind, how about adding the missing @Override for interfaces.