### PR TITLE
LocalTransactionHandler: cleanup exception suppression for jdbi3

### DIFF
--- a/core/src/main/java/org/jdbi/v3/tweak/transactions/LocalTransactionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/tweak/transactions/LocalTransactionHandler.java
@@ -13,7 +13,6 @@
  */
 package org.jdbi.v3.tweak.transactions;
 
-import java.lang.reflect.InvocationTargetException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Savepoint;
@@ -182,7 +181,7 @@ public class LocalTransactionHandler implements TransactionHandler
             try {
                 handle.rollback();
             } catch (Exception rollback) {
-                suppressOrLog(e, rollback);
+                e.addSuppressed(rollback);
             }
             throw e;
         }
@@ -190,7 +189,7 @@ public class LocalTransactionHandler implements TransactionHandler
             try {
                 handle.rollback();
             } catch (Exception rollback) {
-                suppressOrLog(e, rollback);
+                e.addSuppressed(rollback);
             }
             throw new TransactionFailedException("Transaction failed do to exception being thrown " +
                                                  "from within the callback. See cause " +
@@ -255,22 +254,5 @@ public class LocalTransactionHandler implements TransactionHandler
         {
             return initialAutocommit;
         }
-    }
-
-    /** Java 7 or up: add inner exception as suppressed.  Java 6 just log
-     * and move on with life. */ // TODO: jdbi3 fixup
-    private void suppressOrLog(Throwable outer, Throwable suppressed) {
-        try {
-            Throwable.class.getMethod("addSuppressed", Throwable.class).invoke(outer, suppressed);
-            return;
-        } catch (SecurityException e) {
-        } catch (NoSuchMethodException e) {
-        } catch (IllegalArgumentException e) {
-        } catch (IllegalAccessException e) {
-        } catch (InvocationTargetException e) {
-        }
-        System.err.println("Exception caught while attempting connection rollback in LocalTransactionHandler;"
-                + "in Java 7 or later we would 'suppress' it but since we can't we'll log it here:");
-        suppressed.printStackTrace();
     }
 }

--- a/core/src/test/java/org/jdbi/v3/tweak/transactions/TestLocalTransactionHandler.java
+++ b/core/src/test/java/org/jdbi/v3/tweak/transactions/TestLocalTransactionHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.tweak.transactions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.jdbi.v3.Handle;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class TestLocalTransactionHandler {
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
+
+    @Mock
+    Handle h;
+
+    @Test
+    public void testRollbackThrow() throws Exception {
+        RuntimeException outer = new RuntimeException("Transaction throws!");
+        RuntimeException inner = new RuntimeException("Rollback throws!");
+
+        Mockito.when(h.rollback()).thenThrow(inner);
+
+        try {
+            new LocalTransactionHandler().inTransaction(h,
+                (h, txn) -> { throw outer; });
+        } catch (RuntimeException e) {
+            assertSame(outer, e);
+            assertEquals(1, e.getSuppressed().length);
+            assertSame(inner, e.getSuppressed()[0]);
+        }
+    }
+}


### PR DESCRIPTION
followup to #283 