### PR TITLE
Configure maven-surefire-plugin forkCount to 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,13 @@
                         </toolchains>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <forkCount>1</forkCount>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
The default maven-surefire-plugin `forkCount` configuration from basepom-oss is `1.0C` meaning 1 VM forked per CPU core. Build logs suggest Travis build environments provide 8 cores.

This is often a problem for our Postgres tests since they are actively creating / modifying the same table in the database. I suspect this also explains why our builds time out at the end of the test run so often.