### PR TITLE
Add a bridge for SqlObject API

### DIFF
--- a/core/src/main/java/org/jdbi/v3/BasicHandle.java
+++ b/core/src/main/java/org/jdbi/v3/BasicHandle.java
@@ -420,6 +420,12 @@ class BasicHandle implements Handle
     }
 
     @Override
+    public <SqlObjectType> SqlObjectType attach(Class<SqlObjectType> sqlObjectType)
+    {
+        return SqlObjectBuilderBridge.attach(this, sqlObjectType);
+    }
+
+    @Override
     public void setTransactionIsolation(TransactionIsolationLevel level)
     {
         setTransactionIsolation(level.intValue());

--- a/core/src/main/java/org/jdbi/v3/DBI.java
+++ b/core/src/main/java/org/jdbi/v3/DBI.java
@@ -370,6 +370,40 @@ public class DBI
     }
 
     /**
+     * Open a handle and attach a new sql object of the specified type to that handle. Be sure to close the
+     * sql object (via a close() method, or calling {@link DBI#close(Object)}
+     * @param sqlObjectType an interface with annotations declaring desired behavior
+     * @param <SqlObjectType>
+     * @return a new sql object of the specified type, with a dedicated handle
+     */
+    public <SqlObjectType> SqlObjectType open(Class<SqlObjectType> sqlObjectType)
+    {
+       return SqlObjectBuilderBridge.open(this, sqlObjectType);
+    }
+
+    /**
+     * Create a new sql object which will obtain and release connections from this dbi instance, as it needs to,
+     * and can, respectively. You should not explicitely close this sql object
+     *
+     * @param sqlObjectType an interface with annotations declaring desired behavior
+     * @param <SqlObjectType>
+     * @return a new sql object of the specified type, with a dedicated handle
+     */
+    public <SqlObjectType> SqlObjectType onDemand(Class<SqlObjectType> sqlObjectType)
+    {
+        return SqlObjectBuilderBridge.onDemand(this, sqlObjectType);
+    }
+
+    /**
+     * Used to close a sql object which lacks a close() method.
+     * @param sqlObject the sql object to close
+     */
+    public void close(Object sqlObject)
+    {
+        SqlObjectBuilderBridge.close(sqlObject);
+    }
+
+    /**
      * Convenience methd used to obtain a handle from a specific data source
      *
      * @param dataSource

--- a/core/src/main/java/org/jdbi/v3/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/Handle.java
@@ -267,6 +267,16 @@ public interface Handle extends Closeable
     void registerColumnMapper(ResultColumnMapperFactory factory);
 
     /**
+     * Create an sql object of the specified type bound to this handle. Any state changes to the handle, or the
+     * sql object, such as transaction status, closing it, etc, will apply to both the object and the handle.
+     *
+     * @param sqlObjectType
+     * @param <SqlObjectType>
+     * @return the new sql object bound to this handle
+     */
+    <SqlObjectType> SqlObjectType attach(Class<SqlObjectType> sqlObjectType);
+
+    /**
      * Set the transaction isolation level on the underlying connection
      *
      * @param level the isolation level to use

--- a/core/src/main/java/org/jdbi/v3/SqlObjectBuilderBridge.java
+++ b/core/src/main/java/org/jdbi/v3/SqlObjectBuilderBridge.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3;
+
+import org.jdbi.v3.exceptions.DBIException;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * A bridge to the <b>SqlObjectBuilder</b> class in the <b>jdbi3-sqlobject</b> module.
+ */
+class SqlObjectBuilderBridge {
+
+    private static final String SQL_OBJECT_BUILDER_CLASS = "org.jdbi.v3.sqlobject.SqlObjectBuilder";
+
+    private static final MethodHandle ATTACH;
+    private static final MethodHandle OPEN;
+    private static final MethodHandle ON_DEMAND;
+    private static final MethodHandle CLOSE;
+
+    static {
+        Class<?> sqlObjectBuilder = null;
+        try {
+            sqlObjectBuilder = Class.forName(SQL_OBJECT_BUILDER_CLASS);
+        } catch (ClassNotFoundException ignore) {
+        }
+
+        if (sqlObjectBuilder != null) {
+            try {
+                MethodHandles.Lookup lookup = MethodHandles.lookup();
+                ATTACH = lookup.findStatic(sqlObjectBuilder, "attach",
+                        MethodType.methodType(Object.class, Handle.class, Class.class));
+                OPEN = lookup.findStatic(sqlObjectBuilder, "open",
+                        MethodType.methodType(Object.class, DBI.class, Class.class));
+                ON_DEMAND = lookup.findStatic(sqlObjectBuilder, "onDemand",
+                        MethodType.methodType(Object.class, DBI.class, Class.class));
+                CLOSE = lookup.findStatic(sqlObjectBuilder, "close",
+                        MethodType.methodType(void.class, Object.class));
+            } catch (NoSuchMethodException | IllegalAccessException e) {
+                throw new RuntimeException("Unable to locate methods of SqlObjectBuilder", e);
+            }
+        } else {
+            ATTACH = null;
+            OPEN = null;
+            ON_DEMAND = null;
+            CLOSE = null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T attach(Handle handle, Class<T> sqlObjectType) {
+        try {
+            check(ATTACH);
+            return (T) ATTACH.invoke(handle, sqlObjectType);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new RuntimeException("Error during `SqlObjectBuilder.attach` invocation", t);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T open(DBI dbi, Class<T> sqlObjectType) {
+        try {
+            check(OPEN);
+            return (T) OPEN.invoke(dbi, sqlObjectType);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new RuntimeException("Error during `SqlObjectBuilder.open` invocation", t);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T onDemand(DBI dbi, Class<T> sqlObjectType) {
+        try {
+            check(ON_DEMAND);
+            return (T) ON_DEMAND.invoke(dbi, sqlObjectType);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new RuntimeException("Error during `SqlObjectBuilder.onDemand` invocation", t);
+        }
+    }
+
+    public static void close(Object sqlObject) {
+        try {
+            check(CLOSE);
+            CLOSE.invoke(sqlObject);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new RuntimeException("Error during `SqlObjectBuilder.close` invocation", t);
+        }
+    }
+
+    private static void check(MethodHandle mh) {
+        if (mh == null) {
+            throw new IllegalStateException("SQL Object API is not available");
+        }
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectBuilder.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectBuilder.java
@@ -17,7 +17,7 @@ import org.jdbi.v3.DBI;
 import org.jdbi.v3.Handle;
 
 /**
- * This duplicates the API on {@link org.skife.jdbi.v2.DBI} and {@link Handle} for creating sql objects. While it is fine to use these
+ * This duplicates the API on {@link DBI} and {@link Handle} for creating sql objects. While it is fine to use these
  * methods to create sql objects, there is no real difference between them and the oones on DBI and Handle.
  */
 public class SqlObjectBuilder
@@ -38,7 +38,7 @@ public class SqlObjectBuilder
 
     /**
      * Open a handle and attach a new sql object of the specified type to that handle. Be sure to close the
-     * sql object (via a close() method, or calling {@link org.skife.jdbi.v3.IDBI#close(Object)}
+     * sql object (via a close() method, or calling {@link DBI#close(Object)}
      *
      * @param dbi             the dbi to be used for opening the underlying handle
      * @param sqlObjectType   an interface with annotations declaring desired behavior

--- a/sqlobject/src/test/java/org/jdbi/v3/docs/TestDocumentation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/docs/TestDocumentation.java
@@ -74,7 +74,7 @@ public class TestDocumentation
     @Test
     public void testFiveMinuteSqlObjectExample() throws Exception
     {
-        try (MyDAO dao = SqlObjectBuilder.open(db.getDbi(), MyDAO.class)) {
+        try (MyDAO dao = db.getDbi().open(MyDAO.class)) {
             dao.insert(2, "Aaron");
 
             String name = dao.findNameById(2);
@@ -157,7 +157,7 @@ public class TestDocumentation
     public void testAttachToObject() throws Exception
     {
         try (Handle h = db.openHandle();
-             MyDAO dao = SqlObjectBuilder.attach(h, MyDAO.class)) {
+             MyDAO dao = h.attach(MyDAO.class)) {
             dao.insert(1, "test");
         }
     }
@@ -165,7 +165,7 @@ public class TestDocumentation
     @Test
     public void testOnDemandDao() throws Exception
     {
-        try (MyDAO dao = SqlObjectBuilder.onDemand(db.getDbi(), MyDAO.class)) {
+        try (MyDAO dao = db.getDbi().onDemand(MyDAO.class)) {
             dao.insert(2, "test");
         }
     }
@@ -193,7 +193,7 @@ public class TestDocumentation
                 .next().bind("id", 4).bind("name", "Maniax")
                 .submit().execute();
 
-            SomeQueries sq = SqlObjectBuilder.attach(h, SomeQueries.class);
+            SomeQueries sq = h.attach(SomeQueries.class);
             assertThat(sq.findName(2), equalTo("Robert"));
             assertThat(sq.findNamesBetween(1, 4), equalTo(Arrays.asList("Robert", "Patrick")));
 
@@ -230,12 +230,12 @@ public class TestDocumentation
     public void testAnotherCoupleInterfaces() throws Exception
     {
         try (Handle h = db.openHandle()) {
-            SqlObjectBuilder.attach(h, BatchInserter.class).insert(new Something(1, "Brian"),
-                                                 new Something(3, "Patrick"),
-                                                 new Something(2, "Robert"));
+            h.attach(BatchInserter.class).insert(new Something(1, "Brian"),
+                    new Something(3, "Patrick"),
+                    new Something(2, "Robert"));
 
-            AnotherQuery aq = SqlObjectBuilder.attach(h, AnotherQuery.class);
-            YetAnotherQuery yaq = SqlObjectBuilder.attach(h, YetAnotherQuery.class);
+            AnotherQuery aq = h.attach(AnotherQuery.class);
+            YetAnotherQuery yaq = h.attach(YetAnotherQuery.class);
 
             assertThat(yaq.findById(3), equalTo(new Something(3, "Patrick")));
             assertThat(aq.findById(2), equalTo(new Something(2, "Robert")));
@@ -252,11 +252,11 @@ public class TestDocumentation
     public void testFoo() throws Exception
     {
         try (Handle h = db.openHandle()) {
-            SqlObjectBuilder.attach(h, BatchInserter.class).insert(new Something(1, "Brian"),
+            h.attach(BatchInserter.class).insert(new Something(1, "Brian"),
                                                  new Something(3, "Patrick"),
                                                  new Something(2, "Robert"));
 
-            QueryReturningQuery qrq = SqlObjectBuilder.attach(h, QueryReturningQuery.class);
+            QueryReturningQuery qrq = h.attach(QueryReturningQuery.class);
 
             Query<String> q = qrq.findById(1);
             q.setMaxFieldSize(100);
@@ -277,7 +277,7 @@ public class TestDocumentation
     public void testUpdateAPI() throws Exception
     {
         try (Handle h = db.openHandle()) {
-            Update u = SqlObjectBuilder.attach(h, Update.class);
+            Update u = h.attach(Update.class);
             u.insert(17, "David");
             u.update(new Something(17, "David P."));
 
@@ -304,7 +304,7 @@ public class TestDocumentation
     public void testBatchExample() throws Exception
     {
         try (Handle h = db.openHandle()) {
-            BatchExample b = SqlObjectBuilder.attach(h, BatchExample.class);
+            BatchExample b = h.attach(BatchExample.class);
 
             List<Integer> ids = asList(1, 2, 3, 4, 5);
             Iterator<String> first_names = asList("Tip", "Jane", "Brian", "Keith", "Eric").iterator();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOnDemandSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOnDemandSqlObject.java
@@ -74,7 +74,7 @@ public class TestOnDemandSqlObject
     @Test
     public void testAPIWorks() throws Exception
     {
-        Spiffy s = SqlObjectBuilder.onDemand(dbi, Spiffy.class);
+        Spiffy s = dbi.onDemand(Spiffy.class);
 
         s.insert(7, "Bill");
 
@@ -86,8 +86,8 @@ public class TestOnDemandSqlObject
     @Test
     public void testTransactionBindsTheHandle() throws Exception
     {
-        TransactionStuff txl = SqlObjectBuilder.onDemand(dbi, TransactionStuff.class);
-        TransactionStuff tx2 = SqlObjectBuilder.onDemand(dbi, TransactionStuff.class);
+        TransactionStuff txl = dbi.onDemand(TransactionStuff.class);
+        TransactionStuff tx2 = dbi.onDemand(TransactionStuff.class);
 
         txl.insert(8, "Mike");
 
@@ -109,7 +109,7 @@ public class TestOnDemandSqlObject
     @Test
     public void testIteratorBindsTheHandle() throws Exception
     {
-        Spiffy s = SqlObjectBuilder.onDemand(dbi, Spiffy.class);
+        Spiffy s = dbi.onDemand(Spiffy.class);
 
         s.insert(1, "Tom");
         s.insert(2, "Sam");
@@ -146,13 +146,13 @@ public class TestOnDemandSqlObject
         };
         dbi.installPlugin(plugin);
 
-        Spiffy s = SqlObjectBuilder.onDemand(dbi, Spiffy.class);
+        Spiffy s = dbi.onDemand(Spiffy.class);
         s.insert(1, "Tom");
     }
 
     @Test
     public void testIteratorCloseHandleOnError() throws Exception {
-        Spiffy s = SqlObjectBuilder.onDemand(dbi, Spiffy.class);
+        Spiffy s = dbi.onDemand(Spiffy.class);
         try {
             s.crashNow();
             fail();
@@ -164,7 +164,7 @@ public class TestOnDemandSqlObject
 
     @Test
     public void testIteratorClosedOnReadError() throws Exception {
-        Spiffy spiffy = SqlObjectBuilder.onDemand(dbi, Spiffy.class);
+        Spiffy spiffy = dbi.onDemand(Spiffy.class);
         spiffy.insert(1, "Tom");
 
         Iterator<Something> i = spiffy.crashOnFirstRead();
@@ -179,7 +179,7 @@ public class TestOnDemandSqlObject
 
     @Test
     public void testIteratorClosedIfEmpty() throws Exception {
-        Spiffy spiffy = SqlObjectBuilder.onDemand(dbi, Spiffy.class);
+        Spiffy spiffy = dbi.onDemand(Spiffy.class);
 
         spiffy.findAll();
 
@@ -188,7 +188,7 @@ public class TestOnDemandSqlObject
 
     @Test
     public void testIteratorPrepatureClose() throws Exception {
-        Spiffy spiffy = SqlObjectBuilder.onDemand(dbi, Spiffy.class);
+        Spiffy spiffy = dbi.onDemand(Spiffy.class);
         spiffy.insert(1, "Tom");
 
         try (ResultIterator<Something> all = spiffy.findAll()) {}
@@ -199,8 +199,8 @@ public class TestOnDemandSqlObject
     @Test
     public void testSqlFromExternalFileWorks() throws Exception
     {
-        Spiffy spiffy = SqlObjectBuilder.onDemand(dbi, Spiffy.class);
-        ExternalSql external = SqlObjectBuilder.onDemand(dbi, ExternalSql.class);
+        Spiffy spiffy = dbi.onDemand(Spiffy.class);
+        ExternalSql external = dbi.onDemand(ExternalSql.class);
 
         spiffy.insert(1, "Tom");
         spiffy.insert(2, "Sam");

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQuery.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQuery.java
@@ -44,11 +44,13 @@ public class TestReturningQuery
     {
         handle.execute("insert into something (id, name) values (7, 'Tim')");
 
-        Spiffy spiffy = SqlObjectBuilder.attach(handle, Spiffy.class);
+        Spiffy spiffy = db.getDbi().open(Spiffy.class);
 
         Something s = spiffy.findById(7).findOnly();
 
         assertEquals("Tim", s.getName());
+
+        db.getDbi().close(spiffy);
     }
 
     @Test
@@ -56,11 +58,13 @@ public class TestReturningQuery
     {
         handle.execute("insert into something (id, name) values (7, 'Tim')");
 
-        Spiffy2 spiffy = SqlObjectBuilder.attach(handle, Spiffy2.class);
+        Spiffy2 spiffy = db.getDbi().open(Spiffy2.class);
 
         Something s = spiffy.findByIdWithExplicitMapper(7).findOnly();
 
         assertEquals("Tim", s.getName());
+
+        db.getDbi().close(spiffy);
     }
 
     @RegisterMapper(SomethingMapper.class)

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQueryResults.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQueryResults.java
@@ -61,7 +61,7 @@ public class TestReturningQueryResults
         handle.execute("insert into something (id, name) values (7, 'Tim')");
         handle.execute("insert into something (id, name) values (3, 'Diego')");
 
-        Spiffy spiffy = SqlObjectBuilder.open(db.getDbi(), Spiffy.class);
+        Spiffy spiffy = db.getDbi().open(Spiffy.class);
 
 
         Iterator<Something> itty = spiffy.findByIdRange(2, 10);
@@ -73,6 +73,8 @@ public class TestReturningQueryResults
         assertEquals(2, all.size());
         assertTrue(all.contains(new Something(7, "Tim")));
         assertTrue(all.contains(new Something(3, "Diego")));
+
+        db.getDbi().close(spiffy);
     }
 
 
@@ -82,7 +84,7 @@ public class TestReturningQueryResults
         handle.execute("insert into something (id, name) values (7, 'Tim')");
         handle.execute("insert into something (id, name) values (3, 'Diego')");
 
-        Spiffy spiffy = SqlObjectBuilder.open(db.getDbi(), Spiffy.class);
+        Spiffy spiffy = db.getDbi().open(Spiffy.class);
 
 
         List<Something> all = spiffy.findTwoByIds(3, 7);
@@ -90,6 +92,8 @@ public class TestReturningQueryResults
         assertEquals(2, all.size());
         assertTrue(all.contains(new Something(7, "Tim")));
         assertTrue(all.contains(new Something(3, "Diego")));
+
+        db.getDbi().close(spiffy);
     }
 
     public interface Spiffy extends CloseMe

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestStatements.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestStatements.java
@@ -28,7 +28,7 @@ public class TestStatements
     @Test
     public void testInsert() throws Exception
     {
-        try (Inserter i = SqlObjectBuilder.open(db.getDbi(), Inserter.class)) {
+        try (Inserter i = db.getDbi().open(Inserter.class)) {
             // this is what is under test here
             int rows_affected = i.insert(2, "Diego");
 
@@ -42,7 +42,7 @@ public class TestStatements
     @Test
     public void testInsertWithVoidReturn() throws Exception
     {
-        try (Inserter i = SqlObjectBuilder.open(db.getDbi(), Inserter.class)) {
+        try (Inserter i = db.getDbi().open(Inserter.class)) {
             // this is what is under test here
             i.insertWithVoidReturn(2, "Diego");
 


### PR DESCRIPTION
In JDBI 2 there is the possibilty to create proxies for SqlObject interfaces via the `DBI` and `Handle` class instances. Actually, it's very convienent and even JDBI official docs mentions this as the standard way for using the SqlObject API.

This API was removed in JDBI 3, because the JDBI core and the SQLObject API are now in different modules.

This commit adds a bridge from the JDBI core to the SQLObject API. It uses method handles to dynamically call the methods of the `SqlObjectBuilder` class. It changes some tests to show that the bridge to `SqlObjectBuilder` in the JDBI core actually works.

Also it fixes a broken link in the `SqlObjectBuilder` javadoc.