### PR TITLE
BasicHandle.close() can fail to close connection if StatementBuilder.close() fails

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/BasicHandle.java
+++ b/src/main/java/org/skife/jdbi/v2/BasicHandle.java
@@ -112,16 +112,19 @@ class BasicHandle implements Handle
     public void close()
     {
         if (!closed) {
-            statementBuilder.close(getConnection());
             try {
-                connection.close();
-            }
-            catch (SQLException e) {
-                throw new UnableToCloseResourceException("Unable to close Connection", e);
-            }
-            finally {
-                log.logReleaseHandle(this);
-                closed = true;
+                statementBuilder.close(getConnection());
+            } finally {
+                try {
+                    connection.close();
+                }
+                catch (SQLException e) {
+                    throw new UnableToCloseResourceException("Unable to close Connection", e);
+                }
+                finally {
+                    log.logReleaseHandle(this);
+                    closed = true;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #180