### PR TITLE
Use st3 locator implicitly for BindIn

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/SQLStatement.java
+++ b/src/main/java/org/skife/jdbi/v2/SQLStatement.java
@@ -215,7 +215,7 @@ public abstract class SQLStatement<SelfType extends SQLStatement<SelfType>> exte
         return statementBuilder;
     }
 
-    protected StatementLocator getStatementLocator()
+    public StatementLocator getStatementLocator()
     {
         return this.locator;
     }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/Define.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/Define.java
@@ -13,10 +13,13 @@
  */
 package org.skife.jdbi.v2.sqlobject.customizers;
 
+import org.skife.jdbi.v2.ClasspathStatementLocator;
 import org.skife.jdbi.v2.SQLStatement;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizer;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizerFactory;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizingAnnotation;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator.LocatorFactory;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocatorImpl;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
@@ -24,6 +27,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.sql.SQLException;
 
 /**
  * Used to set attributes on the StatementContext for the statement generated for this method.
@@ -54,16 +58,19 @@ public @interface Define
         }
 
         @Override
-        public SqlStatementCustomizer createForParameter(Annotation annotation, Class sqlObjectType, Method method, final Object arg)
+        public SqlStatementCustomizer createForParameter(Annotation annotation, final Class sqlObjectType, Method method, final Object arg)
         {
             Define d = (Define) annotation;
             final String key = d.value();
             return new SqlStatementCustomizer()
             {
                 @Override
-                public void apply(SQLStatement q)
+                public void apply(SQLStatement q) throws SQLException
                 {
                     q.define(key, arg);
+                    if (q.getStatementLocator() instanceof ClasspathStatementLocator) {
+                        new LocatorFactory().createForType(UseStringTemplate3StatementLocatorImpl.defaultInstance(), sqlObjectType).apply(q);
+                    }
                 }
             };
         }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/UseStringTemplate3StatementLocatorImpl.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/UseStringTemplate3StatementLocatorImpl.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject.stringtemplate;
+
+import java.lang.annotation.Annotation;
+
+public class UseStringTemplate3StatementLocatorImpl implements UseStringTemplate3StatementLocator
+{
+    private static final UseStringTemplate3StatementLocator DEFAULT = createDefault();
+
+    private final String value;
+    private final Class errorListener;
+    private final boolean cacheable;
+
+    public UseStringTemplate3StatementLocatorImpl(String value, Class errorListener, boolean cacheable)
+    {
+        assert value != null;
+        assert errorListener != null;
+        this.value = value;
+        this.errorListener = errorListener;
+        this.cacheable = cacheable;
+    }
+
+    public static UseStringTemplate3StatementLocator defaultInstance()
+    {
+        return DEFAULT;
+    }
+
+    private static UseStringTemplate3StatementLocator createDefault()
+    {
+        String defaultValue = defaultValueForMethod("value", String.class);
+        Class defaultErrorListener = defaultValueForMethod("errorListener", Class.class);
+        boolean defaultCacheable = defaultValueForMethod("cacheable", Boolean.class);
+
+        return new UseStringTemplate3StatementLocatorImpl(defaultValue, defaultErrorListener, defaultCacheable);
+    }
+
+    private static <T> T defaultValueForMethod(String method, Class<T> returnType)
+    {
+        try {
+            return returnType.cast(UseStringTemplate3StatementLocator.class.getMethod(method).getDefaultValue());
+        }
+        catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String value()
+    {
+        return value;
+    }
+
+    @Override
+    public Class errorListener()
+    {
+        return errorListener;
+    }
+
+    @Override
+    public boolean cacheable()
+    {
+        return cacheable;
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType()
+    {
+        return UseStringTemplate3StatementLocator.class;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UseStringTemplate3StatementLocatorImpl that = (UseStringTemplate3StatementLocatorImpl) o;
+        return value.equals(that.value) && errorListener.equals(that.errorListener) && cacheable == that.cacheable;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return ((127 * "value".hashCode()) ^ value().hashCode()) +
+            ((127 * "errorListener".hashCode()) ^ errorListener().hashCode()) +
+            ((127 * "cacheable".hashCode()) ^ Boolean.valueOf(cacheable).hashCode());
+    }
+}

--- a/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
+++ b/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
@@ -13,6 +13,7 @@
  */
 package org.skife.jdbi.v2.unstable;
 
+import org.skife.jdbi.v2.ClasspathStatementLocator;
 import org.skife.jdbi.v2.SQLStatement;
 import org.skife.jdbi.v2.sqlobject.Binder;
 import org.skife.jdbi.v2.sqlobject.BinderFactory;
@@ -20,6 +21,8 @@ import org.skife.jdbi.v2.sqlobject.BindingAnnotation;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizer;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizerFactory;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizingAnnotation;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator.LocatorFactory;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocatorImpl;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
@@ -55,7 +58,7 @@ public @interface BindIn
 
         @Override
         public SqlStatementCustomizer createForParameter(Annotation annotation,
-                                                         Class sqlObjectType,
+                                                         final Class sqlObjectType,
                                                          Method method,
                                                          Object arg)
         {
@@ -82,6 +85,9 @@ public @interface BindIn
                 public void apply(SQLStatement q) throws SQLException
                 {
                     q.define(key, ns);
+                    if (q.getStatementLocator() instanceof ClasspathStatementLocator) {
+                        new LocatorFactory().createForType(UseStringTemplate3StatementLocatorImpl.defaultInstance(), sqlObjectType).apply(q);
+                    }
                 }
             };
         }

--- a/src/test/java/org/skife/jdbi/v2/docs/TestInClauseExpansion.java
+++ b/src/test/java/org/skife/jdbi/v2/docs/TestInClauseExpansion.java
@@ -67,7 +67,6 @@ public class TestInClauseExpansion
         assertThat(dao.findIdsForNames(asList(1, 2)), equalTo(ImmutableSet.of("Brian", "Jeff")));
     }
 
-    @UseStringTemplate3StatementLocator
     @RegisterContainerMapper(ImmutableSetContainerFactory.class)
     public static interface DAO
     {


### PR DESCRIPTION
This is something we're probably going to use in our fork but just wanted to get your thoughts on it, potentially for jdbi3. The problem we run into is that people use `@BindIn` without remembering to use `@UseStringTemplate3StatementLocator`. After a bit of debugging they realize what happened and add `@UseStringTemplate3StatementLocator`, but the annotation isn't very granular (can only be applied to an entire DAO) so then some unrelated queries start failing because they contain SQL like `a < b` which the `StringTemplate3StatementLocator` requires you to escape.

I was considering updating `@UseStringTemplate3StatementLocator` to target `ElementType.METHOD` as well, that way you could only annotate methods using `@BindIn` and save some headaches there. But it seems to me that this is all unnecessary if `@BindIn` added the necessary statement locator. The heuristic I'm using for this is whether the `SQLStatement` is still using the default `ClasspathStatementLocator`, if so we apply the `UseStringTemplate3StatementLocator` customizer to the `SQLStatement` using the default annotation options. Let me know what you think of this approach.