### PR TITLE
Switch to standard maven toolchains for building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: java
 jdk:
-  - openjdk6
   - oraclejdk7
   - oraclejdk8
+
+before_install:
+    - cp src/build/travis-toolchains.xml ~/.m2/toolchains.xml
+
 install: mvn -DskipTests=true -Dbasepom.check.skip-all=true -B install
 script: mvn -B verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: java
+
 jdk:
   - oraclejdk7
   - oraclejdk8
+
+sudo: false
 
 before_install:
     - cp src/build/travis-toolchains.xml ~/.m2/toolchains.xml

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,8 @@
+2.64
+  - switch to standard Maven toolchains.xml for cross-compilation, #169.
+    See https://maven.apache.org/guides/mini/guide-using-toolchains.html
+    for instructions on how to use it.
+
 2.63
   - Include lambda-friendly callback methods on Handle and DBI, #156
 
@@ -40,7 +45,7 @@
 
 
 2.53
-  - Tests now run in parallel 
+  - Tests now run in parallel
   - Added Template supergroup loading to StringTemplate3StatementLocator
   - add a global cache for templates loaded from an annotation.
   - fix a handler cache bug.

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@
     </developers>
 
     <properties>
-        <project.jdk6.home>${env.JAVA6_HOME}</project.jdk6.home>
         <project.build.targetJdk>1.6</project.build.targetJdk>
         <basepom.maven.version>2.0.9</basepom.maven.version>
         <dep.antlr.version>3.4</dep.antlr.version>
@@ -142,6 +141,9 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
+            <!-- needs to be a JDK 6 compatible version, otherwise
+                 the Java 6 compiler will fail to build the jar -->
+            <version>2.0.3</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -272,9 +274,34 @@
                         </excludes>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-toolchains-plugin</artifactId>
+                    <version>1.1</version>
+                    <configuration>
+                        <toolchains>
+                            <jdk>
+                                <version>${project.build.targetJdk}</version>
+                                <vendor>sun</vendor>
+                            </jdk>
+                        </toolchains>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr3-maven-plugin</artifactId>
@@ -336,70 +363,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>travis</id>
-            <activation>
-                <property>
-                    <name>env.TRAVIS</name>
-                </property>
-            </activation>
-            <properties>
-                <project.jdk6.home>${env.JAVA_HOME}</project.jdk6.home>
-            </properties>
-        </profile>
-        <profile>
-            <id>cross-compile</id>
-            <activation>
-                 <jdk>(1.6,]</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <compilerArguments children.combine="append">
-                                    <bootclasspath>${project.jdk6.home}/jre/lib/rt.jar:${project.jdk6.home}/jre/lib/jce.jar:${project.jdk6.home}/../classes/classes.jar</bootclasspath>
-                                </compilerArguments>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <id>compat-jdk6</id>
-            <activation>
-                <jdk>[,1.7)</jdk>
-            </activation>
-            <properties>
-                <!-- findbugs 3.x.x is java 7+ -->
-                <dep.findbugs.version>2.0.3</dep.findbugs.version>
-                <dep.plugin.findbugs.version>2.5.5</dep.plugin.findbugs.version>
-
-                <!-- checkstyle post 6.1 is java 7+ -->
-                <dep.checkstyle.version>6.1</dep.checkstyle.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>javadoc</id>
-            <!-- The javadoc profile is only required for 1.7; 1.6 and 1.8+ work just fine with their normal class path. -->
-            <activation>
-                <jdk>1.7</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <bootclasspath>${project.jdk6.home}/jre/lib/rt.jar:${project.jdk6.home}/jre/lib/jce.jar:${project.jdk6.home}/../classes/classes.jar</bootclasspath>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
         <profile>
             <id>doclint</id>
             <activation>

--- a/src/build/travis-toolchains.xml
+++ b/src/build/travis-toolchains.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF8"?>
+<!--
+~   Copyright (C) 2004 - 2014 Brian McCallister
+~
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<toolchains>
+    <!-- JDK toolchains -->
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.6</version>
+            <vendor>sun</vendor>
+        </provides>
+        <configuration>
+            <!-- Location of a JDK6 in the Travis build environment -->
+            <jdkHome>/usr/lib/jvm/java-6-openjdk-amd64</jdkHome>
+        </configuration>
+    </toolchain>
+</toolchains>


### PR DESCRIPTION
Use toolchains.xml abstraction to select build JDK. This is supported
(but not well documented) in maven for a long time. This alleviates the
need for the various build profiles.