### PR TITLE
Factor out property naming strategies

### DIFF
--- a/CHANGES_PLANNED_FOR_3_0
+++ b/CHANGES_PLANNED_FOR_3_0
@@ -14,3 +14,4 @@ This file describes the changes expected in some eventual 3.0 release.
 * Rework the sharing of StatementContext and Mappers to make ownership of these objects more clear
 * Consider using Jackson for type mapping?
 * Consider CallbackFailedException wrapping policy (see #198)
+* Decide if ColumnNameMappingStrategy is the right abstraction?

--- a/core/src/main/java/org/jdbi/v3/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/FieldMapper.java
@@ -36,18 +36,18 @@ import org.jdbi.v3.util.bean.ColumnNameMappingStrategy;
  *
  * The class must have a default constructor.
  */
-public class ReflectiveFieldMapper<T> implements ResultSetMapper<T>
+public class FieldMapper<T> implements ResultSetMapper<T>
 {
     private final Class<T> type;
     private final ConcurrentMap<String, Optional<Field>> fieldByNameCache = new ConcurrentHashMap<>();
     private final Collection<ColumnNameMappingStrategy> nameMappingStrategies;
 
-    public ReflectiveFieldMapper(Class<T> type)
+    public FieldMapper(Class<T> type)
     {
         this(type, BeanMapper.DEFAULT_STRATEGIES);
     }
 
-    public ReflectiveFieldMapper(Class<T> type, Collection<ColumnNameMappingStrategy> nameMappingStrategies)
+    public FieldMapper(Class<T> type, Collection<ColumnNameMappingStrategy> nameMappingStrategies)
     {
         this.type = type;
         this.nameMappingStrategies = Collections.unmodifiableList(new ArrayList<>(nameMappingStrategies));

--- a/core/src/main/java/org/jdbi/v3/util/bean/CaseInsensitiveColumnNameStrategy.java
+++ b/core/src/main/java/org/jdbi/v3/util/bean/CaseInsensitiveColumnNameStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.util.bean;
+
+import java.util.Locale;
+
+public class CaseInsensitiveColumnNameStrategy implements ColumnNameMappingStrategy {
+
+    public static final CaseInsensitiveColumnNameStrategy INSTANCE = new CaseInsensitiveColumnNameStrategy();
+
+    private final Locale locale;
+
+    public CaseInsensitiveColumnNameStrategy() {
+        this(Locale.ROOT);
+    }
+
+    public CaseInsensitiveColumnNameStrategy(Locale locale) {
+        this.locale = locale;
+    }
+
+    @Override
+    public boolean nameMatches(String propertyName, String columnName) {
+        return propertyName.toLowerCase(locale).equals(columnName.toLowerCase(locale));
+    }
+
+    @Override
+    public String toString() {
+        return "LowercaseColumnNamingStrategy" + (locale != Locale.ROOT ? " (" + locale + ")" : "");
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/util/bean/ColumnNameMappingStrategy.java
+++ b/core/src/main/java/org/jdbi/v3/util/bean/ColumnNameMappingStrategy.java
@@ -17,6 +17,7 @@ package org.jdbi.v3.util.bean;
  * Strategy for mapping Java bean property and field names
  * to SQL column names.
  */
+// TODO 3: Is this the right pattern?
 public interface ColumnNameMappingStrategy {
     /**
      * Given the Java name and SQL column name,

--- a/core/src/main/java/org/jdbi/v3/util/bean/ColumnNameMappingStrategy.java
+++ b/core/src/main/java/org/jdbi/v3/util/bean/ColumnNameMappingStrategy.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.util.bean;
+
+/**
+ * Strategy for mapping Java bean property and field names
+ * to SQL column names.
+ */
+public interface ColumnNameMappingStrategy {
+    /**
+     * Given the Java name and SQL column name,
+     * return true if they are logically equivalent.
+     */
+    boolean nameMatches(String propertyName, String sqlColumnName);
+}

--- a/core/src/main/java/org/jdbi/v3/util/bean/SnakeCaseColumnNameStrategy.java
+++ b/core/src/main/java/org/jdbi/v3/util/bean/SnakeCaseColumnNameStrategy.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.util.bean;
+
+import java.util.Locale;
+
+public class SnakeCaseColumnNameStrategy implements ColumnNameMappingStrategy {
+    public static final SnakeCaseColumnNameStrategy INSTANCE = new SnakeCaseColumnNameStrategy();
+
+    private final Locale locale;
+
+    public SnakeCaseColumnNameStrategy() {
+        this(Locale.ROOT);
+    }
+
+    public SnakeCaseColumnNameStrategy(Locale locale) {
+        this.locale = locale;
+    }
+
+    @Override
+    public boolean nameMatches(String propertyName, String sqlColumnName) {
+        // Convert the property name from camel-case to underscores syntax. Freely adapted from Spring
+        // BeanPropertyRowMapper.
+        StringBuilder propertyNameWithUnderscores = new StringBuilder();
+        propertyNameWithUnderscores.append(propertyName.substring(0, 1));
+        for (int i = 1; i < propertyName.length(); i++) {
+            // Do case comparison using strings rather than chars (avoid to deal with non-BMP char handling).
+            String s = propertyName.substring(i, i + 1);
+            String slc = s.toLowerCase(locale);
+            if (!s.equals(slc)) {
+                // Different cases: tokenize.
+                propertyNameWithUnderscores.append("_").append(slc);
+            }
+            else {
+                propertyNameWithUnderscores.append(s);
+            }
+        }
+        return propertyNameWithUnderscores.toString().equals(sqlColumnName.toLowerCase(locale));
+    }
+
+    @Override
+    public String toString() {
+        return "SnakeCaseColumnNamingStrategy" + (locale != Locale.ROOT ? " (" + locale + ")" : "");
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/FieldMapperTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 
 
 @RunWith(EasyMockRunner.class)
-public class ReflectiveFieldMapperTest {
+public class FieldMapperTest {
 
     @Mock
     ResultSet resultSet;
@@ -41,7 +41,7 @@ public class ReflectiveFieldMapperTest {
 
     TestingStatementContext ctx = new TestingStatementContext(Collections.emptyMap());
 
-    ReflectiveFieldMapper<SampleBean> mapper = new ReflectiveFieldMapper<SampleBean>(SampleBean.class);
+    FieldMapper<SampleBean> mapper = new FieldMapper<SampleBean>(SampleBean.class);
 
     @Test
     public void shouldSetValueOnPrivateField() throws Exception {
@@ -153,7 +153,7 @@ public class ReflectiveFieldMapperTest {
         expect(resultSet.wasNull()).andReturn(false).anyTimes();
         replay(resultSet);
 
-        ReflectiveFieldMapper<DerivedBean> mapper = new ReflectiveFieldMapper<DerivedBean>(DerivedBean.class);
+        FieldMapper<DerivedBean> mapper = new FieldMapper<DerivedBean>(DerivedBean.class);
 
         DerivedBean derivedBean = mapper.map(0, resultSet, ctx);
 


### PR DESCRIPTION
Lets our two different bean mappers use the same underlying code to figure out SQL name <-> Java name mappings, and makes it pluggable without needing to subclass.

Probably best viewed with `?w=1`