### PR TITLE
Rename HandleSupplier.get() to .getHandle(), add documentation.

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/ConstantHandleSupplier.java
+++ b/core/src/main/java/org/jdbi/v3/core/ConstantHandleSupplier.java
@@ -25,7 +25,7 @@ class ConstantHandleSupplier implements HandleSupplier {
     }
 
     @Override
-    public Handle get() {
+    public Handle getHandle() {
         return handle;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/HandleSupplier.java
+++ b/core/src/main/java/org/jdbi/v3/core/HandleSupplier.java
@@ -13,12 +13,10 @@
  */
 package org.jdbi.v3.core;
 
-import java.util.function.Supplier;
-
 /**
- * A handle supplier used by extension implementors.
+ * A handle supplier for extension implementors.
  */
-public interface HandleSupplier extends Supplier<Handle> {
+public interface HandleSupplier {
     /**
      * Returns the extension method currently being called with this handle.
      */
@@ -26,7 +24,14 @@ public interface HandleSupplier extends Supplier<Handle> {
 
     /**
      * Sets the extension method currently being called with this handle.
+     *
      * @param extensionMethod the extension method
      */
     void setExtensionMethod(ExtensionMethod extensionMethod);
+
+    /**
+     * Returns a handle, possibly creating it lazily. A Handle holds a database connection, so extensions should only
+     * call this method in order to interact with the database.
+     */
+    Handle getHandle();
 }

--- a/core/src/main/java/org/jdbi/v3/core/LazyHandleSupplier.java
+++ b/core/src/main/java/org/jdbi/v3/core/LazyHandleSupplier.java
@@ -35,7 +35,7 @@ class LazyHandleSupplier implements HandleSupplier, AutoCloseable {
         this.extensionMethod.set(extensionMethod);
     }
 
-    public Handle get() {
+    public Handle getHandle() {
         if (handle == null) {
             initHandle();
         }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BatchHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BatchHandler.java
@@ -102,7 +102,7 @@ class BatchHandler extends CustomizingStatementHandler
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier h)
     {
         boolean foundIterator = false;
-        Handle handle = h.get();
+        Handle handle = h.getHandle();
 
         List<Iterator<?>> extras = new ArrayList<>();
         for (final Object arg : args) {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BeginHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BeginHandler.java
@@ -22,7 +22,7 @@ class BeginHandler implements Handler
     @Override
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
-        handle.get().begin();
+        handle.getHandle().begin();
         return null;
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CallHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CallHandler.java
@@ -46,7 +46,7 @@ class CallHandler extends CustomizingStatementHandler
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
         String sql = config.getSqlLocator().locate(sqlObjectType, method);
-        Call call = handle.get().createCall(sql);
+        Call call = handle.getHandle().createCall(sql);
         applyCustomizers(call, args);
         applyBinders(call, args);
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CheckpointHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CheckpointHandler.java
@@ -22,7 +22,7 @@ class CheckpointHandler implements Handler
     @Override
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
-        handle.get().checkpoint(String.valueOf(args[0]));
+        handle.getHandle().checkpoint(String.valueOf(args[0]));
         return null;
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CommitHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CommitHandler.java
@@ -22,7 +22,7 @@ class CommitHandler implements Handler
     @Override
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
-        handle.get().commit();
+        handle.getHandle().commit();
         return null;
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GetHandleHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GetHandleHandler.java
@@ -22,6 +22,6 @@ class GetHandleHandler implements Handler
     @Override
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
-        return handle.get();
+        return handle.getHandle();
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/InTransactionHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/InTransactionHandler.java
@@ -25,6 +25,6 @@ class InTransactionHandler implements Handler
     public Object invoke(final Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle) throws Exception
     {
         final TransactionalCallback callback = (TransactionalCallback) args[0];
-        return handle.get().inTransaction((conn, status) -> callback.inTransaction(Transactional.class.cast(target), status));
+        return handle.getHandle().inTransaction((conn, status) -> callback.inTransaction(Transactional.class.cast(target), status));
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/InTransactionWithIsolationLevelHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/InTransactionWithIsolationLevelHandler.java
@@ -28,6 +28,6 @@ class InTransactionWithIsolationLevelHandler implements Handler
         final TransactionalCallback callback = (TransactionalCallback) args[1];
         final TransactionIsolationLevel level = (TransactionIsolationLevel) args[0];
 
-        return handle.get().inTransaction(level, (conn, status) -> callback.inTransaction(Transactional.class.cast(target), status));
+        return handle.getHandle().inTransaction(level, (conn, status) -> callback.inTransaction(Transactional.class.cast(target), status));
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/QueryHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/QueryHandler.java
@@ -34,7 +34,7 @@ class QueryHandler extends CustomizingStatementHandler
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
         String sql = config.getSqlLocator().locate(sqlObjectType, method);
-        Query<?> q = handle.get().createQuery(sql);
+        Query<?> q = handle.getHandle().createQuery(sql);
         applyCustomizers(q, args);
         applyBinders(q, args);
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ReleaseCheckpointHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ReleaseCheckpointHandler.java
@@ -22,7 +22,7 @@ class ReleaseCheckpointHandler implements Handler
     @Override
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
-        handle.get().release(String.valueOf(args[0]));
+        handle.getHandle().release(String.valueOf(args[0]));
         return null;
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ResultReturnThing.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ResultReturnThing.java
@@ -16,11 +16,10 @@ package org.jdbi.v3.sqlobject;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Iterator;
-import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 
-import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.HandleSupplier;
 import org.jdbi.v3.core.Query;
 import org.jdbi.v3.core.ResultBearing;
 import org.jdbi.v3.core.ResultIterator;
@@ -32,7 +31,7 @@ import org.jdbi.v3.core.util.GenericTypes;
 
 abstract class ResultReturnThing
 {
-    public Object map(Method method, Query<?> q, Supplier<Handle> handle)
+    public Object map(Method method, Query<?> q, HandleSupplier handle)
     {
         if (method.isAnnotationPresent(UseRowMapper.class)) {
             final RowMapper<?> mapper;
@@ -73,7 +72,7 @@ abstract class ResultReturnThing
         }
     }
 
-    protected abstract Object result(ResultBearing<?> q, Supplier<Handle> handle);
+    protected abstract Object result(ResultBearing<?> q, HandleSupplier handle);
 
     protected abstract Type elementType(StatementContext ctx);
 
@@ -89,7 +88,7 @@ abstract class ResultReturnThing
         }
 
         @Override
-        protected Object result(ResultBearing<?> q, Supplier<Handle> handle) {
+        protected Object result(ResultBearing<?> q, HandleSupplier handle) {
             return q.stream();
         }
 
@@ -110,7 +109,7 @@ abstract class ResultReturnThing
 
         @Override
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        protected Object result(ResultBearing<?> q, Supplier<Handle> handle)
+        protected Object result(ResultBearing<?> q, HandleSupplier handle)
         {
             if (q instanceof Query) {
                 Collector collector = ((Query)q).getContext().findCollectorFor(returnType).orElse(null);
@@ -143,7 +142,7 @@ abstract class ResultReturnThing
         }
 
         @Override
-        protected Object result(ResultBearing<?> q, Supplier<Handle> handle)
+        protected Object result(ResultBearing<?> q, HandleSupplier handle)
         {
             return q;
         }
@@ -167,7 +166,7 @@ abstract class ResultReturnThing
         }
 
         @Override
-        protected Object result(ResultBearing<?> q, final Supplier<Handle> handle)
+        protected Object result(ResultBearing<?> q, final HandleSupplier handle)
         {
             final ResultIterator<?> itty = q.iterator();
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/RollbackCheckpointHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/RollbackCheckpointHandler.java
@@ -22,7 +22,7 @@ class RollbackCheckpointHandler implements Handler
     @Override
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
-        handle.get().rollback(String.valueOf(args[0]));
+        handle.getHandle().rollback(String.valueOf(args[0]));
         return null;
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/RollbackHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/RollbackHandler.java
@@ -22,7 +22,7 @@ class RollbackHandler implements Handler
     @Override
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
-        handle.get().rollback();
+        handle.getHandle().rollback();
         return null;
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/TransactionDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/TransactionDecorator.java
@@ -37,7 +37,7 @@ class TransactionDecorator implements Handler
     @Override
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle) throws Exception
     {
-        Handle h = handle.get();
+        Handle h = handle.getHandle();
 
         if (h.isInTransaction()) {
             TransactionIsolationLevel currentLevel = h.getTransactionIsolationLevel();

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UpdateHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UpdateHandler.java
@@ -15,10 +15,8 @@ package org.jdbi.v3.sqlobject;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.function.Supplier;
 
 import org.jdbi.v3.core.GeneratedKeys;
-import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleSupplier;
 import org.jdbi.v3.core.Update;
 import org.jdbi.v3.core.exception.UnableToCreateStatementException;
@@ -72,7 +70,7 @@ class UpdateHandler extends CustomizingStatementHandler
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
         String sql = config.getSqlLocator().locate(sqlObjectType, method);
-        Update q = handle.get().createStatement(sql);
+        Update q = handle.getHandle().createStatement(sql);
         applyCustomizers(q, args);
         applyBinders(q, args);
         return this.returner.value(q, handle);
@@ -81,7 +79,7 @@ class UpdateHandler extends CustomizingStatementHandler
 
     private interface Returner
     {
-        Object value(Update update, Supplier<Handle> handle);
+        Object value(Update update, HandleSupplier handle);
     }
 
     private boolean returnTypeIsInvalid(Class<?> type) {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectMethodBehavior.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectMethodBehavior.java
@@ -42,7 +42,7 @@ public class TestSqlObjectMethodBehavior {
             }
 
             @Override
-            public Handle get() {
+            public Handle getHandle() {
                 throw new UnsupportedOperationException();
             }
         };


### PR DESCRIPTION
Just a small refactor so that documentation is more complete.

HandleSupplier used to implement Supplier<Handle> but now we just declare out own method for this, with our own JDBI-specific documentation.