### PR TITLE
ResultBearing: add reduce method, and docs

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/ResultBearing.java
@@ -17,6 +17,7 @@ import static java.util.Spliterators.spliteratorUnknownSize;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -139,4 +140,20 @@ public interface ResultBearing<T> extends Iterable<T>
         }
     }
 
+    /**
+     * Reduce the results.  Using a {@code BiFunction<U, T, U>}, repeatedly
+     * combine query results until only a single value remains.
+     *
+     * @param identity the {@code U} to combine with the first result
+     * @param accumulator the function to apply repeatedly
+     * @return the final {@code U}
+     */
+    default <U> U reduce(U identity, BiFunction<U, T, U> accumulator) {
+        try (Stream<T> stream = stream()) {
+            return stream.reduce(identity, accumulator,
+                (u, v) -> {
+                    throw new UnsupportedOperationException("parallel operation not supported");
+                });
+        }
+    }
 }

--- a/core/src/test/java/org/jdbi/v3/core/TestResultBearing.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestResultBearing.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestResultBearing
+{
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule();
+
+    @Before
+    public void setUp() throws Exception
+    {
+        Handle h = db.getSharedHandle();
+        h.execute("CREATE TABLE reduce (u INT)");
+        for (int u = 0; u < 5; u++)
+        {
+            h.execute("INSERT INTO reduce VALUES (?)", u);
+        }
+    }
+
+    @Test
+    public void testReduceBiFunction() throws Exception
+    {
+        assertThat(
+            db.getSharedHandle().createQuery("SELECT * FROM reduce")
+                .mapTo(Integer.class)
+                .reduce(0, TestResultBearing::add))
+            .isEqualTo(10);
+    }
+
+    public static Integer add(Integer u, Integer v)
+    {
+        return u + v;
+    }
+}

--- a/docs/src/adoc/results.adoc
+++ b/docs/src/adoc/results.adoc
@@ -98,3 +98,45 @@ include::ResultsTest.java[tags=beanMapper]
 You can register mappers declaratively on SqlObjects using e.g.
 `@RegisterRowMapper`, `@RegisterColumnMapper`, `@RegisterConstructorMapper`,
 and so on.
+
+
+
+= ResultBearing
+
+The *ResultBearing* interface determines how the statement results
+are gathered and returned to you.  The methods are designed to
+interact well with the new Java 8 *@FunctionalInterface*s and
+*Stream* library.  Given a type T that can be mapped by the registered
+mappers,
+
+== Find a Single Result
+
+*ResultBearing#findOnly* returns the only row in the result set.  If zero
+or multiple rows are encountered, it will throw *IllegalStateException*.
+
+*#findFirst* returns an *Optional<T>* with the first row, if any.
+
+== Stream
+
+*#stream* returns a *Stream<T>*.  You should then process the stream and
+produce a result.  This stream must be closed to release any database
+resources held, so we recommend using a *try-with-resources* block to
+ensure that no resources are leaked.
+
+*#withStream* and *#useStream* handle closing the stream for you.  You
+provide a *StreamCallback* that produces a result or a *StreamConsumer*
+that produces no result, respectively.
+
+== Collections
+
+*#list* emits a *List<T>*.  This necessarily buffers all results in memory.
+
+*#collect* takes a *Collector<T, ? , R>* that builds a resulting collection
+*R<T>*.  The *java.util.stream.Collectors* class has a number of interesting
+*Collector*s to start with.
+
+== Reduction
+
+*#reduce* provides a simplified *Stream#reduce*.  Given an identity
+starting value and a *BiFunction<U, T, U>* it will repeatedly combine
+*U*s until only a single remains, and then return that.


### PR DESCRIPTION
Here's a partial pass at #526 

It's nice shorthand for the `.stream().reduce(...)` version which takes the unnecessary parallel combiner.