### PR TITLE
Allow imperative SQL object methods to locate SQL statements in the s…

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
+++ b/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
@@ -45,18 +45,17 @@ public final class ConcreteStatementContext implements StatementContext
     private Foreman           foreman;
 
     ConcreteStatementContext() {
-        this(new HashMap<String, Object>(), new MappingRegistry(), null, null);
+        this(new HashMap<String, Object>(), new MappingRegistry(), new SqlObjectContext());
     }
 
     ConcreteStatementContext(Map<String, Object> globalAttributes,
                              MappingRegistry mappingRegistry,
-                             Class<?> sqlObjectType,
-                             Method sqlObjectMethod)
+                             SqlObjectContext sqlObjectContext)
     {
         attributes.putAll(globalAttributes);
         this.mappingRegistry = mappingRegistry;
-        this.sqlObjectType = sqlObjectType;
-        this.sqlObjectMethod = sqlObjectMethod;
+        this.sqlObjectType = sqlObjectContext.type;
+        this.sqlObjectMethod = sqlObjectContext.method;
     }
 
     /**

--- a/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
+++ b/src/main/java/org/skife/jdbi/v2/ConcreteStatementContext.java
@@ -44,10 +44,19 @@ public final class ConcreteStatementContext implements StatementContext
     private String[]          generatedKeysColumnNames;
     private Foreman           foreman;
 
-    ConcreteStatementContext(Map<String, Object> globalAttributes, MappingRegistry mappingRegistry)
+    ConcreteStatementContext() {
+        this(new HashMap<String, Object>(), new MappingRegistry(), null, null);
+    }
+
+    ConcreteStatementContext(Map<String, Object> globalAttributes,
+                             MappingRegistry mappingRegistry,
+                             Class<?> sqlObjectType,
+                             Method sqlObjectMethod)
     {
         attributes.putAll(globalAttributes);
         this.mappingRegistry = mappingRegistry;
+        this.sqlObjectType = sqlObjectType;
+        this.sqlObjectMethod = sqlObjectMethod;
     }
 
     /**

--- a/src/main/java/org/skife/jdbi/v2/Handle.java
+++ b/src/main/java/org/skife/jdbi/v2/Handle.java
@@ -24,6 +24,7 @@ import org.skife.jdbi.v2.tweak.StatementLocator;
 import org.skife.jdbi.v2.tweak.StatementRewriter;
 
 import java.io.Closeable;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
@@ -310,4 +311,9 @@ public interface Handle extends Closeable
     void registerArgumentFactory(ArgumentFactory argumentFactory);
 
     void registerContainerFactory(ContainerFactory<?> factory);
+
+    void setSqlObjectContext(Class<?> sqlObjectType, Method sqlObjectMethod);
+
+    Class<?> getSqlObjectType();
+    Method getSqlObjectMethod();
 }

--- a/src/main/java/org/skife/jdbi/v2/Handle.java
+++ b/src/main/java/org/skife/jdbi/v2/Handle.java
@@ -24,7 +24,6 @@ import org.skife.jdbi.v2.tweak.StatementLocator;
 import org.skife.jdbi.v2.tweak.StatementRewriter;
 
 import java.io.Closeable;
-import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
@@ -312,8 +311,7 @@ public interface Handle extends Closeable
 
     void registerContainerFactory(ContainerFactory<?> factory);
 
-    void setSqlObjectContext(Class<?> sqlObjectType, Method sqlObjectMethod);
+    void setSqlObjectContext(SqlObjectContext context);
 
-    Class<?> getSqlObjectType();
-    Method getSqlObjectMethod();
+    SqlObjectContext getSqlObjectContext();
 }

--- a/src/main/java/org/skife/jdbi/v2/Script.java
+++ b/src/main/java/org/skife/jdbi/v2/Script.java
@@ -18,10 +18,8 @@ import org.antlr.runtime.Token;
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.tweak.StatementLocator;
 
-import java.util.regex.Pattern;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Represents a number of SQL statements which will be executed in a batch statement.

--- a/src/main/java/org/skife/jdbi/v2/SqlObjectContext.java
+++ b/src/main/java/org/skife/jdbi/v2/SqlObjectContext.java
@@ -11,23 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.skife.jdbi.v2.sqlobject;
+package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.SqlObjectContext;
+import java.lang.reflect.Method;
 
-interface HandleDing
-{
-    /**
-     * Sets a new sql object context and returns the old one
-     * @param context the new context
-     * @return the previous context
-     */
-    SqlObjectContext setContext(SqlObjectContext context);
+public class SqlObjectContext {
+    public final Class<?> type;
+    public final Method method;
 
-    Handle getHandle();
+    public SqlObjectContext() {
+        this(null, null);
+    }
 
-    void release(String name);
-
-    void retain(String name);
+    public SqlObjectContext(Class<?> type, Method method) {
+        this.type = type;
+        this.method = method;
+    }
 }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import net.sf.cglib.proxy.MethodProxy;
 
