### PR TITLE
Additional fix for #314 .

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/StringTemplate3StatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/StringTemplate3StatementLocator.java
@@ -260,6 +260,7 @@ public class StringTemplate3StatementLocator implements StatementLocator
                 literals.defineTemplate(key, name);
             }
             StringTemplate t = literals.lookupTemplate(key);
+            t.reset();
             for (Map.Entry<String, Object> entry : ctx.getAttributes().entrySet()) {
                 t.setAttribute(entry.getKey(), entry.getValue());
             }


### PR DESCRIPTION
Resets the reused string template before parameter substitution.