### PR TITLE
Upgrade the Spring integration to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <project.build.targetJdk>1.8</project.build.targetJdk>
         <basepom.maven.version>2.0.9</basepom.maven.version>
         <dep.antlr.version>3.4</dep.antlr.version>
-        <dep.spring.version>2.0.1</dep.spring.version>
+        <dep.spring.version>4.2.4.RELEASE</dep.spring.version>
         <basepom.check.fail-all>true</basepom.check.fail-all>
 
         <basepom.test.fork-count>8</basepom.test.fork-count>
@@ -177,7 +177,28 @@
 
             <dependency>
                 <groupId>org.springframework</groupId>
-                <artifactId>spring</artifactId>
+                <artifactId>spring-jdbc</artifactId>
+                <version>${dep.spring.version}</version>
+                <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${dep.spring.version}</version>
+                <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-tx</artifactId>
+                <version>${dep.spring.version}</version>
+                <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
                 <version>${dep.spring.version}</version>
                 <optional>true</optional>
             </dependency>
@@ -197,7 +218,7 @@
 
             <dependency>
                 <groupId>org.springframework</groupId>
-                <artifactId>spring-mock</artifactId>
+                <artifactId>spring-test</artifactId>
                 <version>${dep.spring.version}</version>
             </dependency>
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -45,7 +45,17 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring</artifactId>
+            <artifactId>spring-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
         </dependency>
 
         <dependency>
@@ -56,7 +66,13 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-mock</artifactId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/spring/src/main/java/org/jdbi/v3/spring/DBIFactoryBean.java
+++ b/spring/src/main/java/org/jdbi/v3/spring/DBIFactoryBean.java
@@ -21,13 +21,14 @@ import javax.sql.DataSource;
 import org.jdbi.v3.DBI;
 import org.jdbi.v3.tweak.StatementLocator;
 import org.springframework.beans.factory.FactoryBean;
-import org.springframework.beans.factory.InitializingBean;
+
+import javax.annotation.PostConstruct;
 
 /**
- * Utility class which constructs an IDBI instance which can conveniently participate
+ * Utility class which constructs an {@link DBI} instance which can conveniently participate
  * in Spring's transaction management system.
  */
-public class DBIFactoryBean implements FactoryBean, InitializingBean
+public class DBIFactoryBean implements FactoryBean<DBI>
 {
     private DataSource dataSource;
     private StatementLocator statementLocator;
@@ -46,10 +47,10 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
     }
 
     /**
-     * See org.springframework.beans.factory.FactoryBean#getObject
+     * See {@link org.springframework.beans.factory.FactoryBean#getObject}
      */
     @Override
-    public Object getObject() throws Exception
+    public DBI getObject() throws Exception
     {
         final DBI dbi = DBI.create(new SpringDataSourceConnectionFactory(dataSource));
         if (statementLocator != null) {
@@ -64,7 +65,7 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
     }
 
     /**
-     * See org.springframework.beans.factory.FactoryBean#getObjectType
+     * See {@link org.springframework.beans.factory.FactoryBean#getObjectType}
      */
     @Override
     public Class<?> getObjectType()
@@ -73,7 +74,7 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
     }
 
     /**
-     * See org.springframework.beans.factory.FactoryBean#isSingleton
+     * See {@link org.springframework.beans.factory.FactoryBean#isSingleton}
      *
      * @return false
      */
@@ -85,7 +86,7 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
 
     /**
      * The datasource, which should be managed by spring's transaction system, from which
-     * the IDBI will obtain connections
+     * the {@link DBI} will obtain connections
      */
     public void setDataSource(DataSource dataSource)
     {
@@ -104,8 +105,8 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
     /**
      * Verifies that a dataSource has been set
      */
-    @Override
-    public void afterPropertiesSet() throws Exception
+    @PostConstruct
+    private void afterPropertiesSet()
     {
         if (dataSource == null) {
             throw new IllegalStateException("'dataSource' property must be set");

--- a/spring/src/test/java/org/jdbi/v3/spring/TestDBIFactoryBean.java
+++ b/spring/src/test/java/org/jdbi/v3/spring/TestDBIFactoryBean.java
@@ -13,41 +13,50 @@
  */
 package org.jdbi.v3.spring;
 
-import java.sql.SQLException;
-
 import javax.sql.DataSource;
 
 import org.jdbi.v3.DBI;
 import org.jdbi.v3.Handle;
-import org.springframework.test.AbstractDependencyInjectionSpringContextTests;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-public class TestDBIFactoryBean extends AbstractDependencyInjectionSpringContextTests
-{
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-    protected Service service;
-    protected DataSource ds;
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/org/jdbi/v3/spring/test-context.xml")
+@TestExecutionListeners(listeners = {DependencyInjectionTestExecutionListener.class})
+public class TestDBIFactoryBean {
 
+    private Service service;
+    private DataSource ds;
+
+    @Autowired
     public void setService(Service service)
     {
         this.service = service;
     }
 
-    public void setDataSource(DataSource ds) throws SQLException
+    @Autowired
+    public void setDataSource(DataSource ds)
     {
         this.ds = ds;
     }
 
-    @Override
-    protected String[] getConfigLocations()
-    {
-        return new String[]{"org/jdbi/v3/spring/test-context.xml"};
-    }
-
+    @Test
     public void testServiceIsActuallySet() throws Exception
     {
         assertNotNull(service);
     }
 
+    @Test
     public void testFailsViaException() throws Exception
     {
         try {
@@ -76,6 +85,7 @@ public class TestDBIFactoryBean extends AbstractDependencyInjectionSpringContext
         }
     }
 
+    @Test
     public void testNested() throws Exception
     {
         try {
@@ -114,6 +124,7 @@ public class TestDBIFactoryBean extends AbstractDependencyInjectionSpringContext
         });
     }
 
+    @Test
     public void testRequiresNew() throws Exception
     {
         service.inPropagationRequired(outer -> {

--- a/spring/src/test/resources/org/jdbi/v3/spring/test-context.xml
+++ b/spring/src/test/resources/org/jdbi/v3/spring/test-context.xml
@@ -14,12 +14,9 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.2.xsd">
 
     <tx:annotation-driven transaction-manager="transactionManager"/>
 

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -109,12 +109,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-mock</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Spring 2.x is a rather outdated version of the framework and not supported anymore. This change upgrades the Spring dependency to the latest version 4.2.4.RELEASE.

This allows to take advantage from modern Spring features like annotation processing and the Spring JUnit test runner.