### PR TITLE
Resurrect container builders in JDBI 3

### DIFF
--- a/core/src/main/java/org/jdbi/v3/Call.java
+++ b/core/src/main/java/org/jdbi/v3/Call.java
@@ -42,9 +42,11 @@ public class Call extends SQLStatement<Call>
          ConcreteStatementContext ctx,
          TimingCollector timingCollector,
          Collection<StatementCustomizer> customizers,
-         Foreman foreman)
+         Foreman foreman,
+         CollectorFactoryRegistry collectorFactoryRegistry)
     {
-        super(new Binding(), locator, rewriter, handle, cache, sql, ctx, timingCollector, customizers, foreman);
+        super(new Binding(), locator, rewriter, handle, cache, sql, ctx, timingCollector, customizers, foreman,
+                collectorFactoryRegistry);
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/CollectorFactoryRegistry.java
+++ b/core/src/main/java/org/jdbi/v3/CollectorFactoryRegistry.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3;
+
+import org.jdbi.v3.tweak.CollectorFactory;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/**
+ * Registry of collector factories.
+ * Contains a set of collector factories, registered by the application.
+ */
+class CollectorFactoryRegistry {
+
+    private final Set<CollectorFactory<?, ?>> factories = new CopyOnWriteArraySet<>();
+
+    CollectorFactoryRegistry() {
+        factories.add(new ListCollectorFactory<>());
+        factories.add(new SortedSetCollectorFactory<>());
+        factories.add(new SetCollectorFactory<>());
+    }
+
+    CollectorFactoryRegistry createChild() {
+        return copyOf(this);
+    }
+
+    void register(CollectorFactory<?, ?> factory) {
+        factories.add(factory);
+    }
+
+    @SuppressWarnings("unchecked")
+    <T, R> Collector<T, ?, R> createCollectorFor(Class<R> type) {
+        for (CollectorFactory<?, ?> factory : factories) {
+            if (factory.accepts(type)) {
+                return ((CollectorFactory<T, R>) factory).newCollector(type);
+            }
+        }
+
+        throw new IllegalStateException("No collector builder available for " + type.getName());
+    }
+
+    static CollectorFactoryRegistry copyOf(CollectorFactoryRegistry registry) {
+        CollectorFactoryRegistry newRegistry = new CollectorFactoryRegistry();
+        newRegistry.factories.addAll(registry.factories);
+        return newRegistry;
+    }
+
+    private static class SortedSetCollectorFactory<T> implements CollectorFactory<T, SortedSet<T>> {
+
+        public boolean accepts(Class<?> type) {
+            return type.equals(SortedSet.class);
+        }
+
+        public Collector<T, ?, SortedSet<T>> newCollector(Class<SortedSet<T>> type) {
+            return Collectors.toCollection(TreeSet::new);
+        }
+    }
+
+    private static class ListCollectorFactory<T> implements CollectorFactory<T, List<T>> {
+
+        public boolean accepts(Class<?> type) {
+            return type.equals(List.class);
+        }
+
+        public Collector<T, ?, List<T>> newCollector(Class<List<T>> type) {
+            return Collectors.toList();
+        }
+    }
+
+    private static class SetCollectorFactory<T> implements CollectorFactory<T, Set<T>> {
+
+        public boolean accepts(Class<?> type) {
+            return type.equals(Set.class);
+        }
+
+        public Collector<T, ?, Set<T>> newCollector(Class<Set<T>> type) {
+            return Collectors.toSet();
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/DBI.java
+++ b/core/src/main/java/org/jdbi/v3/DBI.java
@@ -51,6 +51,7 @@ public class DBI
 
     private final Map<String, Object> globalStatementAttributes = new ConcurrentHashMap<String, Object>();
     private final MappingRegistry mappingRegistry = new MappingRegistry();
+    private final CollectorFactoryRegistry collectorFactoryRegistry = new CollectorFactoryRegistry();
     private final Foreman foreman = new Foreman();
 
     private final ConnectionFactory connectionFactory;
@@ -195,7 +196,8 @@ public class DBI
                                        globalStatementAttributes,
                                        timingCollector.get(),
                                        MappingRegistry.copyOf(mappingRegistry),
-                                       foreman.createChild());
+                                       foreman.createChild(),
+                                       collectorFactoryRegistry.createChild());
             LOG.trace("DBI [{}] obtain handle [{}] in {}ms", this, h, (stop - start) / 1000000L);
             return h;
         }

--- a/core/src/main/java/org/jdbi/v3/GeneratedKeys.java
+++ b/core/src/main/java/org/jdbi/v3/GeneratedKeys.java
@@ -32,6 +32,7 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
     private final Statement                stmt;
     private final ResultSet                results;
     private final StatementContext         context;
+    private final CollectorFactoryRegistry collectorFactoryRegistry;
 
     /**
      * Creates a new wrapper object for generated keys as returned by the {@link Statement#getGeneratedKeys()}
@@ -45,7 +46,8 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
     GeneratedKeys(ResultSetMapper<Type> mapper,
                   SQLStatement<?> jdbiStatement,
                   Statement stmt,
-                  StatementContext context) throws SQLException
+                  StatementContext context,
+                  CollectorFactoryRegistry collectorFactoryRegistry) throws SQLException
     {
         this.mapper = mapper;
         this.jdbiStatement = jdbiStatement;
@@ -53,6 +55,7 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
         this.results = stmt.getGeneratedKeys();
         this.context = context;
         this.jdbiStatement.addCleanable(Cleanables.forResultSet(results));
+        this.collectorFactoryRegistry = collectorFactoryRegistry.createChild();
     }
 
     /**
@@ -73,5 +76,10 @@ public class GeneratedKeys<Type> implements ResultBearing<Type>
         catch (SQLException e) {
             throw new ResultSetException("Exception thrown while attempting to traverse the result set", e, context);
         }
+    }
+
+    @Override
+    public <ContainerType> ContainerType collectInto(Class<ContainerType> containerType) {
+        return collect(collectorFactoryRegistry.createCollectorFor(containerType));
     }
 }

--- a/core/src/main/java/org/jdbi/v3/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/Handle.java
@@ -25,6 +25,7 @@ import org.jdbi.v3.tweak.ResultSetMapper;
 import org.jdbi.v3.tweak.StatementBuilder;
 import org.jdbi.v3.tweak.StatementLocator;
 import org.jdbi.v3.tweak.StatementRewriter;
+import org.jdbi.v3.tweak.CollectorFactory;
 
 /**
  * This represents a connection to the database system. It usually is a wrapper around
@@ -287,4 +288,6 @@ public interface Handle extends Closeable
     TransactionIsolationLevel getTransactionIsolationLevel();
 
     void registerArgumentFactory(ArgumentFactory<?> argumentFactory);
+
+    void registerCollectorFactory(CollectorFactory<?, ?> factory);
 }

--- a/core/src/main/java/org/jdbi/v3/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/PreparedBatch.java
@@ -55,9 +55,11 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
                   ConcreteStatementContext ctx,
                   TimingCollector timingCollector,
                   Collection<StatementCustomizer> statementCustomizers,
-                  Foreman foreman)
+                  Foreman foreman,
+                  CollectorFactoryRegistry collectorFactoryRegistry)
     {
-        super(new Binding(), locator, rewriter, handle, statementBuilder, sql, ctx, timingCollector, statementCustomizers, foreman);
+        super(new Binding(), locator, rewriter, handle, statementBuilder, sql, ctx, timingCollector,
+                statementCustomizers, foreman, collectorFactoryRegistry);
         this.currentBinding = new Binding();
     }
 
@@ -106,7 +108,8 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
                 new GeneratedKeys<GeneratedKeyType>(mapper,
                                                     PreparedBatch.this,
                                                     results,
-                                                    getContext()));
+                                                    getContext(),
+                                                    getCollectorFactoryRegistry()));
 
     }
 
@@ -203,7 +206,8 @@ public class PreparedBatch extends SQLStatement<PreparedBatch>
                                                        getSql(),
                                                        getConcreteContext(),
                                                        getTimingCollector(),
-                                                       getForeman());
+                                                       getForeman(),
+                                                       getCollectorFactoryRegistry());
         parts.add(part);
         this.currentBinding = new Binding();
         return part;

--- a/core/src/main/java/org/jdbi/v3/PreparedBatchPart.java
+++ b/core/src/main/java/org/jdbi/v3/PreparedBatchPart.java
@@ -38,9 +38,11 @@ public class PreparedBatchPart extends SQLStatement<PreparedBatchPart>
                       String sql,
                       ConcreteStatementContext context,
                       TimingCollector timingCollector,
-                      Foreman foreman)
+                      Foreman foreman,
+                      CollectorFactoryRegistry collectorFactoryRegistry)
     {
-        super(binding, locator, rewriter, handle, cache, sql, context, timingCollector, Collections.<StatementCustomizer>emptyList(), foreman);
+        super(binding, locator, rewriter, handle, cache, sql, context, timingCollector,
+                Collections.<StatementCustomizer>emptyList(), foreman, collectorFactoryRegistry);
         this.batch = batch;
     }
 

--- a/core/src/main/java/org/jdbi/v3/Query.java
+++ b/core/src/main/java/org/jdbi/v3/Query.java
@@ -50,9 +50,11 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
           TimingCollector timingCollector,
           Collection<StatementCustomizer> customizers,
           MappingRegistry mappingRegistry,
-          Foreman foreman)
+          Foreman foreman,
+          CollectorFactoryRegistry collectorFactoryRegistry)
     {
-        super(params, locator, statementRewriter, handle, cache, sql, ctx, timingCollector, customizers, foreman);
+        super(params, locator, statementRewriter, handle, cache, sql, ctx, timingCollector, customizers, foreman,
+                collectorFactoryRegistry);
         this.mapper = mapper;
         this.mappingRegistry = mappingRegistry;
     }
@@ -70,6 +72,11 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
                                                         stmt,
                                                         stmt.getResultSet(),
                                                         getContext()));
+    }
+
+    @Override
+    public <ContainerType> ContainerType collectInto(Class<ContainerType> containerType) {
+        return collect(getCollectorFactoryRegistry().createCollectorFor(containerType));
     }
 
     /**
@@ -115,7 +122,8 @@ public class Query<ResultType> extends SQLStatement<Query<ResultType>> implement
                             getTimingCollector(),
                             getStatementCustomizers(),
                             MappingRegistry.copyOf(mappingRegistry),
-                            getForeman().createChild());
+                            getForeman().createChild(),
+                            getCollectorFactoryRegistry().createChild());
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/ResultBearing.java
@@ -15,6 +15,7 @@ package org.jdbi.v3;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -59,8 +60,32 @@ public interface ResultBearing<ResultType> extends Iterable<ResultType>
     }
 
     default List<ResultType> list() {
+        return collect(Collectors.toList());
+    }
+
+    /**
+     * Collect the query results into a container specified by a collector.
+     *
+     * @param collector       the collector
+     * @param <ContainerType> the generic type of the container
+     * @param <A>             the generic type of the container builder
+     * @return the container with the query result
+     */
+    default <ContainerType, A> ContainerType collect(Collector<ResultType, A, ContainerType> collector) {
         try (Stream<ResultType> stream = stream()) {
-            return stream.collect(Collectors.<ResultType>toList());
+            return stream.collect(collector);
         }
     }
+
+    /**
+     * Collect the query result into a container of the type specified by the given class.
+     * A factory for building the container should be registered in the query's
+     * collector factory registry.
+     *
+     * @param containerType   the class that represents the container
+     * @param <ContainerType> the generic type of the container
+     * @return the container with the query result
+     */
+    <ContainerType> ContainerType collectInto(Class<ContainerType> containerType);
+
 }

