### PR TITLE
Expose the SQL method in StatementContext

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/StatementContext.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.core;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -41,6 +42,8 @@ public final class StatementContext
     private PreparedStatement statement;
     private Connection        connection;
     private Binding           binding;
+    private Method            extensionMethod;
+    private Class<?>          extensionType;
     private boolean           returningGeneratedKeys;
     private boolean           concurrentUpdatable;
     private String[]          generatedKeysColumnNames;
@@ -206,6 +209,26 @@ public final class StatementContext
 
     Cleanables getCleanables() {
         return cleanables;
+    }
+
+    public Method getExtensionMethod()
+    {
+        return extensionMethod;
+    }
+
+    public void setExtensionMethod(Method extensionMethod)
+    {
+        this.extensionMethod = extensionMethod;
+    }
+
+    public Class<?> getExtensionType()
+    {
+        return extensionType;
+    }
+
+    public void setExtensionType(Class<?> extensionType)
+    {
+        this.extensionType = extensionType;
     }
 
     void setReturningGeneratedKeys(boolean b)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BatchHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BatchHandler.java
@@ -118,6 +118,7 @@ class BatchHandler extends CustomizingStatementHandler
 
         String sql = config.getSqlLocator().locate(sqlObjectType, method);
         PreparedBatch batch = handle.prepareBatch(sql);
+        populateSqlObjectData(batch.getContext());
         applyCustomizers(batch, args);
         Object[] _args;
         int chunk_size = batchChunkSize.call(args);
@@ -131,6 +132,7 @@ class BatchHandler extends CustomizingStatementHandler
                 processed = 0;
                 rs_parts.add(executeBatch(handle, batch));
                 batch = handle.prepareBatch(sql);
+                populateSqlObjectData(batch.getContext());
                 applyCustomizers(batch, args);
             }
         }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CallHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CallHandler.java
@@ -48,6 +48,7 @@ class CallHandler extends CustomizingStatementHandler
     {
         String sql = config.getSqlLocator().locate(sqlObjectType, method);
         Call call = handle.get().createCall(sql);
+        populateSqlObjectData(call.getContext());
         applyCustomizers(call, args);
         applyBinders(call, args);
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CustomizingStatementHandler.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jdbi.v3.core.StatementContext;
 import org.jdbi.v3.core.exception.UnableToCreateStatementException;
 import org.jdbi.v3.core.SqlStatement;
 
@@ -110,6 +111,11 @@ abstract class CustomizingStatementHandler implements Handler
                 binders.add(new Bindifier<>(method, null, paramIndex, new DefaultObjectBinder()));
             }
         }
+    }
+
+    protected final void populateSqlObjectData(StatementContext q) {
+        q.setExtensionMethod(method);
+        q.setExtensionType(sqlObjectType);
     }
 
     protected void applyBinders(SqlStatement<?> q, Object[] args)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/QueryHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/QueryHandler.java
