### PR TITLE
Cache maven repo to speed builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ jdk:
 
 sudo: false
 
+cache:
+  directories:
+    - '$HOME/.m2/repository'
+
 before_install:
     - cp src/build/travis-toolchains.xml ~/.m2/toolchains.xml
 


### PR DESCRIPTION
seems to cut time of the `install` phase on Travis in half (67 -> 33 seconds) although that's a point measurement, not scientific.  saves bandwidth either way.