### PR TITLE
Initial support for plugging in new exception handling strategies.

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/BaseStatement.java
+++ b/src/main/java/org/skife/jdbi/v2/BaseStatement.java
@@ -1,6 +1,5 @@
 package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.BaseStatementCustomizer;
 import org.skife.jdbi.v2.tweak.StatementCustomizer;
 
@@ -63,7 +62,7 @@ abstract class BaseStatement
                 customizer.beforeExecution(stmt, context);
             }
             catch (SQLException e) {
-                throw new UnableToExecuteStatementException("Exception thrown in statement customization", e, context);
+                throw context.getExceptionPolicy().unableToExecuteStatement("Exception thrown in statement customization", e, context);
             }
         }
     }
@@ -75,7 +74,7 @@ abstract class BaseStatement
                 customizer.afterExecution(stmt, context);
             }
             catch (SQLException e) {
-                throw new UnableToExecuteStatementException("Exception thrown in statement customization", e, context);
+                throw context.getExceptionPolicy().unableToExecuteStatement("Exception thrown in statement customization", e, context);
             }
         }
     }
@@ -87,7 +86,7 @@ abstract class BaseStatement
                 customizer.cleanup(context);
             }
             catch (SQLException e) {
-                throw new UnableToExecuteStatementException("Could not clean up", e, context);
+                throw context.getExceptionPolicy().unableToExecuteStatement("Could not clean up", e, context);
             }
         }
     }

--- a/src/main/java/org/skife/jdbi/v2/BeanPropertyArguments.java
+++ b/src/main/java/org/skife/jdbi/v2/BeanPropertyArguments.java
@@ -16,7 +16,6 @@
 
 package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
 import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.NamedArgumentFinder;
 
@@ -47,10 +46,9 @@ class BeanPropertyArguments implements NamedArgumentFinder
         }
         catch (IntrospectionException e)
         {
-            throw new UnableToCreateStatementException("Failed to introspect object which is supposed ot be used to" +
+            throw ctx.getExceptionPolicy().unableToCreateStatement("Failed to introspect object which is supposed ot be used to" +
                                                        " set named args for a statement via JavaBean properties", e, ctx);
         }
-
     }
 
     public Argument find(String name)
@@ -67,13 +65,13 @@ class BeanPropertyArguments implements NamedArgumentFinder
                 }
                 catch (IllegalAccessException e)
                 {
-                    throw new UnableToCreateStatementException(String.format("Access excpetion invoking getter for " +
+                    throw ctx.getExceptionPolicy().unableToCreateStatement(String.format("Access excpetion invoking getter for " +
                                                                              "bean property [%s] on [%s]",
                                                                              name, bean), e, ctx);
                 }
                 catch (InvocationTargetException e)
                 {
-                    throw new UnableToCreateStatementException(String.format("Invocation target exception invoking " +
+                    throw ctx.getExceptionPolicy().unableToCreateStatement(String.format("Invocation target exception invoking " +
                                                                              "getter for bean property [%s] on [%s]",
                                                                              name, bean), e, ctx);
                 }

--- a/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
@@ -119,7 +119,7 @@ public class ClasspathStatementLocator implements StatementLocator
                 }
             }
             catch (IOException e) {
-                throw new UnableToCreateStatementException(e.getMessage(), e, ctx);
+                throw ctx.getExceptionPolicy().unableToCreateStatement(e.getMessage(), e, ctx);
             }
 
             String sql = buffer.toString();

--- a/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
@@ -19,8 +19,6 @@ package org.skife.jdbi.v2;
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.Token;
 import org.skife.jdbi.rewriter.colon.ColonStatementLexer;
-import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
-import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.RewrittenStatement;
 import org.skife.jdbi.v2.tweak.StatementRewriter;
@@ -57,7 +55,7 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
             return new MyRewrittenStatement(parsedSql, stmt, ctx);
         }
         catch (IllegalArgumentException e) {
-            throw new UnableToCreateStatementException("Exception parsing for named parameter replacement", e, ctx);
+            throw ctx.getExceptionPolicy().unableToCreateStatement("Exception parsing for named parameter replacement", e, ctx);
         }
 
     }
@@ -120,7 +118,7 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
                         a.apply(i + 1, statement, this.context);
                         }
                         catch (SQLException e) {
-                            throw new UnableToExecuteStatementException(
+                            throw context.getExceptionPolicy().unableToExecuteStatement(
                                     String.format("Exception while binding positional param at (0 based) position %d",
                                                   i), e, context);
                         }
@@ -145,14 +143,14 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
                                                    "\"%s\" and no positional param for place %d (which is %d in " +
                                                    "the JDBC 'start at 1' scheme) has been set.",
                                                    named_param, i, i + 1);
