### PR TITLE
Throw appropriate exception in case of nested transactions

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/PassThroughTransactionHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/PassThroughTransactionHandler.java
@@ -20,6 +20,7 @@ import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.TransactionCallback;
 import org.skife.jdbi.v2.TransactionIsolationLevel;
 import org.skife.jdbi.v2.TransactionStatus;
+import org.skife.jdbi.v2.exceptions.TransactionException;
 
 import java.lang.reflect.Method;
 
@@ -38,6 +39,11 @@ class PassThroughTransactionHandler implements Handler
         ding.retain("pass-through-transaction");
         try {
             Handle h = ding.getHandle();
+
+            if (h.isInTransaction()) {
+                throw new TransactionException("Nested @Transaction detected - this is currently not supported.");
+            }
+
             if (isolation == TransactionIsolationLevel.INVALID_LEVEL) {
                 return h.inTransaction(new TransactionCallback<Object>()
                 {

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestClassBasedSqlObject.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestClassBasedSqlObject.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Something;
+import org.skife.jdbi.v2.exceptions.TransactionException;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.subpackage.SomethingDao;
 
@@ -85,6 +86,28 @@ public class TestClassBasedSqlObject
         dao.totallyBroken();
     }
 
+    @Test
+    public void testSimpleTransactionsSucceed() throws Exception
+    {
+        final SomethingDao dao = dbi.onDemand(SomethingDao.class);
+
+        dao.insertInSingleTransaction(10, "Linda");
+    }
+
+    /**
+     * Currently, nested transactions are not supported. Make sure an appropriate exception is
+     * thrown in that case.
+     * <p>
+     *
+     * Side note: H2 does not have a problem with nested transactions - but MySQL has.
+     */
+    @Test(expected = TransactionException.class)
+    public void testNestedTransactionsThrowException()
+    {
+        final SomethingDao dao = dbi.onDemand(SomethingDao.class);
+        dao.insertInNestedTransaction(11, "Angelina");
+    }
+
     @RegisterMapper(SomethingMapper.class)
     public static abstract class Dao
     {
@@ -101,4 +124,5 @@ public class TestClassBasedSqlObject
         public abstract void totallyBroken();
 
     }
+
 }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestTransactionAnnotation.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestTransactionAnnotation.java
@@ -84,16 +84,6 @@ public class TestTransactionAnnotation
     }
 
     @Test
-    public void testNestedTransactions() throws Exception
-    {
-        Dao dao = handle.attach(Dao.class);
-
-        Something s = dao.insertAndFetchWithNestedTransaction(1, "Ian");
-        assertThat(s, equalTo(new Something(1, "Ian")));
-
-    }
-
-    @Test
     public void testTxActuallyCommits() throws Exception
     {
         Handle h2 = dbi.open();
@@ -194,12 +184,6 @@ public class TestTransactionAnnotation
         {
             insert(id, name);
             return findById(id);
-        }
-
-        @Transaction
-        public Something insertAndFetchWithNestedTransaction(int id, String name)
-        {
-            return insertAndFetch(id, name);
         }
 
         @Transaction

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/subpackage/SomethingDao.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/subpackage/SomethingDao.java
@@ -20,6 +20,7 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SomethingMapper;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.Transaction;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 
 @RegisterMapper(SomethingMapper.class)
@@ -36,5 +37,19 @@ public abstract class SomethingDao
     }
 
     public abstract void totallyBroken();
+
+
+    @Transaction
+    public void insertInSingleTransaction(final int id, final String name)
+    {
+        insert(id, name);
+    }
+
+    @Transaction
+    public void insertInNestedTransaction(final int id, final String name)
+    {
+        insertInSingleTransaction(id, name);
+    }
+
 
 }


### PR DESCRIPTION
* When making a call through several methods of a DAO, and more than one
of those methods have a @Transaction annotation, an exception is thrown
by certain databases (e.g. MySQL). 

* This exception, however, is not really clear and does not help to
detect the error.

* Since nested transactions are not supported by JDBI at the moment,
throw a TransactionException with a more meaninful error message.

Fixes #165