### PR TITLE
[WIP] Support for enum Sets as bit strings

### DIFF
--- a/postgres/src/main/java/org/jdbi/v3/postgres/EnumSetArgument.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/EnumSetArgument.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.postgres;
+
+import org.jdbi.v3.core.StatementContext;
+import org.jdbi.v3.core.argument.Argument;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.EnumSet;
+
+public class EnumSetArgument implements Argument {
+
+    private Enum<?>[] enumConstants;
+    private EnumSet<?> elements;
+
+    public EnumSetArgument(Class<Enum<?>> enumType, EnumSet<?> elements) {
+        this.elements = elements;
+        enumConstants = enumType.getEnumConstants();
+    }
+
+    @Override
+    public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException {
+        if (elements == null) {
+            statement.setString(position, null);
+            return;
+        }
+
+        char[] bits = new char[enumConstants.length];
+        for (int i = 0; i < enumConstants.length; i++) {
+            bits[i] = elements.contains(enumConstants[i]) ? '1' : '0';
+        }
+        statement.setString(position, new String(bits));
+    }
+}

--- a/postgres/src/main/java/org/jdbi/v3/postgres/EnumSetArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/EnumSetArgumentFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.postgres;
+
+import org.jdbi.v3.core.StatementContext;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.argument.ArgumentFactory;
+import org.jdbi.v3.core.util.GenericTypes;
+
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+import java.util.Optional;
+
+public class EnumSetArgumentFactory implements ArgumentFactory {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<Argument> build(Type type, Object value, StatementContext ctx) {
+        Class<?> erasedType = GenericTypes.getErasedType(type);
+        if (EnumSet.class.isAssignableFrom(erasedType)) {
+            Optional<Type> genericParameter = GenericTypes.findGenericParameter(type, EnumSet.class);
+            Class<Enum<?>> enumType = (Class<Enum<?>>) genericParameter
+                    .orElseThrow(() -> new IllegalArgumentException("No generic type information for " + type));
+            return Optional.of(new EnumSetArgument(enumType, (EnumSet<?>) value));
+        }
+        return Optional.empty();
+    }
+}

--- a/postgres/src/main/java/org/jdbi/v3/postgres/EnumSetColumnMapper.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/EnumSetColumnMapper.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.postgres;
+
+import org.jdbi.v3.core.StatementContext;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.EnumSet;
+
+public class EnumSetColumnMapper<E extends Enum<E>> implements ColumnMapper<EnumSet<E>> {
+
+    private Class<E> enumType;
+    private E[] enumConstants;
+
+    public EnumSetColumnMapper(Class<E> enumType) {
+        this.enumType = enumType;
+        enumConstants = enumType.getEnumConstants();
+    }
+
+    @Override
+    public EnumSet<E> map(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        String bits = r.getString(columnNumber);
+        if (bits == null) {
+            return null;
+        }
+
+        EnumSet<E> elements = EnumSet.noneOf(enumType);
+        for (int i = 0; i < bits.length(); i++) {
+            char bit = bits.charAt(i);
+            if (bit != '0' && bit != '1') {
+                throw new IllegalArgumentException("Wrong element in a bit string: " + bits);
+            }
+            if (bit == '1') {
+                elements.add(enumConstants[i]);
+            }
+        }
+        return elements;
+    }
+}