-                        throw new UnableToExecuteStatementException(msg, context);
+                        throw context.getExceptionPolicy().unableToExecuteStatement(msg, context);
                     }
 
                     try {
                         a.apply(i + 1, statement, this.context);
                     }
                     catch (SQLException e) {
-                        throw new UnableToCreateStatementException(String.format("Exception while binding '%s'",
+                        throw context.getExceptionPolicy().unableToCreateStatement(String.format("Exception while binding '%s'",
                                                                                  named_param), e, context);
                     }
                     i++;

--- a/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
+++ b/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
@@ -8,10 +8,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
+
 public final class ConcreteStatementContext implements StatementContext
 {
     private final List<Cleanable> cleanables = new ArrayList<Cleanable>();
     private final Map<String, Object>        attributes = new HashMap<String, Object>();
+    private final Handle handle;
 
     private String            rawSql;
     private String            rewrittenSql;
@@ -23,8 +26,9 @@ public final class ConcreteStatementContext implements StatementContext
     private Method            sqlObjectMethod;
     private boolean           returningGeneratedKeys;
 
-    ConcreteStatementContext(Map<String, Object> globalAttributes)
+    ConcreteStatementContext(Handle handle, Map<String, Object> globalAttributes)
     {
+        this.handle = handle;
         attributes.putAll(globalAttributes);
     }
 
@@ -193,5 +197,16 @@ public final class ConcreteStatementContext implements StatementContext
     public List<Cleanable> getCleanables()
     {
         return cleanables;
+    }
+    
+    public Handle getHandle()
+    {
+        return handle;
+    }
+
+    public ExceptionPolicy getExceptionPolicy()
+    {
+        // Handle will be null in tests sometimes
+        return handle == null ? new ExceptionPolicy() : handle.getExceptionPolicy();
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/DefaultMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/DefaultMapper.java
@@ -16,7 +16,6 @@
 
 package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.exceptions.ResultSetException;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.sql.ResultSet;
@@ -37,7 +36,7 @@ public class DefaultMapper implements ResultSetMapper<Map<String, Object>>
         }
         catch (SQLException e)
         {
-            throw new ResultSetException("Unable to obtain metadata from result set", e, ctx);
+            throw ctx.getExceptionPolicy().resultSetFailure("Unable to obtain metadata from result set", e, ctx);
         }
 
         try
@@ -52,7 +51,7 @@ public class DefaultMapper implements ResultSetMapper<Map<String, Object>>
         }
         catch (SQLException e)
         {
-            throw new ResultSetException("Unable to access specific metadata from " +
+            throw ctx.getExceptionPolicy().resultSetFailure("Unable to access specific metadata from " +
                                          "result set metadata", e, ctx);
         }
         return row;

--- a/src/main/java/org/skife/jdbi/v2/GeneratedKeys.java
+++ b/src/main/java/org/skife/jdbi/v2/GeneratedKeys.java
@@ -16,7 +16,6 @@
 
 package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.exceptions.ResultSetException;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.sql.ResultSet;
@@ -80,7 +79,7 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
             }
         }
         catch (SQLException e) {
-            throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, context);
+            throw context.getExceptionPolicy().resultSetFailure("Exception thrown while attempting to traverse the result set", e, context);
         }
         finally {
             jdbiStatement.cleanup();
@@ -114,7 +113,7 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
             return resultList;
         }
         catch (SQLException e) {
-            throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, context);
+            throw context.getExceptionPolicy().resultSetFailure("Exception thrown while attempting to traverse the result set", e, context);
         }
         finally {
             jdbiStatement.cleanup();
@@ -142,7 +141,7 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
             return new ResultSetResultIterator<Type>(mapper, jdbiStatement, stmt, context);
         }
         catch (SQLException e) {
-            throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, context);
+            throw context.getExceptionPolicy().resultSetFailure("Exception thrown while attempting to traverse the result set", e, context);
         }
     }
 
@@ -172,7 +171,7 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
             return value;
         }
         catch (SQLException e) {
-            throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, context);
+            throw context.getExceptionPolicy().resultSetFailure("Exception thrown while attempting to traverse the result set", e, context);
         }
         finally {
             jdbiStatement.cleanup();

--- a/src/main/java/org/skife/jdbi/v2/Handle.java
+++ b/src/main/java/org/skife/jdbi/v2/Handle.java
@@ -16,6 +16,7 @@
 
 package org.skife.jdbi.v2;
 
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
 import org.skife.jdbi.v2.exceptions.TransactionFailedException;
 import org.skife.jdbi.v2.tweak.ArgumentFactory;
 import org.skife.jdbi.v2.tweak.ContainerFactory;
@@ -271,4 +272,6 @@ public interface Handle
     public void registerArgumentFactory(ArgumentFactory argumentFactory);
 
     public void registerContainerFactory(ContainerFactory<?> factory);
+    
+    public ExceptionPolicy getExceptionPolicy();
 }

--- a/src/main/java/org/skife/jdbi/v2/HashPrefixStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/HashPrefixStatementRewriter.java
@@ -19,8 +19,6 @@ package org.skife.jdbi.v2;
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.Token;
 import org.skife.jdbi.rewriter.hash.HashStatementLexer;
