### PR TITLE
Cache original query, not key

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
@@ -111,7 +111,7 @@ public class ClasspathStatementLocator implements StatementLocator
             if (in_stream == null) {
                 // Ensure we don't store an identity map entry which has a hard reference
                 // to the key (through the value) by copying the value, avoids potential memory leak.
-                found.put(cache_key, name == cache_key ? new String(name) : cache_key);
+                found.put(cache_key, name == cache_key ? new String(name) : name);
                 return name;
             }
 

--- a/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
@@ -42,7 +42,7 @@ public class ClasspathStatementLocator implements StatementLocator
      */
     public static boolean looksLikeSql(String sql)
     {
-        final String local = left(stripStart(sql), 7).toLowerCase();
+        final String local = left(stripStart(sql), 8).toLowerCase();
         return local.startsWith("insert ")
                || local.startsWith("update ")
                || local.startsWith("select ")
@@ -51,6 +51,7 @@ public class ClasspathStatementLocator implements StatementLocator
                || local.startsWith("create ")
                || local.startsWith("alter ")
                || local.startsWith("merge ")
+               || local.startsWith("replace ")
                || local.startsWith("drop ");
     }
 


### PR DESCRIPTION
It looks like dd1e5ac25043c27f29a2509d2e64221667b530f7 introduced a pretty serious bug in `ClasspathStatementLocator` that we found when upgrading to 2.58. It was inserting `cache_key` instead of `name`, which seems to open up the possibility of the memory leak it was trying to prevent, but more importantly `cache_key` has the FQCN of the SqlObjectType prepended. Additionally, MySQL `replace` queries were sneaking past the `looksLikeSql` check. The end result was that our queries were getting transformed from something like `REPLACE INTO table (columns) VALUES (:values)` to `com/hubspot/ExampleDao/REPLACE INTO table (columns) VALUES (:values)` which is obviously invalid

@hgschmie @stevenschlansker 