### PR TITLE
BeanMapper property names also map to underscored column names

### DIFF
--- a/core/src/main/java/org/jdbi/v3/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/BeanMapper.java
@@ -21,15 +21,21 @@ import java.lang.reflect.InvocationTargetException;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.jdbi.v3.tweak.ResultColumnMapper;
 import org.jdbi.v3.tweak.ResultSetMapper;
 
 /**
- * A result set mapper which maps the fields in a statement into a JavaBean. This uses
- * the JDK's built in bean mapping facilities, so it does not support nested properties.
+ * A result set mapper which maps the fields in a statement into a JavaBean. The default implementation will perform a
+ * case insensitive mapping between the bean property names and the column labels, also considering camel-case to
+ * underscores conversion. This uses the JDK's built in bean mapping facilities, so it does not support nested
+ * properties.
  */
 public class BeanMapper<T> implements ResultSetMapper<T>
 {
@@ -39,16 +45,78 @@ public class BeanMapper<T> implements ResultSetMapper<T>
     public BeanMapper(Class<T> type)
     {
         this.type = type;
-        try {
+
+        try
+        {
             BeanInfo info = Introspector.getBeanInfo(type);
 
+            Locale locale = getLocale();
+
             for (PropertyDescriptor descriptor : info.getPropertyDescriptors()) {
-                properties.put(descriptor.getName().toLowerCase(), descriptor);
+                    Collection<String> columnNames = mapToColumnNames(descriptor.getName());
+                    if (columnNames == null) {
+                        continue;
+                    }
+                    for (String columnName : columnNames) {
+                        properties.put(columnName.toLowerCase(locale), descriptor);
+                    }
             }
         }
         catch (IntrospectionException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    /**
+     * Maps a property name to possible column names candidates. This default implementation will map the property name
+     * as-is, and converted from the camel-case syntax to an underscore separated name.
+     * <p>
+     * Processing of the returned mappings will be case insensitive. The mappings are not expected to change across
+     * invocations.
+     *
+     * @param propertyName the bean property name
+     *
+     * @return a collection holding the possible column names (mutable in the default implementation)
+     */
+    protected Collection<String> mapToColumnNames(String propertyName)
+    {
+        Locale locale = getLocale();
+
+        List<String> columnName = new ArrayList<String>(5);
+
+        // Add the bean property name as-is.
+        columnName.add(propertyName);
+
+        // Convert the property name from camel-case to underscores syntax. Freely adapted from Spring
+        // BeanPropertyRowMapper.
+        StringBuilder propertyNameWithUnderscores = new StringBuilder();
+        propertyNameWithUnderscores.append(propertyName.substring(0, 1));
+        for (int i = 1; i < propertyName.length(); i++) {
+            // Do case comparison using strings rather than chars (avoid to deal with non-BMP char handling).
+            String s = propertyName.substring(i, i + 1);
+            String slc = s.toLowerCase(locale);
+            if (!s.equals(slc)) {
+                // Different cases: tokenize.
+                propertyNameWithUnderscores.append("_").append(slc);
+            }
+            else {
+                propertyNameWithUnderscores.append(s);
+            }
+        }
+        columnName.add(propertyNameWithUnderscores.toString());
+
+        return columnName;
+    }
+
+    /**
+     * Gets the locale used to manipulate the Bean properties name. This locale is useful, for example, when doing
+     * case conversion. The locale is expected to be constant across method invocations. By default the {@code US}
+     * locale will be used.
+     *
+     * @return the target locale, never {@code null}
+     */
+    protected Locale getLocale() {
+        return Locale.US;
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/BeanMapper.java
@@ -82,10 +82,10 @@ public class BeanMapper<T> implements ResultSetMapper<T>
     {
         Locale locale = getLocale();
 
-        List<String> columnName = new ArrayList<>(5);
+        List<String> columnNames = new ArrayList<>(5);
 
         // Add the bean property name as-is.
-        columnName.add(propertyName);
+        columnNames.add(propertyName);
 
         // Convert the property name from camel-case to underscores syntax. Freely adapted from Spring
         // BeanPropertyRowMapper.
@@ -103,20 +103,20 @@ public class BeanMapper<T> implements ResultSetMapper<T>
                 propertyNameWithUnderscores.append(s);
             }
         }
-        columnName.add(propertyNameWithUnderscores.toString());
+        columnNames.add(propertyNameWithUnderscores.toString());
 
-        return columnName;
+        return columnNames;
     }
 
     /**
      * Gets the locale used to manipulate the Bean properties name. This locale is useful, for example, when doing
-     * case conversion. The locale is expected to be constant across method invocations. By default the {@code US}
+     * case conversion. The locale is expected to be constant across method invocations. By default the {@code ROOT}
      * locale will be used.
      *
      * @return the target locale, never {@code null}
      */
     protected Locale getLocale() {
-        return Locale.US;
+        return Locale.ROOT;
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/BeanMapper.java
@@ -40,7 +40,7 @@ import org.jdbi.v3.tweak.ResultSetMapper;
 public class BeanMapper<T> implements ResultSetMapper<T>
 {
     private final Class<T> type;
-    private final Map<String, PropertyDescriptor> properties = new HashMap<String, PropertyDescriptor>();
+    private final Map<String, PropertyDescriptor> properties = new HashMap<>();
 
     public BeanMapper(Class<T> type)
     {
@@ -82,7 +82,7 @@ public class BeanMapper<T> implements ResultSetMapper<T>
     {
         Locale locale = getLocale();
 
-        List<String> columnName = new ArrayList<String>(5);
+        List<String> columnName = new ArrayList<>(5);
 
         // Add the bean property name as-is.
         columnName.add(propertyName);

--- a/core/src/test/java/org/jdbi/v3/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/BeanMapperTest.java
@@ -66,9 +66,6 @@ public class BeanMapperTest {
         expect(resultSetMetaData.getColumnLabel(1)).andReturn("LONG_FIELD");
         replay(resultSetMetaData);
 
-        expect(ctx.columnMapperFor(Long.class)).andReturn(LongColumnMapper.WRAPPER);
-        replay(ctx);
-
         expect(resultSet.getMetaData()).andReturn(resultSetMetaData);
         Long aLongVal = 100l;
         expect(resultSet.getLong(1)).andReturn(aLongVal);

--- a/core/src/test/java/org/jdbi/v3/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/BeanMapperTest.java
@@ -61,6 +61,26 @@ public class BeanMapperTest {
     }
 
     @Test
+    public void shouldHandleColumNameWithUnderscores() throws Exception {
+        expect(resultSetMetaData.getColumnCount()).andReturn(1).anyTimes();
+        expect(resultSetMetaData.getColumnLabel(1)).andReturn("LONG_FIELD");
+        replay(resultSetMetaData);
+
+        expect(ctx.columnMapperFor(Long.class)).andReturn(LongColumnMapper.WRAPPER);
+        replay(ctx);
+
+        expect(resultSet.getMetaData()).andReturn(resultSetMetaData);
+        Long aLongVal = 100l;
+        expect(resultSet.getLong(1)).andReturn(aLongVal);
+        expect(resultSet.wasNull()).andReturn(false);
+        replay(resultSet);
+
+        SampleBean sampleBean = mapper.map(0, resultSet, ctx);
+
+        assertEquals(aLongVal, sampleBean.getLongField());
+    }
+
+    @Test
     public void shouldHandleEmptyResult() throws Exception {
         expect(resultSetMetaData.getColumnCount()).andReturn(0);
         replay(resultSetMetaData);

--- a/core/src/test/java/org/jdbi/v3/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/BeanMapperTest.java
@@ -78,6 +78,23 @@ public class BeanMapperTest {
     }
 
     @Test
+    public void shouldBeCaseInSensitiveOfColumnWithUnderscoresAndPropertyNames() throws Exception {
+        expect(resultSetMetaData.getColumnCount()).andReturn(1).anyTimes();
+        expect(resultSetMetaData.getColumnLabel(1)).andReturn("LoNg_FiElD");
+        replay(resultSetMetaData);
+
+        expect(resultSet.getMetaData()).andReturn(resultSetMetaData);
+        Long aLongVal = 100l;
+        expect(resultSet.getLong(1)).andReturn(aLongVal);
+        expect(resultSet.wasNull()).andReturn(false);
+        replay(resultSet);
+
+        SampleBean sampleBean = mapper.map(0, resultSet, ctx);
+
+        assertEquals(aLongVal, sampleBean.getLongField());
+    }
+
+    @Test
     public void shouldHandleEmptyResult() throws Exception {
         expect(resultSetMetaData.getColumnCount()).andReturn(0);
         replay(resultSetMetaData);


### PR DESCRIPTION
Note: This is a rebase on the JDBI 3 branch from this PR: https://github.com/jdbi/jdbi/pull/200

Hi,

This PR is about extending the Bean Mapper to allow automatic mappings from column names using the (very common) "underscore" syntax. Such functionality is also supported out-of-the-box in the BeanPropertyRowMapper (http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/core/BeanPropertyRowMapper.html) from Spring.

In addition, it allows to further customize the mappings with two additional protected methods (one to get the mappings related to a given property name, and another to customize the locale used for case manipulation).

This could be considered a breaking change, since setters that were not mapped before may suddenly start to be invoked. However, the potential disruptive effect seems to be low.

Jean
