### PR TITLE
Add stream wrappers which close streams automatically after terminal operations

### DIFF
--- a/core/src/main/java/org/jdbi/v3/SelfClosingDoubleStream.java
+++ b/core/src/main/java/org/jdbi/v3/SelfClosingDoubleStream.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3;
+
+import java.util.DoubleSummaryStatistics;
+import java.util.OptionalDouble;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.function.BiConsumer;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleConsumer;
+import java.util.function.DoubleFunction;
+import java.util.function.DoublePredicate;
+import java.util.function.DoubleToIntFunction;
+import java.util.function.DoubleToLongFunction;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.ObjDoubleConsumer;
+import java.util.function.Supplier;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+class SelfClosingDoubleStream implements DoubleStream {
+    private final DoubleStream delegate;
+
+    SelfClosingDoubleStream(DoubleStream delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public DoubleStream filter(DoublePredicate predicate) {
+        return new SelfClosingDoubleStream(delegate.filter(predicate));
+    }
+
+    @Override
+    public DoubleStream map(DoubleUnaryOperator mapper) {
+        return new SelfClosingDoubleStream(delegate.map(mapper));
+    }
+
+    @Override
+    public <U> Stream<U> mapToObj(DoubleFunction<? extends U> mapper) {
+        return new SelfClosingStream<>(delegate.mapToObj(mapper));
+    }
+
+    @Override
+    public IntStream mapToInt(DoubleToIntFunction mapper) {
+        return new SelfClosingIntStream(delegate.mapToInt(mapper));
+    }
+
+    @Override
+    public LongStream mapToLong(DoubleToLongFunction mapper) {
+        return new SelfClosingLongStream(delegate.mapToLong(mapper));
+    }
+
+    @Override
+    public DoubleStream flatMap(DoubleFunction<? extends DoubleStream> mapper) {
+        return new SelfClosingDoubleStream(delegate.flatMap(mapper));
+    }
+
+    @Override
+    public DoubleStream distinct() {
+        return new SelfClosingDoubleStream(delegate.distinct());
+    }
+
+    @Override
+    public DoubleStream sorted() {
+        return new SelfClosingDoubleStream(delegate.sorted());
+    }
+
+    @Override
+    public DoubleStream peek(DoubleConsumer action) {
+        return new SelfClosingDoubleStream(delegate.peek(action));
+    }
+
+    @Override
+    public DoubleStream limit(long maxSize) {
+        return new SelfClosingDoubleStream(delegate.limit(maxSize));
+    }
+
+    @Override
+    public DoubleStream skip(long n) {
+        return new SelfClosingDoubleStream(delegate.skip(n));
+    }
+
+    @Override
+    public void forEach(DoubleConsumer action) {
+        try {
+            delegate.forEach(action);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public void forEachOrdered(DoubleConsumer action) {
+        try {
+            delegate.forEachOrdered(action);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public double[] toArray() {
+        try {
+            return delegate.toArray();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public double reduce(double identity, DoubleBinaryOperator op) {
+        try {
+            return delegate.reduce(identity, op);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalDouble reduce(DoubleBinaryOperator op) {
+        try {
+            return delegate.reduce(op);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public <R> R collect(Supplier<R> supplier, ObjDoubleConsumer<R> accumulator, BiConsumer<R, R> combiner) {
+        try {
+            return delegate.collect(supplier, accumulator, combiner);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public double sum() {
+        try {
+            return delegate.sum();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalDouble min() {
+        try {
+            return delegate.min();
+        }
+        finally {
+            close();
+        }
+
+    }
+
+    @Override
+    public OptionalDouble max() {
+        try {
+            return delegate.max();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public long count() {
+        try {
+            return delegate.count();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalDouble average() {
+        try {
+            return delegate.average();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public DoubleSummaryStatistics summaryStatistics() {
+        try {
+            return delegate.summaryStatistics();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean anyMatch(DoublePredicate predicate) {
+        try {
+            return delegate.anyMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean allMatch(DoublePredicate predicate) {
+        try {
+            return delegate.allMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean noneMatch(DoublePredicate predicate) {
+        try {
+            return delegate.noneMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalDouble findFirst() {
+        try {
+            return delegate.findFirst();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalDouble findAny() {
+        try {
+            return delegate.findAny();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public Stream<Double> boxed() {
+        return new SelfClosingStream<>(delegate.boxed());
+    }
+
+    @Override
+    public DoubleStream sequential() {
+        return new SelfClosingDoubleStream(delegate.sequential());
+    }
+
+    @Override
+    public DoubleStream parallel() {
+        return new SelfClosingDoubleStream(delegate.parallel());
+    }
+
+    @Override
+    public DoubleStream unordered() {
+        return new SelfClosingDoubleStream(delegate.unordered());
+    }
+
+    @Override
+    public DoubleStream onClose(Runnable closeHandler) {
+        return new SelfClosingDoubleStream(delegate.onClose(closeHandler));
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public PrimitiveIterator.OfDouble iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public Spliterator.OfDouble spliterator() {
+        return delegate.spliterator();
+    }
+
+    @Override
+    public boolean isParallel() {
+        return delegate.isParallel();
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/SelfClosingIntStream.java
+++ b/core/src/main/java/org/jdbi/v3/SelfClosingIntStream.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3;
+
+import java.util.IntSummaryStatistics;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.function.BiConsumer;
+import java.util.function.IntBinaryOperator;
+import java.util.function.IntConsumer;
+import java.util.function.IntFunction;
+import java.util.function.IntPredicate;
+import java.util.function.IntToDoubleFunction;
+import java.util.function.IntToLongFunction;
+import java.util.function.IntUnaryOperator;
+import java.util.function.ObjIntConsumer;
+import java.util.function.Supplier;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+class SelfClosingIntStream implements IntStream {
+    private final IntStream delegate;
+
+    SelfClosingIntStream(IntStream delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public IntStream filter(IntPredicate predicate) {
+        return new SelfClosingIntStream(delegate.filter(predicate));
+    }
+
+    @Override
+    public IntStream map(IntUnaryOperator mapper) {
+        return new SelfClosingIntStream(delegate.map(mapper));
+    }
+
+    @Override
+    public <U> Stream<U> mapToObj(IntFunction<? extends U> mapper) {
+        return new SelfClosingStream<>(delegate.mapToObj(mapper));
+    }
+
+    @Override
+    public LongStream mapToLong(IntToLongFunction mapper) {
+        return new SelfClosingLongStream(delegate.mapToLong(mapper));
+    }
+
+    @Override
+    public DoubleStream mapToDouble(IntToDoubleFunction mapper) {
+        return new SelfClosingDoubleStream(delegate.mapToDouble(mapper));
+    }
+
+    @Override
+    public IntStream flatMap(IntFunction<? extends IntStream> mapper) {
+        return new SelfClosingIntStream(delegate.flatMap(mapper));
+    }
+
+    @Override
+    public IntStream distinct() {
+        return new SelfClosingIntStream(delegate.distinct());
+    }
+
+    @Override
+    public IntStream sorted() {
+        return new SelfClosingIntStream(delegate.sorted());
+    }
+
+    @Override
+    public IntStream peek(IntConsumer action) {
+        return new SelfClosingIntStream(delegate.peek(action));
+    }
+
+    @Override
+    public IntStream limit(long maxSize) {
+        return new SelfClosingIntStream(delegate.limit(maxSize));
+    }
+
+    @Override
+    public IntStream skip(long n) {
+        return new SelfClosingIntStream(delegate.skip(n));
+    }
+
+    @Override
+    public void forEach(IntConsumer action) {
+        try {
+            delegate.forEach(action);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public void forEachOrdered(IntConsumer action) {
+        try {
+            delegate.forEachOrdered(action);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public int[] toArray() {
+        try {
+            return delegate.toArray();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public int reduce(int identity, IntBinaryOperator op) {
+        try {
+            return delegate.reduce(identity, op);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalInt reduce(IntBinaryOperator op) {
+        try {
+            return delegate.reduce(op);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public <R> R collect(Supplier<R> supplier, ObjIntConsumer<R> accumulator, BiConsumer<R, R> combiner) {
+        try {
+            return delegate.collect(supplier, accumulator, combiner);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public int sum() {
+        try {
+            return delegate.sum();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalInt min() {
+        try {
+            return delegate.min();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalInt max() {
+        try {
+            return delegate.max();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public long count() {
+        try {
+            return delegate.count();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalDouble average() {
+        try {
+            return delegate.average();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public IntSummaryStatistics summaryStatistics() {
+        try {
+            return delegate.summaryStatistics();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean anyMatch(IntPredicate predicate) {
+        try {
+            return delegate.anyMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean allMatch(IntPredicate predicate) {
+        try {
+            return delegate.allMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean noneMatch(IntPredicate predicate) {
+        try {
+            return delegate.noneMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalInt findFirst() {
+        try {
+            return delegate.findFirst();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalInt findAny() {
+        try {
+            return delegate.findAny();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public LongStream asLongStream() {
+        return new SelfClosingLongStream(delegate.asLongStream());
+    }
+
+    @Override
+    public DoubleStream asDoubleStream() {
+        return new SelfClosingDoubleStream(delegate.asDoubleStream());
+    }
+
+    @Override
+    public Stream<Integer> boxed() {
+        return new SelfClosingStream<>(delegate.boxed());
+    }
+
+    @Override
+    public IntStream sequential() {
+        return new SelfClosingIntStream(delegate.sequential());
+    }
+
+    @Override
+    public IntStream parallel() {
+        return new SelfClosingIntStream(delegate.parallel());
+    }
+
+    @Override
+    public IntStream unordered() {
+        return new SelfClosingIntStream(delegate.unordered());
+    }
+
+    @Override
+    public IntStream onClose(Runnable closeHandler) {
+        return new SelfClosingIntStream(delegate.onClose(closeHandler));
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public PrimitiveIterator.OfInt iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public Spliterator.OfInt spliterator() {
+        return delegate.spliterator();
+    }
+
+    @Override
+    public boolean isParallel() {
+        return delegate.isParallel();
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/SelfClosingLongStream.java
+++ b/core/src/main/java/org/jdbi/v3/SelfClosingLongStream.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3;
+
+import java.util.LongSummaryStatistics;
+import java.util.OptionalDouble;
+import java.util.OptionalLong;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.function.BiConsumer;
+import java.util.function.LongBinaryOperator;
+import java.util.function.LongConsumer;
+import java.util.function.LongFunction;
+import java.util.function.LongPredicate;
+import java.util.function.LongToDoubleFunction;
+import java.util.function.LongToIntFunction;
+import java.util.function.LongUnaryOperator;
+import java.util.function.ObjLongConsumer;
+import java.util.function.Supplier;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+class SelfClosingLongStream implements LongStream {
+    private final LongStream delegate;
+
+    SelfClosingLongStream(LongStream delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public LongStream filter(LongPredicate predicate) {
+        return new SelfClosingLongStream(delegate.filter(predicate));
+    }
+
+    @Override
+    public LongStream map(LongUnaryOperator mapper) {
+        return new SelfClosingLongStream(delegate.map(mapper));
+    }
+
+    @Override
+    public <U> Stream<U> mapToObj(LongFunction<? extends U> mapper) {
+        return new SelfClosingStream<>(delegate.mapToObj(mapper));
+    }
+
+    @Override
+    public IntStream mapToInt(LongToIntFunction mapper) {
+        return new SelfClosingIntStream(delegate.mapToInt(mapper));
+    }
+
+    @Override
+    public DoubleStream mapToDouble(LongToDoubleFunction mapper) {
+        return new SelfClosingDoubleStream(delegate.mapToDouble(mapper));
+    }
+
+    @Override
+    public LongStream flatMap(LongFunction<? extends LongStream> mapper) {
+        return new SelfClosingLongStream(delegate.flatMap(mapper));
+    }
+
+    @Override
+    public LongStream distinct() {
+        return new SelfClosingLongStream(delegate.distinct());
+    }
+
+    @Override
+    public LongStream sorted() {
+        return new SelfClosingLongStream(delegate.sorted());
+    }
+
+    @Override
+    public LongStream peek(LongConsumer action) {
+        return new SelfClosingLongStream(delegate.peek(action));
+    }
+
+    @Override
+    public LongStream limit(long maxSize) {
+        return new SelfClosingLongStream(delegate.limit(maxSize));
+    }
+
+    @Override
+    public LongStream skip(long n) {
+        return new SelfClosingLongStream(delegate.skip(n));
+    }
+
+    @Override
+    public void forEach(LongConsumer action) {
+        try {
+            delegate.forEach(action);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public void forEachOrdered(LongConsumer action) {
+        try {
+            delegate.forEachOrdered(action);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public long[] toArray() {
+        try {
+            return delegate.toArray();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public long reduce(long identity, LongBinaryOperator op) {
+        try {
+            return delegate.reduce(identity, op);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalLong reduce(LongBinaryOperator op) {
+        try {
+            return delegate.reduce(op);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public <R> R collect(Supplier<R> supplier, ObjLongConsumer<R> accumulator, BiConsumer<R, R> combiner) {
+        try {
+            return delegate.collect(supplier, accumulator, combiner);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public long sum() {
+        try {
+            return delegate.sum();
+        }
+        finally {
+            close();
+        }
+
+    }
+
+    @Override
+    public OptionalLong min() {
+        try {
+            return delegate.min();
+        }
+        finally {
+            close();
+        }
+
+    }
+
+    @Override
+    public OptionalLong max() {
+        try {
+            return delegate.max();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public long count() {
+        try {
+            return delegate.count();
+        }
+        finally {
+            close();
+        }
+
+    }
+
+    @Override
+    public OptionalDouble average() {
+        try {
+            return delegate.average();
+        }
+        finally {
+            close();
+        }
+
+    }
+
+    @Override
+    public LongSummaryStatistics summaryStatistics() {
+        try {
+            return delegate.summaryStatistics();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean anyMatch(LongPredicate predicate) {
+        try {
+            return delegate.anyMatch(predicate);
+        }
+        finally {
+            close();
+        }
+
+    }
+
+    @Override
+    public boolean allMatch(LongPredicate predicate) {
+        try {
+            return delegate.allMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean noneMatch(LongPredicate predicate) {
+        try {
+            return delegate.noneMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalLong findFirst() {
+        try {
+            return delegate.findFirst();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public OptionalLong findAny() {
+        try {
+            return delegate.findAny();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public DoubleStream asDoubleStream() {
+        return new SelfClosingDoubleStream(delegate.asDoubleStream());
+    }
+
+    @Override
+    public Stream<Long> boxed() {
+        return new SelfClosingStream<>(delegate.boxed());
+    }
+
+    @Override
+    public LongStream sequential() {
+        return new SelfClosingLongStream(delegate.sequential());
+    }
+
+    @Override
+    public LongStream parallel() {
+        return new SelfClosingLongStream(delegate.parallel());
+    }
+
+    @Override
+    public LongStream unordered() {
+        return new SelfClosingLongStream(delegate.unordered());
+    }
+
+    @Override
+    public LongStream onClose(Runnable closeHandler) {
+        return new SelfClosingLongStream(delegate.onClose(closeHandler));
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public PrimitiveIterator.OfLong iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public Spliterator.OfLong spliterator() {
+        return delegate.spliterator();
+    }
+
+    @Override
+    public boolean isParallel() {
+        return delegate.isParallel();
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/SelfClosingStream.java
+++ b/core/src/main/java/org/jdbi/v3/SelfClosingStream.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collector;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+class SelfClosingStream<T> implements Stream<T> {
+    private final Stream<T> delegate;
+
+    SelfClosingStream(Stream<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Stream<T> filter(Predicate<? super T> predicate) {
+        return new SelfClosingStream<>(delegate.filter(predicate));
+    }
+
+    @Override
+    public <R> Stream<R> map(Function<? super T, ? extends R> mapper) {
+        return new SelfClosingStream<>(delegate.map(mapper));
+    }
+
+    @Override
+    public IntStream mapToInt(ToIntFunction<? super T> mapper) {
+        return new SelfClosingIntStream(delegate.mapToInt(mapper));
+    }
+
+    @Override
+    public LongStream mapToLong(ToLongFunction<? super T> mapper) {
+        return new SelfClosingLongStream(delegate.mapToLong(mapper));
+    }
+
+    @Override
+    public DoubleStream mapToDouble(ToDoubleFunction<? super T> mapper) {
+        return new SelfClosingDoubleStream(delegate.mapToDouble(mapper));
+    }
+
+    @Override
+    public <R> Stream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
+        return new SelfClosingStream<>(delegate.flatMap(mapper));
+    }
+
+    @Override
+    public IntStream flatMapToInt(Function<? super T, ? extends IntStream> mapper) {
+        return new SelfClosingIntStream(delegate.flatMapToInt(mapper));
+    }
+
+    @Override
+    public LongStream flatMapToLong(Function<? super T, ? extends LongStream> mapper) {
+        return new SelfClosingLongStream(delegate.flatMapToLong(mapper));
+    }
+
+    @Override
+    public DoubleStream flatMapToDouble(Function<? super T, ? extends DoubleStream> mapper) {
+        return new SelfClosingDoubleStream(delegate.flatMapToDouble(mapper));
+    }
+
+    @Override
+    public Stream<T> distinct() {
+        return new SelfClosingStream<>(delegate.distinct());
+    }
+
+    @Override
+    public Stream<T> sorted() {
+        return new SelfClosingStream<>(delegate.sorted());
+    }
+
+    @Override
+    public Stream<T> sorted(Comparator<? super T> comparator) {
+        return new SelfClosingStream<>(delegate.sorted(comparator));
+    }
+
+    @Override
+    public Stream<T> peek(Consumer<? super T> action) {
+        return new SelfClosingStream<>(delegate.peek(action));
+    }
+
+    @Override
+    public Stream<T> limit(long maxSize) {
+        return new SelfClosingStream<>(delegate.limit(maxSize));
+    }
+
+    @Override
+    public Stream<T> skip(long n) {
+        return new SelfClosingStream<>(delegate.skip(n));
+    }
+
+    @Override
+    public void forEach(Consumer<? super T> action) {
+        try {
+            delegate.forEach(action);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public void forEachOrdered(Consumer<? super T> action) {
+        try {
+            delegate.forEachOrdered(action);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public Object[] toArray() {
+        try {
+            return delegate.toArray();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public <A> A[] toArray(IntFunction<A[]> generator) {
+        try {
+            return delegate.toArray(generator);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public T reduce(T identity, BinaryOperator<T> accumulator) {
+        try {
+            return delegate.reduce(identity, accumulator);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public Optional<T> reduce(BinaryOperator<T> accumulator) {
+        try {
+            return delegate.reduce(accumulator);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public <U> U reduce(U identity, BiFunction<U, ? super T, U> accumulator, BinaryOperator<U> combiner) {
+        try {
+            return delegate.reduce(identity, accumulator, combiner);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public <R> R collect(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator, BiConsumer<R, R> combiner) {
+        try {
+            return delegate.collect(supplier, accumulator, combiner);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public <R, A> R collect(Collector<? super T, A, R> collector) {
+        try {
+            return delegate.collect(collector);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public Optional<T> min(Comparator<? super T> comparator) {
+        try {
+            return delegate.min(comparator);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public Optional<T> max(Comparator<? super T> comparator) {
+        try {
+            return delegate.max(comparator);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public long count() {
+        try {
+            return delegate.count();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean anyMatch(Predicate<? super T> predicate) {
+        try {
+            return delegate.anyMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean allMatch(Predicate<? super T> predicate) {
+        try {
+            return delegate.allMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public boolean noneMatch(Predicate<? super T> predicate) {
+        try {
+            return delegate.noneMatch(predicate);
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public Optional<T> findFirst() {
+        try {
+            return delegate.findFirst();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public Optional<T> findAny() {
+        try {
+            return delegate.findAny();
+        }
+        finally {
+            close();
+        }
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public Spliterator<T> spliterator() {
+        return delegate.spliterator();
+    }
+
+    @Override
+    public boolean isParallel() {
+        return delegate.isParallel();
+    }
+
+    @Override
+    public Stream<T> sequential() {
+        return new SelfClosingStream<>(delegate.sequential());
+    }
+
+    @Override
+    public Stream<T> parallel() {
+        return new SelfClosingStream<>(delegate.parallel());
+    }
+
+    @Override
+    public Stream<T> unordered() {
+        return new SelfClosingStream<>(delegate.unordered());
+    }
+
+    @Override
+    public Stream<T> onClose(Runnable closeHandler) {
+        return new SelfClosingStream<>(delegate.onClose(closeHandler));
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}


### PR DESCRIPTION
Adds a wrapper around streams returned from ResultBearing.stream() which automatically closes a stream before returning from any call a terminal operation.

Also documents requirement to explicitly close query streams. 