### PR TITLE
Remove jdbi v2 openjdk8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 
 jdk:
   - oraclejdk7
-  - oraclejdk8
 
 sudo: false
 


### PR DESCRIPTION
Now that we use toolchains to select a jdk6, there's
little reason to select jdk8.  Whether we choose 7 or 8
we then immediately switch to 6, so it's just redundant work.