### PR TITLE
Map null results to absent optional values in SqlObject API

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/collector/OptionalBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/OptionalBuilder.java
@@ -25,7 +25,7 @@ class OptionalBuilder<T> {
                             optional.get(),
                             value));
         }
-        optional = Optional.of(value);
+        optional = Optional.ofNullable(value);
     }
 
     public Optional<T> build() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOptional.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOptional.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject;
 
 import com.google.common.collect.ImmutableList;
+import org.assertj.core.api.Assertions;
 import org.jdbi.v3.core.H2DatabaseRule;
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.sqlobject.customizers.RegisterRowMapper;
@@ -58,6 +59,12 @@ public class TestOptional {
     @Test
     public void testOptionalReturnAbsent() {
         assertThat(dao.findNameById(3), equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void testNullReturnsAbsent() {
+        dao.insert(3, null);
+        Assertions.assertThat(dao.findNameById(3)).isEmpty();
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
Currently we use `Optional` in the SqlObject API to indicate the absence of result in a response. But many developers expect that null values will map to optional absent values as well.
Unfortunately, we don't have two different optional abstraction to represent this use cases, so we have to mix these use cases. On the pragmatic point of view, this change provides better developer experience, because developers can effectively work with nullable values inside the `SqlObjectAPI`. Also, it consistent with the logic when results are presented as plain null values.