### PR TITLE
Convets BinderFactory to generic type

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindFactory.java
@@ -13,14 +13,11 @@
  */
 package org.skife.jdbi.v2.sqlobject;
 
-import java.lang.annotation.Annotation;
-
-class BindFactory implements BinderFactory
+class BindFactory implements BinderFactory<Bind>
 {
     @Override
-    public Binder build(Annotation annotation)
+    public Binder build(Bind bind)
     {
-        Bind bind = (Bind) annotation;
         try {
             return bind.binder().newInstance();
         }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BindMapFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BindMapFactory.java
@@ -27,12 +27,10 @@ class BindMapFactory implements BinderFactory
     @Override
     public Binder build(Annotation annotation)
     {
-        return new Binder<BindMap, Object>()
+        return new Binder<BindMap, Map<String, Object>>()
         {
-            @SuppressWarnings("unchecked")
             @Override
-            public void bind(SQLStatement q, BindMap bind, Object arg)
-            {
+            public void bind(SQLStatement<?> q, BindMap bind, Map<String, Object> map) {
                 final String prefix;
                 if (BindBean.BARE_BINDING.equals(bind.prefix())) {
                     prefix = "";
@@ -42,7 +40,6 @@ class BindMapFactory implements BinderFactory
                 }
 
                 final Set<String> allowedKeys = new HashSet<String>(Arrays.asList(bind.value()));
-                final Map<String, Object> map = (Map<String, Object>) arg;
 
                 for (Entry e : map.entrySet()) {
                     final Object keyObj = e.getKey();

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BinderFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BinderFactory.java
@@ -19,12 +19,12 @@ import java.lang.annotation.Annotation;
  * Factor for building {@link Binder} instances. This interface is used by
  * the {@link BindingAnnotation}
  */
-public interface BinderFactory
+public interface BinderFactory<T extends Annotation>
 {
     /**
      * Called to build a Binder
      * @param annotation the {@link BindingAnnotation} which lead to this call
      * @return a binder to use
      */
-    Binder build(Annotation annotation);
+    Binder build(T annotation);
 }

--- a/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
+++ b/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
@@ -87,21 +87,18 @@ public @interface BindIn
         }
     }
 
-    class BindingFactory implements BinderFactory
+    class BindingFactory implements BinderFactory<BindIn>
     {
         @Override
-        public Binder build(Annotation annotation)
+        public Binder build(BindIn in)
         {
-            final BindIn in = (BindIn) annotation;
             final String key = in.value();
 
-            return new Binder()
+            return new Binder<Annotation, Iterable>()
             {
-
                 @Override
-                public void bind(SQLStatement q, Annotation bind, Object arg)
+                public void bind(SQLStatement q, Annotation bind, Iterable coll)
                 {
-                    Iterable<?> coll = (Iterable<?>) arg;
                     int idx = 0;
                     for (Object s : coll) {
                         q.bind("__" + key + "_" + idx++, s);

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/BindSomething.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/BindSomething.java
@@ -35,18 +35,15 @@ public @interface BindSomething
         @Override
         public Binder build(Annotation annotation)
         {
-            return new Binder()
+            return new Binder<BindSomething, Something>()
             {
                 @Override
-                public void bind(SQLStatement q, Annotation bind, Object arg)
+                public void bind(SQLStatement q, BindSomething bs, Something arg)
                 {
-                    BindSomething bs = (BindSomething) bind;
-                    Something it = (Something) arg;
-                    q.bind(bs.value() + ".id", it.getId());
-                    q.bind(bs.value() + ".name", it.getName());
+                    q.bind(bs.value() + ".id", arg.getId());
+                    q.bind(bs.value() + ".name", arg.getName());
                 }
             };
         }
     }
-
 }


### PR DESCRIPTION
This allows for the elimination of casting annotations in
implementations..

Also squashed unchecked cast warning in BindMapFactory.