### PR TITLE
Decrease ClasspathStatementLocator GC pressure.

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
@@ -39,7 +39,7 @@ public class ClasspathStatementLocator implements StatementLocator
         final Class<?> sqlObjectType;
         final Method sqlObjectMethod;
 
-        public CacheKey(String name, Class<?> sqlObjectType, Method sqlObjectMethod) {
+        CacheKey(String name, Class<?> sqlObjectType, Method sqlObjectMethod) {
             this.name = name;
             this.sqlObjectType = sqlObjectType;
             this.sqlObjectMethod = sqlObjectMethod;
@@ -47,14 +47,21 @@ public class ClasspathStatementLocator implements StatementLocator
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             CacheKey cacheKey = (CacheKey) o;
 
-            if (name != null ? !name.equals(cacheKey.name) : cacheKey.name != null) return false;
-            if (sqlObjectType != null ? !sqlObjectType.equals(cacheKey.sqlObjectType) : cacheKey.sqlObjectType != null)
+            if (name != null ? !name.equals(cacheKey.name) : cacheKey.name != null) {
                 return false;
+            }
+            if (sqlObjectType != null ? !sqlObjectType.equals(cacheKey.sqlObjectType) : cacheKey.sqlObjectType != null) {
+                return false;
+            }
             return sqlObjectMethod != null ? sqlObjectMethod.equals(cacheKey.sqlObjectMethod) : cacheKey.sqlObjectMethod == null;
 
         }

--- a/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
+++ b/src/main/java/org/skife/jdbi/v2/ClasspathStatementLocator.java
@@ -53,22 +53,19 @@ public class ClasspathStatementLocator implements StatementLocator
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
+            CacheKey that = (CacheKey) o;
+            return eq(this.name, that.name)
+                    && eq(this.sqlObjectType, that.sqlObjectType)
+                    && eq(this.sqlObjectMethod, that.sqlObjectMethod);
+        }
 
-            CacheKey cacheKey = (CacheKey) o;
-
-            if (name != null ? !name.equals(cacheKey.name) : cacheKey.name != null) {
-                return false;
-            }
-            if (sqlObjectType != null ? !sqlObjectType.equals(cacheKey.sqlObjectType) : cacheKey.sqlObjectType != null) {
-                return false;
-            }
-            return sqlObjectMethod != null ? sqlObjectMethod.equals(cacheKey.sqlObjectMethod) : cacheKey.sqlObjectMethod == null;
-
+        private boolean eq(Object left, Object right) {
+            return left == null ? right == null : left.equals(right);
         }
 
         @Override
         public int hashCode() {
-            int result = name != null ? name.hashCode() : 0;
+            int result = name == null ? 0 : name.hashCode();
             result = 31 * result + (sqlObjectType != null ? sqlObjectType.hashCode() : 0);
             result = 31 * result + (sqlObjectMethod != null ? sqlObjectMethod.hashCode() : 0);
             return result;

--- a/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/ColonPrefixNamedParamStatementRewriter.java
@@ -75,7 +75,7 @@ public class ColonPrefixNamedParamStatementRewriter implements StatementRewriter
     ParsedStatement parseString(final String sql) throws IllegalArgumentException
     {
         ParsedStatement stmt = new ParsedStatement();
-        StringBuilder b = new StringBuilder();
+        StringBuilder b = new StringBuilder(sql.length());
         ColonStatementLexer lexer = new ColonStatementLexer(new ANTLRStringStream(sql));
         Token t = lexer.nextToken();
         while (t.getType() != ColonStatementLexer.EOF) {

--- a/src/main/java/org/skife/jdbi/v2/HashPrefixStatementRewriter.java
+++ b/src/main/java/org/skife/jdbi/v2/HashPrefixStatementRewriter.java
@@ -74,7 +74,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter
     ParsedStatement parseString(final String sql) throws IllegalArgumentException
     {
         ParsedStatement stmt = new ParsedStatement();
-        StringBuilder b = new StringBuilder();
+        StringBuilder b = new StringBuilder(sql.length());
         HashStatementLexer lexer = new HashStatementLexer(new ANTLRStringStream(sql));
         Token t = lexer.nextToken();
         while (t.getType() != HashStatementLexer.EOF) {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
@@ -210,8 +210,9 @@ class SqlObject
         }
 
         Throwable doNotMask = null;
+        String methodName = method.toString();
         try {
-            ding.retain(method.toString());
+            ding.retain(methodName);
             return handler.invoke(ding, proxy, args, mp);
         }
         catch (Throwable e) {
@@ -220,7 +221,7 @@ class SqlObject
         }
         finally {
             try {
-                ding.release(method.toString());
+                ding.release(methodName);
             }
             catch (Throwable e) {
                 if (doNotMask==null) {

--- a/src/test/resources/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator$SubCromulence/findById.sql
+++ b/src/test/resources/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator$SubCromulence/findById.sql
@@ -1,0 +1,15 @@
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+select something.id, 'overridden' as name from something where id = :id;


### PR DESCRIPTION
Hi!

ClasspathStatementLocator gives essential GC pressure due to many string concatenation for every query even if static SQL objects are used.
```
cache_key = '/' + mungify(ctx.getSqlObjectType().getName() + '.' + name) + ".sql";
```
I propose to use Method object as cache key, this is completely enough for SQL objects.

And also I propose to cache individual SQL statements for SQL object methods cause they are static.