### PR TITLE
Add support for JSR-310 time types

### DIFF
--- a/core/src/main/java/org/jdbi/v3/argument/BuiltInArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/argument/BuiltInArgumentFactory.java
@@ -32,6 +32,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -105,6 +106,7 @@ public class BuiltInArgumentFactory implements ArgumentFactory {
         register(map, LocalDateTime.class, Types.TIMESTAMP, (p, i, v) -> p.setTimestamp(i, Timestamp.valueOf(v)));
         register(map, OffsetDateTime.class, Types.TIMESTAMP, (p, i, v) -> p.setTimestamp(i, Timestamp.from(v.toInstant())));
         register(map, ZonedDateTime.class, Types.TIMESTAMP, (p, i, v) -> p.setTimestamp(i, Timestamp.from(v.toInstant())));
+        register(map, LocalTime.class, Types.TIME, (p, i, v) -> p.setTime(i, Time.valueOf(v)));
 
         return Collections.unmodifiableMap(map);
     }

--- a/core/src/main/java/org/jdbi/v3/mapper/BuiltInMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/mapper/BuiltInMapperFactory.java
@@ -22,6 +22,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -29,6 +30,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -81,6 +83,7 @@ public class BuiltInMapperFactory implements ColumnMapperFactory {
         mappers.put(LocalDateTime.class, referenceMapper(BuiltInMapperFactory::getLocalDateTime));
         mappers.put(OffsetDateTime.class, referenceMapper(BuiltInMapperFactory::getOffsetDateTime));
         mappers.put(ZonedDateTime.class, referenceMapper(BuiltInMapperFactory::getZonedDateTime));
+        mappers.put(LocalTime.class, referenceMapper(BuiltInMapperFactory::getLocalTime));
     }
 
     @Override
@@ -162,5 +165,10 @@ public class BuiltInMapperFactory implements ColumnMapperFactory {
     private static ZonedDateTime getZonedDateTime(ResultSet r, int i) throws SQLException {
         Timestamp ts = r.getTimestamp(i);
         return ts == null ? null : ZonedDateTime.ofInstant(ts.toInstant(), ZoneId.systemDefault());
+    }
+
+    private static LocalTime getLocalTime(ResultSet r, int i) throws SQLException {
+        Time time = r.getTime(i);
+        return time == null ? null : time.toLocalTime();
     }
 }

--- a/core/src/test/java/org/jdbi/v3/TestJsr310.java
+++ b/core/src/test/java/org/jdbi/v3/TestJsr310.java
@@ -23,6 +23,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.LocalTime;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -87,5 +88,15 @@ public class TestJsr310 {
         ZonedDateTime dt = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("America/Denver"));
         h.insert("insert into stuff(ts) values (?)", dt);
         assertTrue(dt.isEqual(h.createQuery("select ts from stuff").mapTo(ZonedDateTime.class).findOnly()));
+    }
+
+    @Test
+    public void localTime(){
+        h.execute("create table schedule (start time, end time)");
+        LocalTime start = LocalTime.of(8, 30, 0);
+        LocalTime end = LocalTime.of(10, 30, 0);
+        h.insert("insert into schedule (start, end) values (?,?)", start, end);
+        assertEquals(start, h.createQuery("select start from schedule").mapTo(LocalTime.class).findOnly());
+        assertEquals(end, h.createQuery("select end from schedule").mapTo(LocalTime.class).findOnly());
     }
 }


### PR DESCRIPTION
They correspondent to the SQL TIME type. `OffsetTime` has a limited usefulness, but it's included for the consistency sake.