--- a/core/src/main/java/org/jdbi/v3/Update.java
+++ b/core/src/main/java/org/jdbi/v3/Update.java
@@ -37,9 +37,11 @@ public class Update extends SQLStatement<Update>
            String sql,
            ConcreteStatementContext ctx,
            TimingCollector timingCollector,
-           Foreman foreman)
+           Foreman foreman,
+           CollectorFactoryRegistry collectorFactoryRegistry)
     {
-        super(new Binding(), locator, statementRewriter, handle, statementBuilder, sql, ctx, timingCollector, Collections.<StatementCustomizer>emptyList(), foreman);
+        super(new Binding(), locator, statementRewriter, handle, statementBuilder, sql, ctx, timingCollector,
+                Collections.<StatementCustomizer>emptyList(), foreman, collectorFactoryRegistry);
     }
 
     /**
@@ -73,7 +75,8 @@ public class Update extends SQLStatement<Update>
                 new GeneratedKeys<GeneratedKeyType>(mapper,
                                                     Update.this,
                                                     results,
-                                                    getContext()));
+                                                    getContext(),
+                                                    getCollectorFactoryRegistry()));
     }
 
     public <GeneratedKeyType> GeneratedKeys<GeneratedKeyType> executeAndReturnGeneratedKeys(final ResultSetMapper<GeneratedKeyType> mapper) {

--- a/core/src/main/java/org/jdbi/v3/tweak/CollectorFactory.java
+++ b/core/src/main/java/org/jdbi/v3/tweak/CollectorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.tweak;
+
+import java.util.stream.Collector;
+
+/**
+ * Factory for building containers of elements.
+ * The collector produces only objects of the type of the container elements.
+ *
+ * @param <T> the type of the container elements
+ * @param <R> the type of the container
+ */
+public interface CollectorFactory<T, R> {
+
+    /**
+     * Whether the corresponding collector accepts objects of the given type.
+     *
+     * @param type the object type
+     * @return {@code true}, if accepts, otherwise {@code false}
+     */
+    boolean accepts(Class<?> type);
+
+    /**
+     * Builds a new {@link Collector}.
+     *
+     * @param type the actual type of the container
+     * @return the {@link Collector}
+     */
+    Collector<T, ?, R> newCollector(Class<R> type);
+}

