### PR TITLE
@Transaction ALL THE THINGS

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
@@ -87,12 +87,12 @@ public class TestClasspathSqlLocator {
     public void testCachesResultAfterFirstLookup() throws Exception {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final AtomicInteger loadCount = new AtomicInteger(0);
+
         Thread.currentThread().setContextClassLoader(new ClassLoader(classLoader) {
             @Override
             public InputStream getResourceAsStream(String s) {
-                InputStream in = super.getResourceAsStream(s);
                 loadCount.incrementAndGet();
-                return in;
+                return super.getResourceAsStream(s);
             }
         });
 

--- a/docs/src/adoc/transaction.adoc
+++ b/docs/src/adoc/transaction.adoc
@@ -26,6 +26,21 @@ Similarly, you may declare transactions with SqlObject annotations:
 include::TransactionTest.java[tags=sqlObjectTransaction]
 -------------------------------------------
 
+SQL methods with a `@Transaction` annotation may optionally specify a transaction isolation level:
+
+[source,java,indent=0]
+-------------------------------------------
+include::TransactionTest.java[tags=sqlObjectTransactionIsolation]
+-------------------------------------------
+
+If a `@Transaction` method calls another `@Transaction` method, they must specify the same isolation level, or the
+inner method must not specify anything, in which case the isolation level of the outer method is used.
+
+[source,java,indent=0]
+-------------------------------------------
+include::TransactionTest.java[tags=sqlObjectNestedTransaction]
+-------------------------------------------
+
 == Serializable Transactions
 
 For more advanced queries, sometimes serializable transactions are required.

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorator.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.reflect.Method;
+
+interface HandlerDecorator {
+    Handler decorateHandler(Handler handler, Class<?> sqlObjectType, Method method);
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodDecoratingAnnotation.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodDecoratingAnnotation.java
@@ -17,21 +17,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.reflect.Method;
 
-import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
-
+/**
+ * Annotation used to identify SQL method decorating annotations. Use this to annotate an annotation.
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
-@SqlMethodDecoratingAnnotation(Transaction.Decorator.class)
-public @interface Transaction
-{
-    TransactionIsolationLevel value() default TransactionIsolationLevel.INVALID_LEVEL;
-
-    class Decorator implements HandlerDecorator {
-        @Override
-        public Handler decorateHandler(Handler handler, Class<?> sqlObjectType, Method method) {
-            return new TransactionDecorator(handler, method.getAnnotation(Transaction.class));
-        }
-    }
+@Target(ElementType.ANNOTATION_TYPE)
+@interface SqlMethodDecoratingAnnotation {
+    Class<? extends HandlerDecorator> value();
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -171,8 +171,8 @@ public enum SqlObjectFactory implements ExtensionFactory<SqlObjectConfig> {
     private static HandlerFactory buildFactory(Class<? extends HandlerFactory> factoryClazz) {
         HandlerFactory factory;
         try {
-            factory = factoryClazz.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+            factory = factoryClazz.getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Factory class " + factoryClazz + "cannot be instantiated", e);
         }
         return factory;
@@ -181,8 +181,8 @@ public enum SqlObjectFactory implements ExtensionFactory<SqlObjectConfig> {
     private static HandlerDecorator buildDecorator(Class<? extends HandlerDecorator> decoratorClass) {
         HandlerDecorator decorator;
         try {
-            decorator = decoratorClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+            decorator = decoratorClass.getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Decorator class " + decoratorClass + "cannot be instantiated", e);
         }
         return decorator;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Transaction.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Transaction.java
@@ -22,9 +22,13 @@ import java.lang.reflect.Method;
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 
 /**
- * Causes the annotated method to be run in a transaction. Nested <code>@Transaction</code> annotations (e.g. one method
- * calls another method, where both methods have this annotation) are collapsed into a single transaction. The
- * transaction isolation level is the level specified out the outermost <code>@Transaction</code> annotation.
+ * Causes the annotated method to be run in a transaction.
+ *
+ * <p>
+ * Nested <code>@Transaction</code> annotations (e.g. one method calls another method, where both methods have this
+ * annotation) are collapsed into a single transaction. If the outer method annotation specifies an isolation level,
+ * then the inner method must either specify the same level, or not specify any level.
+ * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Transaction.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Transaction.java
@@ -21,6 +21,11 @@ import java.lang.reflect.Method;
 
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 
+/**
+ * Causes the annotated method to be run in a transaction. Nested <code>@Transaction</code> annotations (e.g. one method
+ * calls another method, where both methods have this annotation) are collapsed into a single transaction. The
+ * transaction isolation level is the level specified out the outermost <code>@Transaction</code> annotation.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 @SqlMethodDecoratingAnnotation(Transaction.Decorator.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/TransactionDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/TransactionDecorator.java
@@ -21,15 +21,15 @@ import org.jdbi.v3.core.exception.TransactionException;
 import org.jdbi.v3.core.transaction.TransactionCallback;
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 
-class PassThroughTransactionHandler implements Handler
+class TransactionDecorator implements Handler
 {
+    private final Handler delegate;
     private final TransactionIsolationLevel isolation;
-    private final PassThroughHandler delegate;
 
-    PassThroughTransactionHandler(Transaction tx)
+    TransactionDecorator(Handler delegate, Transaction tx)
     {
+        this.delegate = delegate;
         this.isolation = tx.value();
-        this.delegate = new PassThroughHandler();
     }
 
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/TransactionDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/TransactionDecorator.java
@@ -36,8 +36,10 @@ class TransactionDecorator implements Handler
     public Object invoke(Supplier<Handle> handle, SqlObjectConfig config, Object target, Object[] args, Method method) throws Exception
     {
         Handle h = handle.get();
+
         if (h.isInTransaction()) {
-            throw new TransactionException("Nested @Transaction detected - this is currently not supported.");
+            // Already in transaction. The outermost @Transaction method determines the transaction isolation level.
+            return delegate.invoke(handle, config, target, args, method);
         }
 
         TransactionCallback<Object, Exception> callback = (conn, status) -> delegate.invoke(handle, config, target, args, method);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import org.jdbi.v3.core.H2DatabaseRule;
+import org.jdbi.v3.core.Handle;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestSqlMethodAnnotations
+{
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private Handle handle;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        handle = db.getSharedHandle();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testMutuallyExclusiveAnnotations()
+    {
+        handle.attach(DAO.class);
+    }
+
+    interface DAO {
+        @SqlQuery
+        @SqlUpdate
+        void bogus();
+    }
+}


### PR DESCRIPTION
Addresses issues #194, #195:

* Make `@Transaction` combinable with sql method annotations e.g. `@SqlUpdate`, `@SqlCall`, etc.
* Make nested calls to `@Transaction`-annotated methods result in a single transaction (instead of throwing an exception). The transaction isolation level is determined by the annotation on the outermost (first) method in the call chain.

@stevenschlansker Do you have time to review this before you leave? This is a small PR.