### PR TITLE
Fix returning generated keys

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/Update.java
+++ b/src/main/java/org/skife/jdbi/v2/Update.java
@@ -74,7 +74,7 @@ public class Update extends SQLStatement<Update>
     public <GeneratedKeyType> GeneratedKeys<GeneratedKeyType> executeAndReturnGeneratedKeys(final ResultSetMapper<GeneratedKeyType> mapper, String columnName)
     {
         getConcreteContext().setReturningGeneratedKeys(true);
-        if (columnName != null) {
+        if (columnName != null && !columnName.isEmpty()) {
             getConcreteContext().setGeneratedKeysColumnNames(new String[] { columnName } );
         }
         return this.internalExecute(new QueryResultMunger<GeneratedKeys<GeneratedKeyType>>() {

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.sqlobject.mixins.CloseMe;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestGetGeneratedKeysHsqlDb {
+
+    private DBI dbi;
+
+    @Before
+    public void setUp() throws Exception {
+        dbi = new DBI("jdbc:hsqldb:mem:" + UUID.randomUUID(), "username", "password");
+        dbi.withHandle(new HandleCallback<Object>() {
+            @Override
+            public Object withHandle(Handle handle) throws Exception {
+                handle.execute("create table something (id identity primary key, name varchar(32))");
+                return null;
+            }
+        });
+    }
+
+    public static interface DAO extends CloseMe {
+        @SqlUpdate("insert into something (name) values (:it)")
+        @GetGeneratedKeys
+        public long insert(@Bind String name);
+
+        @SqlQuery("select name from something where id = :it")
+        public String findNameById(@Bind long id);
+    }
+
+    @Test
+    public void testFoo() throws Exception {
+        DAO dao = dbi.open(DAO.class);
+
+        long brian_id = dao.insert("Brian");
+        long keith_id = dao.insert("Keith");
+
+        assertThat(dao.findNameById(brian_id), equalTo("Brian"));
+        assertThat(dao.findNameById(keith_id), equalTo("Keith"));
+
+        dao.close();
+    }
+
+}


### PR DESCRIPTION
It looks like that returning generated keys by the  `@GetGeneratedKeys` annotation was broken by #117.

The problem is that the method `columnName` in this annotation by default returns an empty string. But the new code checks only for a null reference. As the result, we pass to a JDBC driver an array
with one empty string as column names in the corresponding method  `prepareStatement`.

Database vendors handle this behavior differently. MySQL and H2 permit it,  but PostgreSQL, Oracle, and HSQLDB don't. Therefore we should not pass an empty string as a column name, because it doesn't work in major databases.

We have a test on generating keys for PostgreSQL, but it's ignored. This change adds a test for HSQDB, which shows broken behaviour.