### PR TITLE
Give a warning if SingleValueResult annotation is omitted

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
@@ -29,9 +29,13 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 abstract class ResultReturnThing
 {
+    private static final Logger LOGGER = Logger.getLogger(ResultReturnThing.class.getName());
+
     public Object map(ResolvedMethod method, Query q, HandleDing h)
     {
         if (method.getRawMember().isAnnotationPresent(Mapper.class)) {
@@ -100,6 +104,11 @@ abstract class ResultReturnThing
                 this.containerType = method.getReturnType().getErasedType();
             }
             else {
+                if (!method.getReturnType().getTypeBindings().isEmpty()) {
+                    LOGGER.log(Level.WARNING, "Generic information about return type '" + method.getReturnType() +
+                            "' in method '" + method.getName() + "' of class '" + method.getDeclaringType() +
+                            "' is ignored. Consider to add @SingleValueResult annotation.");
+                }
                 this.returnType = method.getReturnType().getErasedType();
                 this.containerType = null;
             }

--- a/src/test/java/org/skife/jdbi/v2/TestContainerFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/TestContainerFactory.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableSet;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class TestContainerFactory
 {
@@ -139,6 +140,18 @@ public class TestContainerFactory
         assertThat(rs, equalTo((Set<String>)ImmutableSet.of("Coda", "Brian")));
     }
 
+    @Test
+    public void testWarningAboutMissedSingleValueResultAnnotation() {
+        Dao dao = dbi.onDemand(Dao.class);
+        dao.insert(new Something(1, "Coda"));
+
+        try {
+            dao.wrongFindNameById(1);
+            fail("Should fail because there is no @SingleValueResult annotation");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
     @RegisterContainerMapper({ImmutableListContainerFactory.class, MaybeContainerFactory.class})
     public static interface Dao extends Base<String>
@@ -159,6 +172,9 @@ public class TestContainerFactory
         @SqlQuery("select name from something where id = :id")
         @SingleValueResult
         public Maybe<String> smartFindNameById(@Bind("id") int id);
+
+        @SqlQuery("select name from something where id = :id")
+        public Maybe<String> wrongFindNameById(@Bind("id") int id);
     }
 
     public static interface Base<T>


### PR DESCRIPTION
If a user set a parametrized type as a return type of method and didn't set @SingleValueResult then generic information is erased and JDBI will try to map only generic type.

The problem that the user doesn't have a clue about why his query doesn't work. 
He will just get a mapper exception or null.

In this this case we could give a warning to him that he probably forgot to place an annotation to the method. This is highly useful during development, when probability of missing an annotation is very high.

Because JDBI doesn't have any logger dependency, I've chosen *java.util.logging* as a target. Because this is message is intended only for development environment, printing to the error console should be fine.