### PR TITLE
Type-safe version of DBIFactoryBean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <project.build.targetJdk>1.6</project.build.targetJdk>
         <basepom.maven.version>2.0.9</basepom.maven.version>
         <dep.antlr.version>3.4</dep.antlr.version>
-        <dep.spring.version>2.0.1</dep.spring.version>
+        <dep.spring.version>3.0.0.RELEASE</dep.spring.version>
         <basepom.check.fail-all>true</basepom.check.fail-all>
 
         <basepom.test.fork-count>8</basepom.test.fork-count>
@@ -118,7 +118,21 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring</artifactId>
+            <artifactId>spring-beans</artifactId>
+            <version>${dep.spring.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>${dep.spring.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
             <version>${dep.spring.version}</version>
             <optional>true</optional>
         </dependency>
@@ -190,7 +204,7 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-mock</artifactId>
+            <artifactId>spring-test</artifactId>
             <version>${dep.spring.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/skife/jdbi/v2/spring/DBIFactoryBean.java
+++ b/src/main/java/org/skife/jdbi/v2/spring/DBIFactoryBean.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * Utility class which constructs an IDBI instance which can conveniently participate
  * in Spring's transaction management system.
  */
-public class DBIFactoryBean implements FactoryBean, InitializingBean
+public class DBIFactoryBean implements FactoryBean<IDBI>, InitializingBean
 {
     private DataSource dataSource;
     private StatementLocator statementLocator;
@@ -49,7 +49,7 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
      * See org.springframework.beans.factory.FactoryBean#getObject
      */
     @Override
-    public Object getObject() throws Exception
+    public IDBI getObject() throws Exception
     {
         final DBI dbi = new DBI(new SpringDataSourceConnectionFactory(dataSource));
         if (statementLocator != null) {
@@ -67,7 +67,7 @@ public class DBIFactoryBean implements FactoryBean, InitializingBean
      * See org.springframework.beans.factory.FactoryBean#getObjectType
      */
     @Override
-    public Class<?> getObjectType()
+    public Class<IDBI> getObjectType()
     {
         return IDBI.class;
     }

--- a/src/test/resources/org/skife/jdbi/v2/spring/test-context.xml
+++ b/src/test/resources/org/skife/jdbi/v2/spring/test-context.xml
@@ -33,7 +33,11 @@
     <bean id="derby" factory-bean="derbyFactory" factory-method="getDataSource" />
 
     <bean id="dbi" class="org.skife.jdbi.v2.spring.DBIFactoryBean">
-        <property name="dataSource" ref="derby"/>
+        <property name="dataSource">
+            <bean class="org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy">
+                <constructor-arg ref="derby"/>
+            </bean>
+        </property>
     </bean>
 
     <!--suppress SpringBeanConstructorArgInspection -->


### PR DESCRIPTION
I updated `DBIFactoryBean` to specify a generic type so it can be used to autowire by type. I had to update the Spring dependency so picked the lowest version that provided `FactoryBean<T>`. In the newer version of Spring it's also necessary to explicitly proxy the `DataSource` used by `DBIFactoryBean` for transaction-awareness.