### PR TITLE
Correct splitting SQL statements by a semicolon

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -2,6 +2,9 @@
   - switch to standard Maven toolchains.xml for cross-compilation, #169.
     See https://maven.apache.org/guides/mini/guide-using-toolchains.html
     for instructions on how to use it.
+  - Correctly handle semicolons and inline comments in SQL statements.
+    Existing SQL statements may break due to lexer changes, ensure you have
+    test coverage.
 
 2.63
   - Include lambda-friendly callback methods on Handle and DBI, #156

--- a/src/build/findbugs-exclude.xml
+++ b/src/build/findbugs-exclude.xml
@@ -23,4 +23,7 @@
     <Match>
         <Class name="org.skife.jdbi.rewriter.printf.FormatterStatementLexer" />
     </Match>
+    <Match>
+        <Class name="org.skife.jdbi.v2.SqlScriptLexer" />
+    </Match>
 </FindBugsFilter>

--- a/src/main/antlr3/org/skife/jdbi/v2/SqlScriptLexer.g
+++ b/src/main/antlr3/org/skife/jdbi/v2/SqlScriptLexer.g
@@ -1,0 +1,52 @@
+lexer grammar SqlScriptLexer;
+
+@header {
+    package org.skife.jdbi.v2;
+}
+
+@lexer::members {
+  @Override
+  public void reportError(RecognitionException e) {
+    throw new IllegalArgumentException(e);
+  }
+}
+
+COMMENT
+    : '--' ~(NEWLINE)* |
+      '//' ~(NEWLINE)* |
+      '#'  ~(NEWLINE)*
+     { skip(); }
+    ;
+
+MULTI_LINE_COMMENT
+    : '/*' (options {greedy=false;} :.)* '*/' { skip(); }
+    ;
+
+NEWLINES
+    : NEWLINE+
+    ;
+
+fragment NEWLINE
+    : ('\n'|'\r')
+    ;
+
+QUOTED_TEXT
+    :   ('\'' (ESCAPE_SEQUENCE | ~'\'')* '\'')
+    ;
+
+fragment ESCAPE_SEQUENCE
+    :  '\\' '\''
+    ;
+
+SEMICOLON
+    :  ';'
+    ;
+
+LITERAL
+    :  ('a'..'z'|'A'..'Z'|' '|'\t'|'0'..'9'|
+        ','|'*'|'.'|'@'|'_'|'!'|'='|'('|')'|'['|']')+
+    ;
+
+OTHER
+    :  .
+    ;

--- a/src/main/java/org/skife/jdbi/v2/Script.java
+++ b/src/main/java/org/skife/jdbi/v2/Script.java
@@ -15,19 +15,20 @@
  */
 package org.skife.jdbi.v2;
 
