### PR TITLE
sqlobject: fix connection leak in IteratorResultReturnThing

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
@@ -162,12 +162,18 @@ abstract class ResultReturnThing
         protected Object result(ResultBearing q, final HandleDing baton)
         {
             final ResultIterator itty = q.iterator();
-            baton.retain("iterator");
+
+            final boolean isEmpty = !itty.hasNext();
+            if (isEmpty) {
+                itty.close();
+            } else {
+                baton.retain("iterator");
+            }
 
             return new ResultIterator()
             {
-                private boolean closed = false;
-                private boolean hasNext = itty.hasNext();
+                private boolean closed = isEmpty;
+                private boolean hasNext = !isEmpty;
 
                 @Override
                 public void close()

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestOnDemandSqlObject.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestOnDemandSqlObject.java
@@ -185,6 +185,17 @@ public class TestOnDemandSqlObject
     }
 
     @Test
+    public void testIteratorClosedIfEmpty() throws Exception {
+        HandleTrackerDBI dbi = new HandleTrackerDBI(ds);
+
+        Spiffy spiffy = SqlObjectBuilder.onDemand(dbi, Spiffy.class);
+
+        ResultIterator<Something> nothing = spiffy.findAll();
+
+        assertFalse(dbi.hasOpenedHandle());
+    }
+
+    @Test
     public void testIteratorPrepatureClose() throws Exception {
         HandleTrackerDBI dbi = new HandleTrackerDBI(ds);
 


### PR DESCRIPTION
When the underlying ResultIterator was empty, the HandleDing
wasn't released.

This fixes a regression introduced by 2b4a7247aa2b773d7914809def94520bfa0655a0.