-import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
-import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.RewrittenStatement;
 import org.skife.jdbi.v2.tweak.StatementRewriter;
@@ -56,7 +54,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter
             return new MyRewrittenStatement(parsedSql, stmt, ctx);
         }
         catch (IllegalArgumentException e) {
-            throw new UnableToCreateStatementException("Exception parsing for named parameter replacement", e, ctx);
+            throw ctx.getExceptionPolicy().unableToCreateStatement("Exception parsing for named parameter replacement", e, ctx);
         }
 
     }
@@ -119,7 +117,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter
                             a.apply(i + 1, statement, this.context);
                         }
                         catch (SQLException e) {
-                            throw new UnableToExecuteStatementException(
+                            throw context.getExceptionPolicy().unableToExecuteStatement(
                                 String.format("Exception while binding positional param at (0 based) position %d",
                                               i), e, context);
                         }
@@ -144,14 +142,14 @@ public class HashPrefixStatementRewriter implements StatementRewriter
                                                    "\"%s\" and no positional param for place %d (which is %d in " +
                                                    "the JDBC 'start at 1' scheme) has been set.",
                                                    named_param, i, i + 1);
-                        throw new UnableToExecuteStatementException(msg, context);
+                        throw context.getExceptionPolicy().unableToExecuteStatement(msg, context);
                     }
 
                     try {
                         a.apply(i + 1, statement, this.context);
                     }
                     catch (SQLException e) {
-                        throw new UnableToCreateStatementException(String.format("Exception while binding '%s'",
+                        throw context.getExceptionPolicy().unableToCreateStatement(String.format("Exception while binding '%s'",
                                                                                  named_param), e, context);
                     }
                     i++;

--- a/src/main/java/org/skife/jdbi/v2/PreparedBatch.java
+++ b/src/main/java/org/skife/jdbi/v2/PreparedBatch.java
@@ -16,8 +16,6 @@
 
 package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
-import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.RewrittenStatement;
 import org.skife.jdbi.v2.tweak.SQLLog;
 import org.skife.jdbi.v2.tweak.StatementBuilder;
@@ -103,7 +101,7 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
             my_sql = getStatementLocator().locate(getSql(), getContext());
         }
         catch (Exception e) {
-            throw new UnableToCreateStatementException(String.format("Exception while locating statement for [%s]",
+            throw getHandle().getExceptionPolicy().unableToCreateStatement(String.format("Exception while locating statement for [%s]",
                                                                      getSql()), e, getContext());
         }
         final RewrittenStatement rewritten = getRewriter().rewrite(my_sql, current.getParameters(), getContext());
@@ -114,7 +112,7 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
                 addCleanable(Cleanables.forStatement(stmt));
             }
             catch (SQLException e) {
-                throw new UnableToCreateStatementException(e, getContext());
+                throw getHandle().getExceptionPolicy().unableToCreateStatement(e, getContext());
             }
 
 
@@ -125,7 +123,7 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
                 }
             }
             catch (SQLException e) {
-                throw new UnableToExecuteStatementException("Exception while binding parameters", e, getContext());
+                throw getHandle().getExceptionPolicy().unableToExecuteStatement("Exception while binding parameters", e, getContext());
             }
 
             beforeExecution(stmt);
@@ -142,7 +140,7 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
                 return rs;
             }
             catch (SQLException e) {
-                throw new UnableToExecuteStatementException(e, getContext());
+                throw getHandle().getExceptionPolicy().unableToExecuteStatement(e, getContext());
             }
         }
         finally {

--- a/src/main/java/org/skife/jdbi/v2/ResultSetResultIterator.java
+++ b/src/main/java/org/skife/jdbi/v2/ResultSetResultIterator.java
@@ -16,7 +16,7 @@
 
 package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.exceptions.ResultSetException;
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.sql.ResultSet;
@@ -92,7 +92,7 @@ class ResultSetResultIterator<Type> implements ResultIterator<Type>
             return mapper.map(count++, results, context);
         }
         catch (SQLException e) {
-            throw new ResultSetException("Error thrown mapping result set into return type", e, context);
+            throw context.getExceptionPolicy().resultSetFailure("Error thrown mapping result set into return type", e, context);
         }
         finally {
             alreadyAdvanced = safeNext();
@@ -113,7 +113,7 @@ class ResultSetResultIterator<Type> implements ResultIterator<Type>
             return results.next();
         }
         catch (SQLException e) {
-            throw new ResultSetException("Unable to advance result set", e, context);
+            throw context.getExceptionPolicy().resultSetFailure("Unable to advance result set", e, context);
         }
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/SQLStatement.java
+++ b/src/main/java/org/skife/jdbi/v2/SQLStatement.java
@@ -16,9 +16,6 @@
 
 package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.exceptions.ResultSetException;
-import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
-import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.ArgumentFactory;
 import org.skife.jdbi.v2.tweak.ContainerFactory;