--- a/core/src/test/java/org/jdbi/v3/TestTimingCollector.java
+++ b/core/src/test/java/org/jdbi/v3/TestTimingCollector.java
@@ -49,7 +49,8 @@ public class TestTimingCollector
                                         new HashMap<String, Object>(),
                                         tc,
                                         new MappingRegistry(),
-                                        new Foreman());
+                                        new Foreman(),
+                                        new CollectorFactoryRegistry());
         return h;
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ResultReturnThing.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ResultReturnThing.java
@@ -112,7 +112,7 @@ abstract class ResultReturnThing
         protected Object result(ResultBearing<?> q, HandleDing baton)
         {
             if (containerType != null) {
-                throw new IllegalStateException("TODO: not supported");
+                return q.collectInto(containerType);
             }
             return q.findFirst().orElse(null);
         }
@@ -258,22 +258,11 @@ abstract class ResultReturnThing
         @Override
         protected Object result(ResultBearing<?> q, HandleDing baton)
         {
-            final Object result;
-            final Consumer<Object> consumer;
-            if (erased_type == List.class) {
-                List<Object> list = new ArrayList<>();
-                result = list;
-                consumer = list::add;
-            } else if (erased_type == Set.class) {
-                Set<Object> set = new HashSet<>();
-                result = set;
-                consumer = set::add;
+            if (q instanceof Query) {
+                return ((Query) q).collectInto(erased_type);
             } else {
-                throw new UnsupportedOperationException("TODO: this mapping code sucks");
+                throw new UnsupportedOperationException("Collect is not supported for " + q);
             }
-
-            ((ResultBearing<Object>)q).stream().forEach(consumer);
-            return result;
         }
 
         @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterContainerMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterContainerMapper.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.customizers;
+
+import org.jdbi.v3.Query;
+import org.jdbi.v3.SQLStatement;
+import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
+import org.jdbi.v3.sqlobject.SqlStatementCustomizerFactory;
+import org.jdbi.v3.sqlobject.SqlStatementCustomizingAnnotation;
+import org.jdbi.v3.tweak.CollectorFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Used to register container mappers on the current {@link Query}
+ * either for a sql object type or for a method.
+ */
+@SqlStatementCustomizingAnnotation(RegisterContainerMapper.Factory.class)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RegisterContainerMapper {
+
+    Class<? extends CollectorFactory>[] value();
+
+    class Factory implements SqlStatementCustomizerFactory {
+        public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method) {
+            return new Customizer((RegisterContainerMapper) annotation);
+        }
+
+        public SqlStatementCustomizer createForType(Annotation annotation, Class sqlObjectType) {
+            return new Customizer((RegisterContainerMapper) annotation);
+        }
+
+        public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method,
+                                                         Object arg) {
+            throw new UnsupportedOperationException("@RegisterContainerMapper is not supported on parameters");
+        }
+    }
+
+    class Customizer implements SqlStatementCustomizer {
+        private final List<CollectorFactory<?, ?>> factories;
+
+        Customizer(RegisterContainerMapper annotation) {
+            List<CollectorFactory<?, ?>> factories = new ArrayList<>();
+            for (Class<? extends CollectorFactory> type : annotation.value()) {
+                try {
+                    factories.add(type.newInstance());
+                } catch (InstantiationException | IllegalAccessException e) {
+                    throw new IllegalStateException("Unable to instantiate container factory", e);
+                }
+            }
+            this.factories = factories;
+        }
+
+        public void apply(SQLStatement q) throws SQLException {
+            if (q instanceof Query) {
+                Query<?> query = (Query) q;
+                for (CollectorFactory<?, ?> collectorFactory : factories) {
+                    query.registerCollectorFactory(collectorFactory);
+                }
+            }
+        }
+    }
+}