-import org.skife.jdbi.v2.ConcreteStatementContext;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.PreparedBatch;
 import org.skife.jdbi.v2.PreparedBatchPart;
@@ -184,7 +183,6 @@ class BatchHandler extends CustomizingStatementHandler
         List<int[]> rs_parts = new ArrayList<int[]>();
 
         PreparedBatch batch = handle.prepareBatch(sql);
-        populateSqlObjectData((ConcreteStatementContext) batch.getContext());
         applyCustomizers(batch, args);
         Object[] _args;
         int chunk_size = batchChunkSize.call(args);
@@ -198,7 +196,6 @@ class BatchHandler extends CustomizingStatementHandler
                 processed = 0;
                 rs_parts.add(executeBatch(handle, batch));
                 batch = handle.prepareBatch(sql);
-                populateSqlObjectData((ConcreteStatementContext) batch.getContext());
                 applyCustomizers(batch, args);
             }
         }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/CallHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/CallHandler.java
@@ -16,7 +16,6 @@ package org.skife.jdbi.v2.sqlobject;
 import com.fasterxml.classmate.members.ResolvedMethod;
 import net.sf.cglib.proxy.MethodProxy;
 import org.skife.jdbi.v2.Call;
-import org.skife.jdbi.v2.ConcreteStatementContext;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.OutParameters;
 
@@ -49,7 +48,6 @@ class CallHandler extends CustomizingStatementHandler
     {
         Handle h = ding.getHandle();
         Call call = h.createCall(sql);
-        populateSqlObjectData((ConcreteStatementContext)call.getContext());
         applyCustomizers(call, args);
         applyBinders(call, args);
 

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ConstantHandleDing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ConstantHandleDing.java
@@ -14,6 +14,7 @@
 package org.skife.jdbi.v2.sqlobject;
 
 import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.SqlObjectContext;
 
 class ConstantHandleDing implements HandleDing
 {
@@ -22,6 +23,13 @@ class ConstantHandleDing implements HandleDing
 
     ConstantHandleDing(Handle handle) {
         this.handle = handle;
+    }
+
+    @Override
+    public SqlObjectContext setContext(SqlObjectContext context) {
+        SqlObjectContext oldContext = handle.getSqlObjectContext();
+        handle.setSqlObjectContext(context);
+        return oldContext;
     }
 
     @Override

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/CustomizingStatementHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/CustomizingStatementHandler.java
@@ -14,7 +14,6 @@
 package org.skife.jdbi.v2.sqlobject;
 
 import com.fasterxml.classmate.members.ResolvedMethod;
-import org.skife.jdbi.v2.ConcreteStatementContext;
 import org.skife.jdbi.v2.SQLStatement;
 import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
 
@@ -113,12 +112,6 @@ abstract class CustomizingStatementHandler implements Handler
                 binders.add(new Bindifier(null, param_idx, new PositionalBinder(param_idx)));
             }
         }
