### PR TITLE
Temporarily disable guava dependency check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,13 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-guava</artifactId>
                 <version>3.0.0</version>
+                <!-- XXX: https://github.com/joel-costigliola/assertj-guava/issues/33 -->
+                <exclusions>
+                  <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                  </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fallout from #509 -- assertJ depends on guava 20.0-rc1 (annoying!)
We can just hope they release before we do? *g*