### PR TITLE
Support for executing a script as a set of statements

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/Script.java
+++ b/src/main/java/org/skife/jdbi/v2/Script.java
@@ -49,6 +49,29 @@ public class Script
      */
     public int[] execute()
     {
+        final String[] statements = getStatements();
+        Batch b = handle.createBatch();
+        for (String s : statements)
+        {
+            if ( ! WHITESPACE_ONLY.matcher(s).matches() ) {
+                b.add(s);
+            }
+        }
+        return b.execute();
+    }
+
+    /**
+     * Execute this script as a set of separate statements
+     */
+    public void executeAsSeparateStatements() {
+        for (String s : getStatements()) {
+            if (!WHITESPACE_ONLY.matcher(s).matches()) {
+                handle.execute(s);
+            }
+        }
+    }
+
+    private String[] getStatements() {
         final String script;
         final StatementContext ctx = new ConcreteStatementContext(globalStatementAttributes);
         try
@@ -60,14 +83,6 @@ public class Script
             throw new UnableToExecuteStatementException(String.format("Error while loading script [%s]", name), e, ctx);
         }
 
-        final String[] statements = script.replaceAll("\n", " ").replaceAll("\r", "").split(";");
-        Batch b = handle.createBatch();
-        for (String s : statements)
-        {
-            if ( ! WHITESPACE_ONLY.matcher(s).matches() ) {
-                b.add(s);
-            }
-        }
-        return b.execute();
+        return script.replaceAll("\n", " ").replaceAll("\r", "").split(";");
     }
 }

--- a/src/test/java/org/skife/jdbi/v2/TestScript.java
+++ b/src/test/java/org/skife/jdbi/v2/TestScript.java
@@ -16,9 +16,10 @@
 package org.skife.jdbi.v2;
 
 import org.junit.Test;
-import org.skife.jdbi.v2.sqlobject.stringtemplate.StringTemplate3StatementLocator;
+import org.skife.jdbi.v2.exceptions.StatementException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  *
@@ -42,5 +43,18 @@ public class TestScript extends DBITestCase
         script.execute();
 
         assertEquals(3, h.select("select * from something").size());
+    }
+
+    @Test
+    public void testScriptAsSetOfSeparateStatements() throws Exception {
+        try {
+            BasicHandle h = openHandle();
+            Script script = h.createScript("malformed-sql-script");
+            script.executeAsSeparateStatements();
+            fail("Should fail because the script is malformed");
+        } catch (StatementException e) {
+            StatementContext context = e.getStatementContext();
+            assertEquals(context.getRawSql().trim(), "insert into something(id, name) values (2, eric)");
+        }
     }
 }

--- a/src/test/resources/malformed-sql-script.sql
+++ b/src/test/resources/malformed-sql-script.sql
@@ -1,0 +1,20 @@
+--
+-- Copyright (C) 2004 - 2014 Brian McCallister
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- insert some data to make tests easier
+insert into something(id, name) values (1, 'keith');
+insert into something(id, name) values (2, eric);
+insert into something(id, name) values (3, 'brian');


### PR DESCRIPTION
It's highly useful during development. In that case JDBI returns a debug statement context, where we can inspect information about a failed statement.

If the script is executed as a batch, we don't have such information and are forced to search an error manually.