### PR TITLE
Remove questionable array length check

### DIFF
--- a/postgres/src/main/java/org/jdbi/v3/postgres/SqlArrayArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/SqlArrayArgumentFactory.java
@@ -13,7 +13,6 @@
  */
 package org.jdbi.v3.postgres;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -61,7 +60,7 @@ public class SqlArrayArgumentFactory implements ArgumentFactory {
             throw new IllegalArgumentException("not an array: " + klass);
         }
         String guess = BEST_GUESS.get(klass.getComponentType());
-        if (Array.getLength(array) == 0 || guess == null) {
+        if (guess == null) {
             return "varchar";
         }
         return guess;

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.SqlQuery;
 import org.jdbi.v3.sqlobject.SqlUpdate;
@@ -73,6 +74,12 @@ public class TestSqlArrays {
         ao.insertIntArray(testInts);
         int[] actuals = ao.fetchIntArray();
         assertArrayEquals(testInts, actuals);
+    }
+
+    @Test
+    public void testEmptyIntArray() throws Exception {
+        ao.insertIntArray(new int[0]);
+        assertEquals(0, ao.fetchIntArray().length);
     }
 
     @Test


### PR DESCRIPTION
If we have a component type, why would we override this back to varchar...
just causes type errors in the PG driver.