### PR TITLE
Upgrade Mockito to 2.1.0-RC.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,12 +319,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.objenesis</groupId>
-                <artifactId>objenesis</artifactId>
-                <version>2.2</version>
-            </dependency>
-
-            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
@@ -339,7 +333,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.0.34-beta</version>
+                <version>2.1.0-RC.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
2.0.34-beta has doesn't work with JDK9. See https://github.com/mockito/mockito/issues/355. This update should allow to us to test JDBI against early builds of JDK9.