### PR TITLE
Allows binding bean of inaccessible type (Option 1)

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
@@ -20,12 +20,12 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 class BindBeanFactory implements BinderFactory
 {
     @Override
-    public Binder build(Annotation annotation)
-    {
+    public Binder build(Annotation annotation) {
         return new Binder<BindBean, Object>()
         {
             @Override
@@ -45,6 +45,15 @@ class BindBeanFactory implements BinderFactory
                     for (PropertyDescriptor prop : props) {
                         Method readMethod = prop.getReadMethod();
                         if (readMethod != null) {
+                            int readMethodModifiers = readMethod.getModifiers();
+                            if (Modifier.isPublic(readMethodModifiers)) {
+                                // This check is necessary because we're attempting to invoke the method on arg's type NOT the
+                                // annotated parameters type.  It's possible that BindBeanFactory does not have access to the
+                                // arg's type's methods, even if the method has a public modifier, if the arg's type itself is
+                                // not public and outside of the org.skife.jdbi.v2.sqlobject package.
+                                readMethod.setAccessible(true);
+                            }
+
                             q.dynamicBind(readMethod.getReturnType(), prefix + prop.getName(), readMethod.invoke(arg));
                         }
                     }
@@ -52,8 +61,6 @@ class BindBeanFactory implements BinderFactory
                 catch (Exception e) {
                     throw new IllegalStateException("unable to bind bean properties", e);
                 }
-
-
             }
         };
     }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestBeanBinder.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestBeanBinder.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Something;
+import org.skife.jdbi.v2.sqlobject.subpackage.PrivateImplementationFactory;
 
 import java.util.UUID;
 
@@ -77,5 +78,18 @@ public class TestBeanBinder
         @SqlQuery("select id, name from something where id = :s.id and name = :s.name")
         Something findByEqualsOnBothFields(@BindBean("s") Something s);
 
+        @SqlQuery("select :pi.value")
+        String selectPublicInterfaceValue(@BindBean("pi") PublicInterface pi);
+    }
+
+    @Test
+    public void testBindingPrivateTypeUsingPublicInterface() throws Exception
+    {
+        Spiffy s = handle.attach(Spiffy.class);
+        assertEquals("IShouldBind", s.selectPublicInterfaceValue(PrivateImplementationFactory.create()));
+    }
+
+    public interface PublicInterface {
+        String getValue();
     }
 }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/subpackage/PrivateImplementationFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/subpackage/PrivateImplementationFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject.subpackage;
+
+import org.skife.jdbi.v2.sqlobject.TestBeanBinder;
+
+/**
+ * Factory class that creates an instance whose type inherits from a public type (PublicInterface) but is of a type that is
+ * inaccessible itself outside of its subpackage.
+ *
+ * This is used to verify that such instances' methods can be accessed via BeanBinding in the same way that they can be accessed
+ * outside of the package via polymorphism.
+ */
+public class PrivateImplementationFactory{
+    public static TestBeanBinder.PublicInterface create() {
+        return new TestBeanBinder.PublicInterface(){
+            @Override
+            public String getValue() {
+                return "IShouldBind";
+            }
+        };
+    }
+}


### PR DESCRIPTION
BindBeanFactory will now check the access modifier on arg's method and
use #setAccessible to allow it to be accessible from BindBeanFactory
whether or not this would typically be allowed via Reflection/ObjectAccess
rules.

This will allow for binding a bean, that has a type that is inaccessible
outside of its package, via one of its supertypes.

Adds test case demonstrating issue.

Fixes #242