### PR TITLE
Deprecate primitives mapper factory

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/MappingRegistry.java
+++ b/src/main/java/org/skife/jdbi/v2/MappingRegistry.java
@@ -24,8 +24,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 class MappingRegistry
 {
-    private static final PrimitivesMapperFactory BUILT_IN_MAPPERS = new PrimitivesMapperFactory();
-    private static final PrimitivesColumnMapperFactory BUILT_IN_COLUMN_MAPPERS = new PrimitivesColumnMapperFactory();
+    private static final PrimitivesColumnMapperFactory BUILT_INS = new PrimitivesColumnMapperFactory();
 
     private final List<ResultSetMapperFactory> rowFactories = new CopyOnWriteArrayList<ResultSetMapperFactory>();
     private final ConcurrentHashMap<Class, ResultSetMapper> rowCache = new ConcurrentHashMap<Class, ResultSetMapper>();
@@ -74,13 +73,6 @@ class MappingRegistry
             }
         }
 
-        // TODO remove this and let the column mapper block below take over
-        if (BUILT_IN_MAPPERS.accepts(type, ctx)) {
-            mapper = BUILT_IN_MAPPERS.mapperFor(type, ctx);
-            rowCache.put(type, mapper);
-            return mapper;
-        }
-
         ResultColumnMapper columnMapper = columnMapperFor(type, ctx);
         if (columnMapper != null) {
             mapper = new SingleColumnMapper(columnMapper);
@@ -115,8 +107,8 @@ class MappingRegistry
             }
         }
 
-        if (BUILT_IN_COLUMN_MAPPERS.accepts(type, ctx)) {
-            mapper = BUILT_IN_COLUMN_MAPPERS.columnMapperFor(type, ctx);
+        if (BUILT_INS.accepts(type, ctx)) {
+            mapper = BUILT_INS.columnMapperFor(type, ctx);
             columnCache.put(type, mapper);
             return mapper;
         }

--- a/src/main/java/org/skife/jdbi/v2/PrimitivesMapperFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/PrimitivesMapperFactory.java
@@ -35,7 +35,10 @@ import java.util.Map;
 
 /**
  * Result set mapper factory which knows how to construct java primitive types.
+ *
+ * @deprecated Use {@link PrimitivesColumnMapperFactory} instead.
  */
+@Deprecated
 public class PrimitivesMapperFactory implements ResultSetMapperFactory
 {
     private static final Map<Class, ResultSetMapper> mappers = new HashMap<Class, ResultSetMapper>();

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/FigureItOutResultSetMapper.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/FigureItOutResultSetMapper.java
@@ -13,80 +13,28 @@
  */
 package org.skife.jdbi.v2.sqlobject;
 
-import org.skife.jdbi.v2.PrimitivesMapperFactory;
 import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import org.skife.jdbi.v2.util.BigDecimalMapper;
-import org.skife.jdbi.v2.util.BooleanMapper;
-import org.skife.jdbi.v2.util.ByteArrayMapper;
-import org.skife.jdbi.v2.util.ShortMapper;
-import org.skife.jdbi.v2.util.FloatMapper;
-import org.skife.jdbi.v2.util.DoubleMapper;
-import org.skife.jdbi.v2.util.ByteMapper;
-import org.skife.jdbi.v2.util.URLMapper;
-import org.skife.jdbi.v2.util.IntegerMapper;
-import org.skife.jdbi.v2.util.LongMapper;
-import org.skife.jdbi.v2.util.TimestampMapper;
-import org.skife.jdbi.v2.util.StringMapper;
-
 
 import java.lang.reflect.Method;
-import java.math.BigDecimal;
-import java.net.URL;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 
-class FigureItOutResultSetMapper implements ResultSetMapper<Object>
-{
-    private static final PrimitivesMapperFactory factory = new PrimitivesMapperFactory();
-
+class FigureItOutResultSetMapper implements ResultSetMapper<Object> {
     @Override
-    public Object map(int index, ResultSet r, StatementContext ctx) throws SQLException
-    {
+    public Object map(int index, ResultSet r, StatementContext ctx) throws SQLException {
         Method m = ctx.getSqlObjectMethod();
         Class<?> rt = m.getReturnType();
         GetGeneratedKeys ggk = m.getAnnotation(GetGeneratedKeys.class);
         String keyColumn = ggk.columnName();
 
-        ResultSetMapper f;
-        if (!"".equals(keyColumn)) {
-            f = figureOutMapper(rt, keyColumn);
-        } else {
-            f = factory.mapperFor(rt, ctx);
-        }
-        return f.map(index, r, ctx);
-    }
+        ResultColumnMapper columnMapper = ctx.columnMapperFor(rt);
 
-    ResultSetMapper figureOutMapper(Class keyType, String keyColumn) {
-        ResultSetMapper f;
-        if (keyType.isAssignableFrom(BigDecimal.class)) {
-            f = new BigDecimalMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(Boolean.class) || keyType.isAssignableFrom(boolean.class)) {
-            f = new BooleanMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(byte[].class)) {
-            f = new ByteArrayMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(Short.class) || keyType.isAssignableFrom(short.class)) {
-            f = new ShortMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(float.class) || keyType.isAssignableFrom(Float.class)) {
-            f = new FloatMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(Double.class) || keyType.isAssignableFrom(double.class)) {
-            f = new DoubleMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(Byte.class) || keyType.isAssignableFrom(byte.class)) {
-            f = new ByteMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(URL.class)) {
-            f = new URLMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(Integer.class) || keyType.isAssignableFrom(int.class)) {
-            f = new IntegerMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(Long.class) || keyType.isAssignableFrom(long.class)) {
-            f = new LongMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(Timestamp.class)) {
-            f = new TimestampMapper(keyColumn);
-        } else if (keyType.isAssignableFrom(String.class)) {
-            f = new StringMapper(keyColumn);
-        } else {
-            f = new LongMapper(keyColumn);
+        if ("".equals(keyColumn)) {
+            return columnMapper.mapColumn(r, 1, ctx);
         }
-        return f;
+
+        return columnMapper.mapColumn(r, keyColumn, ctx);
     }
 }


### PR DESCRIPTION
With the introduction of the column mappers, the `PrimitivesMapperFactory` is obsolete and can be deprecated.

We can also address #154 by relying on the column mapper registry, which respects nullability of primitive wrapper types.

Lastly, the internal FigureItOutResultSetMapper can rely on the column mapper registry instead of embedding knowledge of type mappers.