### PR TITLE
Arbitrarily Paramaterized Sql Locators

### DIFF
--- a/core/src/main/java/org/jdbi/v3/Call.java
+++ b/core/src/main/java/org/jdbi/v3/Call.java
@@ -39,7 +39,7 @@ public class Call extends SQLStatement<Call>
          StatementLocator locator,
          StatementRewriter rewriter,
          StatementBuilder cache,
-         String sql,
+         SqlName sql,
          ConcreteStatementContext ctx,
          TimingCollector timingCollector,
          Collection<StatementCustomizer> customizers,

--- a/core/src/main/java/org/jdbi/v3/ClasspathStatementLocator.java
+++ b/core/src/main/java/org/jdbi/v3/ClasspathStatementLocator.java
@@ -32,7 +32,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public class ClasspathStatementLocator implements StatementLocator
 {
-    private final Map<String, String> found = Collections.synchronizedMap(new WeakHashMap<String, String>());
+    private final Map<String, String> found = Collections.synchronizedMap(new WeakHashMap<>());
 
     /**
      * Very basic sanity test to see if a string looks like it might be sql
@@ -72,28 +72,28 @@ public class ClasspathStatementLocator implements StatementLocator
     @Override
     @SuppressWarnings({ "PMD.EmptyCatchBlock", "resource" })
     @SuppressFBWarnings("DM_STRING_CTOR")
-    public String locate(String name, StatementContext ctx)
+    public String locate(SqlName name, StatementContext ctx)
     {
         final String cache_key;
         if (ctx.getSqlObjectType() != null) {
             cache_key = '/' + mungify(ctx.getSqlObjectType().getName() + '.' + name) + ".sql";
         }
         else {
-            cache_key = name;
+            cache_key = name.toString();
         }
 
         if (found.containsKey(cache_key)) {
             return found.get(cache_key);
         }
 
-        if (looksLikeSql(name)) {
+        if (looksLikeSql(name.toString())) {
             // No need to cache individual SQL statements that don't cause us to search the classpath
-            return name;
+            return name.toString();
         }
         final ClassLoader loader = selectClassLoader();
         InputStream in_stream = null;
         try {
-            in_stream = loader.getResourceAsStream(name);
+            in_stream = loader.getResourceAsStream(name.toString());
             if (in_stream == null) {
                 in_stream = loader.getResourceAsStream(name + ".sql");
             }
@@ -109,8 +109,8 @@ public class ClasspathStatementLocator implements StatementLocator
             if (in_stream == null) {
                 // Ensure we don't store an identity map entry which has a hard reference
                 // to the key (through the value) by copying the value, avoids potential memory leak.
-                found.put(cache_key, name == cache_key ? new String(name) : name);
-                return name;
+                found.put(cache_key, name.toString() == cache_key ? new String(name.toString()) : name.toString());
+                return name.toString();
             }
             String sql;
             try {

--- a/core/src/main/java/org/jdbi/v3/Cleanables.java
+++ b/core/src/main/java/org/jdbi/v3/Cleanables.java
@@ -210,8 +210,7 @@ class Cleanables
         }
 
         @Override
-        public void cleanup()
-            throws SQLException
+        public void cleanup() throws SQLException
         {
             if (statementBuilder != null) {
                 statementBuilder.close(conn, sql, stmt);

--- a/core/src/main/java/org/jdbi/v3/ConcreteStatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/ConcreteStatementContext.java
@@ -31,7 +31,7 @@ public final class ConcreteStatementContext implements StatementContext
     private final Map<String, Object>        attributes = new HashMap<String, Object>();
     private final MappingRegistry mappingRegistry;
 
-    private String            rawSql;
+    private SqlName           rawSql;
     private String            rewrittenSql;
     private String            locatedSql;
     private PreparedStatement statement;
@@ -94,7 +94,7 @@ public final class ConcreteStatementContext implements StatementContext
         return mappingRegistry.columnMapperFor(type, this);
     }
 
-    void setRawSql(String rawSql)
+    void setSqlName(SqlName rawSql)
     {
         this.rawSql = rawSql;
     }
@@ -105,7 +105,7 @@ public final class ConcreteStatementContext implements StatementContext
      * @return the initial sql
      */
     @Override
-    public String getRawSql()
+    public SqlName getSqlName()
     {
         return rawSql;
     }

--- a/core/src/main/java/org/jdbi/v3/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/Handle.java
@@ -13,11 +13,6 @@
  */
 package org.jdbi.v3;
 
-import java.io.Closeable;
-import java.sql.Connection;
-import java.util.List;
-import java.util.Map;
-
 import org.jdbi.v3.exceptions.TransactionFailedException;
 import org.jdbi.v3.tweak.ArgumentFactory;
 import org.jdbi.v3.tweak.ResultColumnMapper;
@@ -26,11 +21,15 @@ import org.jdbi.v3.tweak.StatementBuilder;
 import org.jdbi.v3.tweak.StatementLocator;
 import org.jdbi.v3.tweak.StatementRewriter;
 
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+
 /**
  * This represents a connection to the database system. It usually is a wrapper around
  * a JDBC Connection object.
  */
-public interface Handle extends Closeable
+public interface Handle extends AutoCloseable
 {
 
     /**
@@ -43,7 +42,6 @@ public interface Handle extends Closeable
      * @throws org.jdbi.v3.exceptions.UnableToCloseResourceException if any
      * resources throw exception while closing
      */
-    @Override
     void close();
 
     /**
@@ -83,31 +81,36 @@ public interface Handle extends Closeable
 
     /**
      * Return a default Query instance which can be executed later, as long as this handle remains open.
-     * @param sql the select sql
+     *
+     * @param sql the name of the sql to execute (or the raw sql)
+     * @param extra extra arguments used to resolve `name` to sql
      */
-    Query<Map<String, Object>> createQuery(String sql);
+    Query<Map<String, Object>> createQuery(Object sql, Object... extra);
 
     /**
      * Create an Insert or Update statement which returns the number of rows modified.
-     * @param sql The statement sql
+     * @param sql the name of the sql to execute (or the raw sql)
+     * @param extra extra arguments used to resolve `name` to sql
      */
-    Update createStatement(String sql);
+    Update createStatement(Object sql, Object... extra);
 
     /**
      * Create a call to a stored procedure
      *
-     * @param callableSql
+     * @param sql the name of the sql to execute (or the raw sql)
+     * @param extra extra arguments used to resolve `name` to sql
      * @return the Call
      */
-    Call createCall(String callableSql);
+    Call createCall(Object sql, Object... extra);
 
 
     /**
      * Execute a simple insert statement
-     * @param sql the insert SQL
+     * @param sql the name of the sql to execute (or the raw sql)
+     * @param extra extra arguments used to resolve `name` to sql
      * @return the number of rows inserted
      */
-    int insert(String sql, Object... args);
+    int insert(String sql, Object... extra);
 
     /**
      * Execute a simple update statement
@@ -115,15 +118,16 @@ public interface Handle extends Closeable
      * @param args positional arguments
      * @return the number of updated inserted
      */
-    int update(String sql, Object... args);
+    int update(String sql, Object... extra);
 
     /**
      * Prepare a batch to execute. This is for efficiently executing more than one
      * of the same statements with different parameters bound
-     * @param sql the batch SQL
+     * @param sql the name of the sql to execute (or the raw sql)
+     * @param extra extra arguments used to resolve `name` to sql
      * @return a batch which can have "statements" added
      */
-    PreparedBatch prepareBatch(String sql);
+    PreparedBatch prepareBatch(Object sql, Object... extra);
 
     /**
      * Create a non-prepared (no bound parameters, but different SQL, batch statement
@@ -201,15 +205,20 @@ public interface Handle extends Closeable
     /**
      * Creates an SQL script, looking for the source of the script using the
      * current statement locator (which defaults to searching the classpath)
+     *
+     * @param sql the name of the sql to execute (or the raw sql)
+     * @param extra extra arguments used to resolve `name` to sql
+     * @param extra extra arguments used to resolve `name` to sql
      */
-    Script createScript(String name);
+    Script createScript(Object name, Object... extra);
 
     /**
      * Execute some SQL with no return value
-     * @param sql the sql to execute
+     * @param sql the name of the sql to execute (or the raw sql)
+     * @param extra extra arguments used to resolve `name` to sql
      * @param args arguments to bind to the sql
      */
-    void execute(String sql, Object... args);
+    void execute(String sql, Object... extra);
 
     /**
      * Create a transaction checkpoint (savepoint in JDBC terminology) with the name provided.

--- a/core/src/main/java/org/jdbi/v3/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/PreparedBatch.java
@@ -51,7 +51,7 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
                   StatementRewriter rewriter,
                   Handle handle,
                   StatementBuilder statementBuilder,
-                  String sql,
+                  SqlName sql,
                   ConcreteStatementContext ctx,
                   TimingCollector timingCollector,
                   Collection<StatementCustomizer> statementCustomizers,

--- a/core/src/main/java/org/jdbi/v3/PreparedBatchPart.java
+++ b/core/src/main/java/org/jdbi/v3/PreparedBatchPart.java
@@ -35,7 +35,7 @@ public class PreparedBatchPart extends SQLStatement<PreparedBatchPart>
                       StatementRewriter rewriter,
                       Handle handle,
                       StatementBuilder cache,
-                      String sql,
+                      SqlName sql,
                       ConcreteStatementContext context,
                       TimingCollector timingCollector,
                       Foreman foreman)

--- a/core/src/main/java/org/jdbi/v3/Query.java
+++ b/core/src/main/java/org/jdbi/v3/Query.java
@@ -46,7 +46,7 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
           StatementRewriter statementRewriter,
           Handle handle,
           StatementBuilder cache,
-          String sql,
+          SqlName sql,
           ConcreteStatementContext ctx,
           TimingCollector timingCollector,
           Collection<StatementCustomizer> customizers,

--- a/core/src/main/java/org/jdbi/v3/SQLStatement.java
+++ b/core/src/main/java/org/jdbi/v3/SQLStatement.java
@@ -52,7 +52,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
 
     private final Binding          params;
     private final Handle           handle;
-    private final String           sql;
+    private final SqlName           sql;
     private final StatementBuilder statementBuilder;
 
     private StatementLocator  locator;
@@ -70,7 +70,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
                  StatementRewriter rewriter,
                  Handle handle,
                  StatementBuilder statementBuilder,
-                 String sql,
+                 SqlName sql,
                  ConcreteStatementContext ctx,
                  TimingCollector timingCollector,
                  Collection<StatementCustomizer> statementCustomizers,
@@ -90,7 +90,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
         this.locator = locator;
 
         ctx.setConnection(handle.getConnection());
-        ctx.setRawSql(sql);
+        ctx.setSqlName(sql);
         ctx.setBinding(params);
     }
 
@@ -216,7 +216,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
     /**
      * The un-translated SQL used to create this statement
      */
-    protected String getSql()
+    protected SqlName getSql()
     {
         return sql;
     }
@@ -1257,7 +1257,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
         return bind(position, new SqlTypeArgument(value, sqlType));
     }
 
-    private String wrapLookup(String sql)
+    private String wrapLookup(SqlName sql)
     {
         try {
             return locator.locate(sql, this.getContext());
@@ -1287,7 +1287,10 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
 
         // The statement builder might (or might not) clean up the statement when called. E.g. the
         // caching statement builder relies on the statement *not* being closed.
-        addCleanable(new Cleanables.StatementBuilderCleanable(statementBuilder, handle.getConnection(), sql, stmt));
+        addCleanable(new Cleanables.StatementBuilderCleanable(statementBuilder,
+                                                              handle.getConnection(),
+                                                              rewritten.getSql(),
+                                                              stmt));
 
         getConcreteContext().setStatement(stmt);
 

--- a/core/src/main/java/org/jdbi/v3/Script.java
+++ b/core/src/main/java/org/jdbi/v3/Script.java
@@ -29,10 +29,10 @@ public class Script
 
     private final Handle handle;
     private final StatementLocator locator;
-    private final String name;
+    private final SqlName name;
     private final StatementContext statementContext;
 
-    Script(Handle h, StatementLocator locator, String name, StatementContext statementContext)
+    Script(Handle h, StatementLocator locator, SqlName name, StatementContext statementContext)
     {
         this.handle = h;
         this.locator = locator;

--- a/core/src/main/java/org/jdbi/v3/SqlName.java
+++ b/core/src/main/java/org/jdbi/v3/SqlName.java
@@ -1,12 +1,20 @@
 package org.jdbi.v3;
 
 public class SqlName {
-    private final Object name;
+    private final Object   name;
     private final Object[] args;
+    private final String   string;
 
     SqlName(Object name, Object... args) {
         this.name = name;
         this.args = args;
+        StringBuilder sb = new StringBuilder();
+        sb.append(name);
+        for (Object arg : args) {
+            sb.append(" ");
+            sb.append(arg);
+        }
+        this.string = sb.toString();
     }
 
     public Object getName() {
@@ -19,12 +27,6 @@ public class SqlName {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(name);
-        for (Object arg : args) {
-            sb.append(" ");
-            sb.append(arg);
-        }
-        return sb.toString();
+        return string;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/SqlName.java
+++ b/core/src/main/java/org/jdbi/v3/SqlName.java
@@ -1,0 +1,30 @@
+package org.jdbi.v3;
+
+public class SqlName {
+    private final Object name;
+    private final Object[] args;
+
+    SqlName(Object name, Object... args) {
+        this.name = name;
+        this.args = args;
+    }
+
+    public Object getName() {
+        return name;
+    }
+
+    public Object[] getArgs() {
+        return args;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(name);
+        for (Object arg : args) {
+            sb.append(" ");
+            sb.append(arg);
+        }
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/StatementContext.java
@@ -68,7 +68,7 @@ public interface StatementContext
      *
      * @return the initial sql
      */
-    String getRawSql();
+    SqlName getSqlName();
 
     /**
      * Obtain the located and rewritten sql

--- a/core/src/main/java/org/jdbi/v3/Update.java
+++ b/core/src/main/java/org/jdbi/v3/Update.java
@@ -35,7 +35,7 @@ public class Update extends SQLStatement<Update>
            StatementLocator locator,
            StatementRewriter statementRewriter,
            StatementBuilder statementBuilder,
-           String sql,
+           SqlName sql,
            ConcreteStatementContext ctx,
            TimingCollector timingCollector,
            Foreman foreman)

--- a/core/src/main/java/org/jdbi/v3/exceptions/StatementException.java
+++ b/core/src/main/java/org/jdbi/v3/exceptions/StatementException.java
@@ -77,7 +77,7 @@ public abstract class StatementException extends DBIException
         else {
             return String.format("%s [statement:\"%s\", located:\"%s\", rewritten:\"%s\", arguments:%s]",
                                  base,
-                                 ctx.getRawSql(),
+                                 ctx.getSqlName(),
                                  ctx.getLocatedSql(),
                                  ctx.getRewrittenSql(),
                                  ctx.getBinding());

--- a/core/src/main/java/org/jdbi/v3/tweak/StatementLocator.java
+++ b/core/src/main/java/org/jdbi/v3/tweak/StatementLocator.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.tweak;
 
+import org.jdbi.v3.SqlName;
 import org.jdbi.v3.StatementContext;
 
 /**
@@ -28,5 +29,5 @@ public interface StatementLocator
      * @return the SQL to execute, after it goes through a StatementRewriter
      * @throws Exception if anything goes wrong, jDBI will percolate expected exceptions
      */
-    String locate(String name, StatementContext ctx) throws Exception;
+    String locate(SqlName name, StatementContext ctx) throws Exception;
 }

--- a/core/src/test/java/org/jdbi/v3/TestClasspathStatementLocator.java
+++ b/core/src/test/java/org/jdbi/v3/TestClasspathStatementLocator.java
@@ -129,7 +129,7 @@ public class TestClasspathStatementLocator
     public void testCachesOriginalQueryWhenNotFound() throws Exception
     {
         StatementLocator statementLocator = new ClasspathStatementLocator();
-        StatementContext statementContext = new TestingStatementContext(new HashMap<String, Object>()) {
+        StatementContext statementContext = new TestingStatementContext(new HashMap<>()) {
 
             @Override
             public Class<?> getSqlObjectType() {
@@ -137,13 +137,13 @@ public class TestClasspathStatementLocator
             }
         };
 
-        String input = "missing query";
+        SqlName input = new SqlName("missing query");
         String located = statementLocator.locate(input, statementContext);
 
-        assertEquals(input, located); // first time just caches it
+        assertEquals(input.toString(), located); // first time just caches it
 
         located = statementLocator.locate(input, statementContext);
 
-        assertEquals(input, located); // second time reads from cache
+        assertEquals(input.toString(), located); // second time reads from cache
     }
 }

--- a/core/src/test/java/org/jdbi/v3/TestScript.java
+++ b/core/src/test/java/org/jdbi/v3/TestScript.java
@@ -83,7 +83,7 @@ public class TestScript
             fail("Should fail because the script is malformed");
         } catch (StatementException e) {
             StatementContext context = e.getStatementContext();
-            assertEquals("insert into something(id, name) values (2, eric)", context.getRawSql().trim());
+            assertEquals("insert into something(id, name) values (2, eric)", context.getSqlName().toString().trim());
         }
     }
 }

--- a/core/src/test/java/org/jdbi/v3/TestStatementContext.java
+++ b/core/src/test/java/org/jdbi/v3/TestStatementContext.java
@@ -13,34 +13,25 @@
  */
 package org.jdbi.v3;
 
-import static org.junit.Assert.assertEquals;
-
-import org.jdbi.v3.tweak.StatementLocator;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class TestStatementContext
-{
+import static org.junit.Assert.assertEquals;
+
+public class TestStatementContext {
     @Rule
     public H2DatabaseRule db = new H2DatabaseRule();
 
     @Test
-    public void testFoo() throws Exception
-    {
+    public void testFoo() throws Exception {
         Handle h = db.openHandle();
-        h.setStatementLocator(new StatementLocator() {
-
-            @Override
-            public String locate(String name, StatementContext ctx) throws Exception
-            {
-                return name.replaceAll("<table>", String.valueOf(ctx.getAttribute("table")));
-            }
-        });
+        h.setStatementLocator((name, ctx) -> name.toString().replaceAll("<table>",
+                                                                        String.valueOf(ctx.getAttribute("table"))));
         final int inserted = h.createStatement("insert into <table> (id, name) values (:id, :name)")
-                .bind("id", 7)
-                .bind("name", "Martin")
-                .define("table", "something")
-                .execute();
+                              .bind("id", 7)
+                              .bind("name", "Martin")
+                              .define("table", "something")
+                              .execute();
         assertEquals(1, inserted);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/TestStatementExceptionContext.java
+++ b/core/src/test/java/org/jdbi/v3/TestStatementExceptionContext.java
@@ -31,7 +31,7 @@ public class TestStatementExceptionContext
             h.insert("WOOF", 7, "Tom");
         }
         catch (StatementException e) {
-           assertEquals(e.getStatementContext().getRawSql(), "WOOF");
+           assertEquals(e.getStatementContext().getSqlName().toString(), "WOOF");
         }
     }
 }

--- a/core/src/test/java/org/jdbi/v3/TestTimingCollector.java
+++ b/core/src/test/java/org/jdbi/v3/TestTimingCollector.java
@@ -130,7 +130,7 @@ public class TestTimingCollector
         @Override
         public synchronized void collect(final long elapsedTime, final StatementContext ctx)
         {
-            statements.add(ctx.getRawSql());
+            statements.add(ctx.getSqlName().toString());
         }
 
         public synchronized List<String> getStatements()

--- a/core/src/test/java/org/jdbi/v3/TestingStatementContext.java
+++ b/core/src/test/java/org/jdbi/v3/TestingStatementContext.java
@@ -55,7 +55,7 @@ public class TestingStatementContext implements StatementContext
     }
 
     @Override
-    public String getRawSql()
+    public SqlName getSqlName()
     {
         throw new UnsupportedOperationException();
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/stringtemplate/StringTemplate3StatementLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/stringtemplate/StringTemplate3StatementLocator.java
@@ -26,6 +26,7 @@ import org.antlr.stringtemplate.StringTemplate;
 import org.antlr.stringtemplate.StringTemplateErrorListener;
 import org.antlr.stringtemplate.StringTemplateGroup;
 import org.antlr.stringtemplate.language.AngleBracketTemplateLexer;
+import org.jdbi.v3.SqlName;
 import org.jdbi.v3.StatementContext;
 import org.jdbi.v3.tweak.StatementLocator;
 
@@ -242,11 +243,11 @@ public class StringTemplate3StatementLocator implements StatementLocator
     }
 
     @Override
-    public String locate(String name, StatementContext ctx) throws Exception
+    public String locate(SqlName name, StatementContext ctx) throws Exception
     {
-        if (group.isDefined(name)) {
+        if (group.isDefined(name.toString())) {
             // yeah, found template for it!
-            StringTemplate t = group.getInstanceOf(name);
+            StringTemplate t = group.getInstanceOf(name.toString());
             t.reset();
             for (Map.Entry<String, Object> entry : ctx.getAttributes().entrySet()) {
                 t.setAttribute(entry.getKey(), entry.getValue());
@@ -255,9 +256,9 @@ public class StringTemplate3StatementLocator implements StatementLocator
         }
         else if (treatLiteralsAsTemplates) {
             // no template in the template group, but we want literals to be templates
-            final String key = new String(new Base64().encode(name.getBytes(UTF_8)), UTF_8);
+            final String key = new String(new Base64().encode(name.toString().getBytes(UTF_8)), UTF_8);
             if (!literals.isDefined(key)) {
-                literals.defineTemplate(key, name);
+                literals.defineTemplate(key, name.toString());
             }
             StringTemplate t = literals.lookupTemplate(key);
             for (Map.Entry<String, Object> entry : ctx.getAttributes().entrySet()) {
@@ -267,7 +268,7 @@ public class StringTemplate3StatementLocator implements StatementLocator
         }
         else {
             // no template, no literals as template, just use the literal as sql
-            return name;
+            return name.toString();
         }
     }
 


### PR DESCRIPTION
Change sql "naming" to be (Object,Object...) based instead of a String.
This allows for much more sophisticated naming strategies, such as using
the SQL Object class and the method name, or doing classpath lookups
relative to the passed in class, etc.

In order to keep flexibility, it is done as just objects. Ideally it
would be type parameterized on the sql locator, but that would require
the sql locator setter become a builder, plus it would make for *really*
verbose type names, which would suck. This seems like a pragmatic
compromise, and fits with other dynamic aspects of jdbi.