### PR TITLE
Correctly escape the at-sign in code examples in Javadoc

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/UseClasspathSqlLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/UseClasspathSqlLocator.java
@@ -36,12 +36,12 @@ import org.jdbi.v3.sqlobject.SqlObjectConfiguringAnnotation;
  * object method will be used:
  *
  * <pre>
- *     &amp;UseClasspathSqlLocator
+ *     &#064;UseClasspathSqlLocator
  *     interface Viccini {
- *         &amp;SqlUpdate
+ *         &#064;SqlUpdate
  *         void doTheThing(long id);     // =&gt; ClasspathSqlLocator.findSqlOnClasspath(Viccini.class, "doTheThing")
  *
- *         &amp;SqlUpdate("thatOtherThing")
+ *         &#064;SqlUpdate("thatOtherThing")
  *         void doTheThing(String name); // =&gt; ClasspathSqlLocator.findSqlOnClasspath(Viccini.class, "thatOtherThing")
  *     }
  * </pre>

--- a/string-template/src/main/java/org/jdbi/v3/stringtemplate/UseStringTemplateSqlLocator.java
+++ b/string-template/src/main/java/org/jdbi/v3/stringtemplate/UseStringTemplateSqlLocator.java
@@ -34,12 +34,12 @@ import org.jdbi.v3.sqlobject.locator.SqlLocator;
  * object method will be used:
  *
  * <pre>
- *     &amp;UseStringTemplateSqlLocator
+ *     &#064;UseStringTemplateSqlLocator
  *     interface Viccini {
- *         &amp;SqlUpdate
+ *         &#064;SqlUpdate
  *         void doTheThing(long id);     // =&gt; StringTemplateSqlLocator.findStringTemplateSql(Viccini.class, "doTheThing")
  *
- *         &amp;SqlUpdate("thatOtherThing")
+ *         &#064;SqlUpdate("thatOtherThing")
  *         void doTheThing(String name); // =&gt; StringTemplateSqlLocator.findStringTemplateSql(Viccini.class, "thatOtherThing")
  *     }
  * </pre>


### PR DESCRIPTION
The correct representations of the at-sign(@) in XML is code `&#064;` rather than `&amp;` which correspondents to the ampersand (&) symbol .