--- a/postgres/src/main/java/org/jdbi/v3/postgres/EnumSetMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/EnumSetMapperFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.postgres;
+
+import org.jdbi.v3.core.StatementContext;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.ColumnMapperFactory;
+import org.jdbi.v3.core.util.GenericTypes;
+
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+import java.util.Optional;
+
+public class EnumSetMapperFactory implements ColumnMapperFactory {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<ColumnMapper<?>> build(Type type, StatementContext ctx) {
+        Class<?> erasedType = GenericTypes.getErasedType(type);
+        if (erasedType == EnumSet.class) {
+            Optional<Type> genericParameter = GenericTypes.findGenericParameter(type, EnumSet.class);
+            Type type1 = genericParameter
+                    .orElseThrow(() -> new IllegalArgumentException("No generic information for " + type));
+            if (Enum.class.isAssignableFrom((Class<?>) type1)) {
+                return Optional.of(new EnumSetColumnMapper<>((Class<Enum>) type1));
+            } else {
+                throw new IllegalArgumentException("Generic type is not enum");
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PostgresJdbiPlugin.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PostgresJdbiPlugin.java
@@ -30,5 +30,8 @@ public class PostgresJdbiPlugin implements JdbiPlugin {
 
         db.registerColumnMapper(new HStoreColumnMapper());
         db.registerArgumentFactory(new HStoreArgumentFactory());
+
+        db.registerColumnMapper(new EnumSetMapperFactory());
+        db.registerArgumentFactory(new EnumSetArgumentFactory());
     }
 }

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestEnumSets.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestEnumSets.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.postgres;
+
+import org.jdbi.v3.core.PreparedBatch;
+import org.jdbi.v3.core.util.GenericType;
+import org.jdbi.v3.sqlobject.SqlQuery;
+import org.jdbi.v3.sqlobject.SqlUpdate;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestEnumSets {
+
+    private static final GenericType<EnumSet<Platform>> PLATFORM_SET = new GenericType<EnumSet<Platform>>() {
+    };
+
+    @ClassRule
+    public static PostgresDbRule db = new PostgresDbRule();
+
+    private VideoDao videoDao;
+
+    @Before
+    public void setupDbi() throws Exception {
+        db.getSharedHandle().useTransaction((h, status) -> {
+            h.execute("drop table if exists videos");
+            h.execute("create table videos (id int primary key, supported_platforms bit(5))");
+            PreparedBatch batch = h.prepareBatch("insert into videos(id, supported_platforms) values (:id,:supported_platforms::varbit)");
+            batch.add()
+                    .bind("id", 0)
+                    .bindByType("supported_platforms", EnumSet.of(Platform.IOS, Platform.ANDROID, Platform.WEB), PLATFORM_SET);
+            batch.add()
+                    .bind("id", 1)
+                    .bindByType("supported_platforms", EnumSet.of(Platform.SMART_TV), PLATFORM_SET);
+            batch.add()
+                    .bind("id", 2)
+                    .bindByType("supported_platforms", EnumSet.of(Platform.ANDROID, Platform.STB), PLATFORM_SET);
+            batch.add()
+                    .bind("id", 3)
+                    .bindByType("supported_platforms", EnumSet.of(Platform.IOS, Platform.WEB), PLATFORM_SET);
+            batch.add()
+                    .bind("id", 4)
+                    .bindByType("supported_platforms", EnumSet.noneOf(Platform.class), PLATFORM_SET);
+            batch.add()
+                    .bind("id", 5)
+                    .bindByType("supported_platforms", null, PLATFORM_SET);
+            batch.execute();
+        });
+        videoDao = db.getSharedHandle().attach(VideoDao.class);
+    }
+
+    @Test
+    public void testInserts() {
+        videoDao.insert(6, EnumSet.of(Platform.IOS, Platform.ANDROID));
+        assertThat(getSupportedPlatforms(6)).containsExactly(Platform.ANDROID, Platform.IOS);
+    }
+
+    @Test
+    public void testInsertsEmpty() {
+        videoDao.insert(7, EnumSet.noneOf(Platform.class));
+        assertThat(getSupportedPlatforms(7)).isEmpty();
+    }
+
+    @Test
+    public void testInsertsNull() {
+        videoDao.insert(8, null);
+        assertThat(getSupportedPlatforms(8)).isNull();
+    }
+
+    @Test
+    public void testReads() {
+        EnumSet<Platform> supportedPlatforms = videoDao.getSupportedPlatforms(0);
+        assertThat(supportedPlatforms).containsOnly(Platform.ANDROID, Platform.IOS, Platform.WEB);
+    }
+
+    @Test
+    public void testReadsEmpty() {
+        EnumSet<Platform> supportedPlatforms = videoDao.getSupportedPlatforms(4);
+        assertThat(supportedPlatforms).isEmpty();
+    }
+
+    @Test
+    public void testReadsNull() {
+        EnumSet<Platform> supportedPlatforms = videoDao.getSupportedPlatforms(5);
+        assertThat(supportedPlatforms).isNull();
+    }
+
+    @Test
+    public void testBitwiseWorksForNoneElements() {
+        List<Integer> notNullVideos = videoDao.getSupportedVideosOnPlatforms(EnumSet.noneOf(Platform.class));
+        assertThat(notNullVideos).containsExactly(0, 1, 2, 3, 4);
+    }
+
+    @Test
+    public void testBitwiseWorksForOneElement() {
+        List<Integer> stbVideos = videoDao.getSupportedVideosOnPlatforms(EnumSet.of(Platform.STB));
+        assertThat(stbVideos).containsOnlyOnce(2);
+    }
+
+    @Test
+    public void testBitwiseWorksForSeveralElements() {
+        List<Integer> webIosVideos = videoDao.getSupportedVideosOnPlatforms(EnumSet.of(Platform.WEB, Platform.IOS));
+        assertThat(webIosVideos).containsExactly(0, 3);
+    }
+
+    @Test
+    public void testBitwiseAdditionWorks() {
+        videoDao.addPlatforms(1, EnumSet.of(Platform.IOS, Platform.ANDROID));
+        EnumSet<Platform> supportedPlatforms = getSupportedPlatforms(1);
+        assertThat(supportedPlatforms).containsExactly(Platform.ANDROID, Platform.IOS, Platform.SMART_TV);
+    }
+
+    @Test
+    public void testBitwiseRemovingWorks() {
+        videoDao.removePlatforms(0, EnumSet.of(Platform.IOS, Platform.ANDROID, Platform.SMART_TV));
+        EnumSet<Platform> supportedPlatforms = getSupportedPlatforms(0);
+        assertThat(supportedPlatforms).containsOnlyOnce(Platform.WEB);
+    }
+
+    @Test
+    public void testAmountPlatforms(){
+        int amount = videoDao.getAmountOfSupportedPlatforms(0);
+        assertThat(amount).isEqualTo(3);
+    }
+
+    private EnumSet<Platform> getSupportedPlatforms(int id) {
+        return db.getSharedHandle()
+                .createQuery("select supported_platforms from videos where id=:id")
+                .bind("id", id)
+                .mapTo(PLATFORM_SET)
+                .findOnly();
+    }
+
+    public interface VideoDao {
+
+        @SqlUpdate("insert into videos(id, supported_platforms) values (:id, :platforms::varbit)")
+        void insert(int id, EnumSet<Platform> platforms);
+
+        @SqlQuery("select supported_platforms from videos where id=:id")
+        EnumSet<Platform> getSupportedPlatforms(int id);
+
+        @SqlQuery("select id from videos " +
+                "where (supported_platforms & :platforms::varbit) = :platforms::varbit " +
+                "order by id")
+        List<Integer> getSupportedVideosOnPlatforms(EnumSet<Platform> platforms);
+        @SqlUpdate("update videos " +
+                "set supported_platforms = (supported_platforms | :platforms::varbit) " +
+                "where id=:id")
+        void addPlatforms(int id, EnumSet<Platform> platforms);
+
+        @SqlUpdate("update videos " +
+                "set supported_platforms = (supported_platforms & ~:platforms::varbit) " +
+                "where id=:id")
+        void removePlatforms(int id, EnumSet<Platform> platforms);
+
+        @SqlQuery("select length(replace(supported_platforms::varchar, '0', '')) from videos " +
+                "where id=:id")
+        int getAmountOfSupportedPlatforms(int id);
+    }
+
+    public enum Platform {
+        ANDROID,
+        IOS,
+        SMART_TV,
+        STB,
+        WEB
+    }
+}


### PR DESCRIPTION
This is a WIP issue for tracking support for mapping Java's enum sets to Postgres' bit strings.

Motivation:
This feature be very useful in scenarios when the parent entity has a lot of one-to-many relationships, and as a consequence joins become painful. If the universe of possible values for the relationship is finite and low,  it could make sense to inline the relationship as a bit string (bitmap).
