### PR TITLE
Add support for Postgres arrays

### DIFF
--- a/postgres/src/main/java/org/jdbi/v3/pg/ArrayColumnMapper.java
+++ b/postgres/src/main/java/org/jdbi/v3/pg/ArrayColumnMapper.java
@@ -43,14 +43,19 @@ public class ArrayColumnMapper implements ColumnMapper<Object> {
             return buildFromResultSet(array);
         }
         try {
-            // We can't cast Object[] to componentType, so we need to create a new array of the correct
-            // type and copy the source array content to it.
             Object[] objectArray = (Object[]) array.getArray();
-            Object componentTypeArray = java.lang.reflect.Array.newInstance(componentType, objectArray.length);
-            for (int i = 0; i < objectArray.length; i++) {
-                java.lang.reflect.Array.set(componentTypeArray, i,objectArray[i]);
+            if (componentType == Object.class) {
+                // more efficient, doesn't have to copy an unknown size array
+                return objectArray;
+            } else {
+                // We can't cast Object[] to componentType, so we need to create a new array of the correct
+                // type and copy the source array's content to it.
+                Object componentTypeArray = java.lang.reflect.Array.newInstance(componentType, objectArray.length);
+                for (int i = 0; i < objectArray.length; i++) {
+                    java.lang.reflect.Array.set(componentTypeArray, i, objectArray[i]);
+                }
+                return componentTypeArray;
             }
-            return componentTypeArray;
         } catch (SQLFeatureNotSupportedException e) {
             UNSUPPORTED_TYPES.add(array.getBaseType());
             return buildFromResultSet(array);

--- a/postgres/src/main/java/org/jdbi/v3/pg/SqlArrayArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/pg/SqlArrayArgumentFactory.java
@@ -39,11 +39,15 @@ public class SqlArrayArgumentFactory implements ArgumentFactory {
     static {
         final Map<Class<?>, String> map = new IdentityHashMap<>();
         map.put(int.class, "integer");
+        map.put(Integer.class, "integer");
         map.put(long.class, "bigint");
+        map.put(Long.class, "bigint");
         map.put(String.class, "varchar");
         map.put(UUID.class, "uuid");
         map.put(float.class, "real");
+        map.put(Float.class, "real");
         map.put(double.class, "double precision");
+        map.put(Double.class, "double precision");
         BEST_GUESS = Collections.unmodifiableMap(map);
     }
 

--- a/postgres/src/main/java/org/jdbi/v3/pg/SqlArrayArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/pg/SqlArrayArgumentFactory.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.pg;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -56,7 +57,7 @@ public class SqlArrayArgumentFactory implements ArgumentFactory {
             throw new IllegalArgumentException("not an array: " + klass);
         }
         String guess = BEST_GUESS.get(klass.getComponentType());
-        if (((Object[]) array).length == 0 || guess == null) {
+        if (Array.getLength(array) == 0 || guess == null) {
             return "varchar";
         }
         return guess;

--- a/postgres/src/test/java/org/jdbi/v3/pg/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/v3/pg/TestSqlArrays.java
@@ -85,6 +85,14 @@ public class TestSqlArrays {
     }
 
     @Test
+    public void testObjectArray() throws Exception {
+        ao.insertIntArray(testInts);
+        Object[] actuals = ao.fetchObjectArray();
+        Object[] expecteds = IntStream.of(testInts).mapToObj(Integer::valueOf).toArray(Object[]::new);
+        assertArrayEquals(expecteds, actuals);
+    }
+
+    @Test
     @Ignore("Inserting lists to arrays is not supported")
     public void testIntList() throws Exception {
         List<Integer> testIntList = new ArrayList<Integer>();
@@ -112,6 +120,9 @@ public class TestSqlArrays {
 
         @SqlQuery(I_SELECT)
         Integer[] fetchBoxedIntArray();
+
+        @SqlQuery(I_SELECT)
+        Object[] fetchObjectArray();
 
         @SqlUpdate(I_INSERT)
         void insertIntArray(int[] ints);

--- a/postgres/src/test/java/org/jdbi/v3/pg/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/v3/pg/TestSqlArrays.java
@@ -20,8 +20,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-
+import java.util.stream.IntStream;
 import org.jdbi.v3.Handle;
+import org.jdbi.v3.sqlobject.Bind;
 import org.jdbi.v3.sqlobject.SqlQuery;
 import org.jdbi.v3.sqlobject.SqlUpdate;
 import org.junit.Before;
@@ -29,7 +30,6 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-@Ignore // XXX: this doesn't work yet!
 public class TestSqlArrays {
     private static final String U_SELECT = "SELECT u FROM uuids";
     private static final String U_INSERT = "INSERT INTO uuids VALUES(:uuids, NULL)";
@@ -63,6 +63,7 @@ public class TestSqlArrays {
     }
 
     @Test
+    @Ignore("Inserting lists to arrays is not supported")
     public void testUuidList() throws Exception {
         ao.insertUuidList(Arrays.asList(testUuids));
         assertEquals(Arrays.asList(testUuids), ao.fetchUuidList());
@@ -71,10 +72,20 @@ public class TestSqlArrays {
     @Test
     public void testIntArray() throws Exception {
         ao.insertIntArray(testInts);
-        assertArrayEquals(testInts, ao.fetchIntArray());
+        int[] actuals = ao.fetchIntArray();
+        assertArrayEquals(testInts, actuals);
     }
 
     @Test
+    public void testBoxedIntArray() throws Exception {
+        Integer[] source = IntStream.of(testInts).mapToObj(Integer::valueOf).toArray(Integer[]::new);
+        ao.insertBoxedIntArray(source);
+        Integer[] actuals = ao.fetchBoxedIntArray();
+        assertArrayEquals(source, actuals);
+    }
+
+    @Test
+    @Ignore("Inserting lists to arrays is not supported")
     public void testIntList() throws Exception {
         List<Integer> testIntList = new ArrayList<Integer>();
         Arrays.stream(testInts).forEach(testIntList::add);
@@ -87,7 +98,7 @@ public class TestSqlArrays {
         UUID[] fetchUuidArray();
 
         @SqlUpdate(U_INSERT)
-        void insertUuidArray(UUID[] u);
+        void insertUuidArray(UUID[] uuids);
 
         @SqlQuery(U_SELECT)
         List<UUID> fetchUuidList();
@@ -103,7 +114,10 @@ public class TestSqlArrays {
         Integer[] fetchBoxedIntArray();
 
         @SqlUpdate(I_INSERT)
-        void insertIntArray(int[] u);
+        void insertIntArray(int[] ints);
+
+        @SqlUpdate(I_INSERT)
+        void insertBoxedIntArray(Integer[] ints);
 
         @SqlQuery(I_SELECT)
         List<Integer> fetchIntList();


### PR DESCRIPTION
This PR attempts to fix issues with converting arrays between an application and a PostgreSQL JDBC driver. 

* Arrays are covariant, so we can't convert `int[]` to `Object[]` by casting. We should do conversion manually using `java.reflect.Array` which allows to work with arrays of any type.
* We should support boxing arrays as well as the primitive ones.

Unfortunately, it seems not possible to convert between arrays and lists, because JDBI considers lists as containers. I remember, we could tweak such behavior in JDBI2 by using  the `@SingleValueResult`
annotations, but it's gone in JDBI3.