-    }
-
-    protected final void populateSqlObjectData(ConcreteStatementContext q)
-    {
-        q.setSqlObjectMethod(method);
-        q.setSqlObjectType(sqlObjectType);
     }
 
     protected void applyBinders(SQLStatement<?> q, Object[] args)

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/PassThroughHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/PassThroughHandler.java
@@ -17,30 +17,20 @@ import net.sf.cglib.proxy.MethodProxy;
 
 import java.lang.reflect.Method;
 
-import org.skife.jdbi.v2.Handle;
-
 class PassThroughHandler implements Handler
 {
 
-    private final Class<?> type;
     private final Method method;
 
-    PassThroughHandler(Class<?> type, Method method)
+    PassThroughHandler(Method method)
     {
-        this.type = type;
         this.method = method;
     }
 
     @Override
     public Object invoke(HandleDing ding, Object target, Object[] args, MethodProxy mp)
     {
-        Handle h = ding.getHandle();
-        Class<?> oldType = h.getSqlObjectType();
-        Method oldMethod = h.getSqlObjectMethod();
-
         try {
-            h.setSqlObjectContext(type, method);
-
             return mp.invokeSuper(target, args);
         }
         catch (AbstractMethodError e) {
@@ -60,9 +50,6 @@ class PassThroughHandler implements Handler
             else {
                 throw new RuntimeException(throwable);
             }
-        }
-        finally {
-            h.setSqlObjectContext(oldType, oldMethod);
         }
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/PassThroughTransactionHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/PassThroughTransactionHandler.java
@@ -24,10 +24,14 @@ import java.lang.reflect.Method;
 
 class PassThroughTransactionHandler implements Handler
 {
+    private final Class<?> type;
+    private final Method method;
     private final TransactionIsolationLevel isolation;
 
-    PassThroughTransactionHandler(Method m, Transaction tx)
+    PassThroughTransactionHandler(Class<?> type, Method method, Transaction tx)
     {
+        this.type = type;
+        this.method = method;
         this.isolation = tx.value();
     }
 
@@ -42,46 +46,55 @@ class PassThroughTransactionHandler implements Handler
                 throw new TransactionException("Nested @Transaction detected - this is currently not supported.");
             }
 
-            if (isolation == TransactionIsolationLevel.INVALID_LEVEL) {
-                return h.inTransaction(new TransactionCallback<Object>()
-                {
-                    @Override
-                    public Object inTransaction(Handle conn, TransactionStatus status) throws Exception
-                    {
-                        try {
-                            return mp.invokeSuper(target, args);
-                        }
-                        catch (Throwable throwable) {
-                            if (throwable instanceof Exception) {
-                                throw (Exception) throwable;
-                            }
-                            else {
-                                throw new RuntimeException(throwable);
-                            }
-                        }
-                    }
-                });
-            }
-            else {
-                return h.inTransaction(isolation, new TransactionCallback<Object>()
-                {
-                    @Override
-                    public Object inTransaction(Handle conn, TransactionStatus status) throws Exception
-                    {
-                        try {
-                            return mp.invokeSuper(target, args);
-                        }
-                        catch (Throwable throwable) {
-                            if (throwable instanceof Exception) {
-                                throw (Exception) throwable;
-                            }
-                            else {
-                                throw new RuntimeException(throwable);
-                            }
-                        }
-                    }
-                });
+            Class<?> oldType = h.getSqlObjectType();
+            Method oldMethod = h.getSqlObjectMethod();
 
+            try {
+                h.setSqlObjectContext(type, method);
+
+                if (isolation == TransactionIsolationLevel.INVALID_LEVEL) {
+                    return h.inTransaction(new TransactionCallback<Object>()
+                    {
+                        @Override
+                        public Object inTransaction(Handle conn, TransactionStatus status) throws Exception
+                        {
+                            try {
+                                return mp.invokeSuper(target, args);
+                            }
+                            catch (Throwable throwable) {
+                                if (throwable instanceof Exception) {
+                                    throw (Exception) throwable;
+                                }
+                                else {
+                                    throw new RuntimeException(throwable);
+                                }
+                            }
+                        }
+                    });
+                }
+                else {
+                    return h.inTransaction(isolation, new TransactionCallback<Object>()
+                    {
+                        @Override
+                        public Object inTransaction(Handle conn, TransactionStatus status) throws Exception
+                        {
+                            try {
+                                return mp.invokeSuper(target, args);
+                            }
+                            catch (Throwable throwable) {
+                                if (throwable instanceof Exception) {
+                                    throw (Exception) throwable;
+                                }
+                                else {
+                                    throw new RuntimeException(throwable);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+            finally {
+                h.setSqlObjectContext(oldType, oldMethod);
             }
         }
 

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/QueryHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/QueryHandler.java
@@ -15,7 +15,6 @@ package org.skife.jdbi.v2.sqlobject;
 
 import com.fasterxml.classmate.members.ResolvedMethod;
 import net.sf.cglib.proxy.MethodProxy;
-import org.skife.jdbi.v2.ConcreteStatementContext;
 import org.skife.jdbi.v2.Query;
 
 class QueryHandler extends CustomizingStatementHandler
@@ -36,7 +35,6 @@ class QueryHandler extends CustomizingStatementHandler
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         Query q = h.getHandle().createQuery(sql);
-        populateSqlObjectData((ConcreteStatementContext) q.getContext());
         applyCustomizers(q, args);
         applyBinders(q, args);
 

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
@@ -168,13 +168,13 @@ class SqlObject
                 // no handler for finalize()
             }
             else if (raw_method.isAnnotationPresent(Transaction.class)) {
-                handlers.put(raw_method, new PassThroughTransactionHandler(raw_method, raw_method.getAnnotation(Transaction.class)));
+                handlers.put(raw_method, new PassThroughTransactionHandler(sqlObjectType, raw_method, raw_method.getAnnotation(Transaction.class)));
             }
             else if (mixinHandlers.containsKey(raw_method)) {
                 handlers.put(raw_method, mixinHandlers.get(raw_method));
             }
             else {
-                handlers.put(raw_method, new PassThroughHandler(raw_method));
+                handlers.put(raw_method, new PassThroughHandler(sqlObjectType, raw_method));
             }
         }
 

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/SqlObject.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.skife.jdbi.v2.SqlObjectContext;
+
 class SqlObject
 {
     private static final TypeResolver                                  typeResolver  = new TypeResolver();
@@ -77,7 +79,7 @@ class SqlObject
                 e.setSuperclass(sqlObjectType);
             }
             e.setInterfaces(interfaces.toArray(new Class[interfaces.size()]));
-            final SqlObject so = new SqlObject(buildHandlersFor(sqlObjectType), handle);
+            final SqlObject so = new SqlObject(sqlObjectType, buildHandlersFor(sqlObjectType), handle);
 
             e.setCallbackFilter(new CallbackFilter() {
 
@@ -119,7 +121,7 @@ class SqlObject
             f = (Factory) actual;
         }
 
-        final SqlObject so = new SqlObject(buildHandlersFor(sqlObjectType), handle);
+        final SqlObject so = new SqlObject(sqlObjectType, buildHandlersFor(sqlObjectType), handle);
         return (T) f.newInstance(new Callback[] {
                 new MethodInterceptor() {
                     @Override
@@ -168,13 +170,13 @@ class SqlObject
                 // no handler for finalize()
             }
             else if (raw_method.isAnnotationPresent(Transaction.class)) {
-                handlers.put(raw_method, new PassThroughTransactionHandler(sqlObjectType, raw_method, raw_method.getAnnotation(Transaction.class)));
+                handlers.put(raw_method, new PassThroughTransactionHandler(raw_method.getAnnotation(Transaction.class)));
             }
             else if (mixinHandlers.containsKey(raw_method)) {
                 handlers.put(raw_method, mixinHandlers.get(raw_method));
             }
             else {
-                handlers.put(raw_method, new PassThroughHandler(sqlObjectType, raw_method));
+                handlers.put(raw_method, new PassThroughHandler(raw_method));
             }
         }
 
@@ -190,12 +192,13 @@ class SqlObject
         return handlers;
     }
 
-
+    private final Class<?>             sqlObjectType;
     private final Map<Method, Handler> handlers;
     private final HandleDing           ding;
 
-    SqlObject(Map<Method, Handler> handlers, HandleDing ding)
+    SqlObject(Class<?> sqlObjectType, Map<Method, Handler> handlers, HandleDing ding)
     {
+        this.sqlObjectType = sqlObjectType;
         this.handlers = handlers;
         this.ding = ding;
     }
@@ -211,6 +214,7 @@ class SqlObject
 
         Throwable doNotMask = null;
         String methodName = method.toString();
+        SqlObjectContext oldContext = ding.setContext(new SqlObjectContext(sqlObjectType, method));
         try {
             ding.retain(methodName);
             return handler.invoke(ding, proxy, args, mp);
@@ -220,6 +224,7 @@ class SqlObject
             throw e;
         }
         finally {
+            ding.setContext(oldContext);
             try {
                 ding.release(methodName);
             }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
@@ -75,7 +75,6 @@ class UpdateHandler extends CustomizingStatementHandler
     public Object invoke(HandleDing h, Object target, Object[] args, MethodProxy mp)
     {
         Update q = h.getHandle().createStatement(sql);
-        populateSqlObjectData((ConcreteStatementContext)q.getContext());
         applyCustomizers(q, args);
         applyBinders(q, args);
         return this.returner.value(q, h);

--- a/src/test/java/org/skife/jdbi/v2/ConcreteStatementContextTest.java
+++ b/src/test/java/org/skife/jdbi/v2/ConcreteStatementContextTest.java
@@ -28,8 +28,7 @@ public class ConcreteStatementContextTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testShouldNotBeAbleToCombineGeneratedKeysAndConcurrentUpdatable() throws Exception {
-        final ConcreteStatementContext context =
-                new ConcreteStatementContext(Collections.<String, Object>emptyMap(), new MappingRegistry());
+        final ConcreteStatementContext context = new ConcreteStatementContext();
 
         context.setReturningGeneratedKeys(true);
         context.setConcurrentUpdatable(true);
@@ -37,8 +36,7 @@ public class ConcreteStatementContextTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testShouldNotBeAbleToCombineConcurrentUpdatableAndGeneratedKeys() throws Exception {
-        final ConcreteStatementContext context =
-                new ConcreteStatementContext(Collections.<String, Object>emptyMap(), new MappingRegistry());
+        final ConcreteStatementContext context = new ConcreteStatementContext();
 
         context.setConcurrentUpdatable(true);
         context.setReturningGeneratedKeys(true);
@@ -67,7 +65,7 @@ public class ConcreteStatementContextTest {
         registry.addColumnMapper(mapper);
 
         final ConcreteStatementContext context =
-                new ConcreteStatementContext(Collections.<String, Object>emptyMap(), registry);
+                new ConcreteStatementContext(Collections.<String, Object>emptyMap(), registry, null, null);
 
         assertThat(context.columnMapperFor(Foo.class), equalTo(mapper));
     }

--- a/src/test/java/org/skife/jdbi/v2/ConcreteStatementContextTest.java
+++ b/src/test/java/org/skife/jdbi/v2/ConcreteStatementContextTest.java
@@ -65,7 +65,7 @@ public class ConcreteStatementContextTest {
         registry.addColumnMapper(mapper);
 
         final ConcreteStatementContext context =
-                new ConcreteStatementContext(Collections.<String, Object>emptyMap(), registry, null, null);
+                new ConcreteStatementContext(Collections.<String, Object>emptyMap(), registry, new SqlObjectContext());
 
         assertThat(context.columnMapperFor(Foo.class), equalTo(mapper));
     }

--- a/src/test/java/org/skife/jdbi/v2/TestColonStatementRewriter.java
+++ b/src/test/java/org/skife/jdbi/v2/TestColonStatementRewriter.java
@@ -38,7 +38,7 @@ public class TestColonStatementRewriter
     {
         return rw.rewrite(sql,
                 new Binding(),
-                new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry()));
+                new ConcreteStatementContext());
     }
 
     @Test

--- a/src/test/java/org/skife/jdbi/v2/TestHashPrefixStatementRewriter.java
+++ b/src/test/java/org/skife/jdbi/v2/TestHashPrefixStatementRewriter.java
@@ -41,7 +41,7 @@ public class TestHashPrefixStatementRewriter
     public void testNewlinesOkay() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from something\n where id = #id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry()));
+                                            new ConcreteStatementContext());
         assertEquals("select * from something\n where id = ?", rws.getSql());
     }
 
@@ -49,7 +49,7 @@ public class TestHashPrefixStatementRewriter
     public void testOddCharacters() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("~* #boo '#nope' _%&^& *@ #id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry()));
+                                            new ConcreteStatementContext());
         assertEquals("~* ? '#nope' _%&^& *@ ?", rws.getSql());
     }
 
@@ -57,7 +57,7 @@ public class TestHashPrefixStatementRewriter
     public void testNumbers() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("#bo0 '#nope' _%&^& *@ #id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry()));
+                                            new ConcreteStatementContext());
         assertEquals("? '#nope' _%&^& *@ ?", rws.getSql());
     }
 
@@ -65,7 +65,7 @@ public class TestHashPrefixStatementRewriter
     public void testDollarSignOkay() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from v$session", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry()));
+                                            new ConcreteStatementContext());
         assertEquals("select * from v$session", rws.getSql());
     }
 
@@ -73,7 +73,7 @@ public class TestHashPrefixStatementRewriter
     public void testColonIsLiteral() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from foo where id = :id", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry()));
+                                            new ConcreteStatementContext());
         assertEquals("select * from foo where id = :id", rws.getSql());
     }
 
@@ -81,7 +81,7 @@ public class TestHashPrefixStatementRewriter
     public void testBacktickOkay() throws Exception
     {
         RewrittenStatement rws = rw.rewrite("select * from `v$session", new Binding(),
-                                            new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry()));
+                                            new ConcreteStatementContext());
         assertEquals("select * from `v$session", rws.getSql());
     }
 