@@ -1258,7 +1255,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
             return locator.locate(sql, this.getContext());
         }
         catch (Exception e) {
-            throw new UnableToCreateStatementException("Exception thrown while looking for statement", e, getContext());
+            throw handle.getExceptionPolicy().unableToCreateStatement("Exception thrown while looking for statement", e, getContext());
         }
     }
 
@@ -1277,7 +1274,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
             }
         }
         catch (SQLException e) {
-            throw new UnableToCreateStatementException(e, getContext());
+            throw handle.getExceptionPolicy().unableToCreateStatement(e, getContext());
         }
 
         // The statement builder might (or might not) clean up the statement when called. E.g. the
@@ -1290,7 +1287,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
             rewritten.bind(getParameters(), stmt);
         }
         catch (SQLException e) {
-            throw new UnableToExecuteStatementException("Unable to bind parameters to query", e, getContext());
+            throw handle.getExceptionPolicy().unableToExecuteStatement("Unable to bind parameters to query", e, getContext());
         }
 
         beforeExecution(stmt);
@@ -1303,7 +1300,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
             timingCollector.collect(elapsedTime, getContext());
         }
         catch (SQLException e) {
-            throw new UnableToExecuteStatementException(e, getContext());
+            throw handle.getExceptionPolicy().unableToExecuteStatement(e, getContext());
         }
 
         afterExecution(stmt);
@@ -1312,7 +1309,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
             return munger.munge(stmt);
         }
         catch (SQLException e) {
-            throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, getContext());
+            throw handle.getExceptionPolicy().resultSetFailure("Exception thrown while attempting to traverse the result set", e, getContext());
         }
     }
 

--- a/src/main/java/org/skife/jdbi/v2/Script.java
+++ b/src/main/java/org/skife/jdbi/v2/Script.java
@@ -16,7 +16,6 @@
 
 package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.StatementLocator;
 
 import java.util.Map;
@@ -30,7 +29,7 @@ public class Script
 
     private static final Pattern WHITESPACE_ONLY = Pattern.compile("^\\s*$");
 
-    private Handle handle;
+    private final Handle handle;
     private final StatementLocator locator;
     private final String name;
     private final Map<String, Object> globalStatementAttributes;
