### PR TITLE
Reuse a Postgres instance during tests

### DIFF
--- a/docs/src/test/java/jdbi/doc/TransactionTest.java
+++ b/docs/src/test/java/jdbi/doc/TransactionTest.java
@@ -37,6 +37,7 @@ import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.jdbi.v3.core.transaction.TransactionStatus;
 import org.jdbi.v3.sqlobject.mixins.GetHandle;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -44,8 +45,9 @@ import org.junit.rules.ExpectedException;
 import jdbi.doc.ResultsTest.User;
 
 public class TransactionTest {
-    @Rule
-    public PostgresDbRule db = new PostgresDbRule();
+
+    @ClassRule
+    public static PostgresDbRule db = new PostgresDbRule();
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -62,10 +64,13 @@ public class TransactionTest {
 
     @Before
     public void setUp() throws Exception {
-        handle.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR)");
-        for (String name : Arrays.asList("Alice", "Bob", "Charlie", "Data")) {
-            handle.execute("INSERT INTO users(name) VALUES (?)", name);
-        }
+        handle.useTransaction((th, status) -> {
+            th.execute("DROP TABLE IF EXISTS users");
+            th.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR)");
+            for (String name : Arrays.asList("Alice", "Bob", "Charlie", "Data")) {
+                th.execute("INSERT INTO users(name) VALUES (?)", name);
+            }
+        });
     }
 
     @Test

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestPostgresJsr310.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestPostgresJsr310.java
@@ -24,19 +24,23 @@ import java.time.ZoneOffset;
 
 import org.jdbi.v3.core.Handle;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 public class TestPostgresJsr310 {
-    @Rule
-    public PostgresDbRule db = new PostgresDbRule();
+
+    @ClassRule
+    public static PostgresDbRule db = new PostgresDbRule();
 
     Handle h;
 
     @Before
     public void setUp() {
         h = db.getSharedHandle();
-        h.execute("create table stuff (ts timestamp, d date)");
+        h.useTransaction((th, status) -> {
+            th.execute("drop table if exists stuff");
+            th.execute("create table stuff (ts timestamp, d date)");
+        });
     }
 
     @Test

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
@@ -25,10 +25,7 @@ import java.util.stream.IntStream;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.SqlQuery;
 import org.jdbi.v3.sqlobject.SqlUpdate;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 
 public class TestSqlArrays {
     private static final String U_SELECT = "SELECT u FROM uuids";
@@ -36,15 +33,19 @@ public class TestSqlArrays {
     private static final String I_SELECT = "SELECT i FROM uuids";
     private static final String I_INSERT = "INSERT INTO uuids VALUES(NULL, :ints)";
 
-    @Rule
-    public PostgresDbRule db = new PostgresDbRule();
+    @ClassRule
+    public static PostgresDbRule db = new PostgresDbRule();
+
     private Handle h;
     private ArrayObject ao;
 
     @Before
     public void setUp() {
         h = db.getSharedHandle();
-        h.execute("CREATE TABLE uuids (u UUID[], i INT[])");
+        h.useTransaction((th, status) -> {
+            th.execute("DROP TABLE IF EXISTS uuids");
+            th.execute("CREATE TABLE uuids (u UUID[], i INT[])");
+        });
         ao = h.attach(ArrayObject.class);
     }
 

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestUuid.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestUuid.java
@@ -22,21 +22,22 @@ import java.util.UUID;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.SqlQuery;
 import org.jdbi.v3.sqlobject.SqlUpdate;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 
 public class TestUuid {
-    @Rule
-    public PostgresDbRule db = new PostgresDbRule();
+
+    @ClassRule
+    public static PostgresDbRule db = new PostgresDbRule();
 
     public Handle h;
 
     @Before
     public void setupDbi() throws Exception {
         h = db.getJdbi().open();
-        h.execute("CREATE TABLE foo (bar UUID)");
+        h.useTransaction((th, status) -> {
+            th.execute("DROP TABLE IF EXISTS foo");
+            th.execute("CREATE TABLE foo (bar UUID)");
+        });
     }
 
     @After


### PR DESCRIPTION
Starting up and shutting down a Postgres instance are rather heavy operations. As a consequence of this, unit tests for the Postgres module takes a considerable amount of time (1 min). We could speed this process up, by reusing `PostgresDbRule` on the unit class level, and recreating the relevant table before every test. This should be a more fast process (~15 sec), because dropping and creating tables are relatively cheap operations.