### PR TITLE
Batch: rewrite SQLException.getNextException into Throwable.addSuppressed

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Batch.java
+++ b/core/src/main/java/org/jdbi/v3/core/Batch.java
@@ -122,11 +122,25 @@ public class Batch extends BaseStatement
             }
             catch (SQLException e)
             {
-                throw new UnableToExecuteStatementException(e, getContext());
+                throw new UnableToExecuteStatementException(mungeBatchException(e), getContext());
             }
         }
         finally {
             cleanup();
         }
+    }
+
+    /**
+     * SQLExceptions thrown from batch executions have errors
+     * in a {@link SQLException#getNextException()} chain, which
+     * doesn't print out when you log them.  Convert them to be
+     * {@link Throwable#addSuppressed(Throwable)} exceptions,
+     * which do print out with common logging frameworks.
+     */
+    static SQLException mungeBatchException(SQLException e) {
+        for (SQLException next = e.getNextException(); next != null; next = next.getNextException()) {
+            e.addSuppressed(next);
+        }
+        return e;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/PreparedBatch.java
@@ -196,7 +196,7 @@ public class PreparedBatch extends SqlStatement<PreparedBatch>
                 return generateKeys ? munger.apply(stmt) : rs;
             }
             catch (SQLException e) {
-                throw new UnableToExecuteStatementException(e, getContext());
+                throw new UnableToExecuteStatementException(Batch.mungeBatchException(e), getContext());
             }
         }
         finally {

--- a/core/src/test/java/org/jdbi/v3/core/TestBatchExceptionRewrite.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestBatchExceptionRewrite.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.exception.UnableToExecuteStatementException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+public class TestBatchExceptionRewrite
+{
+    @Rule
+    public PGDatabaseRule db = new PGDatabaseRule();
+
+    @Before
+    public void createTable() {
+        db.getDbi().useHandle(h -> h.execute("create table something ( id int primary key, name varchar(50), integerValue integer, intValue integer )"));
+    }
+
+    @Test
+    public void testSimpleBatch() throws Exception
+    {
+        Batch b = db.openHandle().createBatch();
+        b.add("insert into something (id, name) values (0, 'Keith')");
+        b.add("insert into something (id, name) values (0, 'Keith')");
+        try {
+            b.execute();
+            fail();
+        } catch (UnableToExecuteStatementException e) {
+            assertSuppressions(e.getCause());
+        }
+    }
+
+    @Test
+    public void testPreparedBatch() throws Exception
+    {
+        PreparedBatch b = db.openHandle().prepareBatch("insert into something (id, name) values (?,?)");
+        b.add(0, "a");
+        b.add(0, "a");
+        try {
+            b.execute();
+            fail();
+        } catch (UnableToExecuteStatementException e) {
+            assertSuppressions(e.getCause());
+        }
+    }
+
+    private void assertSuppressions(Throwable cause) {
+        LoggerFactory.getLogger(TestBatchExceptionRewrite.class).info("exception", cause);
+        SQLException e = (SQLException) cause;
+        assertEquals(e.getNextException(), e.getSuppressed()[0]);
+        assertNull(e.getNextException().getNextException());
+        assertEquals(1, e.getSuppressed().length);
+    }
+}


### PR DESCRIPTION
Previously if your batch insert has trouble with e.g. Postgres, you would see:
```
java.sql.BatchUpdateException: Batch entry 1 insert into something (id, name) values (0, 'Keith') was aborted.  Call getNextException to see the cause.
  at org.postgresql.jdbc.BatchResultHandler.handleError(BatchResultHandler.java:136)
```
Now, you get the actual information!
```
java.sql.BatchUpdateException: Batch entry 1 insert into something (id, name) values (0, 'Keith') was aborted.  Call getNextException to see the cause.
  at org.postgresql.jdbc.BatchResultHandler.handleError(BatchResultHandler.java:136)
Suppressed: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "something_pkey"
  Detail: Key (id)=(0) already exists.
```