@@ -51,14 +50,14 @@ public class Script
     public int[] execute()
     {
         final String script;
-        final StatementContext ctx = new ConcreteStatementContext(globalStatementAttributes);
+        final StatementContext ctx = new ConcreteStatementContext(handle, globalStatementAttributes);
         try
         {
             script = locator.locate(name, ctx);
         }
         catch (Exception e)
         {
-            throw new UnableToExecuteStatementException(String.format("Error while loading script [%s]", name), e, ctx);
+            throw handle.getExceptionPolicy().unableToExecuteStatement(String.format("Error while loading script [%s]", name), e, ctx);
         }
 
         final String[] statements = script.replaceAll("\n", " ").replaceAll("\r", "").split(";");

--- a/src/main/java/org/skife/jdbi/v2/StatementContext.java
+++ b/src/main/java/org/skife/jdbi/v2/StatementContext.java
@@ -21,6 +21,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.util.Map;
 
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
+
 /**
  * The statement context provides a means for passing client specific information through the
  * evaluation of a statement. The context is not used by jDBI internally, but will be passed
@@ -111,4 +113,7 @@ public interface StatementContext
 
     public void addCleanable(Cleanable cleanable);
 
+    public Handle getHandle();
+
+    public ExceptionPolicy getExceptionPolicy();
 }

--- a/src/main/java/org/skife/jdbi/v2/exceptions/ExceptionPolicy.java
+++ b/src/main/java/org/skife/jdbi/v2/exceptions/ExceptionPolicy.java
@@ -1,0 +1,102 @@
+package org.skife.jdbi.v2.exceptions;
+
+import org.skife.jdbi.v2.StatementContext;
+
+/**
+ * Controls the exceptions that jDBI throws in response to various failures.
+ * Most of these are not interesting to override, but in particular
+ * {@link #unableToExecuteStatement(String, Throwable, StatementContext)}
+ * would let you give more detailed responses to {@link java.sql.SQLException}s.
+ */
+public class ExceptionPolicy
+{
+    public DBIException unableToOpenConnection(Throwable cause)
+    {
+        throw new UnableToObtainConnectionException(cause);
+    }
+
+    public final DBIException unableToExecuteStatement(Throwable cause, StatementContext ctx)
+    {
+        throw unableToExecuteStatement(null, cause, ctx);
+    }
+
+    public final DBIException unableToExecuteStatement(String msg, StatementContext ctx)
+    {
+        throw unableToExecuteStatement(msg, null, ctx);
+    }
+
+    public DBIException unableToExecuteStatement(String msg, Throwable cause, StatementContext ctx)
+    {
+        throw new UnableToExecuteStatementException(msg, cause, ctx);
+    }
+
+    public final DBIException unableToCreateStatement(Throwable cause, StatementContext ctx)
+    {
+        throw unableToCreateStatement(null, cause, ctx);
+    }
+
+    public DBIException unableToCreateStatement(String msg, Throwable cause, StatementContext ctx)
+    {
+        throw new UnableToCreateStatementException(msg, cause, ctx);
+    }
+
+    public DBIException unableToCloseResource(String msg, Throwable cause)
+    {
+        throw new UnableToCloseResourceException(msg, cause);
+    }
+
+    public DBIException transactionFailed(String msg, Throwable cause)
+    {
+        throw new TransactionFailedException(msg, cause);
+    }
+
+    public final DBIException transactionFailed(Throwable cause)
+    {
+        throw transactionFailed(null, cause);
+    }
+
+    public final DBIException transactionFailed(String msg)
+    {
+        throw transactionFailed(msg, null);
+    }
+
+    public DBIException transactionException(String msg, Throwable cause)
+    {
+        throw new TransactionException(msg, cause);
+    }
+
+    public final DBIException transactionException(Throwable cause)
+    {
+        throw transactionException(null, cause);
+    }
+
+    public final DBIException transactionException(String msg)
+    {
+        throw transactionException(msg, null);
+    }
+
+    public DBIException callbackFailed(String msg, Throwable cause)
+    {
+        throw new CallbackFailedException(msg, cause);
+    }
+
+    public final DBIException callbackFailed(Throwable cause)
+    {
+        throw callbackFailed(null, cause);
+    }
+
+    public DBIException resultSetFailure(String msg, Exception e, StatementContext ctx)
+    {
+        throw new ResultSetException(msg, e, ctx);
+    }
+
+    public final DBIException unableToSetTransactionIsolation(int i, Throwable cause)
+    {
+        throw unableToSetTransactionIsolation("Unable to set isolation level to " + i, cause);
+    }
+
+    public DBIException unableToSetTransactionIsolation(String msg, Throwable cause)
+    {
+        throw new UnableToManipulateTransactionIsolationLevelException(msg, cause);
+    }
+}

--- a/src/main/java/org/skife/jdbi/v2/exceptions/UnableToManipulateTransactionIsolationLevelException.java
+++ b/src/main/java/org/skife/jdbi/v2/exceptions/UnableToManipulateTransactionIsolationLevelException.java
@@ -1,16 +1,14 @@
 package org.skife.jdbi.v2.exceptions;
 
-import java.sql.SQLException;
-
 public class UnableToManipulateTransactionIsolationLevelException extends DBIException
 {
-    public UnableToManipulateTransactionIsolationLevelException(int i, SQLException e)
+    public UnableToManipulateTransactionIsolationLevelException(int i, Throwable cause)
     {
-        super("Unable to set isolation level to " + i, e);
+        super("Unable to set isolation level to " + i, cause);
     }
 
-    public UnableToManipulateTransactionIsolationLevelException(String msg, SQLException e)
+    public UnableToManipulateTransactionIsolationLevelException(String msg, Throwable cause)
     {
-        super(msg, e);
+        super(msg, cause);
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/CustomizingStatementHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/CustomizingStatementHandler.java
@@ -3,7 +3,6 @@ package org.skife.jdbi.v2.sqlobject;
 import com.fasterxml.classmate.members.ResolvedMethod;
 import org.skife.jdbi.v2.ConcreteStatementContext;
 import org.skife.jdbi.v2.SQLStatement;
-import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -116,7 +115,7 @@ abstract class CustomizingStatementHandler implements Handler
                 pair.factory.createForType(pair.annotation, sqlObjectType).apply(q);
             }
             catch (SQLException e) {
-                throw new UnableToCreateStatementException("unable to apply customizer", e, q.getContext());
+                throw q.getContext().getExceptionPolicy().unableToCreateStatement("unable to apply customizer", e, q.getContext());
             }
         }
 
@@ -125,7 +124,7 @@ abstract class CustomizingStatementHandler implements Handler
                 pair.factory.createForMethod(pair.annotation, sqlObjectType, method).apply(q);
             }
             catch (SQLException e) {
-                throw new UnableToCreateStatementException("unable to apply customizer", e, q.getContext());
+                throw q.getContext().getExceptionPolicy().unableToCreateStatement("unable to apply customizer", e, q.getContext());
             }
         }
 
@@ -137,7 +136,7 @@ abstract class CustomizingStatementHandler implements Handler
                         .apply(q);
                 }
                 catch (SQLException e) {
-                    throw new UnableToCreateStatementException("unable to apply customizer", e, q.getContext());
+                    throw q.getContext().getExceptionPolicy().unableToCreateStatement("unable to apply customizer", e, q.getContext());
                 }
             }
         }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
@@ -6,7 +6,6 @@ import com.fasterxml.classmate.members.ResolvedMethod;
 import org.skife.jdbi.v2.Query;
 import org.skife.jdbi.v2.ResultBearing;
 import org.skife.jdbi.v2.ResultIterator;
-import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
 import org.skife.jdbi.v2.sqlobject.customizers.Mapper;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
