### PR TITLE
Move mapper registration to SqlStatement, generalize Register*Mapper

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Query.java
+++ b/core/src/main/java/org/jdbi/v3/core/Query.java
@@ -23,9 +23,6 @@ import java.util.Locale;
 
 import org.jdbi.v3.core.exception.ResultSetException;
 import org.jdbi.v3.core.mapper.BeanMapper;
-import org.jdbi.v3.core.mapper.ColumnMapper;
-import org.jdbi.v3.core.mapper.ColumnMapperFactory;
-import org.jdbi.v3.core.mapper.InferredRowMapperFactory;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.statement.StatementBuilder;
@@ -242,25 +239,5 @@ public class Query<ResultType> extends SqlStatement<Query<ResultType>> implement
     public Query<ResultType> concurrentUpdatable() {
         getContext().setConcurrentUpdatable(true);
         return this;
-    }
-
-    public void registerRowMapper(RowMapper<?> m)
-    {
-        config.mappingRegistry.addRowMapper(new InferredRowMapperFactory(m));
-    }
-
-    public void registerRowMapper(RowMapperFactory m)
-    {
-        config.mappingRegistry.addRowMapper(m);
-    }
-
-    public void registerColumnMapper(ColumnMapper<?> m)
-    {
-        config.mappingRegistry.addColumnMapper(m);
-    }
-
-    public void registerColumnMapper(ColumnMapperFactory m)
-    {
-        config.mappingRegistry.addColumnMapper(m);
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/SqlStatement.java
@@ -37,7 +37,11 @@ import org.jdbi.v3.core.argument.ObjectArgument;
 import org.jdbi.v3.core.collector.CollectorFactory;
 import org.jdbi.v3.core.exception.UnableToCreateStatementException;
 import org.jdbi.v3.core.exception.UnableToExecuteStatementException;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.ColumnMapperFactory;
+import org.jdbi.v3.core.mapper.InferredRowMapperFactory;
 import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.rewriter.RewrittenStatement;
 import org.jdbi.v3.core.rewriter.StatementRewriter;
 import org.jdbi.v3.core.statement.StatementBuilder;
@@ -107,6 +111,30 @@ public abstract class SqlStatement<SelfType extends SqlStatement<SelfType>> exte
     public SelfType registerArgumentFactory(ArgumentFactory argumentFactory)
     {
         getArgumentRegistry().register(argumentFactory);
+        return typedThis;
+    }
+
+    public SelfType registerRowMapper(RowMapper<?> m)
+    {
+        config.mappingRegistry.addRowMapper(new InferredRowMapperFactory(m));
+        return typedThis;
+    }
+
+    public SelfType registerRowMapper(RowMapperFactory m)
+    {
+        config.mappingRegistry.addRowMapper(m);
+        return typedThis;
+    }
+
+    public SelfType registerColumnMapper(ColumnMapper<?> m)
+    {
+        config.mappingRegistry.addColumnMapper(m);
+        return typedThis;
+    }
+
+    public SelfType registerColumnMapper(ColumnMapperFactory m)
+    {
+        config.mappingRegistry.addColumnMapper(m);
         return typedThis;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/StatementContext.java
@@ -24,6 +24,7 @@ import java.util.stream.Collector;
 
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.RowMapper;
 
 /**
  * The statement context provides a means for passing client specific information through the
@@ -97,11 +98,22 @@ public final class StatementContext
      * Obtain a column mapper for the given type in this context.
      *
      * @param type the target type to map to
-     * @return a ColumnMapper for the given type, or null if no column mapper is registered for the given type.
+     * @return a ColumnMapper for the given type, or empty if no column mapper is registered for the given type.
      */
     public Optional<ColumnMapper<?>> findColumnMapperFor(Type type)
     {
         return config.mappingRegistry.findColumnMapperFor(type, this);
+    }
+
+    /**
+     * Obtain a row mapper for the given type in this context.
+     *
+     * @param type the target type to map to
+     * @return a RowMapper for the given type, or empty if no row mapper is registered for the given type.
+     */
+    public Optional<RowMapper<?>> findRowMapperFor(Type type)
+    {
+        return config.mappingRegistry.findRowMapperFor(type, this);
     }
 
     /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultGeneratedKeyMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultGeneratedKeyMapper.java
@@ -32,11 +32,16 @@ class DefaultGeneratedKeyMapper implements RowMapper<Object> {
 
     @Override
     public Object map(ResultSet r, StatementContext ctx) throws SQLException {
-        ColumnMapper<?> columnMapper = ctx.findColumnMapperFor(returnType)
-                .orElseThrow(() -> new IllegalStateException("No column mapper for " + returnType));
-
-        return "".equals(columnName)
+        ColumnMapper<?> columnMapper = ctx.findColumnMapperFor(returnType).orElse(null);
+        if (columnMapper != null) {
+            return "".equals(columnName)
                 ? columnMapper.map(r, 1, ctx)
                 : columnMapper.map(r, columnName, ctx);
+        }
+        RowMapper<?> rowMapper = ctx.findRowMapperFor(returnType).orElse(null);
+        if (rowMapper != null) {
+            return rowMapper.map(r, ctx);
+        }
+        throw new IllegalStateException("No column or row mapper for " + returnType);
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterBeanMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterBeanMapper.java
@@ -20,7 +20,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 
-import org.jdbi.v3.core.Query;
 import org.jdbi.v3.core.mapper.BeanMapperFactory;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizerFactory;
@@ -51,10 +50,8 @@ public @interface RegisterBeanMapper
         }
 
         private SqlStatementCustomizer create(RegisterBeanMapper annotation) {
-            return statement -> {
-                Query<?> query = (Query<?>) statement;
-                query.registerRowMapper(new BeanMapperFactory(annotation.value()));
-            };
+            return statement ->
+                statement.registerRowMapper(new BeanMapperFactory(annotation.value()));
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterCollectorFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterCollectorFactory.java
@@ -70,10 +70,7 @@ public @interface RegisterCollectorFactory {
 
         @Override
         public void apply(SqlStatement<?> q) throws SQLException {
-            if (q instanceof Query) {
-                Query<?> query = (Query<?>) q;
-                factories.forEach(query::registerCollectorFactory);
-            }
+            factories.forEach(q::registerCollectorFactory);
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterColumnMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterColumnMapper.java
@@ -19,8 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
-import org.jdbi.v3.core.Query;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizerFactory;
@@ -65,14 +65,7 @@ public @interface RegisterColumnMapper
             catch (Exception e) {
                 throw new IllegalStateException("unable to create a specified column mapper", e);
             }
-            return statement -> {
-                if (statement instanceof Query) {
-                    Query<?> q = (Query<?>) statement;
-                    for (ColumnMapper<?> mapper : m) {
-                        q.registerColumnMapper(mapper);
-                    }
-                }
-            };
+            return stmt -> Arrays.asList(m).forEach(stmt::registerColumnMapper);
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterColumnMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterColumnMapper.java
@@ -19,7 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
@@ -55,17 +56,17 @@ public @interface RegisterColumnMapper
         }
 
         private SqlStatementCustomizer create(RegisterColumnMapper ma) {
-            final ColumnMapper<?>[] m = new ColumnMapper[ma.value().length];
+            final List<ColumnMapper<?>> m = new ArrayList<ColumnMapper<?>>(ma.value().length);
             try {
                 Class<? extends ColumnMapper<?>>[] mcs = ma.value();
                 for (int i = 0; i < mcs.length; i++) {
-                    m[i] = mcs[i].newInstance();
+                    m.add(mcs[i].newInstance());
                 }
             }
             catch (Exception e) {
                 throw new IllegalStateException("unable to create a specified column mapper", e);
             }
-            return stmt -> Arrays.asList(m).forEach(stmt::registerColumnMapper);
+            return stmt -> m.forEach(stmt::registerColumnMapper);
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterColumnMapperFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterColumnMapperFactory.java
@@ -19,7 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
@@ -56,17 +57,17 @@ public @interface RegisterColumnMapperFactory
         }
 
         private SqlStatementCustomizer create(RegisterColumnMapperFactory ma) {
-            final ColumnMapperFactory[] m = new ColumnMapperFactory[ma.value().length];
+            final List<ColumnMapperFactory> m = new ArrayList<ColumnMapperFactory>(ma.value().length);
             try {
                 Class<? extends ColumnMapperFactory>[] mcs = ma.value();
                 for (int i = 0; i < mcs.length; i++) {
-                    m[i] = mcs[i].newInstance();
+                    m.add(mcs[i].newInstance());
                 }
             }
             catch (Exception e) {
                 throw new IllegalStateException("unable to create a specified column mapper factory", e);
             }
-            return stmt -> Arrays.asList(m).forEach(stmt::registerColumnMapper);
+            return stmt -> m.forEach(stmt::registerColumnMapper);
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterColumnMapperFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterColumnMapperFactory.java
@@ -19,8 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
-import org.jdbi.v3.core.Query;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizerFactory;
@@ -62,20 +62,11 @@ public @interface RegisterColumnMapperFactory
                 for (int i = 0; i < mcs.length; i++) {
                     m[i] = mcs[i].newInstance();
                 }
-
             }
             catch (Exception e) {
                 throw new IllegalStateException("unable to create a specified column mapper factory", e);
             }
-            return statement -> {
-                if (statement instanceof Query) {
-                    Query<?> q = (Query<?>) statement;
-                    for (ColumnMapperFactory factory : m) {
-                        q.registerColumnMapper(factory);
-                    }
-
-                }
-            };
+            return stmt -> Arrays.asList(m).forEach(stmt::registerColumnMapper);
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterRowMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterRowMapper.java
@@ -19,8 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
-import org.jdbi.v3.core.Query;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizerFactory;
@@ -65,14 +65,7 @@ public @interface RegisterRowMapper
             catch (Exception e) {
                 throw new IllegalStateException("unable to create a specified row mapper", e);
             }
-            return statement -> {
-                if (statement instanceof Query) {
-                    Query<?> q = (Query<?>) statement;
-                    for (RowMapper<?> mapper : m) {
-                        q.registerRowMapper(mapper);
-                    }
-                }
-            };
+            return stmt -> Arrays.asList(m).forEach(stmt::registerRowMapper);
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterRowMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterRowMapper.java
@@ -19,7 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
@@ -55,17 +56,17 @@ public @interface RegisterRowMapper
         }
 
         private SqlStatementCustomizer create(RegisterRowMapper ma) {
-            final RowMapper<?>[] m = new RowMapper[ma.value().length];
+            final List<RowMapper<?>> m = new ArrayList<RowMapper<?>>(ma.value().length);
             try {
                 Class<? extends RowMapper<?>>[] mcs = ma.value();
                 for (int i = 0; i < mcs.length; i++) {
-                    m[i] = mcs[i].newInstance();
+                    m.add(mcs[i].newInstance());
                 }
             }
             catch (Exception e) {
                 throw new IllegalStateException("unable to create a specified row mapper", e);
             }
-            return stmt -> Arrays.asList(m).forEach(stmt::registerRowMapper);
+            return stmt -> m.forEach(stmt::registerRowMapper);
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterRowMapperFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterRowMapperFactory.java
@@ -19,7 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
@@ -52,18 +53,18 @@ public @interface RegisterRowMapperFactory
         }
 
         private SqlStatementCustomizer create(RegisterRowMapperFactory ma) {
-            final RowMapperFactory[] m = new RowMapperFactory[ma.value().length];
+            final List<RowMapperFactory> m = new ArrayList<RowMapperFactory>(ma.value().length);
             try {
                 Class<? extends RowMapperFactory>[] mcs = ma.value();
                 for (int i = 0; i < mcs.length; i++) {
-                    m[i] = mcs[i].newInstance();
+                    m.add(mcs[i].newInstance());
                 }
 
             }
             catch (Exception e) {
                 throw new IllegalStateException("unable to create a specified row mapper factory", e);
             }
-            return stmt -> Arrays.asList(m).forEach(stmt::registerRowMapper);
+            return stmt -> m.forEach(stmt::registerRowMapper);
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterRowMapperFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/RegisterRowMapperFactory.java
@@ -19,8 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
-import org.jdbi.v3.core.Query;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizerFactory;
@@ -63,15 +63,7 @@ public @interface RegisterRowMapperFactory
             catch (Exception e) {
                 throw new IllegalStateException("unable to create a specified row mapper factory", e);
             }
-            return statement -> {
-                if (statement instanceof Query) {
-                    Query<?> q = (Query<?>) statement;
-                    for (RowMapperFactory factory : m) {
-                        q.registerRowMapper(factory);
-                    }
-
-                }
-            };
+            return stmt -> Arrays.asList(m).forEach(stmt::registerRowMapper);
         }
     }
 }


### PR DESCRIPTION
`@GetGeneratedKeys` is going to do actual mapping, which means registering is important on `@SqlUpdate` and `@SqlBatch` as well.  So might as well just move it up.

Extend the generated key mapper to use both column or row mappers, if available.