--- a/sqlobject/src/test/java/org/jdbi/v3/docs/TestPaging.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/docs/TestPaging.java
@@ -29,6 +29,8 @@ import org.jdbi.v3.sqlobject.SomethingMapper;
 import org.jdbi.v3.sqlobject.SqlBatch;
 import org.jdbi.v3.sqlobject.SqlObjectBuilder;
 import org.jdbi.v3.sqlobject.SqlQuery;
+import org.jdbi.v3.sqlobject.TestCollectorFactory;
+import org.jdbi.v3.sqlobject.customizers.RegisterContainerMapper;
 import org.jdbi.v3.sqlobject.customizers.RegisterMapper;
 import org.junit.After;
 import org.junit.Before;
@@ -87,12 +89,13 @@ public class TestPaging
     }
 
     @RegisterMapper(SomethingMapper.class)
+    @RegisterContainerMapper(TestCollectorFactory.ImmutableListCollectorFactory.class)
     public interface Sql
     {
         @SqlBatch("insert into something (id, name) values (:id, :name)")
         int[] insert(@Bind("id") Iterable<Integer> ids, @Bind("name") Iterable<String> names);
 
         @SqlQuery("select id, name from something where id > :end_of_last_page order by id limit :size")
-        List<Something> loadPage(@Bind("end_of_last_page") int last, @Bind("size") int size);
+        ImmutableList<Something> loadPage(@Bind("end_of_last_page") int last, @Bind("size") int size);
     }
 }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import org.jdbi.v3.H2DatabaseRule;