@@ -90,7 +90,7 @@ public class TestHashPrefixStatementRewriter
     {
         try {
             rw.rewrite("select * from something\n where id = #\u0087\u008e\u0092\u0097\u009c", new Binding(),
-                       new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry()));
+                       new ConcreteStatementContext());
 
             Assert.fail("Expected 'UnableToCreateStatementException' but got none");
         }

--- a/src/test/java/org/skife/jdbi/v2/TestMapArguments.java
+++ b/src/test/java/org/skife/jdbi/v2/TestMapArguments.java
@@ -32,7 +32,7 @@ public class TestMapArguments
         Map<String, Object> args = new HashMap<String, Object>();
         args.put("foo", BigDecimal.ONE);
         Foreman foreman = new Foreman();
-        StatementContext ctx = new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry());
+        StatementContext ctx = new ConcreteStatementContext();
         MapArguments mapArguments = new MapArguments(foreman, ctx, args);
         Argument argument = mapArguments.find("foo");
         assertThat(argument, instanceOf(BigDecimalArgument.class));
@@ -44,7 +44,7 @@ public class TestMapArguments
         Map<String, Object> args = new HashMap<String, Object>();
         args.put("foo", null);
         Foreman foreman = new Foreman();
-        StatementContext ctx = new ConcreteStatementContext(new HashMap<String, Object>(), new MappingRegistry());
+        StatementContext ctx = new ConcreteStatementContext();
         MapArguments mapArguments = new MapArguments(foreman, ctx, args);
         Argument argument = mapArguments.find("foo");
         assertThat(argument, instanceOf(ObjectArgument.class));

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator.java
@@ -21,7 +21,9 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Something;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.sqlobject.mixins.GetHandle;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -70,11 +72,36 @@ public class TestClasspathStatementLocator {
     }
 
     @RegisterMapper(SomethingMapper.class)
