### PR TITLE
Migrate SqlObject from CGLIB to Java Proxy implementation. 

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -186,24 +186,12 @@
                                 <includes>
                                     <include>org.antlr:antlr-runtime</include>
                                     <include>com.google.guava:guava</include>
-                                    <include>cglib:cglib</include>
-                                    <include>org.ow2.asm:asm</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
-                                    <pattern>org.objectweb.asm</pattern>
-                                    <shadedPattern>org.jdbi.v3.asm</shadedPattern>
-                                </relocation>
-
-                                <relocation>
                                     <pattern>org.antlr.runtime</pattern>
                                     <shadedPattern>org.jdbi.v3.org.antlr.runtime</shadedPattern>
-                                </relocation>
-
-                                <relocation>
-                                    <pattern>net.sf.cglib</pattern>
-                                    <shadedPattern>org.jdbi.v3.cglib</shadedPattern>
                                 </relocation>
 
                                 <relocation>

--- a/jpa/src/test/java/org/jdbi/v3/jpa/JpaTest.java
+++ b/jpa/src/test/java/org/jdbi/v3/jpa/JpaTest.java
@@ -61,7 +61,7 @@ public class JpaTest {
         public void setName(String name) { this.name = name; }
     }
 
-    interface EntityThingDao {
+    public interface EntityThingDao {
         @SqlUpdate(INSERT_BY_PROPERTY_NAME)
         void insert(@BindJpa EntityThing thing);
 
@@ -101,7 +101,7 @@ public class JpaTest {
         public void setName(String name) { this.name = name; }
     }
 
-    interface FieldThingDao {
+    public interface FieldThingDao {
         @SqlUpdate(INSERT_BY_PROPERTY_NAME)
         void insert(@BindJpa FieldThing thing);
 
@@ -141,7 +141,7 @@ public class JpaTest {
         public void setName(String name) { this.name = name; }
     }
 
-    interface NamedFieldThingDao {
+    public interface NamedFieldThingDao {
         @SqlUpdate(INSERT_BY_ANNOTATION_NAME)
         void insert(@BindJpa NamedFieldThing thing);
 
@@ -181,7 +181,7 @@ public class JpaTest {
         public void setName(String name) { this.name = name; }
     }
 
-    interface GetterThingDao {
+    public interface GetterThingDao {
         @SqlUpdate(INSERT_BY_PROPERTY_NAME)
         void insert(@BindJpa GetterThing thing);
 
@@ -221,7 +221,7 @@ public class JpaTest {
         public void setName(String name) { this.name = name; }
     }
 
-    interface NamedGetterThingDao {
+    public interface NamedGetterThingDao {
         @SqlUpdate(INSERT_BY_ANNOTATION_NAME)
         void insert(@BindJpa NamedGetterThing thing);
 
@@ -261,7 +261,7 @@ public class JpaTest {
         @Column public void setName(String name) { this.name = name; }
     }
 
-    interface SetterThingDao {
+    public interface SetterThingDao {
         @SqlUpdate(INSERT_BY_PROPERTY_NAME)
         void insert(@BindJpa SetterThing thing);
 
@@ -301,7 +301,7 @@ public class JpaTest {
         @Column(name = "bar") public void setName(String name) { this.name = name; }
     }
 
-    interface NamedSetterThingDao {
+    public interface NamedSetterThingDao {
         @SqlUpdate(INSERT_BY_ANNOTATION_NAME)
         void insert(@BindJpa NamedSetterThing thing);
 
@@ -343,7 +343,7 @@ public class JpaTest {
         public void setName(String name) { this.name = name; }
     }
 
-    interface MappedSuperclassThingDao {
+    public interface MappedSuperclassThingDao {
         @SqlUpdate(INSERT_BY_PROPERTY_NAME)
         void insert(@BindJpa ExtendsMappedSuperclassThing thing);
 
@@ -383,7 +383,7 @@ public class JpaTest {
         @Column(name = "ignored") public void setName(String name) { this.name = name; }
     }
 
-    interface AnnotationPriorityThingDao {
+    public interface AnnotationPriorityThingDao {
         @SqlUpdate(INSERT_BY_ANNOTATION_NAME)
         void insert(@BindJpa AnnotationPriorityThing thing);
 
@@ -409,7 +409,7 @@ public class JpaTest {
         assertThingEquals(keith, rs.get(1));
     }
 
-    interface SuperfluousColumnDao {
+    public interface SuperfluousColumnDao {
         @SqlUpdate(INSERT_BY_PROPERTY_NAME)
         void insert(@BindJpa FieldThing thing);
 
@@ -434,7 +434,7 @@ public class JpaTest {
         assertThingEquals(keith, rs.get(1));
     }
 
-    interface MissingColumnDao {
+    public interface MissingColumnDao {
         @SqlUpdate("insert into something(id) values (:id)")
         void insert(@BindJpa FieldThing thing);
 
@@ -479,7 +479,7 @@ public class JpaTest {
         @Override @Column(name = "meow") public int getId() { return super.getId(); }
     }
 
-    interface OverridingSubclassThingDao {
+    public interface OverridingSubclassThingDao {
         @SqlUpdate("insert into something(id, name) values (:meow, :bar)")
         void insert(@BindJpa OverridingSubclassThing thing);
 

--- a/jpa/src/test/java/org/jdbi/v3/jpa/PluginTest.java
+++ b/jpa/src/test/java/org/jdbi/v3/jpa/PluginTest.java
@@ -43,7 +43,7 @@ public class PluginTest {
         public void setName(String name) { this.name = name; }
     }
 
-    interface ThingDao {
+    public interface ThingDao {
         @SqlUpdate("insert into something (id, name) values (:id, :name)")
         void insert(@BindJpa Thing thing);
 

--- a/pom.xml
+++ b/pom.xml
@@ -225,12 +225,6 @@
             </dependency>
 
             <dependency>
-                <groupId>cglib</groupId>
-                <artifactId>cglib</artifactId>
-                <version>3.2.2</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr-runtime</artifactId>
                 <version>${dep.antlr.version}</version>
@@ -305,12 +299,6 @@
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-pg-embedded</artifactId>
                 <version>0.7.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>5.1</version>
             </dependency>
 
             <dependency>

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
@@ -100,7 +100,7 @@ public class TestSqlArrays {
         assertEquals(testIntList, ao.fetchIntList());
     }
 
-    interface ArrayObject {
+    public interface ArrayObject {
         @SqlQuery(U_SELECT)
         UUID[] fetchUuidArray();
 

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -51,11 +51,6 @@
         </dependency>
 
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
         </dependency>

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -42,20 +42,6 @@ public enum SqlObjectFactory implements ExtensionFactory<SqlObjectConfig> {
     INSTANCE;
 
     private static final Object[] NO_ARGS = new Object[0];
-    private static final Method EQUALS_METHOD;
-    private static final Method HASHCODE_METHOD;
-    private static final Method TOSTRING_METHOD;
-
-    static {
-        try {
-            EQUALS_METHOD = Object.class.getMethod("equals", Object.class);
-            HASHCODE_METHOD = Object.class.getMethod("hashCode");
-            TOSTRING_METHOD = Object.class.getMethod("toString");
-        }
-        catch (NoSuchMethodException wat) {
-            throw new IllegalStateException("JVM error", wat);
-        }
-    }
 
     private final Map<Method, Handler> mixinHandlers = new HashMap<>();
     private final ConcurrentMap<Class<?>, Map<Method, Handler>> handlersCache = new ConcurrentHashMap<>();
@@ -199,18 +185,6 @@ public enum SqlObjectFactory implements ExtensionFactory<SqlObjectConfig> {
                                                       Map<Method, Handler> handlers,
                                                       HandleSupplier handle) {
         return (proxy, method, args) -> {
-            if (EQUALS_METHOD.equals(method)) {
-                return proxy == args[0];
-            }
-
-            if (HASHCODE_METHOD.equals(method)) {
-                return System.identityHashCode(proxy);
-            }
-
-            if (TOSTRING_METHOD.equals(method)) {
-                return sqlObjectType + "@" + Integer.toHexString(System.identityHashCode(proxy));
-            }
-
             ExtensionMethod oldMethod = handle.getExtensionMethod();
             handle.setExtensionMethod(new ExtensionMethod(sqlObjectType, method));
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
@@ -199,7 +199,7 @@ public class TestBatching
         void invalidInsertString(@Bind("id") String id);
     }
 
-    interface BadBatch
+    public interface BadBatch
     {
         @SqlBatch("insert into something (id, name) values (:id, :name)")
         int[] insertBeans(@BindBean Something elements); // whoops, no Iterable!

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanBinder.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanBinder.java
@@ -57,7 +57,7 @@ public class TestBeanBinder
     }
 
     @RegisterRowMapper(SomethingMapper.class)
-    interface Spiffy {
+    public interface Spiffy {
 
         @SqlUpdate("insert into something (id, name) values (:id, :name)")
         int insert(@BindBean Something s);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCreateSqlObjectAnnotation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCreateSqlObjectAnnotation.java
@@ -97,12 +97,12 @@ public class TestCreateSqlObjectAnnotation
         }
     }
 
-    public static abstract class Bar
+    public interface Bar
     {
         @SqlQuery("select id, name from something where id = :id")
-        public abstract Something findById(@Bind("id") int id);
+        Something findById(@Bind("id") int id);
 
-        public Something explode()
+        default Something explode()
         {
             throw new RuntimeException();
         }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefineParameter.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefineParameter.java
@@ -60,7 +60,7 @@ public class TestDefineParameter
     }
 
     @RegisterRowMapper(SomethingMapper.class)
-    interface HoneyBadger
+    public interface HoneyBadger
     {
         @SqlUpdate("insert into <table> (id, name) values (:id, :name)")
         void insert(@Define("table") String table, @BindBean Something s);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestFoldToObjectGraph.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestFoldToObjectGraph.java
@@ -87,7 +87,7 @@ public class TestFoldToObjectGraph
         assertThat(dao.findAllTeams(), equalTo(expected));
     }
 
-    public static abstract class Dao
+    public interface Dao
     {
         @SqlQuery("select t.name as teamName, " +
                   "       t.mascot as mascot, " +
@@ -95,9 +95,9 @@ public class TestFoldToObjectGraph
                   "       p.role as role " +
                   "from team t inner join person p on (t.name = p.team)")
         @RegisterBeanMapper(TeamPersonJoinRow.class)
-        public abstract Iterator<TeamPersonJoinRow> findAllTeamsAndPeople();
+        Iterator<TeamPersonJoinRow> findAllTeamsAndPeople();
 
-        public Map<String, Team> findAllTeams()
+        default Map<String, Team> findAllTeams()
         {
             Iterator<TeamPersonJoinRow> i = findAllTeamsAndPeople();
             Map<String, Team> acc = new HashMap<>();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMapBinder.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMapBinder.java
@@ -110,7 +110,7 @@ public class TestMapBinder
         return map;
     }
 
-    interface Spiffy
+    public interface Spiffy
     {
         @SqlUpdate("insert into something (id, a, b, c) values (:id, :a, :b, :c)")
         int insert(@BindMap Map<String, Object> bindings);
@@ -126,7 +126,7 @@ public class TestMapBinder
         Result load(@Bind("id") int id);
     }
 
-    static class ResultMapper implements RowMapper<Result>
+    public static class ResultMapper implements RowMapper<Result>
     {
         @Override
         public Result map(ResultSet r, StatementContext ctx)
@@ -141,7 +141,7 @@ public class TestMapBinder
         }
     }
 
-    static class Result
+    public static class Result
     {
         String a, c;
         int id, b;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNull.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNull.java
@@ -50,7 +50,7 @@ public class TestNull {
         assertThat(dao.findNameById(3), nullValue());
     }
 
-    interface DAO {
+    public interface DAO {
 
         @SqlUpdate("insert into something (id, name) values (:id, :name)")
         void insert(@Bind("id") long id, @Bind("name") String name);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestObjectMethodBehavior.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestObjectMethodBehavior.java
@@ -31,10 +31,9 @@ public class TestObjectMethodBehavior
     private Jdbi    dbi;
     private UselessDao dao;
 
-    public interface UselessDao extends Cloneable, GetHandle
+    public interface UselessDao extends GetHandle
     {
         void finalize();
-        Object clone();
     }
 
     /**
@@ -50,23 +49,17 @@ public class TestObjectMethodBehavior
     }
 
     @Test
-    public void testClone() throws Exception
-    {
-        assertNotSame(dao, dao.clone());
-    }
-
-    @Test
     public void testEquals() throws Exception
     {
         assertEquals(dao, dao);
-        assertNotEquals(dao, dao.clone());
+        assertNotEquals(dao, dbi.onDemand(UselessDao.class));
     }
 
     @Test
     public void testHashCode() throws Exception
     {
         assertEquals(dao.hashCode(), dao.hashCode());
-        assertNotEquals(dao.hashCode(), dao.clone().hashCode());
+        assertNotEquals(dao.hashCode(), dbi.onDemand(UselessDao.class).hashCode());
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOverrideStatementRewriter.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOverrideStatementRewriter.java
@@ -59,7 +59,7 @@ public class TestOverrideStatementRewriter
 
     @OverrideStatementRewriterWith(HashPrefixStatementRewriter.class)
     @RegisterRowMapper(SomethingMapper.class)
-    interface Hashed
+    public interface Hashed
     {
         @SqlUpdate("insert into something (id, name) values (#id, #name)")
         void insert(@BindBean Something s);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPositionalBinder.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPositionalBinder.java
@@ -81,7 +81,7 @@ public class TestPositionalBinder {
         assertEquals(row.get("code"), 21);
     }
 
-    interface SomethingDao {
+    public interface SomethingDao {
 
         @SqlQuery("select name from something where something_id=:0")
         String findNameById(int i);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterConstructorMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterConstructorMapper.java
@@ -50,7 +50,7 @@ public class TestRegisterConstructorMapper {
     }
 
     @RegisterConstructorMapper(SubSomething.class)
-    interface Dao {
+    public interface Dao {
         @SqlUpdate("insert into something (id, name) values (:id, :name)")
         void insert(@Bind("id") int id, @Bind("name") String name);
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
@@ -38,7 +38,7 @@ public class TestSqlMethodAnnotations
         handle.attach(DAO.class);
     }
 
-    interface DAO {
+    public interface DAO {
         @SqlQuery
         @SqlUpdate
         void bogus();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObject.java
@@ -34,7 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class TestClassBasedSqlObject
+public class TestSqlObject
 {
     @Rule
     public H2DatabaseRule db = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectMethodBehavior.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectMethodBehavior.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.sql.Connection;
+
+import org.jdbi.v3.core.ExtensionMethod;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.HandleSupplier;
+import org.jdbi.v3.sqlobject.mixins.GetHandle;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSqlObjectMethodBehavior
+{
+    private UselessDao dao;
+    private UselessDao anotherDao;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        HandleSupplier handleSupplier = new HandleSupplier() {
+            private ExtensionMethod extensionMethod;
+            @Override
+            public ExtensionMethod getExtensionMethod() {
+                return extensionMethod;
+            }
+
+            @Override
+            public void setExtensionMethod(ExtensionMethod extensionMethod) {
+                this.extensionMethod = extensionMethod;
+            }
+
+            @Override
+            public Handle get() {
+                throw new UnsupportedOperationException();
+            }
+        };
+        dao = SqlObjectFactory.INSTANCE.attach(UselessDao.class, new SqlObjectConfig(), handleSupplier);
+        anotherDao = SqlObjectFactory.INSTANCE.attach(UselessDao.class, new SqlObjectConfig(), handleSupplier);
+    }
+
+    public interface UselessDao extends GetHandle
+    {
+        void finalize();
+    }
+
+    /**
+     * Sometimes the GC will call {@link #finalize()} on a SqlObject from
+     * extremely sensitive places from within the GC machinery.  JDBI should not
+     * open a {@link Connection} just to satisfy a (no-op) finalizer.
+     * <a href="https://github.com/brianm/jdbi/issues/82">Issue #82</a>.
+     */
+    @Test
+    public void testFinalizeDoesntConnect() throws Exception
+    {
+        dao.finalize(); // Normally GC would do this, but just fake it
+    }
+
+    @Test
+    public void testEquals() throws Exception
+    {
+        assertEquals(dao, dao);
+        assertNotEquals(dao, anotherDao);
+    }
+
+    @Test
+    public void testHashCode() throws Exception
+    {
+        assertEquals(dao.hashCode(), dao.hashCode());
+        assertNotEquals(dao.hashCode(), anotherDao.hashCode());
+    }
+
+    @Test
+    public void testToStringDoesntConnect() throws Exception
+    {
+        dao.toString();
+    }
+}

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseClasspathSqlLocator.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseClasspathSqlLocator.java
@@ -61,12 +61,12 @@ public class TestUseClasspathSqlLocator {
 
     @UseClasspathSqlLocator
     @RegisterRowMapper(SomethingMapper.class)
-    interface Cromulence {
+    public interface Cromulence {
         @SqlQuery
         Something findById(@Bind("id") Long id);
     }
 
     @RegisterRowMapper(SomethingMapper.class)
     @UseClasspathSqlLocator
-    static interface SubCromulence extends Cromulence { }
+    public interface SubCromulence extends Cromulence { }
 }

--- a/string-template/src/test/java/org/jdbi/v3/sqlobject/BindInNullTest.java
+++ b/string-template/src/test/java/org/jdbi/v3/sqlobject/BindInNullTest.java
@@ -95,7 +95,7 @@ public class BindInNullTest
     }
 
     @UseStringTemplateStatementRewriter
-    private interface SomethingByIterableHandleNull
+    public interface SomethingByIterableHandleNull
     {
         @SqlQuery("select id, name from something where name in (<names>)")
         List<Something> get(@BindIn(value = "names", onEmpty = NULL) Iterable<Object> ids);
@@ -132,7 +132,7 @@ public class BindInNullTest
     }
 
     @UseStringTemplateStatementRewriter(SpyingRewriter.class)
-    private interface SomethingByIterableHandleVoid
+    public interface SomethingByIterableHandleVoid
     {
         @SqlQuery("select id, name from something where id in (<ids>);")
         List<Something> get(@BindIn(value = "ids", onEmpty = VOID) Iterable<Object> ids);

--- a/string-template/src/test/java/org/jdbi/v3/sqlobject/BindInTest.java
+++ b/string-template/src/test/java/org/jdbi/v3/sqlobject/BindInTest.java
@@ -75,7 +75,7 @@ public class BindInTest
     }
 
     @UseStringTemplateStatementRewriter
-    private interface SomethingByVarargsHandleDefault
+    public interface SomethingByVarargsHandleDefault
     {
         @SqlQuery("select id, name from something where id in (<ids>)")
         List<Something> get(@BindIn("ids") int... ids);
@@ -114,7 +114,7 @@ public class BindInTest
     }
 
     @UseStringTemplateStatementRewriter
-    private interface SomethingByArrayHandleVoid
+    public interface SomethingByArrayHandleVoid
     {
         @SqlQuery("select id, name from something where id in (<ids>)")
         List<Something> get(@BindIn(value = "ids", onEmpty = VOID) int[] ids);
@@ -175,7 +175,7 @@ public class BindInTest
     }
 
     @UseStringTemplateStatementRewriter
-    private interface SomethingByIterableHandleDefault
+    public interface SomethingByIterableHandleDefault
     {
         @SqlQuery("select id, name from something where id in (<ids>)")
         List<Something> get(@BindIn(value = "ids", onEmpty = VOID) Iterable<Integer> ids);

--- a/string-template/src/test/java/org/jdbi/v3/stringtemplate/TestConditionalStringTemplateLocator.java
+++ b/string-template/src/test/java/org/jdbi/v3/stringtemplate/TestConditionalStringTemplateLocator.java
@@ -63,7 +63,7 @@ public class TestConditionalStringTemplateLocator {
         assertThat(ids).containsExactly(1, 2, 3);
     }
 
-    interface Dao {
+    public interface Dao {
         @SqlQuery
         @UseStringTemplateSqlLocator
         List<Integer> findLocated(@Define("sort") boolean sort, @Define("sortBy") String sortBy);

--- a/string-template/src/test/java/org/jdbi/v3/stringtemplate/TestStringTemplateGroupReference.java
+++ b/string-template/src/test/java/org/jdbi/v3/stringtemplate/TestStringTemplateGroupReference.java
@@ -50,7 +50,7 @@ public class TestStringTemplateGroupReference {
     }
 
     @UseStringTemplateSqlLocator
-    interface Dao {
+    public interface Dao {
         @SqlUpdate
         void insert(long id, String name);
 

--- a/string-template/src/test/java/org/jdbi/v3/stringtemplate/TestStringTemplateSqlLocator.java
+++ b/string-template/src/test/java/org/jdbi/v3/stringtemplate/TestStringTemplateSqlLocator.java
@@ -103,7 +103,7 @@ public class TestStringTemplateSqlLocator
 
     @UseStringTemplateSqlLocator
     @RegisterRowMapper(SomethingMapper.class)
-    interface Wombat
+    public interface Wombat
     {
         @SqlUpdate
         void insert(@BindBean Something s);


### PR DESCRIPTION
Submitted for discussion with the team.

This PR removes CGLIB and ASM from the project. It also restricts SqlObject extensions to public interfaces only.

This was surprisingly straightforward. Only drawback I saw was that extending Cloneable in a SqlObject class stopped working, which forced me to change some tests--pretty sure we don't want our users using `clone()` in their SQL Objects any way.