+import org.antlr.runtime.ANTLRStringStream;
+import org.antlr.runtime.Token;
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.StatementLocator;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 /**
  * Represents a number of SQL statements which will be executed in a batch statement.
  */
 public class Script
 {
-
-    private static final Pattern WHITESPACE_ONLY = Pattern.compile("^\\s*$");
 
     private Handle handle;
     private final StatementLocator locator;
@@ -47,15 +48,11 @@ public class Script
      *
      * @return an array of ints which are the results of each statement in the script
      */
-    public int[] execute()
-    {
-        final String[] statements = getStatements();
+    public int[] execute() {
+        final List<String> statements = getStatements();
         Batch b = handle.createBatch();
-        for (String s : statements)
-        {
-            if ( ! WHITESPACE_ONLY.matcher(s).matches() ) {
-                b.add(s);
-            }
+        for (String s : statements) {
+            b.add(s);
         }
         return b.execute();
     }
@@ -65,24 +62,41 @@ public class Script
      */
     public void executeAsSeparateStatements() {
         for (String s : getStatements()) {
-            if (!WHITESPACE_ONLY.matcher(s).matches()) {
-                handle.execute(s);
-            }
+            handle.execute(s);
         }
     }
 
-    private String[] getStatements() {
+    private List<String> getStatements() {
         final String script;
         final StatementContext ctx = new ConcreteStatementContext(globalStatementAttributes);
-        try
-        {
+        try {
             script = locator.locate(name, ctx);
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             throw new UnableToExecuteStatementException(String.format("Error while loading script [%s]", name), e, ctx);
         }
 
-        return script.replaceAll("\n", " ").replaceAll("\r", "").split(";");
+        return splitToStatements(script);
+    }
+
+    private List<String> splitToStatements(String script) {
+        final List<String> statements = new ArrayList<String>();
+        String lastStatement = new SqlScriptParser(new SqlScriptParser.TokenHandler() {
+            @Override
+            public void handle(Token t, StringBuilder sb) {
+                addStatement(sb.toString(), statements);
+                sb.setLength(0);
+            }
+        }).parse(new ANTLRStringStream(script));
+        addStatement(lastStatement, statements);
+
+        return statements;
+    }
+
+    private void addStatement(String statement, List<String> statements) {
+        String trimmedStatement = statement.trim();
+        if (trimmedStatement.isEmpty()) {
+            return;
+        }
+        statements.add(trimmedStatement);
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/SqlScriptParser.java
+++ b/src/main/java/org/skife/jdbi/v2/SqlScriptParser.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2004 - 2014 Brian McCallister
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2;
+
+import org.antlr.runtime.CharStream;
+import org.antlr.runtime.Token;
+
+/**
+ * An SQL script parser.
+ *
+ * <p>It performs lexical analysis of a script and generates events for semicolons.
+ * As a result it returns a script without comments and newlines.</p>
+ */
+class SqlScriptParser {
+
+    private final TokenHandler semicolonHandler;
+
+    public SqlScriptParser(TokenHandler semicolonHandler) {
+        this.semicolonHandler = semicolonHandler;
+    }
+
+    public String parse(CharStream charStream) {
+        StringBuilder sb = new StringBuilder();
+        SqlScriptLexer lexer = new SqlScriptLexer(charStream);
+        boolean endOfFile = false;
+        while (!endOfFile) {
+            Token t = lexer.nextToken();
+            switch (t.getType()) {
+                case Token.EOF:
+                    endOfFile = true;
+                    break;
+                case SqlScriptLexer.SEMICOLON:
+                    semicolonHandler.handle(t, sb);
+                    break;
+                case SqlScriptLexer.COMMENT:
+                case SqlScriptLexer.MULTI_LINE_COMMENT:
+                    break;
+                case SqlScriptLexer.NEWLINES:
+                    if (sb.length() > 0) {
+                        sb.append(" ");
+                    }
+                    break;
+                case SqlScriptLexer.QUOTED_TEXT:
+                case SqlScriptLexer.LITERAL:
+                case SqlScriptLexer.OTHER:
+                    sb.append(t.getText());
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unrecognizable token " + t);
+            }
+        }
+        return sb.toString();
+    }
+
+    interface TokenHandler {
+        void handle(Token t, StringBuilder sb);
+    }
+}

--- a/src/test/java/org/skife/jdbi/v2/TestScript.java
+++ b/src/test/java/org/skife/jdbi/v2/TestScript.java
@@ -18,6 +18,9 @@ package org.skife.jdbi.v2;
 import org.junit.Test;
 import org.skife.jdbi.v2.exceptions.StatementException;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -43,6 +46,33 @@ public class TestScript extends DBITestCase
         script.execute();
 
         assertEquals(3, h.select("select * from something").size());
+    }
+
+    @Test
+    public void testScriptWithStringSemicolon() throws Exception {
+        BasicHandle h = openHandle();
+        Script script = h.createScript("insert-with-string-semicolons");
+        script.execute();
+
+        assertEquals(3, h.select("select * from something").size());
+    }
+
+    @Test
+    public void testFuzzyScript() throws Exception {
+        BasicHandle h = openHandle();
+        Script script = h.createScript("fuzzy-script");
+        script.executeAsSeparateStatements();
+
+        List<Map<String, Object>> rows = h.select("select * from something order by id");
+        assertEquals(4, rows.size());
+        assertEquals(rows.get(0).get("id"), (Integer) 1);
+        assertEquals(rows.get(0).get("name"), "eric");
+        assertEquals(rows.get(1).get("id"), (Integer) 2);
+        assertEquals(rows.get(1).get("name"), "sally;ann");
+        assertEquals(rows.get(2).get("id"), (Integer) 3);
+        assertEquals(rows.get(2).get("name"), "bob");
+        assertEquals(rows.get(3).get("id"), (Integer) 12);
+        assertEquals(rows.get(3).get("name"), "sally;ann;junior");
     }
 
     @Test

--- a/src/test/resources/fuzzy-script.sql
+++ b/src/test/resources/fuzzy-script.sql
@@ -1,0 +1,33 @@
+--
+-- Copyright (C) 2004 - 2014 Brian McCallister
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+INSERT INTO something(id, name) VALUES (1, 'keith');; ;
+INSERT INTO something(id, name) VALUES (2, 'sally;ann') ;INSERT INTO something(id, name) values (3, 'eric');
+INSERT INTO something(id, name)
+       SELECT id+10, name || ';junior' FROM something WHERE name='sally;ann';
+;DELETE FROM something where id=1;UPDATE something set id=1 WHERE NAME ='eric';-- Add a separator
+ALTER TABLE something ADD COLUMN separator VARCHAR(1) DEFAULT ';';
+/*Call*/
+CALL syscs_util.syscs_set_database_property('foo', 'bar');
+
+/*
+   Function;
+*/
+CREATE FUNCTION P_INT(VARCHAR(10)) RETURNS INTEGER
+EXTERNAL NAME 'java.lang.Integer.parseInt'
+LANGUAGE JAVA PARAMETER STYLE JAVA;
+
+INSERT INTO something(id, name) VALUES (P_INT('3'), 'bob')

--- a/src/test/resources/insert-with-string-semicolons.sql
+++ b/src/test/resources/insert-with-string-semicolons.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright (C) 2004 - 2014 Brian McCallister
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into something(id, name) values (1, 'keith');
+insert into something(id, name) values (2, 'sally;ann');
+insert into something(id, name) values (3, 'eric');


### PR DESCRIPTION
Currently semicolons in a script are treated as statements separators. Not all are. Semicolons in string literals are just symbols. The statement separator should be followed by a reserved
SQL word or the end of string.

The implementation is not guaranteed to work for all cases, but should cover the most common.