-    static interface Cromulence {
+    interface Cromulence {
         @SqlQuery
-        public Something findById(@Bind("id") Long id);
+        Something findById(@Bind("id") Long id);
     }
 
     @RegisterMapper(SomethingMapper.class)
-    static interface SubCromulence extends Cromulence { }
+    interface SubCromulence extends Cromulence { }
+
+    @Test
+    public void testLocationWithConcreteMethod() {
+        // Issue #441 - A call to e.g. getHandle.createQuery() in a sql object method should look for SQL in the
+        // usual directory for the SQL object class.
+        Dao dao = handle.attach(Dao.class);
+
+        dao.insert(1, "Bob");
+        dao.insert(2, "Alice");
+
+        List<Something> list = dao.list();
+        assertThat(list.get(0).getName(), equalTo("Alice"));
+        assertThat(list.get(1).getName(), equalTo("Bob"));
+    }
+
+    static abstract class Dao implements GetHandle {
+        @SqlUpdate
+        abstract void insert(@Bind("id") long id, @Bind("name") String name);
+
+        public List<Something> list() {
+            return getHandle().createQuery("list-order-by-name")
+                    .map(new SomethingMapper())
+                    .list();
+        }
+    }
 }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestOnDemandSqlObject.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestOnDemandSqlObject.java
