### PR TITLE
statement rewriters use a cache

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
@@ -26,6 +26,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static org.skife.jdbi.rewriter.colon.ColonStatementLexer.DOUBLE_QUOTED_TEXT;
 import static org.skife.jdbi.rewriter.colon.ColonStatementLexer.ESCAPED_TEXT;
@@ -41,6 +43,8 @@ import static org.skife.jdbi.rewriter.colon.ColonStatementLexer.QUOTED_TEXT;
  */
 public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
 {
+    private final ConcurrentMap<String, ParsedStatement> cache = new ConcurrentHashMap<String, ParsedStatement>();
+
     /**
      * Munge up the SQL as desired. Responsible for figuring out ow to bind any
      * arguments in to the resultant prepared statement.
@@ -48,25 +52,28 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
      * @param sql The SQL to rewrite
      * @param params contains the arguments which have been bound to this statement.
      * @param ctx The statement context for the statement being executed
-     * @return somethign which can provde the actual SQL to prepare a statement from
+     * @return something which can provide the actual SQL to prepare a statement from
      *         and which can bind the correct arguments to that prepared statement
      */
     @Override
     public RewrittenStatement rewrite(String sql, Binding params, StatementContext ctx)
     {
-        final ParsedStatement stmt = new ParsedStatement();
-        try {
-            final String parsedSql = parseString(sql, stmt);
-            return new MyRewrittenStatement(parsedSql, stmt, ctx);
+        ParsedStatement stmt = cache.get(sql);
+        if (stmt == null) {
+            try {
+                stmt = parseString(sql);
+                cache.putIfAbsent(sql, stmt);
+            }
+            catch (IllegalArgumentException e) {
+                throw new UnableToCreateStatementException("Exception parsing for named parameter replacement", e, ctx);
+            }
         }
-        catch (IllegalArgumentException e) {
-            throw new UnableToCreateStatementException("Exception parsing for named parameter replacement", e, ctx);
-        }
-
+        return new MyRewrittenStatement(stmt, ctx);
     }
 
-    String parseString(final String sql, final ParsedStatement stmt) throws IllegalArgumentException
+    ParsedStatement parseString(final String sql) throws IllegalArgumentException
     {
+        ParsedStatement stmt = new ParsedStatement();
         StringBuilder b = new StringBuilder();
         ColonStatementLexer lexer = new ColonStatementLexer(new ANTLRStringStream(sql));
         Token t = lexer.nextToken();
@@ -97,19 +104,18 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
             }
             t = lexer.nextToken();
         }
-        return b.toString();
+        stmt.sql = b.toString();
+        return stmt;
     }
 
     private static class MyRewrittenStatement implements RewrittenStatement
     {
-        private final String sql;
         private final ParsedStatement stmt;
         private final StatementContext context;
 
-        public MyRewrittenStatement(String sql, ParsedStatement stmt, StatementContext ctx)
+        public MyRewrittenStatement(ParsedStatement stmt, StatementContext ctx)
         {
             this.context = ctx;
-            this.sql = sql;
             this.stmt = stmt;
         }
 
@@ -171,12 +177,13 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
         @Override
         public String getSql()
         {
-            return sql;
+            return stmt.getParsedSql();
         }
     }
 
     static class ParsedStatement
     {
+        private String sql;
         private boolean positionalOnly = true;
         private List<String> params = new ArrayList<String>();
 
@@ -189,6 +196,11 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
         public void addPositionalParamAt()
         {
             params.add("*");
+        }
+
+        public String getParsedSql()
+        {
+            return sql;
         }
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/tweak/StatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/tweak/StatementRewriter.java
@@ -22,13 +22,13 @@ import org.skife.jdbi.v2.StatementContext;
 public interface StatementRewriter
 {
     /**
-     * Munge up the SQL as desired. Responsible for figuring out ow to bind any
+     * Munge up the SQL as desired. Responsible for figuring out how to bind any
      * arguments in to the resultant prepared statement.
      *
      * @param sql The SQL to rewrite
      * @param params contains the arguments which have been bound to this statement.
      * @param ctx The statement context for the statement being executed
-     * @return somethign which can provde the actual SQL to prepare a statement from
+     * @return something which can provide the actual SQL to prepare a statement from
      *         and which can bind the correct arguments to that prepared statement
      */
     RewrittenStatement rewrite(String sql, Binding params, StatementContext ctx);

--- a/src/test/java/org/skife/jdbi/v2/TestEscapedCharacters.java
+++ b/src/test/java/org/skife/jdbi/v2/TestEscapedCharacters.java
@@ -25,7 +25,7 @@ public class TestEscapedCharacters
 
     private String parseString(final String src)
     {
-        return rewriter.parseString(src, new ColonPrefixNamedParamStatementRewriter.ParsedStatement());
+        return rewriter.parseString(src).getParsedSql();
     }
 
     @Test


### PR DESCRIPTION
avoids doing redundant work in the lexer, since parsing a sql statement should be deterministic