### PR TITLE
Fix regression in withHandle

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/BasicHandle.java
+++ b/src/main/java/org/skife/jdbi/v2/BasicHandle.java
@@ -328,12 +328,12 @@ class BasicHandle implements Handle
     }
 
     @Override
-    public void inTransaction(final TransactionConsumer callback)
+    public void useTransaction(final TransactionConsumer callback)
     {
         transactions.inTransaction(this, new VoidTransactionCallback() {
             @Override
             protected void execute(Handle handle, TransactionStatus status) throws Exception {
-                callback.inTransaction(handle, status);
+                callback.useTransaction(handle, status);
             }
         });
     }
@@ -367,12 +367,12 @@ class BasicHandle implements Handle
     }
 
     @Override
-    public void inTransaction(TransactionIsolationLevel level, final TransactionConsumer callback)
+    public void useTransaction(TransactionIsolationLevel level, final TransactionConsumer callback)
     {
         inTransaction(level, new VoidTransactionCallback() {
             @Override
             protected void execute(Handle handle, TransactionStatus status) throws Exception {
-                callback.inTransaction(handle, status);
+                callback.useTransaction(handle, status);
             }
         });
     }

--- a/src/main/java/org/skife/jdbi/v2/DBI.java
+++ b/src/main/java/org/skife/jdbi/v2/DBI.java
@@ -300,12 +300,12 @@ public class DBI implements IDBI
      *                                 wrap the exception thrown by the callback.
      */
     @Override
-    public void withHandle(final HandleConsumer callback) throws CallbackFailedException
+    public void useHandle(final HandleConsumer callback) throws CallbackFailedException
     {
         withHandle(new VoidHandleCallback() {
             @Override
             protected void execute(Handle handle) throws Exception {
-                callback.withHandle(handle);
+                callback.useHandle(handle);
             }
         });
     }
@@ -336,13 +336,13 @@ public class DBI implements IDBI
     }
 
     @Override
