### PR TITLE
Remove Maven Toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ cache:
 before_install:
     - cp src/build/travis-toolchains.xml ~/.m2/toolchains.xml
 
-install: mvn -DskipTests=true -Dbasepom.check.skip-all=true -B install
-script: mvn -B verify
+install: mvn -Ptoolchains -DskipTests=true -Dbasepom.check.skip-all=true -B install
+script: mvn -Ptoolchains -B verify

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,53 @@
         <basepom.test.timeout>240</basepom.test.timeout>
     </properties>
 
+    <profiles>
+      <profile>
+        <id>toolchains</id>
+        <build>
+         <pluginManagement>
+           <plugins>
+             <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-compiler-plugin</artifactId>
+               <configuration>
+                 <compilerArguments>
+                   <parameters/>
+                 </compilerArguments>
+               </configuration>
+             </plugin>
+             <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-toolchains-plugin</artifactId>
+               <version>1.1</version>
+               <configuration>
+                 <toolchains>
+                   <jdk>
+                     <version>${project.build.targetJdk}</version>
+                     <vendor>oracle</vendor>
+                   </jdk>
+                 </toolchains>
+               </configuration>
+             </plugin>
+           </plugins>
+         </pluginManagement>
+         <plugins>
+           <plugin>
+             <groupId>org.apache.maven.plugins</groupId>
+             <artifactId>maven-toolchains-plugin</artifactId>
+             <executions>
+               <execution>
+                 <goals>
+                   <goal>toolchain</goal>
+                 </goals>
+               </execution>
+             </executions>
+           </plugin>
+         </plugins>
+        </build>
+      </profile>
+    </profiles>
+
     <build>
       <pluginManagement>
         <plugins>
@@ -98,39 +145,15 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
+                <source>${project.build.targetJdk}</source>
+                <target>${project.build.targetJdk}</target>
               <compilerArguments>
                 <parameters />
               </compilerArguments>
             </configuration>
           </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-toolchains-plugin</artifactId>
-            <version>1.1</version>
-            <configuration>
-              <toolchains>
-                <jdk>
-                  <version>${project.build.targetJdk}</version>
-                  <vendor>oracle</vendor>
-                </jdk>
-              </toolchains>
-            </configuration>
-          </plugin>
         </plugins>
       </pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-toolchains-plugin</artifactId>
-          <executions>
-            <execution>
-              <goals>
-                <goal>toolchain</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
     </build>
 
     <dependencyManagement>


### PR DESCRIPTION
Toolchains are useful when we compile against different JDKs or want to use a
specific old JDK. Since we target JDK8 in JDBI3, there is no big benefit in
using toolchains. In most development installations JDK8 is default and usually
already set in the PATH environment variable, so Maven can find it without
specific assistance. We only need to set-up source and target for the Java
compiler.

Also, avoiding using toolchains simplifies the process of contributing to JDBI,
because developers don't need to add specific steps to configure the development
environment and can build the project with `mvn clean install`.