### PR TITLE
Add @GetGeneratedKeys support to @SqlBatch

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
@@ -32,6 +32,7 @@ import org.skife.jdbi.v2.TransactionStatus;
 import org.skife.jdbi.v2.exceptions.UnableToCreateSqlObjectException;
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
+import org.skife.jdbi.v2.util.IntegerColumnMapper;
 
 import com.fasterxml.classmate.members.ResolvedMethod;
 
@@ -42,6 +43,7 @@ class BatchHandler extends CustomizingStatementHandler
     private final String  sql;
     private final boolean transactional;
     private final ChunkSizeFunction batchChunkSize;
+    private final Returner returner;
 
     BatchHandler(Class<?> sqlObjectType, ResolvedMethod method)
     {
@@ -54,6 +56,38 @@ class BatchHandler extends CustomizingStatementHandler
         this.sql = SqlObject.getSql(anno, raw_method);
         this.transactional = anno.transactional();
         this.batchChunkSize = determineBatchChunkSize(sqlObjectType, raw_method);
+        final GetGeneratedKeys getGeneratedKeys = raw_method.getAnnotation(GetGeneratedKeys.class);
+        if (getGeneratedKeys == null) {
+            returner = new Returner()
+            {
+                @Override
+                public int[] value(PreparedBatch batch)
+                {
+                    return batch.execute();
+                }
+            };
+        }
+        else if (getGeneratedKeys.columnName().isEmpty()) {
+            returner = new Returner()
+            {
+                @Override
+                public int[] value(PreparedBatch batch)
+                {
+                    return toPrimitiveArray(batch.executeAndGenerateKeys(IntegerColumnMapper.PRIMITIVE).list());
+                }
+            };
+        }
+        else {
+            returner = new Returner()
+            {
+                @Override
+                public int[] value(PreparedBatch batch)
+                {
+                    String columnName = getGeneratedKeys.columnName();
+                    return toPrimitiveArray(batch.executeAndGenerateKeys(IntegerColumnMapper.PRIMITIVE, columnName).list());
+                }
+            };
+        }
     }
 
     private ChunkSizeFunction determineBatchChunkSize(Class<?> sqlObjectType, Method raw_method)
@@ -197,13 +231,23 @@ class BatchHandler extends CustomizingStatementHandler
                 @Override
                 public int[] inTransaction(Handle conn, TransactionStatus status) throws Exception
                 {
-                    return batch.execute();
+                    return returner.value(batch);
                 }
             });
         }
         else {
-            return batch.execute();
+            return returner.value(batch);
         }
+    }
+
+    private static int[] toPrimitiveArray(List<Integer> list)
+    {
+        int[] array = new int[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            array[i] = list.get(i);
+        }
+
+        return array;
     }
 
     private static Object[] next(List<Iterator> args)
@@ -218,6 +262,11 @@ class BatchHandler extends CustomizingStatementHandler
             }
         }
         return rs.toArray();
+    }
+
+    private interface Returner
+    {
+        int[] value(PreparedBatch batch);
     }
 
     private interface ChunkSizeFunction

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
@@ -20,6 +20,8 @@ import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.sqlobject.mixins.CloseMe;
 import org.skife.jdbi.v2.tweak.HandleCallback;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -46,6 +48,10 @@ public class TestGetGeneratedKeysHsqlDb {
         @GetGeneratedKeys
         public long insert(@Bind String name);
 
+        @SqlBatch("insert into something (name) values (:it)")
+        @GetGeneratedKeys
+        public int[] insert(@Bind List<String> names);
+
         @SqlQuery("select name from something where id = :it")
         public String findNameById(@Bind long id);
     }
@@ -59,6 +65,19 @@ public class TestGetGeneratedKeysHsqlDb {
 
         assertThat(dao.findNameById(brian_id), equalTo("Brian"));
         assertThat(dao.findNameById(keith_id), equalTo("Keith"));
+
+        dao.close();
+    }
+
+    @Test
+    public void testBatch() throws Exception
+    {
+        DAO dao = dbi.open(DAO.class);
+
+        int[] ids = dao.insert(Arrays.asList("Burt", "Macklin"));
+
+        assertThat(dao.findNameById(ids[0]), equalTo("Burt"));
+        assertThat(dao.findNameById(ids[1]), equalTo("Macklin"));
 
         dao.close();
     }


### PR DESCRIPTION
Right now annotating an `@SqlBatch` method with `@GetGeneratedKeys` has no effect even though the `PreparedBatch` class has support for it. This PR adds very limited support, only allowing `int[]` as a return type. We've had this modification in our fork for over a year without issue. Let me know if that limitation seems reasonable and I can try to add some tests, otherwise I can try to do a more extensive refactor to add more complete support.