+import org.jdbi.v3.Handle;
+import org.jdbi.v3.Something;
+import org.jdbi.v3.sqlobject.customizers.RegisterContainerMapper;
+import org.jdbi.v3.sqlobject.customizers.SingleValueResult;
+import org.jdbi.v3.tweak.CollectorFactory;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.SortedSet;
+import java.util.stream.Collector;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestCollectorFactory {
+
+    @Rule
+    public H2DatabaseRule h2 = new H2DatabaseRule();
+
+    @Test
+    public void testExists() throws Exception {
+        Handle h = h2.getSharedHandle();
+        h.execute("insert into something (id, name) values (1, 'Coda')");
+        h.registerCollectorFactory(new GuavaOptionalCollectorFactory());
+
+        @SuppressWarnings("unchecked")
+        Optional<String> rs = h.createQuery("select name from something where id = :id")
+                .bind("id", 1)
+                .mapTo(String.class)
+                .collectInto(Optional.class);
+
+        assertThat(rs.isPresent(), equalTo(true));
+        assertThat(rs.get(), equalTo("Coda"));
+    }
+
+    @Test
+    public void testDoesNotExist() throws Exception {
+        Handle h = h2.getSharedHandle();
+        h.execute("insert into something (id, name) values (1, 'Coda')");
+        h.registerCollectorFactory(new GuavaOptionalCollectorFactory());
+
+        @SuppressWarnings("unchecked")
+        Optional<String> rs = h.createQuery("select name from something where id = :id")
+                .bind("id", 2)
+                .mapTo(String.class)
+                .collectInto(Optional.class);
+
+        assertThat(rs.isPresent(), equalTo(false));
+    }
+
+    @Test
+    public void testOnList() throws Exception {
+        Handle h = h2.getSharedHandle();
+        h.registerCollectorFactory(new ImmutableListCollectorFactory());
+
+        h.execute("insert into something (id, name) values (1, 'Coda')");
+        h.execute("insert into something (id, name) values (2, 'Brian')");
+
+        @SuppressWarnings("unchecked")
+        ImmutableList<String> rs = h.createQuery("select name from something order by id")
+                .mapTo(String.class)
+                .collectInto(ImmutableList.class);
+
+        assertThat(rs, equalTo(ImmutableList.of("Coda", "Brian")));
+    }
+
+    @Test
+    public void testWithSqlObject() throws Exception {
+        Dao dao = SqlObjectBuilder.onDemand(h2.getDbi(), Dao.class);
+        dao.insert(new Something(1, "Coda"));
+        dao.insert(new Something(2, "Brian"));
+
+        ImmutableList<String> rs = dao.findAll();
+        assertThat(rs, equalTo(ImmutableList.of("Coda", "Brian")));
+    }
+
+    @Test
+    public void testWithSqlObjectSingleValue() throws Exception {
+        Dao dao = SqlObjectBuilder.onDemand(h2.getDbi(), Dao.class);
+        dao.insert(new Something(1, "Coda"));
+        dao.insert(new Something(2, "Brian"));
+
+        Optional<String> rs = dao.findNameById(1);
+        assertThat(rs, equalTo(Optional.of("Coda")));
+
+        rs = dao.smartFindNameById(1);
+        assertThat(rs, equalTo(Optional.of("Coda")));
+
+        rs = dao.inheritedGenericFindNameById(1);
+        assertThat(rs, equalTo(Optional.of("Coda")));
+    }
+
+    @Test
+    public void testWithSqlObjectSetReturnValue() throws Exception {
+        Dao dao = SqlObjectBuilder.onDemand(h2.getDbi(), Dao.class);
+        dao.insert(new Something(1, "Coda"));
+        dao.insert(new Something(2, "Brian"));
+
+        SortedSet<String> rs = dao.findAllAsSet();
+        assertThat(rs, equalTo(ImmutableSortedSet.of("Brian", "Coda")));
+    }
+
+
+    @RegisterContainerMapper({ImmutableListCollectorFactory.class, GuavaOptionalCollectorFactory.class})
+    public interface Dao extends Base<String> {
+        @SqlQuery("select name from something order by id")
+        ImmutableList<String> findAll();
+
+        @SqlQuery("select name from something order by id")
+        SortedSet<String> findAllAsSet();
+
+        @SqlUpdate("insert into something (id, name) values (:id, :name)")
+        void insert(@BindBean Something it);
+
+        @SqlQuery("select name from something where id = :id")
+        @SingleValueResult(String.class)
+        Optional<String> findNameById(@Bind("id") int id);
+
+        @SqlQuery("select name from something where id = :id")
+        @SingleValueResult
+        Optional<String> smartFindNameById(@Bind("id") int id);
+    }
+
+    public interface Base<T> {
+        @SqlQuery("select name from something where id = :id")
+        @SingleValueResult
+        Optional<T> inheritedGenericFindNameById(@Bind("id") int id);
+    }
+
+    public static class ImmutableListCollectorFactory<T> implements CollectorFactory<T, ImmutableList<T>> {
+
+        public boolean accepts(Class<?> type) {
+            return ImmutableList.class.equals(type);
+        }
+
+        @Override
+        public Collector<T, ImmutableList.Builder<T>, ImmutableList<T>> newCollector(Class<ImmutableList<T>> type) {
+            return Collector.of(ImmutableList.Builder::new, ImmutableList.Builder::add, (first, second) -> {
+                throw new UnsupportedOperationException("Parallel collecting is not supported");
+            }, ImmutableList.Builder<T>::build);
+        }
+    }
+
+    public static class GuavaOptionalCollectorFactory<T> implements CollectorFactory<T, Optional<T>> {
+
+        public boolean accepts(Class<?> type) {
+            return type.equals(Optional.class);
+        }
+
+        @Override
+        public Collector<T, GuavaOptionalBuilder<T>, Optional<T>> newCollector(Class<Optional<T>> type) {
+            return Collector.of(GuavaOptionalBuilder::new, GuavaOptionalBuilder::set, (first, second) -> {
+                throw new UnsupportedOperationException("Parallel collecting is not supported");
+            }, GuavaOptionalBuilder::build);
+        }
+    }
+
+    private static class GuavaOptionalBuilder<T> {
+
+        private Optional<T> optional = Optional.absent();
+
+        public void set(T value) {
+            optional = Optional.of(value);
+        }
+
+        public Optional<T> build() {
+            return optional;
+        }
+    }
+
+}


### PR DESCRIPTION
Container builders are actually quite useful for collecting query results into types that are not shipped with the JDK.  For example, Google Guava's immutable collections and optional values.

Also, they are indispensable for SQLObject API, where we don't have Stream API for providing implementations of custom types.