### PR TITLE
Add a chain of parameter binder factories that can provide binders, defaulting to PositionalBinder when all else fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,8 +287,8 @@
                     <configuration>
                         <toolchains>
                             <jdk>
-                                <version>1.7</version>
-                                <vendor>oracle</vendor>
+                                <version>${project.build.targetJdk}</version>
+                                <vendor>sun</vendor>
                             </jdk>
                         </toolchains>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -287,8 +287,8 @@
                     <configuration>
                         <toolchains>
                             <jdk>
-                                <version>${project.build.targetJdk}</version>
-                                <vendor>sun</vendor>
+                                <version>1.7</version>
+                                <vendor>oracle</vendor>
                             </jdk>
                         </toolchains>
                     </configuration>

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
@@ -41,9 +41,9 @@ class BatchHandler extends CustomizingStatementHandler
     private final boolean transactional;
     private final ChunkSizeFunction batchChunkSize;
 
-    BatchHandler(Class<?> sqlObjectType, ResolvedMethod method)
+    BatchHandler(Class<?> sqlObjectType, ResolvedMethod method, ParameterBinderRegistry binderRegistry)
     {
-        super(sqlObjectType, method);
+        super(sqlObjectType, method, binderRegistry);
         if(!returnTypeIsValid(method.getRawMember().getReturnType()) ) {
             throw new UnableToCreateSqlObjectException(invalidReturnTypeMessage(method));
         }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/CallHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/CallHandler.java
@@ -25,9 +25,9 @@ class CallHandler extends CustomizingStatementHandler
     private final String sql;
     private final boolean returnOutParams;
 
-    CallHandler(Class<?> sqlObjectType, ResolvedMethod method)
+    CallHandler(Class<?> sqlObjectType, ResolvedMethod method, ParameterBinderRegistry binderRegistry)
     {
-        super(sqlObjectType, method);
+        super(sqlObjectType, method, binderRegistry);
 
         if (null != method.getReturnType() ) {
             if (method.getReturnType().isInstanceOf(OutParameters.class)){

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/CustomizingStatementHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/CustomizingStatementHandler.java
@@ -32,11 +32,13 @@ abstract class CustomizingStatementHandler implements Handler
     private final List<FactoryAnnotationIndexTriple> paramBasedCustomizerFactories  = new ArrayList<FactoryAnnotationIndexTriple>();
     private final Class<?> sqlObjectType;
     private final Method method;
+    private final ParameterBinderRegistry binderRegistry;
 
-    CustomizingStatementHandler(Class<?> sqlObjectType, ResolvedMethod method)
+    CustomizingStatementHandler(Class<?> sqlObjectType, ResolvedMethod method, ParameterBinderRegistry binderRegistry)
     {
         this.sqlObjectType = sqlObjectType;
         this.method = method.getRawMember();
+        this.binderRegistry = binderRegistry;
 
         for (final Annotation annotation : sqlObjectType.getAnnotations()) {
             if (annotation.annotationType().isAnnotationPresent(SqlStatementCustomizingAnnotation.class)) {
@@ -110,7 +112,7 @@ abstract class CustomizingStatementHandler implements Handler
             if (!thereBindingAnnotation) {
                 // If there is no binding annotation on a parameter,
                 // then add a positional parameter binder
-                binders.add(new Bindifier(null, param_idx, new PositionalBinder(param_idx)));
+                binders.add(new Bindifier(null, param_idx, binderRegistry.binderFor(method.getRawMember().getDeclaringClass(), method.getRawMember(), param_idx)));
             }
         }
     }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ParameterBinderFactory.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ParameterBinderFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject;
+
+import org.skife.jdbi.v2.StatementContext;
+
+import java.lang.reflect.Method;
+
+/**
+ * Factory interface used to produce result set mappers.
+ */
+public interface ParameterBinderFactory
+{
+    /**
+     * Can this factory provide a parameter binder for binding a method parameter to a sql bound parameter?
+     * @param type the class containing the method
+     * @param method the method that requires binders
+     * @param param_idx the current parameter index that will be bound
+     * @return true if it can, false if it cannot
+     */
+    boolean accepts(Class type, Method method, int param_idx);
+
+    /**
+     * Supplies a binder for the given parameter, or null to fallback to a default binder
+     */
+    Binder binderFor(Class type, Method method, int param_idx);
+}

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ParameterBinderRegistry.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ParameterBinderRegistry.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+class ParameterBinderRegistry
+{
+    static final ParameterBinderFactory DEFAULT_BINDER_FACTORY = new ParameterBinderFactory() {
+        @Override
+        public boolean accepts(Class type, Method method, int param_idx) {
+            return true;
+        }
+
+        @Override
+        public Binder binderFor(Class type, Method method, int param_idx) {
+            return new PositionalBinder(param_idx);
+        }
+    };
+
+    private final List<ParameterBinderFactory> orderedBinderFactories = new CopyOnWriteArrayList<ParameterBinderFactory>();
+    private final ConcurrentHashMap<ClassMethodParameter, ParameterBinderFactory> factoryCache = new ConcurrentHashMap<ClassMethodParameter, ParameterBinderFactory>();
+
+    private static class ClassMethodParameter {
+        final Class type;
+        final Method method;
+        final int param_idx;
+
+        ClassMethodParameter(Class type, Method method, int param_idx) {
+            this.type = type;
+            this.method = method;
+            this.param_idx = param_idx;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            } else if (obj == null) {
+                return false;
+            } else if (obj instanceof ClassMethodParameter) {
+                ClassMethodParameter other = (ClassMethodParameter)obj;
+                return (other.type.equals(type) && other.method.equals(method) && other.param_idx == param_idx);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return type.hashCode() + method.hashCode() + param_idx;
+        }
+    }
+
+    /**
+     * Copy Constructor
+     */
+    ParameterBinderRegistry(ParameterBinderRegistry parent)
+    {
+        orderedBinderFactories.addAll(parent.orderedBinderFactories);
+        factoryCache.putAll(parent.factoryCache);
+    }
+
+    ParameterBinderRegistry() {
+
+    }
+
+    /**
+     * Add factory to the front of the list, so it has precedence over previously added
+     * @param factory
+     */
+    public void addFactoryAsFirst(ParameterBinderFactory factory) {
+        orderedBinderFactories.add(0, factory);
+        factoryCache.clear();
+    }
+
+    /**
+     * Add factory to the end of the list, so it has lowest precedence other than for the DEFAULT_BINDER_FACTORY which is always last
+     * @param factory
+     */
+    public void addFactoryAsLast(ParameterBinderFactory factory) {
+        orderedBinderFactories.add(factory);
+        factoryCache.clear();
+    }
+
+    /**
+     * Clear all registered binder factories, other than DEFAULT_BINDER_FACTORY which is always implied as lowest precedence
+     */
+    public void reset() {
+        orderedBinderFactories.clear();
+                factoryCache.clear();
+    }
+
+    public Binder binderFor(Class type, Method method, int param_idx) {
+        final ClassMethodParameter cacheKey = new ClassMethodParameter(type, method, param_idx);
+        final ParameterBinderFactory cached = factoryCache.get(cacheKey);
+        if (cached != null) {
+            return cached.binderFor(type, method, param_idx);
+        }
+
+        for (ParameterBinderFactory factory : orderedBinderFactories) {
+            if (factory.accepts(type, method, param_idx)) {
+                Binder binder = factory.binderFor(type, method, param_idx);
+                if (binder != null) {
+                    factoryCache.put(cacheKey, factory);
+                    return factory.binderFor(type, method, param_idx);
+                }
+            }
+        }
+
+        factoryCache.put(cacheKey, DEFAULT_BINDER_FACTORY);
+        return DEFAULT_BINDER_FACTORY.binderFor(type, method, param_idx);
+    }
+}

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/QueryHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/QueryHandler.java
@@ -24,9 +24,9 @@ class QueryHandler extends CustomizingStatementHandler
     private final ResolvedMethod    method;
     private final ResultReturnThing magic;
 
-    QueryHandler(Class<?> sqlObjectType, ResolvedMethod method, ResultReturnThing magic)
+    QueryHandler(Class<?> sqlObjectType, ResolvedMethod method, ResultReturnThing magic, ParameterBinderRegistry binderRegistry)
     {
-        super(sqlObjectType, method);
+        super(sqlObjectType, method, binderRegistry);
         this.method = method;
         this.magic = magic;
         this.sql = SqlObject.getSql(method.getRawMember().getAnnotation(SqlQuery.class), method.getRawMember());

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
@@ -190,6 +190,22 @@ class SqlObject
         return handlers;
     }
 
+    /**
+     * Register a binder factory that can decide for a given method parameter which Binder to use.  The factory
+     * is added to the front of the chain, giving it higher precedence over previously registered factories.  The
+     * default binder factory will always be last in the chain.
+     */
+    public static void registerBinderFactory(ParameterBinderFactory factory) {
+        binderRegistry.addFactoryAsFirst(factory);
+    }
+
+    /**
+     * Clear all registered binder factories.  The default binder factory will still be used, and is implied at the
+     * end of the factory chain.
+     */
+    public static void resetBinderFactories() {
+        binderRegistry.reset();
+    }
 
     private final Map<Method, Handler> handlers;
     private final HandleDing           ding;

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
@@ -41,6 +41,7 @@ class SqlObject
     private static final Map<Method, Handler>                          mixinHandlers = new HashMap<Method, Handler>();
     private static final ConcurrentMap<Class<?>, Map<Method, Handler>> handlersCache = new ConcurrentHashMap<Class<?>, Map<Method, Handler>>();
     private static final ConcurrentMap<Class<?>, Factory>              factories     = new ConcurrentHashMap<Class<?>, Factory>();
+    private static final ParameterBinderRegistry                       binderRegistry = new ParameterBinderRegistry();
 
     private static Method jdk8DefaultMethod = null;
 
@@ -60,6 +61,8 @@ class SqlObject
     @SuppressWarnings("unchecked")
     static <T> T buildSqlObject(final Class<T> sqlObjectType, final HandleDing handle)
     {
+        final ParameterBinderRegistry clonedBinderRegistry = new ParameterBinderRegistry(binderRegistry);
+
         Factory f;
         if (factories.containsKey(sqlObjectType)) {
             f = factories.get(sqlObjectType);
@@ -77,7 +80,7 @@ class SqlObject
                 e.setSuperclass(sqlObjectType);
             }
             e.setInterfaces(interfaces.toArray(new Class[interfaces.size()]));
-            final SqlObject so = new SqlObject(buildHandlersFor(sqlObjectType), handle);
+            final SqlObject so = new SqlObject(buildHandlersFor(sqlObjectType, clonedBinderRegistry), handle);
 
             e.setCallbackFilter(new CallbackFilter() {
 
@@ -119,7 +122,7 @@ class SqlObject
             f = (Factory) actual;
         }
 
-        final SqlObject so = new SqlObject(buildHandlersFor(sqlObjectType), handle);
+        final SqlObject so = new SqlObject(buildHandlersFor(sqlObjectType, clonedBinderRegistry), handle);
         return (T) f.newInstance(new Callback[] {
                 new MethodInterceptor() {
                     @Override
@@ -131,7 +134,7 @@ class SqlObject
         });
     }
 
-    private static Map<Method, Handler> buildHandlersFor(Class<?> sqlObjectType)
+    private static Map<Method, Handler> buildHandlersFor(Class<?> sqlObjectType, ParameterBinderRegistry clonedBinderRegistry)
     {
         if (handlersCache.containsKey(sqlObjectType)) {
             return handlersCache.get(sqlObjectType);
@@ -147,16 +150,16 @@ class SqlObject
             final Method raw_method = method.getRawMember();
 
             if (raw_method.isAnnotationPresent(SqlQuery.class)) {
-                handlers.put(raw_method, new QueryHandler(sqlObjectType, method, ResultReturnThing.forType(method)));
+                handlers.put(raw_method, new QueryHandler(sqlObjectType, method, ResultReturnThing.forType(method), clonedBinderRegistry));
             }
             else if (raw_method.isAnnotationPresent(SqlUpdate.class)) {
-                handlers.put(raw_method, new UpdateHandler(sqlObjectType, method));
+                handlers.put(raw_method, new UpdateHandler(sqlObjectType, method, clonedBinderRegistry));
             }
             else if (raw_method.isAnnotationPresent(SqlBatch.class)) {
-                handlers.put(raw_method, new BatchHandler(sqlObjectType, method));
+                handlers.put(raw_method, new BatchHandler(sqlObjectType, method, clonedBinderRegistry));
             }
             else if (raw_method.isAnnotationPresent(SqlCall.class)) {
-                handlers.put(raw_method, new CallHandler(sqlObjectType, method));
+                handlers.put(raw_method, new CallHandler(sqlObjectType, method, clonedBinderRegistry));
             }
             else if(raw_method.isAnnotationPresent(CreateSqlObject.class)) {
                 handlers.put(raw_method, new CreateSqlObjectHandler(raw_method.getReturnType()));
@@ -190,6 +193,7 @@ class SqlObject
 
     private final Map<Method, Handler> handlers;
     private final HandleDing           ding;
+
 
     SqlObject(Map<Method, Handler> handlers, HandleDing ding)
     {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
@@ -27,9 +27,9 @@ class UpdateHandler extends CustomizingStatementHandler
     private final String sql;
     private final Returner returner;
 
-    UpdateHandler(Class<?> sqlObjectType, ResolvedMethod method)
+    UpdateHandler(Class<?> sqlObjectType, ResolvedMethod method, ParameterBinderRegistry binderRegistry)
     {
-        super(sqlObjectType, method);
+        super(sqlObjectType, method, binderRegistry);
 
         if(returnTypeIsInvalid(method.getRawMember().getReturnType()) ) {
             throw new UnableToCreateSqlObjectException(invalidReturnTypeMessage(method));


### PR DESCRIPTION
When annotations do not provide binders, use a chain of parameter binding factories to find a binder, falling back to the default PositionalBinder when nothing else accepts or provides a non-null binder.