### PR TITLE
SqlObject now supports default methods

### DIFF
--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefaultMethods.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefaultMethods.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jdbi.v3.H2DatabaseRule;
+import org.jdbi.v3.Something;
+import org.jdbi.v3.sqlobject.customizers.Mapper;
+import org.jdbi.v3.sqlobject.mixins.CloseMe;
+import org.junit.Rule;
+import org.junit.Test;
+
+@SuppressWarnings("resource")
+public class TestDefaultMethods
+{
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule();
+
+    @Test
+    public void testDefaultMethod() throws Exception {
+        Spiffy dao = SqlObjectBuilder.onDemand(db.getDbi(), Spiffy.class);
+        Something test = dao.insertAndReturn(3, "test");
+        assertEquals(3, test.getId());
+        assertEquals("test", test.getName());
+    }
+
+    @Test
+    public void testOverride() throws Exception {
+        SpiffyOverride dao = SqlObjectBuilder.onDemand(db.getDbi(), SpiffyOverride.class);
+        assertEquals(null, dao.insertAndReturn(123, "fake"));
+    }
+
+    @Test
+    public void testOverrideWithDefault() throws Exception {
+        SpiffyOverrideWithDefault dao = SqlObjectBuilder.onDemand(db.getDbi(), SpiffyOverrideWithDefault.class);
+        assertEquals(-6, dao.insertAndReturn(123, "fake").getId());
+    }
+
+    public static interface Spiffy extends CloseMe
+    {
+        @SqlQuery("select id, name from something where id = :id")
+        @Mapper(SomethingMapper.class)
+        public Something byId(@Bind("id") int id);
+
+        @SqlUpdate("insert into something (id, name) values (:it.id, :it.name)")
+        public void insert(@Bind(value = "it", binder = SomethingBinderAgainstBind.class) Something it);
+
+        default Something insertAndReturn(int id, String name) {
+            insert(new Something(id, name));
+            return byId(id);
+        }
+    }
+
+    public static interface SpiffyOverride extends Spiffy
+    {
+        @Override
+        @SqlQuery("select id, name from something where id = :id")
+        Something insertAndReturn(@Bind int id, @Bind String name);
+    }
+
+    public static interface SpiffyOverrideWithDefault extends SpiffyOverride
+    {
+        @Override
+        default Something insertAndReturn(int id, String name) {
+            return new Something(-6, "what");
+        }
+    }
+}


### PR DESCRIPTION
tag @qualidafial so that approach you linked doesn't seem to work:
```
java.lang.RuntimeException: java.lang.IllegalAccessException: no private access for invokespecial: interface org.jdbi.v3.sqlobject.TestJava8Features$Spiffy, from org.jdbi.v3.sqlobject.TestJava8Features$Spiffy/package
	at com.google.common.base.Throwables.propagate(Throwables.java:160)
	at org.jdbi.v3.sqlobject.PassThroughHandler.invokeDefault(PassThroughHandler.java:71)
	at org.jdbi.v3.sqlobject.PassThroughHandler.invoke(PassThroughHandler.java:41)
	at org.jdbi.v3.sqlobject.SqlObject.invoke(SqlObject.java:173)
	at org.jdbi.v3.sqlobject.SqlObject$1.intercept(SqlObject.java:73)
	at org.jdbi.v3.sqlobject.CloseInternalDoNotUseThisClass$$EnhancerByCGLIB$$bc09080d.insertAndReturn(<generated>)
	at org.jdbi.v3.sqlobject.TestJava8Features.testDefaultMethod(TestJava8Features.java:34)
Caused by: java.lang.IllegalAccessException: no private access for invokespecial: interface org.jdbi.v3.sqlobject.TestJava8Features$Spiffy, from org.jdbi.v3.sqlobject.TestJava8Features$Spiffy/package
	at java.lang.invoke.MemberName.makeAccessException(MemberName.java:855)
	at java.lang.invoke.MethodHandles$Lookup.checkSpecialCaller(MethodHandles.java:1565)
	at java.lang.invoke.MethodHandles$Lookup.unreflectSpecial(MethodHandles.java:1224)
	at org.jdbi.v3.sqlobject.PassThroughHandler.invokeDefault(PassThroughHandler.java:67)
	... 30 more
```

but I think I got it working!