### PR TITLE
Use Types.NULL for null objects

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/ObjectArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/ObjectArgument.java
@@ -40,7 +40,7 @@ class ObjectArgument implements Argument
             statement.setObject(position, value);
         }
         else {
-            statement.setNull(position, Types.OTHER);
+            statement.setNull(position, Types.NULL);
         }
     }
 


### PR DESCRIPTION
Oracle fails using PreparedBatches without this change. Any reason why it would not be correct for other databases? The tests all appear to still pass.