### PR TITLE
Added support for concurrent updatable resultsets.

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilder.java
+++ b/src/main/java/org/skife/jdbi/v2/DefaultStatementBuilder.java
@@ -20,6 +20,7 @@ import org.skife.jdbi.v2.tweak.StatementBuilder;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -43,6 +44,9 @@ public class DefaultStatementBuilder implements StatementBuilder
     {
         if (ctx.isReturningGeneratedKeys()) {
             return conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+        }
+        else if (ctx.isConcurrentUpdatable()) {
+            return conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
         }
         else {
             return conn.prepareStatement(sql);

--- a/src/main/java/org/skife/jdbi/v2/Query.java
+++ b/src/main/java/org/skife/jdbi/v2/Query.java
@@ -398,6 +398,19 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
         return this;
     }
 
+    /**
+     * Specify that the result set should be concurrent updatable.
+     *
+     * This will allow the update methods to be called on the result set produced by this
+     * Query.
+     *
+     * @return the modified query
+     */
+    public Query<ResultType> concurrentUpdatable() {
+        getConcreteContext().setConcurrentUpdatable(true);
+        return this;
+    }
+
     public void registerMapper(ResultSetMapper m)
     {
         this.mappingRegistry.add(new InferredMapperFactory(m));

--- a/src/main/java/org/skife/jdbi/v2/StatementContext.java
+++ b/src/main/java/org/skife/jdbi/v2/StatementContext.java
@@ -110,4 +110,15 @@ public interface StatementContext
 
     void addCleanable(Cleanable cleanable);
 
+    /**
+     * Return if the statement should be concurrent updatable.
+     *
+     * If this returns true, the concurrency level of the created ResultSet will be
+     * {@link java.sql.ResultSet#CONCUR_UPDATABLE}, otherwise the result set is not updatable,
+     * and will have concurrency level {@link java.sql.ResultSet#CONCUR_READ_ONLY}.
+     *
+     * @return if the statement generated should be concurrent updatable.
+     */
+    boolean isConcurrentUpdatable();
+
 }

--- a/src/test/java/org/skife/jdbi/v2/ConcreteStatementContextTest.java
+++ b/src/test/java/org/skife/jdbi/v2/ConcreteStatementContextTest.java
@@ -1,6 +1,20 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.skife.jdbi.v2;
 
-import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.util.Collections;

--- a/src/test/java/org/skife/jdbi/v2/ConcreteStatementContextTest.java
+++ b/src/test/java/org/skife/jdbi/v2/ConcreteStatementContextTest.java
@@ -1,0 +1,28 @@
+package org.skife.jdbi.v2;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class ConcreteStatementContextTest {
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testShouldNotBeAbleToCombineGeneratedKeysAndConcurrentUpdatable() throws Exception {
+        final ConcreteStatementContext context =
+                new ConcreteStatementContext(Collections.<String, Object>emptyMap());
+
+        context.setReturningGeneratedKeys(true);
+        context.setConcurrentUpdatable(true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testShouldNotBeAbleToCombineConcurrentUpdatableAndGeneratedKeys() throws Exception {
+        final ConcreteStatementContext context =
+                new ConcreteStatementContext(Collections.<String, Object>emptyMap());
+
+        context.setConcurrentUpdatable(true);
+        context.setReturningGeneratedKeys(true);
+    }
+}

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestConcurrentUpdatingQuery.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestConcurrentUpdatingQuery.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.Query;
+import org.skife.jdbi.v2.Something;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.sqlobject.customizers.Mapper;
+import org.skife.jdbi.v2.sqlobject.mixins.CloseMe;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.skife.jdbi.v2.util.StringMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class TestConcurrentUpdatingQuery
+{
+    private DBI    dbi;
+    private Handle handle;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:" + UUID.randomUUID());
+        dbi = new DBI(ds);
+        handle = dbi.open();
+
+        handle.execute("create table something (id int primary key, name varchar(100))");
+
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        handle.execute("drop table something");
+        handle.close();
+    }
+
+    @Test
+    public void testConcurrentUpdateableResultSet() throws Exception
+    {
+        handle.execute("insert into something (id, name) values (7, 'Tim')");
+        handle.createQuery("select id, name from something where id = :id")
+                .bind("id", 7)
+                .concurrentUpdatable()
+                .map(new ResultSetMapper<Object>() {
+                    @Override
+                    public Object map(final int index,
+                                      final ResultSet r,
+                                      final StatementContext ctx) throws SQLException {
+                        r.updateString("name", "Tom");
+                        r.updateRow();
+                        return null;
+                    }
+                }).list();
+
+        final String name = handle.createQuery("select name from something where id = :id")
+                .bind("id", 7)
+                .map(StringMapper.FIRST)
+                .first();
+
+        assertEquals("Tom", name);
+    }
+
+}

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/stringtemplate/TestingStatementContext.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/stringtemplate/TestingStatementContext.java
@@ -111,4 +111,10 @@ public class TestingStatementContext implements StatementContext
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean isConcurrentUpdatable() {
+        throw new UnsupportedOperationException();
+    }
+
 }


### PR DESCRIPTION
This adds support for creating result sets that are concurrent
updatable. This is usefull for when one needs to traverse and update a
result set in one query.