@@ -36,6 +36,7 @@ class QueryHandler extends CustomizingStatementHandler
     {
         String sql = config.getSqlLocator().locate(sqlObjectType, method);
         Query<?> q = handle.get().createQuery(sql);
+        populateSqlObjectData(q.getContext());
         applyCustomizers(q, args);
         applyBinders(q, args);
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UpdateHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UpdateHandler.java
@@ -72,6 +72,7 @@ class UpdateHandler extends CustomizingStatementHandler
     {
         String sql = config.getSqlLocator().locate(sqlObjectType, method);
         Update q = handle.get().createStatement(sql);
+        populateSqlObjectData(q.getContext());
         applyCustomizers(q, args);
         applyBinders(q, args);
         return this.returner.value(q, handle);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTimingCollector.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTimingCollector.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.hamcrest.CoreMatchers;
+import org.jdbi.v3.core.*;
+import org.jdbi.v3.sqlobject.customizers.BatchChunkSize;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestTimingCollector {
+
+    @Rule
+    public H2DatabaseRule h2DatabaseRule = new H2DatabaseRule().withPlugins();
+
+    private CustomTimingCollector timingCollector = new CustomTimingCollector();
+    private DAO dao;
+    private Jdbi jdbi;
+
+    @Before
+    public void setUp() throws Exception {
+        jdbi = h2DatabaseRule.getJdbi();
+        jdbi.useHandle(h -> h.execute("CREATE ALIAS custom_insert FOR " +
+                "\"org.jdbi.v3.sqlobject.TestTimingCollector.customInsert\";"));
+        jdbi.setTimingCollector(timingCollector);
+        dao = jdbi.onDemand(DAO.class);
+    }
+
+
+    @Test
+    public void testInsert() {
+        dao.insert(1, "Brian");
+        dao.insert(2, "Jeff");
+        assertThat(timingCollector.statementNames, equalTo(ImmutableSet.of("org.jdbi.v3.sqlobject.DAO.insert")));
+    }
+
+    @Test
+    public void testInsertBatch() {
+        dao.insertBatch(Arrays.asList(1, 2, 3), Arrays.asList("Mary", "David", "Kate"));
+        assertThat(timingCollector.statementNames, equalTo(ImmutableSet.of("org.jdbi.v3.sqlobject.DAO.insertBatch")));
+    }
+
+    @Test
+    public void testCustomInsert() {
+        dao.customInsert(1, "Robb");
+        dao.customInsert(2, "Greg");
+
+        assertThat(timingCollector.statementNames, equalTo(ImmutableSet.of("org.jdbi.v3.sqlobject.DAO.customInsert")));
+    }
+
+    @Test
+    public void testSqlQuery() {
+        AdvancedDAO advancedDAO = jdbi.onDemand(AdvancedDAO.class);
+        advancedDAO.insertBatch(Arrays.asList(1, 2, 3), Arrays.asList("Mary", "David", "Kate"));
+        String name = advancedDAO.findNameById(3);
+        assertThat(name, equalTo("Kate"));
+        assertThat(timingCollector.statementNames, equalTo(ImmutableSet.of("org.jdbi.v3.sqlobject.AdvancedDAO.insertBatch",
+                        "org.jdbi.v3.sqlobject.AdvancedDAO.findNameById")));
+    }
+
+    @Test
+    public void testRawSql() {
+        jdbi.useHandle(h -> {
+            PreparedBatch batch = h.prepareBatch("insert into something (id, name) values (?, ?)");
+            batch.add(1, "Mary");
+            batch.add(2, "David");
+            batch.add(3, "Kate");
+            batch.execute();
+        });
+        List<String> names = jdbi.withHandle(h -> h.createQuery("select name from something order by name")
+                .mapTo(String.class)
+                .list());
+        assertThat(names, equalTo(ImmutableList.of("David", "Kate", "Mary")));
+        assertThat(timingCollector.statementNames, equalTo(ImmutableSet.of(
+                "sql.raw.insert into something (id, name) values (?, ?)",
+                "sql.raw.select name from something order by name")));
+    }
+
+    public static int customInsert(Connection conn, int id, String name) throws SQLException {
+        PreparedStatement stmt = conn.prepareStatement("insert into something (id, name) values (?, ?)");
+        stmt.setInt(1, id);
+        stmt.setString(2, name);
+        return stmt.executeUpdate();
+    }
+
+    private static class CustomTimingCollector implements TimingCollector {
+
+        private Set<String> statementNames = new HashSet<>();
+        private SqlObjectStrategy statementNameStrategy = new SqlObjectStrategy();
+
+        @Override
+        public void collect(long elapsedTime, StatementContext ctx) {
+            statementNames.add(statementNameStrategy.getStatementName(ctx));
+        }
+    }
+
+    private static class SqlObjectStrategy {
+
+        String getStatementName(StatementContext statementContext) {
+            Method method = statementContext.getExtensionMethod();
+            if (method != null) {
+                Class<?> clazz = statementContext.getExtensionType();
+                String group = clazz.getPackage().getName();
+                String name = clazz.getSimpleName();
+                return group + "." + name + "." + method.getName();
+            } else {
+                return "sql.raw." + statementContext.getRawSql();
+            }
+        }
+    }
+
+    public interface DAO {
+
+        @SqlUpdate("insert into something (id, name) values (:id, :name)")
+        void insert(@Bind("id") int id, @Bind("name") String name);
+
+        @SqlBatch("insert into something (id, name) values (:id, :name)")
+        @BatchChunkSize(2)
+        void insertBatch(@Bind("id") List<Integer> ids, @Bind("name") List<String> names);
+
+        @SqlCall("call custom_insert(:id, :name)")
+        void customInsert(@Bind("id") int id, @Bind("name") String name);
+    }
+
+    public interface AdvancedDAO extends DAO {
+
+        @SqlQuery("select name from something where id = :id")
+        String findNameById(@Bind("id") int id);
+    }
+}


### PR DESCRIPTION
It's useful in timing collectors when we want to track the time of completing of SQL queries of different methods.

See [metrics-jdbi](https://github.com/dropwizard/metrics/tree/3.2-development/metrics-jdbi) as an example.