### PR TITLE
Remove final modifier from StatementContext

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/StatementContext.java
@@ -33,7 +33,7 @@ import org.jdbi.v3.core.mapper.RowMapper;
  * to all statement customizers. This makes it possible to parameterize the processing of
  * the tweakable parts of the statement processing cycle.
  */
-public final class StatementContext
+public class StatementContext
 {
     private final JdbiConfig config;
     private final ExtensionMethod extensionMethod;

--- a/core/src/main/java/org/jdbi/v3/core/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/StatementContext.java
@@ -32,6 +32,9 @@ import org.jdbi.v3.core.mapper.RowMapper;
  * evaluation of a statement. The context is not used by jDBI internally, but will be passed
  * to all statement customizers. This makes it possible to parameterize the processing of
  * the tweakable parts of the statement processing cycle.
+ *
+ * DISCLAIMER: The class is not intended to be extended. The final modifier is absent to allow
+ * mock tools to create a mock object of this class in the user code.
  */
 public class StatementContext
 {
@@ -49,7 +52,7 @@ public class StatementContext
     private boolean           concurrentUpdatable;
     private String[]          generatedKeysColumnNames;
 
-    public StatementContext() {
+    StatementContext() {
         this(new JdbiConfig());
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/rewriter/TestColonStatementRewriter.java
+++ b/core/src/test/java/org/jdbi/v3/core/rewriter/TestColonStatementRewriter.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
+import org.mockito.Mockito;
 
 public class TestColonStatementRewriter
 {
@@ -43,8 +44,10 @@ public class TestColonStatementRewriter
     }
 
     private RewrittenStatement rewrite(String sql, Map<String, Object> attributes) {
-        StatementContext ctx = new StatementContext();
-        attributes.forEach(ctx::setAttribute);
+        StatementContext ctx = Mockito.mock(StatementContext.class);
+        for (Map.Entry<String, Object> e : attributes.entrySet()) {
+            Mockito.when(ctx.getAttribute(e.getKey())).thenReturn(e.getValue());
+        }
 
         return rw.rewrite(sql, new Binding(), ctx);
     }


### PR DESCRIPTION
`StatementContext` is exposed publicly from `TimingCollector`, so it makes sense to allow users to mock it to test their `TimingCollector` implementations.