### PR TITLE
Correctly handle null values in a response in JDBI3

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/ResultBearing.java
@@ -56,7 +56,7 @@ public interface ResultBearing<T> extends Iterable<T>
      */
     default Optional<T> findFirst() {
         try (ResultIterator<T> iter = iterator()) {
-            return iter.hasNext() ? Optional.of(iter.next()) : Optional.empty();
+            return iter.hasNext() ? Optional.ofNullable(iter.next()) : Optional.empty();
         }
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/TestQueries.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestQueries.java
@@ -303,6 +303,14 @@ public class TestQueries
     }
 
     @Test
+    public void testNullValueInColumn() throws Exception
+    {
+        h.insert("insert into something (id, name) values (?, ?)", 1, null);
+        Optional<String> s = h.createQuery("select name from something where id=1").mapTo(String.class).findFirst();
+        assertFalse(s.isPresent());
+    }
+
+    @Test
     public void testListWithMaxRows() throws Exception
     {
         h.prepareBatch("insert into something (id, name) values (:id, :name)")

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNull.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNull.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import org.jdbi.v3.core.H2DatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class TestNull {
+
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private DAO dao;
+
+    @Before
+    public void setUp() throws Exception {
+        dao = db.getSharedHandle().attach(DAO.class);
+        dao.insert(1, "brian");
+        dao.insert(2, null);
+    }
+    @Test
+    public void testNotNullResult() {
+        assertThat(dao.findNameById(1), equalTo("brian"));
+    }
+
+    @Test
+    public void testNullResult() {
+        assertThat(dao.findNameById(2), nullValue());
+    }
+
+    @Test
+    public void testNoResult() {
+        assertThat(dao.findNameById(3), nullValue());
+    }
+
+    interface DAO {
+
+        @SqlUpdate("insert into something (id, name) values (:id, :name)")
+        void insert(@Bind("id") long id, @Bind("name") String name);
+
+        @SqlQuery("select name from something where id = :id")
+        String findNameById(@Bind("id") long id);
+    }
+}


### PR DESCRIPTION
Users often use methods which return only a single result. In this case a returned `null` indicates that a RDBMS didn't find a document which satisfies the passed arguments. But actually the returned document can be `null` itself, if it's a nullable column.

We should expect such values and return them as null/optional values to the user. Currently we throw a `NullPointerException` instead, which is a rather harsh strategy for handling nullable values.