### PR TITLE
Switch cglib-nodep to cglib, so we can manage ASM version to bring in bugfixes

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -3,6 +3,8 @@
   - Add support for /* */ style comments in statements
   - Add @BindMap annotation which allows parameters passed in a Map<String, Object>
   - Add support for running Script objects as individual statements rather than batch
+  - Add support for default bind name based on argument position number (thanks @arteam)
+  - Fix SqlObject connection leak through result iterator (thanks @pierre)
 
 2.59
   - Fixes #137, broken ClasspathStatementLocator cache (thanks @HiJon89).

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -5,6 +5,8 @@
   - Add support for running Script objects as individual statements rather than batch
   - Add support for default bind name based on argument position number (thanks @arteam)
   - Fix SqlObject connection leak through result iterator (thanks @pierre)
+  - Switch to using cglib instead of cglib-nodep so we can pull ASM 5.0.2 which is Java 8 compatible
+  - Classmate to 1.1.0
 
 2.59
   - Fixes #137, broken ClasspathStatementLocator cache (thanks @HiJon89).

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.basepom</groupId>
         <artifactId>basepom-standard-oss</artifactId>
-        <version>9</version>
+        <version>11</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -97,14 +97,14 @@
 
         <dependency>
             <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
+            <artifactId>cglib</artifactId>
             <version>3.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml</groupId>
             <artifactId>classmate</artifactId>
-            <version>0.9.0</version>
+            <version>1.1.0</version>
         </dependency>
 
         <dependency>
@@ -163,6 +163,12 @@
             <artifactId>easymock</artifactId>
             <version>3.3</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>cglib</groupId>
+                    <artifactId>cglib-nodep</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -209,6 +215,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>5.0.2</version>
+            </dependency>
+
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>

--- a/src/main/java/org/skife/jdbi/v2/ObjectArgument.java
+++ b/src/main/java/org/skife/jdbi/v2/ObjectArgument.java
@@ -21,9 +21,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 
-/**
- *
- */
 class ObjectArgument implements Argument
 {
     private final Object value;
@@ -47,5 +44,9 @@ class ObjectArgument implements Argument
     @Override
     public String toString() {
         return String.valueOf(value);
+    }
+
+    public Object getValue() {
+        return value;
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindBean.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindBean.java
@@ -25,6 +25,6 @@ import java.lang.annotation.Target;
 @BindingAnnotation(BindBeanFactory.class)
 public @interface BindBean
 {
-    static final String BARE_BINDING = "___jdbi_bare___";
+    final String BARE_BINDING = "___jdbi_bare___";
     String value() default BARE_BINDING;
 }


### PR DESCRIPTION
Need to exclude cglib-nodep from easymock
Manage ASM to 5.0.2 which works on Java 8, fixes #144