@@ -24,7 +23,7 @@ abstract class ResultReturnThing
                 mapper = method.getRawMember().getAnnotation(Mapper.class).value().newInstance();
             }
             catch (Exception e) {
-                throw new UnableToCreateStatementException("unable to access mapper", e);
+                throw q.getContext().getExceptionPolicy().unableToCreateStatement("unable to access mapper", e, null);
             }
             return result(q.map(mapper), h);
         }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
@@ -5,6 +5,7 @@ import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.ResolvedTypeWithMembers;
 import com.fasterxml.classmate.TypeResolver;
 import com.fasterxml.classmate.members.ResolvedMethod;
+
 import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.Factory;
 import net.sf.cglib.proxy.MethodInterceptor;
@@ -51,7 +52,7 @@ class SqlObject
                 e.setSuperclass(sqlObjectType);
             }
             e.setInterfaces(interfaces.toArray(new Class[interfaces.size()]));
-            final SqlObject so = new SqlObject(buildHandlersFor(sqlObjectType), handle);
+            final SqlObject so = new SqlObject(buildHandlersFor(handle, sqlObjectType), handle);
             e.setCallback(new MethodInterceptor()
             {
                 @Override
@@ -65,7 +66,7 @@ class SqlObject
             return t;
         }
 
-        final SqlObject so = new SqlObject(buildHandlersFor(sqlObjectType), handle);
+        final SqlObject so = new SqlObject(buildHandlersFor(handle, sqlObjectType), handle);
         return (T) f.newInstance(new MethodInterceptor()
         {
             @Override
@@ -76,7 +77,7 @@ class SqlObject
         });
     }
 
-    private static Map<Method, Handler> buildHandlersFor(Class<?> sqlObjectType)
+    private static Map<Method, Handler> buildHandlersFor(HandleDing handle, Class<?> sqlObjectType)
     {
         if (handlersCache.containsKey(sqlObjectType)) {
             return handlersCache.get(sqlObjectType);
@@ -95,7 +96,7 @@ class SqlObject
                 handlers.put(raw_method, new QueryHandler(sqlObjectType, method, ResultReturnThing.forType(method)));
             }
             else if (raw_method.isAnnotationPresent(SqlUpdate.class)) {
-                handlers.put(raw_method, new UpdateHandler(sqlObjectType, method));
+                handlers.put(raw_method, new UpdateHandler(handle, sqlObjectType, method));
             }
             else if (raw_method.isAnnotationPresent(SqlBatch.class)) {
                 handlers.put(raw_method, new BatchHandler(sqlObjectType, method));

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
@@ -4,8 +4,8 @@ import com.fasterxml.classmate.members.ResolvedMethod;
 import net.sf.cglib.proxy.MethodProxy;
 import org.skife.jdbi.v2.ConcreteStatementContext;
 import org.skife.jdbi.v2.GeneratedKeys;
+import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Update;
-import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 class UpdateHandler extends CustomizingStatementHandler
@@ -13,7 +13,7 @@ class UpdateHandler extends CustomizingStatementHandler
     private final String sql;
     private final Returner returner;
 
-    public UpdateHandler(Class<?> sqlObjectType, ResolvedMethod method)
+    public UpdateHandler(HandleDing handle, Class<?> sqlObjectType, ResolvedMethod method)
     {
         super(sqlObjectType, method);
         this.sql = SqlObject.getSql(method.getRawMember().getAnnotation(SqlUpdate.class), method.getRawMember());
@@ -26,7 +26,7 @@ class UpdateHandler extends CustomizingStatementHandler
                 mapper = ggk.value().newInstance();
             }
             catch (Exception e) {
-                throw new UnableToCreateStatementException("Unable to instantiate result set mapper for statement", e);
+                throw handle.getHandle().getExceptionPolicy().unableToCreateStatement("Unable to instantiate result set mapper for statement", e, null);
             }
             this.returner = new Returner()
             {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/WithHandleHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/WithHandleHandler.java
@@ -2,7 +2,6 @@ package org.skife.jdbi.v2.sqlobject;
 
 import net.sf.cglib.proxy.MethodProxy;
 import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.exceptions.CallbackFailedException;
 import org.skife.jdbi.v2.tweak.HandleCallback;
 
 class WithHandleHandler implements Handler
@@ -15,7 +14,7 @@ class WithHandleHandler implements Handler
             return callback.withHandle(handle);
         }
         catch (Exception e) {
-            throw new CallbackFailedException(e);
+            throw handle.getExceptionPolicy().callbackFailed(e);
         }
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/tweak/transactions/CMTTransactionHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/transactions/CMTTransactionHandler.java
@@ -20,6 +20,7 @@ import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.TransactionCallback;
 import org.skife.jdbi.v2.TransactionIsolationLevel;
 import org.skife.jdbi.v2.TransactionStatus;
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
 import org.skife.jdbi.v2.exceptions.TransactionException;
 import org.skife.jdbi.v2.tweak.TransactionHandler;
 
@@ -54,7 +55,7 @@ public class CMTTransactionHandler implements TransactionHandler
      */
     public void rollback(Handle handle)
     {
-        throw new TransactionException("Rollback called, this runtime exception thrown to halt the transaction");
+        throw handle.getExceptionPolicy().transactionException("Rollback called, this runtime exception thrown to halt the transaction");
     }
 
     /**
@@ -79,7 +80,7 @@ public class CMTTransactionHandler implements TransactionHandler
         }
         catch (SQLException e)
         {
-            throw new TransactionException("Failed to check status of transaction", e);
+            throw handle.getExceptionPolicy().transactionException("Failed to check status of transaction", e);
         }
     }
 
@@ -102,7 +103,7 @@ public class CMTTransactionHandler implements TransactionHandler
      */
     public void release(Handle handle, String checkpointName)
     {
-        throw new TransactionException("Rollback called, this runtime exception thrown to halt the transaction");
+        throw handle.getExceptionPolicy().transactionException("Rollback called, this runtime exception thrown to halt the transaction");
     }
 
     private class ExplodingTransactionStatus implements TransactionStatus
@@ -133,7 +134,7 @@ public class CMTTransactionHandler implements TransactionHandler
             {
                 throw (RuntimeException) e;
             }
-            throw new TransactionException(e);
+            throw handle.getExceptionPolicy().transactionException(e);
         }
     }
 

