### PR TITLE
Add a toolchain for Travis JDK8

### DIFF
--- a/src/build/travis-toolchains.xml
+++ b/src/build/travis-toolchains.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<toolchains>
+    <!-- JDK toolchains -->
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.8</version>
+            <vendor>oracle</vendor>
+        </provides>
+        <configuration>
+            <!-- Location of a JDK9 in the Travis build environment -->
+            <jdkHome>/usr/lib/jvm/java-8-oracle</jdkHome>
+        </configuration>
+    </toolchain>
+</toolchains>


### PR DESCRIPTION
keeps the build system the same on `master` vs `jdbi3` and perhaps is a bit of future-proofing against the inevitable JDK9.