### PR TITLE
Providing a list of column names returned in a prepared batch

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+2.72
+  - Support for the ability to provide a list of the column names returned
+    in a prepared batch #254
+
 2.71
   - fix @BindBean of private subtypes, #242
 

--- a/src/test/java/org/skife/jdbi/v2/TestPreparedBatchGenerateKeysPostgres.java
+++ b/src/test/java/org/skife/jdbi/v2/TestPreparedBatchGenerateKeysPostgres.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2;
+
+import org.junit.*;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.skife.jdbi.v2.util.IntegerColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+public class TestPreparedBatchGenerateKeysPostgres {
+
+    private Handle h;
+
+    @BeforeClass
+    public static void isPostgresInstalled() {
+        assumeTrue(Boolean.parseBoolean(System.getenv("TRAVIS")));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        h = new DBI("jdbc:postgresql:jdbi_test", "postgres", "").open();
+        h.execute("create table something (id serial, name varchar(50), create_time timestamp default now())");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        h.execute("drop table something");
+        h.close();
+    }
+
+    @Test
+    public void testBatchInsertWithKeyGenerationAndExplicitColumnNames() {
+        PreparedBatch batch = h.prepareBatch("insert into something (name) values (?) ");
+        batch.add("Brian");
+        batch.add("Thom");
+
+        List<Integer> ids = batch.executeAndGenerateKeys(IntegerColumnMapper.WRAPPER, "id").list();
+        assertEquals(Arrays.asList(1, 2), ids);
+
+        List<Something> somethings = h.createQuery("select id, name from something")
+                .map(Something.class)
+                .list();
+        assertEquals(Arrays.asList(new Something(1, "Brian"), new Something(2, "Thom")), somethings);
+    }
+
+    @Test
+    public void testBatchInsertWithKeyGenerationAndExplicitSeveralColumnNames() {
+        PreparedBatch batch = h.prepareBatch("insert into something (name) values (?) ");
+        batch.add("Brian");
+        batch.add("Thom");
+
+        List<IdCreateTime> ids = batch.executeAndGenerateKeys(new ResultSetMapper<IdCreateTime>() {
+            @Override
+            public IdCreateTime map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+                return new IdCreateTime(r.getInt("id"), r.getDate("create_time"));
+            }
+        }, "id", "create_time").list();
+
+        assertEquals(ids.size(), 2);
+        assertTrue(ids.get(0).id == 1);
+        assertTrue(ids.get(1).id == 2);
+        assertNotNull(ids.get(0).createTime);
+        assertNotNull(ids.get(1).createTime);
+    }
+
+    private static class IdCreateTime {
+
+        final Integer id;
+        final Date createTime;
+
+        public IdCreateTime(Integer id, Date createTime) {
+            this.id = id;
+            this.createTime = createTime;
+        }
+    }
+}


### PR DESCRIPTION
References to #253.

Sometimes it's desirable have ability to explicitly provide the names of the columns, which should returned to the client after a query execution. For example, when a row contains many columns, and many rows are returned in a batch response.

JDBC provides such functionality during preparing a statement by using the form: `Connection.preparedStatement(String query, String[] columnNames)`.

If a JDBC driver supports it, it will return only specified columns in a response. For example, the official PostgreSQL driver adds a `RETURNING` clause with a list of the specified columns to a query.

See this [SO discusstion](http://stackoverflow.com/questions/34560647/pg-jdbc-appends-returning-on-prepared-batch-wtih-existing-returning-clause).