### PR TITLE
Rename `createStatement` to `createUpdate`

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -282,7 +282,7 @@ public class Handle implements Closeable
      * @return the number of updated inserted
      */
     public int update(String sql, Object... args) {
-        Update stmt = createStatement(sql);
+        Update stmt = createUpdate(sql);
         int position = 0;
         for (Object arg : args) {
             stmt.bind(position++, arg);
@@ -372,7 +372,7 @@ public class Handle implements Closeable
      *
      * @return the Update
      */
-    public Update createStatement(String sql) {
+    public Update createUpdate(String sql) {
         JdbiConfig updateConfig = JdbiConfig.copyOf(config);
         return new Update(updateConfig,
                           this,

--- a/core/src/test/java/org/jdbi/v3/core/TestArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestArgumentFactory.java
@@ -35,7 +35,7 @@ public class TestArgumentFactory
         final Jdbi dbi = db.getJdbi();
         dbi.registerArgumentFactory(new NameAF());
         try (Handle h = dbi.open()) {
-            h.createStatement("insert into something (id, name) values (:id, :name)")
+            h.createUpdate("insert into something (id, name) values (:id, :name)")
               .bind("id", 7)
               .bind("name", new Name("Brian", "McCallister"))
               .execute();
@@ -51,7 +51,7 @@ public class TestArgumentFactory
     {
         try (Handle h = db.openHandle()) {
             h.registerArgumentFactory(new NameAF());
-            h.createStatement("insert into something (id, name) values (:id, :name)")
+            h.createUpdate("insert into something (id, name) values (:id, :name)")
              .bind("id", 7)
              .bind("name", new Name("Brian", "McCallister"))
              .execute();
@@ -65,7 +65,7 @@ public class TestArgumentFactory
     @Test
     public void testRegisterOnStatement() throws Exception
     {
-        db.getSharedHandle().createStatement("insert into something (id, name) values (:id, :name)")
+        db.getSharedHandle().createUpdate("insert into something (id, name) values (:id, :name)")
          .registerArgumentFactory(new NameAF())
          .bind("id", 1)
          .bind("name", new Name("Brian", "McCallister"))

--- a/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
@@ -42,8 +42,8 @@ public class TestClosingHandle
 
     @Test
     public void testNotClosing() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
 
         List<Map<String, Object>> results = h.createQuery("select * from something order by id").list();
         assertThat(results).hasSize(2);
@@ -53,8 +53,8 @@ public class TestClosingHandle
 
     @Test
     public void testClosing() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
 
         List<Map<String, Object>> results = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -67,8 +67,8 @@ public class TestClosingHandle
 
     @Test
     public void testIterateKeepHandle() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .iterator();
@@ -79,8 +79,8 @@ public class TestClosingHandle
 
     @Test
     public void testIterateAllTheWay() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -92,9 +92,9 @@ public class TestClosingHandle
 
     @Test
     public void testIteratorBehaviour() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
-        h.createStatement("insert into something (id, name) values (3, 'john')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (3, 'john')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -115,9 +115,9 @@ public class TestClosingHandle
 
     @Test
     public void testIteratorClose() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
-        h.createStatement("insert into something (id, name) values (3, 'john')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (3, 'john')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()

--- a/core/src/test/java/org/jdbi/v3/core/TestIterator.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestIterator.java
@@ -42,9 +42,9 @@ public class TestIterator
 
     @Test
     public void testSimple() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
-        h.createStatement("insert into something (id, name) values (3, 'john')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (3, 'john')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -70,9 +70,9 @@ public class TestIterator
 
     @Test
     public void testHasNext() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
-        h.createStatement("insert into something (id, name) values (3, 'john')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (3, 'john')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -97,9 +97,9 @@ public class TestIterator
 
     @Test
     public void testNext() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
-        h.createStatement("insert into something (id, name) values (3, 'john')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (3, 'john')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -114,9 +114,9 @@ public class TestIterator
 
     @Test
     public void testJustNext() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
-        h.createStatement("insert into something (id, name) values (3, 'john')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (3, 'john')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -129,9 +129,9 @@ public class TestIterator
 
     @Test
     public void testTwoTwo() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
-        h.createStatement("insert into something (id, name) values (3, 'john')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (3, 'john')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -148,9 +148,9 @@ public class TestIterator
 
     @Test
     public void testTwoOne() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
-        h.createStatement("insert into something (id, name) values (3, 'john')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (3, 'john')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -166,9 +166,9 @@ public class TestIterator
 
     @Test(expected = IllegalStateException.class)
     public void testExplodeIterator() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
-        h.createStatement("insert into something (id, name) values (3, 'john')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (3, 'john')").execute();
 
         ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
             .cleanupHandle()
@@ -202,7 +202,7 @@ public class TestIterator
 
     @Test
     public void testNonPathologicalJustNext() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
 
         // Yes, you *should* use first(). But sometimes, an iterator is passed 17 levels deep and then
         // used in this way (Hello Jackson!).
@@ -217,8 +217,8 @@ public class TestIterator
 
     @Test
     public void testStillLeakingJustNext() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
 
         // Yes, you *should* use first(). But sometimes, an iterator is passed 17 levels deep and then
         // used in this way (Hello Jackson!).
@@ -243,8 +243,8 @@ public class TestIterator
 
     @Test
     public void testLessLeakingJustNext() throws Exception {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
 
         try (final ResultIterator<Map<String, Object>> it = h.createQuery("select * from something order by id")
                 .cleanupHandle()

--- a/core/src/test/java/org/jdbi/v3/core/TestNamedParams.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestNamedParams.java
@@ -31,7 +31,7 @@ public class TestNamedParams
     public void testInsert() throws Exception
     {
         Handle h = db.openHandle();
-        Update insert = h.createStatement("insert into something (id, name) values (:id, :name)");
+        Update insert = h.createUpdate("insert into something (id, name) values (:id, :name)");
         insert.bind("id", 1);
         insert.bind("name", "Brian");
         int count = insert.execute();
@@ -42,7 +42,7 @@ public class TestNamedParams
     public void testDemo() throws Exception
     {
         Handle h = db.getSharedHandle();
-        h.createStatement("insert into something (id, name) values (:id, :name)")
+        h.createUpdate("insert into something (id, name) values (:id, :name)")
                 .bind("id", 1)
                 .bind("name", "Brian")
                 .execute();
@@ -63,7 +63,7 @@ public class TestNamedParams
     public void testBeanPropertyBinding() throws Exception
     {
         Handle h = db.openHandle();
-        Update s = h.createStatement("insert into something (id, name) values (:id, :name)");
+        Update s = h.createUpdate("insert into something (id, name) values (:id, :name)");
         s.bindBean(new Something(0, "Keith"));
         int insert_count = s.execute();
         assertThat(insert_count).isEqualTo(1);
@@ -73,7 +73,7 @@ public class TestNamedParams
     public void testMapKeyBinding() throws Exception
     {
         Handle h = db.openHandle();
-        Update s = h.createStatement("insert into something (id, name) values (:id, :name)");
+        Update s = h.createUpdate("insert into something (id, name) values (:id, :name)");
         Map<String, Object> args = new HashMap<>();
         args.put("id", 0);
         args.put("name", "Keith");
@@ -86,7 +86,7 @@ public class TestNamedParams
     public void testCascadedLazyArgs() throws Exception
     {
         Handle h = db.openHandle();
-        Update s = h.createStatement("insert into something (id, name) values (:id, :name)");
+        Update s = h.createUpdate("insert into something (id, name) values (:id, :name)");
         Map<String, Object> args = new HashMap<>();
         args.put("id", 0);
         s.bindMap(args);

--- a/core/src/test/java/org/jdbi/v3/core/TestOptional.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestOptional.java
@@ -43,8 +43,8 @@ public class TestOptional {
     @Before
     public void createTestData() {
         handle = db.openHandle();
-        handle.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        handle.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        handle.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        handle.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/TestPositionalParameterBinding.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestPositionalParameterBinding.java
@@ -82,7 +82,7 @@ public class TestPositionalParameterBinding
     @Test
     public void testInsertParamBinding() throws Exception
     {
-        int count = h.createStatement("insert into something (id, name) values (?, 'eric')")
+        int count = h.createUpdate("insert into something (id, name) values (?, 'eric')")
                 .bind(0, 1)
                 .execute();
 

--- a/core/src/test/java/org/jdbi/v3/core/TestQueries.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestQueries.java
@@ -60,8 +60,8 @@ public class TestQueries
     @Test
     public void testCreateQueryObject() throws Exception
     {
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
 
         List<Map<String, Object>> results = h.createQuery("select * from something order by id").list();
         assertThat(results).hasSize(2);
@@ -346,7 +346,7 @@ public class TestQueries
         expectedException.expect(StatementException.class);
         expectedException.expectMessage("arguments:{ positional:{7:8}, named:{name:brian}, finder:[{one=two},{lazy bean property arguments \"java.lang.Object");
 
-        h.createStatement("insert into something (id, name) values (:id, :name)")
+        h.createUpdate("insert into something (id, name) values (:id, :name)")
                 .bind("name", "brian")
                 .bind(7, 8)
                 .bindMap(new HandyMapThing<String>().add("one", "two"))

--- a/core/src/test/java/org/jdbi/v3/core/TestStatementContext.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestStatementContext.java
@@ -27,7 +27,7 @@ public class TestStatementContext
     public void testFoo() throws Exception
     {
         Handle h = db.openHandle();
-        final int inserted = h.createStatement("insert into <table> (id, name) values (:id, :name)")
+        final int inserted = h.createUpdate("insert into <table> (id, name) values (:id, :name)")
                 .bind("id", 7)
                 .bind("name", "Martin")
                 .define("table", "something")

--- a/core/src/test/java/org/jdbi/v3/core/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestStatements.java
@@ -42,7 +42,7 @@ public class TestStatements
     @Test
     public void testStatement() throws Exception
     {
-        int rows = h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
+        int rows = h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
         assertThat(rows).isEqualTo(1);
     }
 
@@ -57,7 +57,7 @@ public class TestStatements
     public void testUpdate() throws Exception
     {
         h.insert("insert into something (id, name) values (1, 'eric')");
-        h.createStatement("update something set name = 'ERIC' where id = 1").execute();
+        h.createUpdate("update something set name = 'ERIC' where id = 1").execute();
         Something eric = h.createQuery("select * from something where id = 1").mapToBean(Something.class).list().get(0);
         assertThat(eric.getName()).isEqualTo("ERIC");
     }

--- a/core/src/test/java/org/jdbi/v3/core/TestTimingCollector.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestTimingCollector.java
@@ -61,7 +61,7 @@ public class TestTimingCollector
     @Test
     public void testStatement() throws Exception
     {
-        int rows = h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
+        int rows = h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
         assertThat(rows).isEqualTo(1);
     }
 
@@ -84,7 +84,7 @@ public class TestTimingCollector
         String stmt3 = "select * from something where id = 1";
 
         h.insert(stmt1);
-        h.createStatement(stmt2).execute();
+        h.createUpdate(stmt2).execute();
         Something eric = h.createQuery(stmt3).mapToBean(Something.class).list().get(0);
         assertThat(eric.getName()).isEqualTo("ERIC");
 

--- a/core/src/test/java/org/jdbi/v3/core/TestUpdateGeneratedKeys.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestUpdateGeneratedKeys.java
@@ -43,13 +43,13 @@ public class TestUpdateGeneratedKeys
     {
         Handle h = db.openHandle();
 
-        Update insert1 = h.createStatement("insert into something_else (name) values (:name)");
+        Update insert1 = h.createUpdate("insert into something_else (name) values (:name)");
         insert1.bind("name", "Brian");
         Long id1 = insert1.executeAndReturnGeneratedKeys(long.class).findOnly();
 
         assertThat(id1).isNotNull();
 
-        Update insert2 = h.createStatement("insert into something_else (name) values (:name)");
+        Update insert2 = h.createUpdate("insert into something_else (name) values (:name)");
         insert2.bind("name", "Tom");
         Long id2 = insert2.executeAndReturnGeneratedKeys(long.class).findOnly();
 
@@ -62,13 +62,13 @@ public class TestUpdateGeneratedKeys
     {
         Handle h = db.openHandle();
 
-        Update insert = h.createStatement("insert into something_else (name) values (:name)");
+        Update insert = h.createUpdate("insert into something_else (name) values (:name)");
         insert.bind("name", "Brian");
         Long id1 = insert.executeAndReturnGeneratedKeys(long.class).findOnly();
 
         assertThat(id1).isNotNull();
 
-        Update update = h.createStatement("update something_else set name = :name where id = :id");
+        Update update = h.createUpdate("update something_else set name = :name where id = :id");
         update.bind("id", id1);
         update.bind("name", "Tom");
         Optional<Long> id2 = update.executeAndReturnGeneratedKeys(long.class).findFirst();
@@ -81,13 +81,13 @@ public class TestUpdateGeneratedKeys
     {
         Handle h = db.openHandle();
 
-        Update insert = h.createStatement("insert into something_else (name) values (:name)");
+        Update insert = h.createUpdate("insert into something_else (name) values (:name)");
         insert.bind("name", "Brian");
         Long id1 = insert.executeAndReturnGeneratedKeys(long.class).findOnly();
 
         assertThat(id1).isNotNull();
 
-        Update delete = h.createStatement("delete from something_else where id = :id");
+        Update delete = h.createUpdate("delete from something_else where id = :id");
         delete.bind("id", id1);
         Optional<Long> id2 = delete.executeAndReturnGeneratedKeys(long.class).findFirst();
 

--- a/core/src/test/java/org/jdbi/v3/core/TestUri.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestUri.java
@@ -30,7 +30,7 @@ public class TestUri
     public void testUri() throws Exception
     {
         Handle h = db.openHandle();
-        h.createStatement("insert into something (id, name) values (1, :uri)")
+        h.createUpdate("insert into something (id, name) values (1, :uri)")
             .bind("uri", TEST_URI).execute();
 
         assertThat(h.createQuery("SELECT name FROM something")

--- a/core/src/test/java/org/jdbi/v3/core/TestUuid.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestUuid.java
@@ -45,7 +45,7 @@ public class TestUuid {
     @Test
     public void testUuid() throws Exception {
         UUID u = UUID.randomUUID();
-        h.createStatement("INSERT INTO foo VALUES (:uuid)")
+        h.createUpdate("INSERT INTO foo VALUES (:uuid)")
             .bind("uuid", u)
             .execute();
 

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestInetAddressH2.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestInetAddressH2.java
@@ -39,11 +39,11 @@ public class TestInetAddressH2
             InetAddress ipv4 = InetAddress.getByName("1.2.3.4");
             InetAddress ipv6 = InetAddress.getByName("fe80::226:8ff:fefa:d1e3");
 
-            h.createStatement(insert)
+            h.createUpdate(insert)
                 .bind(0, ipv4)
                 .execute();
 
-            h.createStatement(insert)
+            h.createUpdate(insert)
                 .bind(0, ipv6)
                 .execute();
 

--- a/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
@@ -58,7 +58,7 @@ public class TestClasspathSqlLocator {
     @Test
     public void testNamedParamsInExternal() throws Exception {
         Handle h = db.openHandle();
-        h.createStatement(findSqlOnClasspath("insert-id-name"))
+        h.createUpdate(findSqlOnClasspath("insert-id-name"))
                 .bind("id", 1)
                 .bind("name", "Tip")
                 .execute();
@@ -72,7 +72,7 @@ public class TestClasspathSqlLocator {
         exception.expect(StatementException.class);
         exception.expectMessage("insert into something(id, name) values (:id, :name)");
         exception.expectMessage("insert into something(id, name) values (?, ?)");
-        h.createStatement(findSqlOnClasspath("insert-id-name"))
+        h.createUpdate(findSqlOnClasspath("insert-id-name"))
                 .bind("id", 1)
                 .execute();
     }

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
@@ -63,8 +63,8 @@ public class TestEnums
     public void testMapEnumValues() throws Exception
     {
         Handle h = db.openHandle();
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
 
         List<SomethingElse> results = h.createQuery("select * from something order by id")
                                    .mapToBean(SomethingElse.class)
@@ -76,8 +76,8 @@ public class TestEnums
     public void testMapToEnum() throws Exception
     {
         Handle h = db.openHandle();
-        h.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        h.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        h.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
 
         List<SomethingElse.Name> results = h.createQuery("select name from something order by id")
                                    .mapTo(SomethingElse.Name.class)
@@ -89,7 +89,7 @@ public class TestEnums
     public void testMapInvalidEnumValue() throws SQLException
     {
         Handle h = db.openHandle();
-        h.createStatement("insert into something (id, name) values (1, 'joe')").execute();
+        h.createUpdate("insert into something (id, name) values (1, 'joe')").execute();
 
         h.createQuery("select * from something order by id")
                 .mapToBean(SomethingElse.class)

--- a/docs/src/test/java/jdbi/doc/HelloWorldTest.java
+++ b/docs/src/test/java/jdbi/doc/HelloWorldTest.java
@@ -31,12 +31,12 @@ public class HelloWorldTest {
         // Easy scope-based transactions
         List<User> users = dbi.inTransaction((handle, status) -> {
             handle.execute("CREATE TABLE user (id INTEGER PRIMARY KEY, name VARCHAR)");
-            handle.createStatement("INSERT INTO user(id, name) VALUES (:id, :name)")
+            handle.createUpdate("INSERT INTO user(id, name) VALUES (:id, :name)")
                 .bind("id", 0)   // Bind arguments by name
                 .bind(1, "You!") // Or by 0-indexed position
                 .execute();
 
-            handle.createStatement("INSERT INTO user(id, name) VALUES (:id, :name)")
+            handle.createUpdate("INSERT INTO user(id, name) VALUES (:id, :name)")
                 .bindBean(new User(1, "Me")) // You can also bind custom types
                 .execute();
 

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaOptional.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaOptional.java
@@ -46,8 +46,8 @@ public class TestGuavaOptional {
     @Before
     public void createTestData() {
         handle = db.openHandle();
-        handle.createStatement("insert into something (id, name) values (1, 'eric')").execute();
-        handle.createStatement("insert into something (id, name) values (2, 'brian')").execute();
+        handle.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        handle.createUpdate("insert into something (id, name) values (2, 'brian')").execute();
     }
 
     @Test

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestUuid.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestUuid.java
@@ -48,7 +48,7 @@ public class TestUuid {
     @Test
     public void testUuid() throws Exception {
         UUID u = UUID.randomUUID();
-        h.createStatement("INSERT INTO foo VALUES (:uuid)")
+        h.createUpdate("INSERT INTO foo VALUES (:uuid)")
             .bind("uuid", u)
             .execute();
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UpdateHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UpdateHandler.java
@@ -70,7 +70,7 @@ class UpdateHandler extends CustomizingStatementHandler
     public Object invoke(Object target, Method method, Object[] args, SqlObjectConfig config, HandleSupplier handle)
     {
         String sql = config.getSqlLocator().locate(sqlObjectType, method);
-        Update q = handle.getHandle().createStatement(sql);
+        Update q = handle.getHandle().createUpdate(sql);
         applyCustomizers(q, args);
         applyBinders(q, args);
         return this.returner.value(q, handle);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanMapperFactory.java
@@ -75,18 +75,18 @@ public class TestBeanMapperFactory
     @Before
     public void createTable() throws Exception {
         h = db.openHandle();
-        h.createStatement("create table testBean (valueType varchar(50))").execute();
+        h.createUpdate("create table testBean (valueType varchar(50))").execute();
         dao = h.attach(TestDao.class);
     }
 
     @After
     public void dropTable() {
-        h.createStatement("drop table testBean").execute();
+        h.createUpdate("drop table testBean").execute();
     }
 
     @Test
     public void testMapBean() {
-        h.createStatement("insert into testBean (valueType) values ('foo')").execute();
+        h.createUpdate("insert into testBean (valueType) values ('foo')").execute();
 
         List<TestBean> beans = dao.listBeans();
         assertThat(beans).extracting(TestBean::getValueType).containsExactly(ValueType.valueOf("foo"));
@@ -94,7 +94,7 @@ public class TestBeanMapperFactory
 
     @Test
     public void testBuiltInColumnMappers() {
-        h.createStatement("insert into testBean (valueType) values ('foo')").execute();
+        h.createUpdate("insert into testBean (valueType) values ('foo')").execute();
 
         List<String> strings = dao.listStrings();
         assertThat(strings).containsExactly("foo");
@@ -105,7 +105,7 @@ public class TestBeanMapperFactory
 
     @Test
     public void testCustomColumnMapper() {
-        h.createStatement("insert into testBean (valueType) values ('foo')").execute();
+        h.createUpdate("insert into testBean (valueType) values ('foo')").execute();
 
         List<ValueType> valueTypes = dao.listValueTypes();
         assertThat(valueTypes).containsExactly(ValueType.valueOf("foo"));

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindInParameter.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindInParameter.java
@@ -37,7 +37,7 @@ public class TestBindInParameter {
         dbi = Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID());
         dbi.installPlugin(new SqlObjectPlugin());
         handle = dbi.open();
-        handle.createStatement(
+        handle.createUpdate(
                 "create table foo (id int, bar varchar(100) default null);")
                 .execute();
         dao = dbi.onDemand(MyDAO.class);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestColumnMappers.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestColumnMappers.java
@@ -130,7 +130,7 @@ public class TestColumnMappers
     @Before
     public void createTable() throws Exception {
         h = db.openHandle();
-        h.createStatement(
+        h.createUpdate(
             "create table someBean (" +
             "  primitiveInt integer, wrapperLong bigint, " +
             "  primitiveChar varchar(1), wrappedChar varchar(1), " +
@@ -142,12 +142,12 @@ public class TestColumnMappers
 
     @After
     public void dropTable() {
-        h.createStatement("drop table someBean").execute();
+        h.createUpdate("drop table someBean").execute();
     }
 
     @Test
     public void testMapPrimitiveInt() throws Exception {
-        h.createStatement("insert into someBean (primitiveInt) values (15)").execute();
+        h.createUpdate("insert into someBean (primitiveInt) values (15)").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getPrimitiveInt).containsExactly(15);
@@ -155,7 +155,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapPrimitiveIntFromNull() throws Exception {
-        h.createStatement("insert into someBean (primitiveInt) values (null)").execute();
+        h.createUpdate("insert into someBean (primitiveInt) values (null)").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getPrimitiveInt).containsExactly(0);
@@ -163,7 +163,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapPrimitiveChar() throws Exception {
-        h.createStatement("insert into someBean (primitiveChar) values ('c')").execute();
+        h.createUpdate("insert into someBean (primitiveChar) values ('c')").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getPrimitiveChar).containsExactly('c');
@@ -171,7 +171,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapPrimitiveCharFromEmpty() throws Exception {
-        h.createStatement("insert into someBean (primitiveChar) values ('')").execute();
+        h.createUpdate("insert into someBean (primitiveChar) values ('')").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getPrimitiveChar).containsExactly('\000');
@@ -179,7 +179,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapPrimitiveCharFromNull() throws Exception {
-        h.createStatement("insert into someBean (primitiveChar) values (null)").execute();
+        h.createUpdate("insert into someBean (primitiveChar) values (null)").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getPrimitiveChar).containsExactly('\000');
@@ -187,7 +187,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapWrappedChar() throws Exception {
-        h.createStatement("insert into someBean (wrappedChar) values ('c')").execute();
+        h.createUpdate("insert into someBean (wrappedChar) values ('c')").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getWrappedChar).containsExactly('c');
@@ -195,7 +195,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapWrappedCharFromEmpty() throws Exception {
-        h.createStatement("insert into someBean (wrappedChar) values ('')").execute();
+        h.createUpdate("insert into someBean (wrappedChar) values ('')").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getWrappedChar).hasSize(1).containsNull();
@@ -203,7 +203,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapWrappedCharFromNull() throws Exception {
-        h.createStatement("insert into someBean (wrappedChar) values (null)").execute();
+        h.createUpdate("insert into someBean (wrappedChar) values (null)").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getWrappedChar).hasSize(1).containsNull();
@@ -211,7 +211,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapWrapper() throws Exception {
-        h.createStatement("insert into someBean (wrapperLong) values (20)").execute();
+        h.createUpdate("insert into someBean (wrapperLong) values (20)").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getWrapperLong).containsExactly(20L);
@@ -219,7 +219,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapWrapperFromNull() throws Exception {
-        h.createStatement("insert into someBean (wrapperLong) values (null)").execute();
+        h.createUpdate("insert into someBean (wrapperLong) values (null)").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getWrapperLong).hasSize(1).containsNull();
@@ -227,7 +227,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapString() throws Exception {
-        h.createStatement("insert into someBean (string) values ('foo')").execute();
+        h.createUpdate("insert into someBean (string) values ('foo')").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getString).containsExactly("foo");
@@ -235,7 +235,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapStringFromNull() throws Exception {
-        h.createStatement("insert into someBean (string) values (null)").execute();
+        h.createUpdate("insert into someBean (string) values (null)").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getString).hasSize(1).containsNull();
@@ -243,7 +243,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapValueType() throws Exception {
-        h.createStatement("insert into someBean (valueType) values ('foo')").execute();
+        h.createUpdate("insert into someBean (valueType) values ('foo')").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getValueType).containsExactly(ValueType.valueOf("foo"));
@@ -251,7 +251,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapValueTypeFromNull() throws Exception {
-        h.createStatement("insert into someBean (valueType) values (null)").execute();
+        h.createUpdate("insert into someBean (valueType) values (null)").execute();
 
         List<SomeBean> beans = dao.listBeans();
         assertThat(beans).extracting(SomeBean::getValueType).hasSize(1).containsNull();
@@ -259,7 +259,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapValueTypeFromColumnMapperFactory() throws Exception {
-        h.createStatement("insert into someBean (valueType) values ('foo')").execute();
+        h.createUpdate("insert into someBean (valueType) values ('foo')").execute();
 
         List<SomeBean> beans = dao.listBeansFactoryMapped();
         assertThat(beans).extracting(SomeBean::getValueType).containsExactly(ValueType.valueOf("foo"));
@@ -267,7 +267,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapToValueTypeFromColumnMapper() throws Exception {
-        h.createStatement("insert into someBean (valueType) values ('foo')").execute();
+        h.createUpdate("insert into someBean (valueType) values ('foo')").execute();
 
         List<ValueType> list = dao.listValueTypes();
         assertThat(list).containsExactly(ValueType.valueOf("foo"));
@@ -275,7 +275,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapToValueTypeFromColumnMapperFactory() throws Exception {
-        h.createStatement("insert into someBean (valueType) values ('foo')").execute();
+        h.createUpdate("insert into someBean (valueType) values ('foo')").execute();
 
         List<ValueType> list = dao.listValueTypesFactoryMapped();
         assertThat(list).containsExactly(ValueType.valueOf("foo"));
@@ -283,7 +283,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapUri() throws Exception {
-        h.createStatement("insert into someBean (uri) values ('urn:foo')").execute();
+        h.createUpdate("insert into someBean (uri) values ('urn:foo')").execute();
 
         List<SomeBean> list = dao.listBeans();
         assertThat(list).extracting(SomeBean::getUri).containsExactly(new URI("urn:foo"));
@@ -291,7 +291,7 @@ public class TestColumnMappers
 
     @Test
     public void testMapUriFromNull() throws Exception {
-        h.createStatement("insert into someBean (uri) values (null)").execute();
+        h.createUpdate("insert into someBean (uri) values (null)").execute();
 
         List<SomeBean> list = dao.listBeans();
         assertThat(list).extracting(SomeBean::getUri).hasSize(1).containsNull();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDocumentation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDocumentation.java
@@ -101,7 +101,7 @@ public class TestDocumentation
     public void testFluentUpdate() throws Exception
     {
         try (Handle h = db.openHandle()) {
-            h.createStatement("insert into something(id, name) values (:id, :name)")
+            h.createUpdate("insert into something(id, name) values (:id, :name)")
                 .bind("id", 4)
                 .bind("name", "Martin")
                 .execute();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOnDemandSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOnDemandSqlObject.java
@@ -92,7 +92,7 @@ public class TestOnDemandSqlObject
             @Override
             public Handle customizeHandle(Handle handle) {
                 Handle h = spy(handle);
-                when(h.createStatement(anyString())).thenThrow(new TransactionException("connection reset"));
+                when(h.createUpdate(anyString())).thenThrow(new TransactionException("connection reset"));
                 doThrow(new UnableToCloseResourceException("already closed", null)).when(h).close();
                 return h;
             }


### PR DESCRIPTION
`Statement` is ambiguous -- it actually returns
an `Update` object (there is the abstract class
`SqlStatement`, but that covers other types too).

Other option would be to rename the `Update` class
to `Statement`, but that's too close to
`SqlStatement`.