--- a/src/main/java/org/skife/jdbi/v2/tweak/transactions/SerializableTransactionRunner.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/transactions/SerializableTransactionRunner.java
@@ -4,7 +4,6 @@ import java.sql.SQLException;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.TransactionCallback;
 import org.skife.jdbi.v2.TransactionIsolationLevel;
-import org.skife.jdbi.v2.exceptions.TransactionFailedException;
 import org.skife.jdbi.v2.tweak.TransactionHandler;
 
 /**
@@ -49,7 +48,7 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
                     {
                         throw (RuntimeException) e;
                     }
-                    throw new TransactionFailedException(e);
+                    throw handle.getExceptionPolicy().transactionFailed(e);
                 }
             }
         }

--- a/src/main/java/org/skife/jdbi/v2/unstable/oracle/OracleReturning.java
+++ b/src/main/java/org/skife/jdbi/v2/unstable/oracle/OracleReturning.java
@@ -17,7 +17,7 @@
 package org.skife.jdbi.v2.unstable.oracle;
 
 import org.skife.jdbi.v2.StatementContext;
-import org.skife.jdbi.v2.exceptions.ResultSetException;
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
 import org.skife.jdbi.v2.tweak.BaseStatementCustomizer;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import org.skife.jdbi.v2.tweak.StatementCustomizer;
@@ -136,7 +136,7 @@ public class OracleReturning<ResultType> extends BaseStatementCustomizer impleme
 			rs = (ResultSet) this.getReturnResultSet.invoke(this.stmt);
 		}
 		catch (Exception e) {
-			throw new ResultSetException("Unable to retrieve return result set", e, ctx);
+			throw context.getExceptionPolicy().resultSetFailure("Unable to retrieve return result set", e, ctx);
 		}
         this.results = new ArrayList<ResultType>();
         try {
@@ -146,7 +146,7 @@ public class OracleReturning<ResultType> extends BaseStatementCustomizer impleme
             }
         }
         catch (SQLException e) {
-            throw new ResultSetException("Unable to retrieve results from returned result set", e, ctx);
+            throw context.getExceptionPolicy().resultSetFailure("Unable to retrieve results from returned result set", e, ctx);
         }
     }
 

--- a/src/test/java/org/skife/jdbi/v2/DBITestCase.java
+++ b/src/test/java/org/skife/jdbi/v2/DBITestCase.java
@@ -17,6 +17,7 @@ package org.skife.jdbi.v2;
 
 import junit.framework.TestCase;
 import org.skife.jdbi.derby.Tools;
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
 import org.skife.jdbi.v2.logging.NoOpLog;
 import org.skife.jdbi.v2.tweak.StatementLocator;
 import org.skife.jdbi.v2.tweak.TransactionHandler;
@@ -68,6 +69,7 @@ public abstract class DBITestCase extends TestCase
                                         getStatementLocator(),
                                         new CachingStatementBuilder(new DefaultStatementBuilder()),
                                         new ColonPrefixNamedParamStatementRewriter(),
+                                        new ExceptionPolicy(),
                                         conn,
                                         new HashMap<String, Object>(),
                                         new NoOpLog(),

--- a/src/test/java/org/skife/jdbi/v2/TestColonStatementRewriter.java
+++ b/src/test/java/org/skife/jdbi/v2/TestColonStatementRewriter.java
@@ -39,35 +39,35 @@ public class TestColonStatementRewriter extends TestCase
     public void testNewlinesOkay() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from something\n where id = :id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("select * from something\n where id = ?", rws.getSql());
     }
 
     public void testOddCharacters() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("~* :boo ':nope' _%&^& *@ :id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("~* ? ':nope' _%&^& *@ ?", rws.getSql());
     }
 
     public void testNumbers() throws Exception
     {
         RewrittenStatement rws = rw.rewrite(":bo0 ':nope' _%&^& *@ :id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("? ':nope' _%&^& *@ ?", rws.getSql());
     }
 
     public void testDollarSignOkay() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from v$session", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("select * from v$session", rws.getSql());
     }
 
     public void testBacktickOkay() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from `v$session", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("select * from `v$session", rws.getSql());
     }
 
@@ -76,7 +76,7 @@ public class TestColonStatementRewriter extends TestCase
     {
         try {
             rw.rewrite("select * from something\n where id = :\u0087\u008e\u0092\u0097\u009c", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
 
             Assert.fail("Expected 'UnableToCreateStatementException' but got none");
         }

--- a/src/test/java/org/skife/jdbi/v2/TestDBI.java
+++ b/src/test/java/org/skife/jdbi/v2/TestDBI.java
@@ -16,6 +16,7 @@
 package org.skife.jdbi.v2;
 
 import org.skife.jdbi.derby.Tools;
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
 import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
 import org.skife.jdbi.v2.tweak.ConnectionFactory;
 import org.skife.jdbi.v2.tweak.HandleCallback;

--- a/src/test/java/org/skife/jdbi/v2/TestHashPrefixStatementRewriter.java
+++ b/src/test/java/org/skife/jdbi/v2/TestHashPrefixStatementRewriter.java
@@ -39,7 +39,7 @@ public class TestHashPrefixStatementRewriter extends TestCase
     public void testNewlinesOkay() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from something\n where id = #id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("select * from something\n where id = ?", rws.getSql());
     }
 
@@ -48,35 +48,35 @@ public class TestHashPrefixStatementRewriter extends TestCase
     public void testOddCharacters() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("~* #boo '#nope' _%&^& *@ #id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("~* ? '#nope' _%&^& *@ ?", rws.getSql());
     }
 
     public void testNumbers() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("#bo0 '#nope' _%&^& *@ #id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("? '#nope' _%&^& *@ ?", rws.getSql());
     }
 
     public void testDollarSignOkay() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from v$session", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("select * from v$session", rws.getSql());
     }
 
     public void testColonIsLiteral() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from foo where id = :id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("select * from foo where id = :id", rws.getSql());
     }
 
     public void testBacktickOkay() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from `v$session", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>()));
+                                            new ConcreteStatementContext(null, new HashMap<String, Object>()));
         assertEquals("select * from `v$session", rws.getSql());
     }
 
@@ -85,7 +85,7 @@ public class TestHashPrefixStatementRewriter extends TestCase
     {
         try {
             rw.rewrite("select * from something\n where id = #\u0087\u008e\u0092\u0097\u009c", new Binding(),
-                       new ConcreteStatementContext(new HashMap<String, Object>()));
+                       new ConcreteStatementContext(null, new HashMap<String, Object>()));
 
             Assert.fail("Expected 'UnableToCreateStatementException' but got none");
         }

--- a/src/test/java/org/skife/jdbi/v2/TestPreparedStatementCache.java
+++ b/src/test/java/org/skife/jdbi/v2/TestPreparedStatementCache.java
@@ -16,6 +16,7 @@
 package org.skife.jdbi.v2;
 
 import org.skife.jdbi.derby.Tools;
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
 import org.skife.jdbi.v2.logging.NoOpLog;
 import org.skife.jdbi.v2.tweak.transactions.LocalTransactionHandler;
 
@@ -52,6 +53,7 @@ public class TestPreparedStatementCache extends DBITestCase
                                         new ClasspathStatementLocator(),
                                         builder,
                                         new ColonPrefixNamedParamStatementRewriter(),
+                                        new ExceptionPolicy(),
                                         c,
                                         new HashMap<String, Object>(),
                                         new NoOpLog(),

--- a/src/test/java/org/skife/jdbi/v2/TestTimingCollector.java
+++ b/src/test/java/org/skife/jdbi/v2/TestTimingCollector.java
@@ -16,6 +16,7 @@
 package org.skife.jdbi.v2;
 
 import org.skife.jdbi.derby.Tools;
+import org.skife.jdbi.v2.exceptions.ExceptionPolicy;
 import org.skife.jdbi.v2.logging.NoOpLog;
 
 import java.sql.Connection;
@@ -43,6 +44,7 @@ public class TestTimingCollector extends DBITestCase
                                         getStatementLocator(),
                                         new CachingStatementBuilder(new DefaultStatementBuilder()),
                                         new ColonPrefixNamedParamStatementRewriter(),
+                                        new ExceptionPolicy(),
                                         conn,
                                         new HashMap<String, Object>(),
                                         new NoOpLog(),


### PR DESCRIPTION
We'd like to move off of Spring JdbcDaoSupport/JdbcTemplate, but one of the features that is lacking is the exception mapping capabilities.  This change looks like it accomplishes that goal and looks like, with a proper default ExceptionPolicy, it would be easliy backwards compatible