### PR TITLE
Allows binding bean of inaccessible type (Option 2)

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
@@ -24,8 +24,7 @@ import java.lang.reflect.Method;
 class BindBeanFactory implements BinderFactory
 {
     @Override
-    public Binder build(Annotation annotation)
-    {
+    public Binder build(Annotation annotation, final Class<?> parameterClass) {
         return new Binder<BindBean, Object>()
         {
             @Override
@@ -40,7 +39,7 @@ class BindBeanFactory implements BinderFactory
                 }
 
                 try {
-                    BeanInfo infos = Introspector.getBeanInfo(arg.getClass());
+                    BeanInfo infos = Introspector.getBeanInfo(parameterClass);
                     PropertyDescriptor[] props = infos.getPropertyDescriptors();
                     for (PropertyDescriptor prop : props) {
                         Method readMethod = prop.getReadMethod();
@@ -52,8 +51,6 @@ class BindBeanFactory implements BinderFactory
                 catch (Exception e) {
                     throw new IllegalStateException("unable to bind bean properties", e);
                 }
-
-
             }
         };
     }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindFactory.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Annotation;
 class BindFactory implements BinderFactory
 {
     @Override
-    public Binder build(Annotation annotation)
+    public Binder build(Annotation annotation, Class<?> parameterClass)
     {
         Bind bind = (Bind) annotation;
         try {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindMapFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindMapFactory.java
@@ -25,7 +25,7 @@ import org.skife.jdbi.v2.SQLStatement;
 class BindMapFactory implements BinderFactory
 {
     @Override
-    public Binder build(Annotation annotation)
+    public Binder build(Annotation annotation, final Class<?> parameterClass)
     {
         return new Binder<BindMap, Object>()
         {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BinderFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BinderFactory.java
@@ -24,7 +24,9 @@ public interface BinderFactory
     /**
      * Called to build a Binder
      * @param annotation the {@link BindingAnnotation} which lead to this call
+     * @param parameterClass the type of the annotated parameter OR in the case its an Array/Iterable/Iterator the contained
+     *                       type.
      * @return a binder to use
      */
-    Binder build(Annotation annotation);
+    Binder build(Annotation annotation, Class<?> parameterClass);
 }

--- a/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
+++ b/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
@@ -90,7 +90,7 @@ public @interface BindIn
     public static class BindingFactory implements BinderFactory
     {
         @Override
-        public Binder build(Annotation annotation)
+        public Binder build(Annotation annotation, Class<?> parameterClass)
         {
             final BindIn in = (BindIn) annotation;
             final String key = in.value();

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/BindSomething.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/BindSomething.java
@@ -33,7 +33,7 @@ public @interface BindSomething
     static class Factory implements BinderFactory
     {
         @Override
-        public Binder build(Annotation annotation)
+        public Binder build(Annotation annotation, Class<?> parameterClass)
         {
             return new Binder()
             {

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestBeanBinder.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestBeanBinder.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Something;
+import org.skife.jdbi.v2.sqlobject.subpackage.PrivateImplementationFactory;
 
 import java.util.UUID;
 
@@ -77,5 +78,18 @@ public class TestBeanBinder
         @SqlQuery("select id, name from something where id = :s.id and name = :s.name")
         Something findByEqualsOnBothFields(@BindBean("s") Something s);
 
+        @SqlQuery("select :pi.value")
+        String selectPublicInterfaceValue(@BindBean("pi") PublicInterface pi);
+    }
+
+    @Test
+    public void testBindingPrivateTypeUsingPublicInterface() throws Exception
+    {
+        Spiffy s = handle.attach(Spiffy.class);
+        assertEquals("IShouldBind", s.selectPublicInterfaceValue(PrivateImplementationFactory.create()));
+    }
+
+    public interface PublicInterface {
+        String getValue();
     }
 }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestBindBeanFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestBindBeanFactory.java
@@ -51,7 +51,7 @@ public class TestBindBeanFactory
     {
         BindBeanFactory factory = new BindBeanFactory();
         @SuppressWarnings("unchecked")
-        Binder<BindBean, Object> beanBinder = factory.build(new BindBeanImpl());
+        Binder<BindBean, Object> beanBinder = factory.build(new BindBeanImpl(), TestBean.class);
 
         final DBI dbi = new DBI(DERBY_HELPER.getDataSource());
         final Handle handle = dbi.open();

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/subpackage/PrivateImplementationFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/subpackage/PrivateImplementationFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject.subpackage;
+
+import org.skife.jdbi.v2.sqlobject.TestBeanBinder;
+
+/**
+ * Factory class that creates an instance whose type inherits from a public type (PublicInterface) but is of a type that is
+ * inaccessible itself outside of its subpackage.
+ *
+ * This is used to verify that such instances' methods can be accessed via BeanBinding in the same way that they can be accessed
+ * outside of the package via polymorphism.
+ */
+public class PrivateImplementationFactory{
+    public static TestBeanBinder.PublicInterface create() {
+        return new TestBeanBinder.PublicInterface(){
+            @Override
+            public String getValue() {
+                return "IShouldBind";
+            }
+        };
+    }
+}


### PR DESCRIPTION
Changes the BinderFactory interface so that the type token of the
annotated parameter is accepted as a parameter on #build.

Changes BindBeanFactory to get the value of its argument using the
Method of the annotated parameter's type instead of the argument's type.
This allows for BindBeanFactory to access methods on args that are of
types that are inaccessible to the SqlObject package.  This changes the
behavior of the BindBeanFactory to behave in a way that is much more
consistent with Java's polymorphic/access mechanism.

Using BindBean with an iterable of a raw type will result in using
Object.  This may be considered a limiting factor or a feature.

Fixes #242