@@ -24,6 +24,7 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.ResultIterator;
 import org.skife.jdbi.v2.Something;
+import org.skife.jdbi.v2.SqlObjectContext;
 import org.skife.jdbi.v2.exceptions.TransactionException;
 import org.skife.jdbi.v2.exceptions.UnableToCloseResourceException;
 import org.skife.jdbi.v2.StatementContext;
@@ -135,6 +136,10 @@ public class TestOnDemandSqlObject
             @Override
             public Handle open() {
                 Handle h = EasyMock.createMock(Handle.class);
+                h.getSqlObjectContext();
+                EasyMock.expectLastCall().andReturn(new SqlObjectContext());
+                h.setSqlObjectContext(EasyMock.anyObject(SqlObjectContext.class));
+                EasyMock.expectLastCall().anyTimes();
                 h.createStatement(EasyMock.anyString());
                 EasyMock.expectLastCall()
                     .andThrow(new TransactionException("connection reset"));

--- a/src/test/resources/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator$Dao/insert.sql
+++ b/src/test/resources/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator$Dao/insert.sql
@@ -1,0 +1,15 @@
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into something (id, name) values (:id, :name);

--- a/src/test/resources/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator$Dao/list-order-by-name.sql
+++ b/src/test/resources/org/skife/jdbi/v2/sqlobject/TestClasspathStatementLocator$Dao/list-order-by-name.sql
@@ -1,0 +1,15 @@
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+select id, name from something order by name;


### PR DESCRIPTION
…ame classpath directories as declarative methods.

Add methods Handle.getSqlObjectType, Handle.getSqlObjectMethod, and Handle.setSqlObjectContext (sets both
properties at once). These values are forwarded to the StatementContext of any Query, Update, Batch, etc
upon creation of a SQLStatement.

In v3, we may want to hoist the setting of these values to a universal Handler wrapper which gets wrapped
around every method. In this way we set the properties once on the Handle and would not have to expose
setters on the StatementContext.