### PR TITLE
Allows binding bean of inaccessible type

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindBean.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindBean.java
@@ -25,4 +25,14 @@ public @interface BindBean
 {
     String BARE_BINDING = "___jdbi_bare___";
     String value() default BARE_BINDING;
+
+    /**
+     * A type to use for resolving a bean's bindings via reflection.  If omitted, <code>argument.getClass()</code> is used.
+     *
+     * @return a type to use for resolving bindings as an alternative to the argument's type, or <code>Default.class</code> if
+     *   type is omitted.
+     */
+    Class<?> type() default Default.class;
+
+    class Default {};
 }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindBeanFactory.java
@@ -40,7 +40,11 @@ class BindBeanFactory implements BinderFactory
                 }
 
                 try {
-                    BeanInfo infos = Introspector.getBeanInfo(arg.getClass());
+                    Class<?> beanType = bind.type().equals(BindBean.Default.class)
+                        ? arg.getClass()
+                        : bind.type();
+
+                    BeanInfo infos = Introspector.getBeanInfo(beanType);
                     PropertyDescriptor[] props = infos.getPropertyDescriptors();
                     for (PropertyDescriptor prop : props) {
                         Method readMethod = prop.getReadMethod();

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestBeanBinder.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestBeanBinder.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Something;
+import org.skife.jdbi.v2.sqlobject.subpackage.PrivateImplementationFactory;
 
 import java.util.UUID;
 
@@ -77,5 +78,18 @@ public class TestBeanBinder
         @SqlQuery("select id, name from something where id = :s.id and name = :s.name")
         Something findByEqualsOnBothFields(@BindBean("s") Something s);
 
+        @SqlQuery("select :pi.value")
+        String selectPublicInterfaceValue(@BindBean(value = "pi", type = PublicInterface.class) PublicInterface pi);
+    }
+
+    @Test
+    public void testBindingPrivateTypeUsingPublicInterface() throws Exception
+    {
+        Spiffy s = handle.attach(Spiffy.class);
+        assertEquals("IShouldBind", s.selectPublicInterfaceValue(PrivateImplementationFactory.create()));
+    }
+
+    public interface PublicInterface {
+        String getValue();
     }
 }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestBindBeanFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestBindBeanFactory.java
@@ -103,7 +103,7 @@ public class TestBindBeanFactory
 
         public Short getAShort()
         {
-            return Short.valueOf((short) 12345);
+            return (short) 12345;
         }
     }
 
@@ -124,6 +124,11 @@ public class TestBindBeanFactory
         public String value()
         {
             return "___jdbi_bare___";
+        }
+
+        @Override
+        public Class<?> type() {
+            return Default.class;
         }
     }
 }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/subpackage/PrivateImplementationFactory.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/subpackage/PrivateImplementationFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject.subpackage;
+
+import org.skife.jdbi.v2.sqlobject.TestBeanBinder;
+
+/**
+ * Factory class that creates an instance whose type inherits from a public type (PublicInterface) but is of a type that is
+ * inaccessible itself outside of its subpackage.
+ *
+ * This is used to verify that such instances' methods can be accessed via BeanBinding in the same way that they can be accessed
+ * outside of the package via polymorphism.
+ */
+public class PrivateImplementationFactory
+{
+    public static TestBeanBinder.PublicInterface create() {
+        return new TestBeanBinder.PublicInterface(){
+            @Override
+            public String getValue() {
+                return "IShouldBind";
+            }
+        };
+    }
+}


### PR DESCRIPTION
Changes BinderFactory so that it allows the specification of the
Annotation type via a type token.

Changes the BindBean annotation such that a type can be provided as an
override.  This override will be used instead of the provided
argument's type for the purpose of binding.  This allows for
BindBeanFactory to access methods on args that are of types that are
inaccessible to the SqlObject package.

Fixes #242