### PR TITLE
Handle '::' Postgres cast syntax in ColonStatementLexer

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+2.73
+  - (finally!) parse Postgres CAST syntax 'value::type' properly in colon
+    prefix statements
+
 2.72
   - Support for the ability to provide a list of the column names returned
     in a prepared batch #254

--- a/src/main/antlr3/org/skife/jdbi/rewriter/colon/ColonStatementLexer.g
+++ b/src/main/antlr3/org/skife/jdbi/rewriter/colon/ColonStatementLexer.g
@@ -11,10 +11,12 @@ lexer grammar ColonStatementLexer;
   }
 }
 
+fragment DOUBLE_COLON: {input.LA(2) == ':'}?=> '::';
+fragment COLON: {input.LA(2) != ':'}?=> ':';
+
 LITERAL: ('a'..'z' | 'A'..'Z' | ' ' | '\t' | '\n' | '\r' | '0'..'9' | ',' | '*' | '#' | '.' | '@' | '_' | '!'
           | '=' | ';' | '(' | ')' | '[' | ']' | '+' | '-' | '/' | '>' | '<' | '%' | '&' | '^' | '|'
-          | '$' | '~' | '{' | '}' | '`')+ ;
-COLON: ':';
+          | '$' | '~' | '{' | '}' | '`' | DOUBLE_COLON)+ ;
 NAMED_PARAM: COLON ('a'..'z' | 'A'..'Z' | '0'..'9' | '_' | '.' | '#')+;
 POSITIONAL_PARAM: '?';
 QUOTED_TEXT: ('\'' ( ESCAPE_SEQUENCE | ~'\'')* '\'');

--- a/src/test/java/org/skife/jdbi/v2/TestColonStatementRewriter.java
+++ b/src/test/java/org/skife/jdbi/v2/TestColonStatementRewriter.java
@@ -83,6 +83,14 @@ public class TestColonStatementRewriter
         assertEquals("select * from `v$session", rws.getSql());
     }
 
+    @Test
+    public void testDoubleColon() throws Exception
+    {
+        final String doubleColon = "select 1::int";
+        RewrittenStatement rws = rewrite(doubleColon);
+        assertEquals(doubleColon, rws.getSql());
+    }
+
     @Test(expected = UnableToCreateStatementException.class)
     public void testBailsOutOnInvalidInput() throws Exception
     {


### PR DESCRIPTION
heads up @orangecoding