-    public void inTransaction(final TransactionConsumer callback) throws CallbackFailedException
+    public void useTransaction(final TransactionConsumer callback) throws CallbackFailedException
     {
-        withHandle(new HandleConsumer() {
+        useHandle(new HandleConsumer() {
             @Override
-            public void withHandle(Handle handle) throws Exception
+            public void useHandle(Handle handle) throws Exception
             {
-                handle.inTransaction(callback);
+                handle.useTransaction(callback);
             }
         });
     }
@@ -360,13 +360,13 @@ public class DBI implements IDBI
     }
 
     @Override
-    public void inTransaction(final TransactionIsolationLevel isolation, final TransactionConsumer callback) throws CallbackFailedException
+    public void useTransaction(final TransactionIsolationLevel isolation, final TransactionConsumer callback) throws CallbackFailedException
     {
-        withHandle(new HandleConsumer() {
+        useHandle(new HandleConsumer() {
             @Override
-            public void withHandle(Handle handle) throws Exception
+            public void useHandle(Handle handle) throws Exception
             {
-                handle.inTransaction(isolation, callback);
+                handle.useTransaction(isolation, callback);
             }
         });
     }

--- a/src/main/java/org/skife/jdbi/v2/Handle.java
+++ b/src/main/java/org/skife/jdbi/v2/Handle.java
@@ -152,7 +152,7 @@ public interface Handle extends Closeable
      *
      * @throws TransactionFailedException if the transaction failed in the callback
      */
-    void inTransaction(TransactionConsumer callback) throws TransactionFailedException;
+    void useTransaction(TransactionConsumer callback) throws TransactionFailedException;
 
     /**
      * Executes <code>callback</code> in a transaction. If the transaction succeeds, the
@@ -179,7 +179,7 @@ public interface Handle extends Closeable
      * @return value returned from the callback
      * @throws TransactionFailedException if the transaction failed in the callback
      */
-    void inTransaction(TransactionIsolationLevel level, TransactionConsumer callback) throws TransactionFailedException;
+    void useTransaction(TransactionIsolationLevel level, TransactionConsumer callback) throws TransactionFailedException;
 
     /**
      * Convenience method which executes a select with purely positional arguments

--- a/src/main/java/org/skife/jdbi/v2/IDBI.java
+++ b/src/main/java/org/skife/jdbi/v2/IDBI.java
@@ -69,7 +69,7 @@ public interface IDBI
      * @throws CallbackFailedException Will be thrown if callback raises an exception. This exception will
      *                                 wrap the exception thrown by the callback.
      */
-    void withHandle(HandleConsumer callback) throws CallbackFailedException;
+    void useHandle(HandleConsumer callback) throws CallbackFailedException;
 
     /**
      * A convenience function which manages the lifecycle of a handle and yields it to a callback
@@ -99,7 +99,7 @@ public interface IDBI
      * @throws CallbackFailedException Will be thrown if callback raises an exception. This exception will
      *                                 wrap the exception thrown by the callback.
      */
-    void inTransaction(TransactionConsumer callback) throws CallbackFailedException;
+    void useTransaction(TransactionConsumer callback) throws CallbackFailedException;
 
     /**
      * A convenience function which manages the lifecycle of a handle and yields it to a callback
@@ -131,7 +131,7 @@ public interface IDBI
      * @throws CallbackFailedException Will be thrown if callback raises an exception. This exception will
      *                                 wrap the exception thrown by the callback.
      */
-    void inTransaction(TransactionIsolationLevel isolation, TransactionConsumer callback) throws CallbackFailedException;
+    void useTransaction(TransactionIsolationLevel isolation, TransactionConsumer callback) throws CallbackFailedException;
 
     /**
      * Open a handle and attach a new sql object of the specified type to that handle. Be sure to close the

--- a/src/main/java/org/skife/jdbi/v2/TransactionConsumer.java
+++ b/src/main/java/org/skife/jdbi/v2/TransactionConsumer.java
@@ -21,5 +21,5 @@ package org.skife.jdbi.v2;
  */
 public interface TransactionConsumer
 {
-    void inTransaction(Handle conn, TransactionStatus status) throws Exception;
+    void useTransaction(Handle conn, TransactionStatus status) throws Exception;
 }

--- a/src/main/java/org/skife/jdbi/v2/tweak/HandleConsumer.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/HandleConsumer.java
@@ -18,7 +18,7 @@ package org.skife.jdbi.v2.tweak;
 import org.skife.jdbi.v2.Handle;
 
 /**
- * Callback for use with {@link org.skife.jdbi.v2.DBI#withHandle(HandleConsumer)}
+ * Callback for use with {@link org.skife.jdbi.v2.DBI#useHandle(HandleConsumer)}
  */
 public interface HandleConsumer
 {
@@ -31,5 +31,5 @@ public interface HandleConsumer
      * @throws Exception will result in a {@link org.skife.jdbi.v2.exceptions.CallbackFailedException} wrapping
      *                   the exception being thrown
      */
-    void withHandle(Handle handle) throws Exception;
+    void useHandle(Handle handle) throws Exception;
 }

--- a/src/test/java/org/skife/jdbi/v2/TestDBI.java
+++ b/src/test/java/org/skife/jdbi/v2/TestDBI.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
 import org.skife.jdbi.v2.tweak.ConnectionFactory;
 import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.skife.jdbi.v2.tweak.HandleConsumer;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -99,12 +100,25 @@ public class TestDBI extends DBITestCase
         DBI dbi = new DBI(DERBY_HELPER.getDataSource());
         String value = dbi.withHandle(new HandleCallback<String>() {
             @Override
-            public String withHandle(Handle handle) throws Exception
-            {
+            public String withHandle(Handle handle) throws Exception {
                 handle.insert("insert into something (id, name) values (1, 'Brian')");
                 return handle.createQuery("select name from something where id = 1").map(Something.class).first().getName();
             }
         });
         assertEquals("Brian", value);
+    }
+
+    @Test
+    public void testUseHandle() throws Exception
+    {
+        DBI dbi = new DBI(DERBY_HELPER.getDataSource());
+        dbi.useHandle(new HandleConsumer() {
+            @Override
+            public void useHandle(Handle handle) throws Exception {
+                handle.insert("insert into something (id, name) values (1, 'Brian')");
+                String value = handle.createQuery("select name from something where id = 1").map(Something.class).first().getName();
+                assertEquals("Brian", value);
+            }
+        });
     }
 }


### PR DESCRIPTION
PR #156 introduced a regression due to Java 8 overload resolution. This change renames all `withHandle` methods that take a `HandleConsumer` to `useHandle`, and all `inTransaction` methods that take a `TransactionConsumer` to `useTransaction`, to eliminate the ambiguous overload.

cc @osi