### PR TITLE
Make `StatementContext` an interface

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/BaseStatement.java
@@ -26,9 +26,9 @@ abstract class BaseStatement
 {
     final JdbiConfig config;
     private final Collection<StatementCustomizer> customizers = new ArrayList<>();
-    private final StatementContext context;
+    private final ConcreteStatementContext context;
 
-    BaseStatement(JdbiConfig config, StatementContext context)
+    BaseStatement(JdbiConfig config, ConcreteStatementContext context)
     {
         this.config = config;
         this.context = context;
@@ -42,7 +42,7 @@ abstract class BaseStatement
     /**
      * @return the statement context associated with this statement
      */
-    public final StatementContext getContext()
+    public final ConcreteStatementContext getContext()
     {
         return context;
     }

--- a/core/src/main/java/org/jdbi/v3/core/Batch.java
+++ b/core/src/main/java/org/jdbi/v3/core/Batch.java
@@ -36,7 +36,7 @@ public class Batch extends BaseStatement
 
     Batch(JdbiConfig config,
           Connection connection,
-          StatementContext statementContext)
+          ConcreteStatementContext statementContext)
     {
         super(config, statementContext);
         this.connection = connection;

--- a/core/src/main/java/org/jdbi/v3/core/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/Call.java
@@ -37,7 +37,7 @@ public class Call extends SqlStatement<Call>
          Handle handle,
          StatementBuilder cache,
          String sql,
-         StatementContext ctx,
+         ConcreteStatementContext ctx,
          Collection<StatementCustomizer> customizers)
     {
         super(config, new Binding(), handle, cache, sql, ctx, customizers);

--- a/core/src/main/java/org/jdbi/v3/core/ConcreteStatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/ConcreteStatementContext.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.reflect.Type;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collector;
+
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.RowMapper;
+
+/**
+ * An implementation of {@link StatementContext} which holds its state and provides a means
+ * only for {@link BaseStatement}'s implementations to alter it. Doing so, we don't expose
+ * the internal state of the context to the user, so he/she can change it only via public
+ * API of {@link Query} or {@link Update}.
+ * <p>
+ * This also make {@link StatementContext} more testable, because components which interact
+ * with it, can now easily create mock implementations of it.
+ */
+public final class ConcreteStatementContext implements StatementContext
+{
+    private final JdbiConfig config;
+    private final ExtensionMethod extensionMethod;
+
+    private final Cleanables cleanables = new Cleanables();
+
+    private String            rawSql;
+    private String            rewrittenSql;
+    private PreparedStatement statement;
+    private Connection        connection;
+    private Binding           binding;
+    private boolean           returningGeneratedKeys;
+    private boolean           concurrentUpdatable;
+    private String[]          generatedKeysColumnNames;
+
+    public ConcreteStatementContext() {
+        this(new JdbiConfig());
+    }
+
+    ConcreteStatementContext(JdbiConfig config)
+    {
+        this(config, null);
+    }
+
+    ConcreteStatementContext(JdbiConfig config, ExtensionMethod extensionMethod)
+    {
+        this.config = requireNonNull(config);
+        this.extensionMethod = extensionMethod;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object setAttribute(String key, Object value)
+    {
+        return config.statementAttributes.put(key, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getAttribute(String key)
+    {
+        return config.statementAttributes.get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, Object> getAttributes()
+    {
+        return config.statementAttributes;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<ColumnMapper<?>> findColumnMapperFor(Type type)
+    {
+        return config.mappingRegistry.findColumnMapperFor(type, this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<RowMapper<?>> findRowMapperFor(Type type)
+    {
+        return config.mappingRegistry.findRowMapperFor(type, this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<Argument> findArgumentFor(Type type, Object value)
+    {
+        return config.argumentRegistry.findArgumentFor(type, value, this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<Collector<?, ?, ?>> findCollectorFor(Type type)
+    {
+        return config.collectorRegistry.findCollectorFor(type);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<Type> elementTypeFor(Type containerType)
+    {
+        return config.collectorRegistry.elementTypeFor(containerType);
+    }
+
+    void setRawSql(String rawSql)
+    {
+        this.rawSql = rawSql;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRawSql()
+    {
+        return rawSql;
+    }
+
+    void setRewrittenSql(String rewrittenSql)
+    {
+        this.rewrittenSql = rewrittenSql;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRewrittenSql()
+    {
+        return rewrittenSql;
+    }
+
+    void setStatement(PreparedStatement stmt)
+    {
+        statement = stmt;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PreparedStatement getStatement()
+    {
+        return statement;
+    }
+
+    void setConnection(Connection connection)
+    {
+        this.connection = connection;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Connection getConnection()
+    {
+        return connection;
+    }
+
+    void setBinding(Binding b)
+    {
+        this.binding = b;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Binding getBinding()
+    {
+        return binding;
+    }
+
+    Cleanables getCleanables() {
+        return cleanables;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ExtensionMethod getExtensionMethod()
+    {
+        return extensionMethod;
+    }
+
+    void setReturningGeneratedKeys(boolean b)
+    {
+        if (isConcurrentUpdatable() && b) {
+            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
+                    + "updatable and is returning generated keys.");
+        }
+        this.returningGeneratedKeys = b;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isReturningGeneratedKeys()
+    {
+        return returningGeneratedKeys || generatedKeysColumnNames != null && generatedKeysColumnNames.length > 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getGeneratedKeysColumnNames()
+    {
+        if (generatedKeysColumnNames == null) {
+            return new String[0];
+        }
+        return Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
+    }
+
+    void setGeneratedKeysColumnNames(String[] generatedKeysColumnNames)
+    {
+        this.generatedKeysColumnNames = Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isConcurrentUpdatable() {
+        return concurrentUpdatable;
+    }
+
+    /**
+     * Set the context to create a concurrent updatable result set.
+     *
+     * This cannot be combined with {@link #isReturningGeneratedKeys()}, only
+     * one option may be selected. It does not make sense to combine these either, as one
+     * applies to queries, and the other applies to updates.
+     *
+     * @param concurrentUpdatable if the result set should be concurrent updatable.
+     */
+    void setConcurrentUpdatable(final boolean concurrentUpdatable)
+    {
+        if (concurrentUpdatable && isReturningGeneratedKeys()) {
+            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
+                    + "updatable and is returning generated keys.");
+        }
+        this.concurrentUpdatable = concurrentUpdatable;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -299,7 +299,7 @@ public class Handle implements Closeable
         JdbiConfig batchConfig = JdbiConfig.copyOf(config);
         return new Batch(batchConfig,
                          this.connection,
-                         new StatementContext(batchConfig, extensionMethod.get()));
+                         new ConcreteStatementContext(batchConfig, extensionMethod.get()));
     }
 
     /**
@@ -315,7 +315,7 @@ public class Handle implements Closeable
                                  this,
                                  statementBuilder,
                                  sql,
-                                 new StatementContext(batchConfig, extensionMethod.get()),
+                                 new ConcreteStatementContext(batchConfig, extensionMethod.get()),
                                  Collections.<StatementCustomizer>emptyList());
     }
 
@@ -332,7 +332,7 @@ public class Handle implements Closeable
                         this,
                         statementBuilder,
                         sql,
-                        new StatementContext(callConfig, extensionMethod.get()),
+                        new ConcreteStatementContext(callConfig, extensionMethod.get()),
                         Collections.<StatementCustomizer>emptyList());
     }
 
@@ -350,7 +350,7 @@ public class Handle implements Closeable
                 this,
                 statementBuilder,
                 sql,
-                new StatementContext(queryConfig, extensionMethod.get()),
+                new ConcreteStatementContext(queryConfig, extensionMethod.get()),
                 Collections.<StatementCustomizer>emptyList());
     }
 
@@ -378,7 +378,7 @@ public class Handle implements Closeable
                           this,
                           statementBuilder,
                           sql,
-                          new StatementContext(updateConfig, extensionMethod.get()));
+                          new ConcreteStatementContext(updateConfig, extensionMethod.get()));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/PreparedBatch.java
@@ -52,7 +52,7 @@ public class PreparedBatch extends SqlStatement<PreparedBatch>
                   Handle handle,
                   StatementBuilder statementBuilder,
                   String sql,
-                  StatementContext ctx,
+                  ConcreteStatementContext ctx,
                   Collection<StatementCustomizer> statementCustomizers)
     {
         super(config, new Binding(), handle, statementBuilder, sql, ctx, statementCustomizers);

--- a/core/src/main/java/org/jdbi/v3/core/PreparedBatchPart.java
+++ b/core/src/main/java/org/jdbi/v3/core/PreparedBatchPart.java
@@ -33,7 +33,7 @@ public class PreparedBatchPart extends SqlStatement<PreparedBatchPart>
                       Handle handle,
                       StatementBuilder cache,
                       String sql,
-                      StatementContext context)
+                      ConcreteStatementContext context)
     {
         super(config, binding, handle, cache, sql, context, Collections.<StatementCustomizer>emptyList());
         this.batch = batch;

--- a/core/src/main/java/org/jdbi/v3/core/Query.java
+++ b/core/src/main/java/org/jdbi/v3/core/Query.java
@@ -49,7 +49,7 @@ public class Query<ResultType> extends SqlStatement<Query<ResultType>> implement
           Handle handle,
           StatementBuilder cache,
           String sql,
-          StatementContext ctx,
+          ConcreteStatementContext ctx,
           Collection<StatementCustomizer> customizers)
     {
         super(config, params, handle, cache, sql, ctx, customizers);

--- a/core/src/main/java/org/jdbi/v3/core/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/SqlStatement.java
@@ -80,7 +80,7 @@ public abstract class SqlStatement<SelfType extends SqlStatement<SelfType>> exte
                  Handle handle,
                  StatementBuilder statementBuilder,
                  String sql,
-                 StatementContext ctx,
+                 ConcreteStatementContext ctx,
                  Collection<StatementCustomizer> statementCustomizers) {
         super(config, ctx);
         assert verifyOurNastyDowncastIsOkay();

--- a/core/src/main/java/org/jdbi/v3/core/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/StatementContext.java
@@ -13,19 +13,16 @@
  */
 package org.jdbi.v3.core;
 
-import static java.util.Objects.requireNonNull;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.RowMapper;
 
 import java.lang.reflect.Type;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collector;
-
-import org.jdbi.v3.core.argument.Argument;
-import org.jdbi.v3.core.mapper.ColumnMapper;
-import org.jdbi.v3.core.mapper.RowMapper;
 
 /**
  * The statement context provides a means for passing client specific information through the
@@ -33,37 +30,7 @@ import org.jdbi.v3.core.mapper.RowMapper;
  * to all statement customizers. This makes it possible to parameterize the processing of
  * the tweakable parts of the statement processing cycle.
  */
-public final class StatementContext
-{
-    private final JdbiConfig config;
-    private final ExtensionMethod extensionMethod;
-
-    private final Cleanables cleanables = new Cleanables();
-
-    private String            rawSql;
-    private String            rewrittenSql;
-    private PreparedStatement statement;
-    private Connection        connection;
-    private Binding           binding;
-    private boolean           returningGeneratedKeys;
-    private boolean           concurrentUpdatable;
-    private String[]          generatedKeysColumnNames;
-
-    public StatementContext() {
-        this(new JdbiConfig());
-    }
-
-    StatementContext(JdbiConfig config)
-    {
-        this(config, null);
-    }
-
-    StatementContext(JdbiConfig config, ExtensionMethod extensionMethod)
-    {
-        this.config = requireNonNull(config);
-        this.extensionMethod = extensionMethod;
-    }
-
+public interface StatementContext {
     /**
      * Specify an attribute on the statement context
      *
@@ -72,10 +39,7 @@ public final class StatementContext
      *
      * @return previous value of this attribute
      */
-    public Object setAttribute(String key, Object value)
-    {
-        return config.statementAttributes.put(key, value);
-    }
+    Object setAttribute(String key, Object value);
 
     /**
      * Obtain the value of an attribute
@@ -84,10 +48,7 @@ public final class StatementContext
      *
      * @return the value of the attribute
      */
-    public Object getAttribute(String key)
-    {
-        return config.statementAttributes.get(key);
-    }
+    Object getAttribute(String key);
 
     /**
      * Obtain all the attributes associated with this context as a map. Changes to the map
@@ -95,10 +56,7 @@ public final class StatementContext
      *
      * @return a map f attributes
      */
-    public Map<String, Object> getAttributes()
-    {
-        return config.statementAttributes;
-    }
+    Map<String, Object> getAttributes();
 
     /**
      * Obtain a column mapper for the given type in this context.
@@ -106,10 +64,7 @@ public final class StatementContext
      * @param type the target type to map to
      * @return a ColumnMapper for the given type, or empty if no column mapper is registered for the given type.
      */
-    public Optional<ColumnMapper<?>> findColumnMapperFor(Type type)
-    {
-        return config.mappingRegistry.findColumnMapperFor(type, this);
-    }
+    Optional<ColumnMapper<?>> findColumnMapperFor(Type type);
 
     /**
      * Obtain a row mapper for the given type in this context.
@@ -117,10 +72,7 @@ public final class StatementContext
      * @param type the target type to map to
      * @return a RowMapper for the given type, or empty if no row mapper is registered for the given type.
      */
-    public Optional<RowMapper<?>> findRowMapperFor(Type type)
-    {
-        return config.mappingRegistry.findRowMapperFor(type, this);
-    }
+    Optional<RowMapper<?>> findRowMapperFor(Type type);
 
     /**
      * Obtain an argument for given value in this context
@@ -128,46 +80,27 @@ public final class StatementContext
      * @param value the argument value.
      * @return an Argument for the given value.
      */
-    public Optional<Argument> findArgumentFor(Type type, Object value) {
-        return config.argumentRegistry.findArgumentFor(type, value, this);
-    }
+    Optional<Argument> findArgumentFor(Type type, Object value);
 
     /**
      * Obtain a collector for the given type in this context
      * @param type the result type of the collector
      * @return a Collector for the given result type, or null if no collector factory is registered for this type.
      */
-    public Optional<Collector<?, ?, ?>> findCollectorFor(Type type) {
-        return config.collectorRegistry.findCollectorFor(type);
-    }
+    Optional<Collector<?, ?, ?>> findCollectorFor(Type type);
 
     /**
      * @param containerType the container type.
      * @return the element type for the given container type, if available.
      */
-    public Optional<Type> elementTypeFor(Type containerType) {
-        return config.collectorRegistry.elementTypeFor(containerType);
-    }
-
-    void setRawSql(String rawSql)
-    {
-        this.rawSql = rawSql;
-    }
+    Optional<Type> elementTypeFor(Type containerType);
 
     /**
      * Obtain the initial sql for the statement used to create the statement
      *
      * @return the initial sql
      */
-    public String getRawSql()
-    {
-        return rawSql;
-    }
-
-    void setRewrittenSql(String rewrittenSql)
-    {
-        this.rewrittenSql = rewrittenSql;
-    }
+    String getRawSql();
 
     /**
      * Obtain the located and rewritten sql
@@ -177,15 +110,7 @@ public final class StatementContext
      *
      * @return the sql as it will be executed against the database
      */
-    public String getRewrittenSql()
-    {
-        return rewrittenSql;
-    }
-
-    void setStatement(PreparedStatement stmt)
-    {
-        statement = stmt;
-    }
+    String getRewrittenSql();
 
     /**
      * Obtain the actual prepared statement being used.
@@ -195,74 +120,25 @@ public final class StatementContext
      *
      * @return Obtain the actual prepared statement being used.
      */
-    public PreparedStatement getStatement()
-    {
-        return statement;
-    }
-
-    void setConnection(Connection connection)
-    {
-        this.connection = connection;
-    }
+    PreparedStatement getStatement();
 
     /**
      * Obtain the JDBC connection being used for this statement
      *
      * @return the JDBC connection
      */
-    public Connection getConnection()
-    {
-        return connection;
-    }
+    Connection getConnection();
 
-    void setBinding(Binding b)
-    {
-        this.binding = b;
-    }
+    Binding getBinding();
 
-    public Binding getBinding()
-    {
-        return binding;
-    }
-
-    Cleanables getCleanables() {
-        return cleanables;
-    }
-
-    public ExtensionMethod getExtensionMethod()
-    {
-        return extensionMethod;
-    }
-
-    void setReturningGeneratedKeys(boolean b)
-    {
-        if (isConcurrentUpdatable() && b) {
-            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
-                    + "updatable and is returning generated keys.");
-        }
-        this.returningGeneratedKeys = b;
-    }
+    ExtensionMethod getExtensionMethod();
 
     /**
      * @return whether the statement being generated is expected to return generated keys.
      */
-    public boolean isReturningGeneratedKeys()
-    {
-        return returningGeneratedKeys || generatedKeysColumnNames != null && generatedKeysColumnNames.length > 0;
-    }
+    boolean isReturningGeneratedKeys();
 
-    public String[] getGeneratedKeysColumnNames()
-    {
-        if (generatedKeysColumnNames == null) {
-            return new String[0];
-        }
-        return Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
-    }
-
-    void setGeneratedKeysColumnNames(String[] generatedKeysColumnNames)
-    {
-        this.generatedKeysColumnNames = Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
-    }
+    String[] getGeneratedKeysColumnNames();
 
     /**
      * Return if the statement should be concurrent updatable.
@@ -273,24 +149,5 @@ public final class StatementContext
      *
      * @return if the statement generated should be concurrent updatable.
      */
-    public boolean isConcurrentUpdatable() {
-        return concurrentUpdatable;
-    }
-
-    /**
-     * Set the context to create a concurrent updatable result set.
-     *
-     * This cannot be combined with {@link #isReturningGeneratedKeys()}, only
-     * one option may be selected. It does not make sense to combine these either, as one
-     * applies to queries, and the other applies to updates.
-     *
-     * @param concurrentUpdatable if the result set should be concurrent updatable.
-     */
-    void setConcurrentUpdatable(final boolean concurrentUpdatable) {
-        if (concurrentUpdatable && isReturningGeneratedKeys()) {
-            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
-                    + "updatable and is returning generated keys.");
-        }
-        this.concurrentUpdatable = concurrentUpdatable;
-    }
+    boolean isConcurrentUpdatable();
 }

--- a/core/src/main/java/org/jdbi/v3/core/Update.java
+++ b/core/src/main/java/org/jdbi/v3/core/Update.java
@@ -37,7 +37,7 @@ public class Update extends SqlStatement<Update>
            Handle handle,
            StatementBuilder statementBuilder,
            String sql,
-           StatementContext ctx)
+           ConcreteStatementContext ctx)
     {
         super(config, new Binding(), handle, statementBuilder, sql, ctx, Collections.<StatementCustomizer>emptyList());
     }

--- a/core/src/test/java/org/jdbi/v3/core/JdbiAccess.java
+++ b/core/src/test/java/org/jdbi/v3/core/JdbiAccess.java
@@ -34,6 +34,6 @@ public class JdbiAccess {
      * with the given handle.
      */
     public static StatementContext createContext(Handle handle) {
-        return new StatementContext(handle.config);
+        return new ConcreteStatementContext(handle.config);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/StatementContextTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/StatementContextTest.java
@@ -26,7 +26,7 @@ public class StatementContextTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testShouldNotBeAbleToCombineGeneratedKeysAndConcurrentUpdatable() throws Exception {
-        final StatementContext context = new StatementContext();
+        final ConcreteStatementContext context = new ConcreteStatementContext();
 
         context.setReturningGeneratedKeys(true);
         context.setConcurrentUpdatable(true);
@@ -34,7 +34,7 @@ public class StatementContextTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testShouldNotBeAbleToCombineConcurrentUpdatableAndGeneratedKeys() throws Exception {
-        final StatementContext context = new StatementContext();
+        final ConcreteStatementContext context = new ConcreteStatementContext();
 
         context.setConcurrentUpdatable(true);
         context.setReturningGeneratedKeys(true);
@@ -57,7 +57,7 @@ public class StatementContextTest {
         JdbiConfig config = new JdbiConfig();
         config.mappingRegistry.addColumnMapper(mapper);
 
-        final StatementContext context = new StatementContext(config);
+        final StatementContext context = new ConcreteStatementContext(config);
 
         assertThat(context.findColumnMapperFor(Foo.class)).contains(mapper);
     }

--- a/core/src/test/java/org/jdbi/v3/core/TestBeanArguments.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestBeanArguments.java
@@ -38,7 +38,7 @@ public class TestBeanArguments
     @Mock
     PreparedStatement stmt;
 
-    StatementContext ctx = new StatementContext();
+    StatementContext ctx = new ConcreteStatementContext();
 
     @Test
     public void testBindBare() throws Exception

--- a/core/src/test/java/org/jdbi/v3/core/TestHashPrefixStatementRewriter.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestHashPrefixStatementRewriter.java
@@ -43,7 +43,7 @@ public class TestHashPrefixStatementRewriter
     }
 
     private RewrittenStatement rewrite(String sql, Map<String, Object> attributes) {
-        StatementContext ctx = new StatementContext();
+        StatementContext ctx = new ConcreteStatementContext();
         attributes.forEach(ctx::setAttribute);
 
         return rw.rewrite(sql, new Binding(), ctx);

--- a/core/src/test/java/org/jdbi/v3/core/TestMapArguments.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestMapArguments.java
@@ -35,7 +35,7 @@ public class TestMapArguments
     @Mock
     PreparedStatement stmt;
 
-    StatementContext ctx = new StatementContext();
+    StatementContext ctx = new ConcreteStatementContext();
 
     @Test
     public void testBind() throws Exception

--- a/core/src/test/java/org/jdbi/v3/core/rewriter/TestColonStatementRewriter.java
+++ b/core/src/test/java/org/jdbi/v3/core/rewriter/TestColonStatementRewriter.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jdbi.v3.core.Binding;
+import org.jdbi.v3.core.ConcreteStatementContext;
 import org.jdbi.v3.core.StatementContext;
 import org.jdbi.v3.core.exception.UnableToCreateStatementException;
 import org.junit.Before;
@@ -43,7 +44,7 @@ public class TestColonStatementRewriter
     }
 
     private RewrittenStatement rewrite(String sql, Map<String, Object> attributes) {
-        StatementContext ctx = new StatementContext();
+        StatementContext ctx = new ConcreteStatementContext();
         attributes.forEach(ctx::setAttribute);
 
         return rw.rewrite(sql, new Binding(), ctx);
@@ -80,8 +81,8 @@ public class TestColonStatementRewriter
     @Test
     public void testHashInColumnNameOkay() throws Exception
     {
-       RewrittenStatement rws = rewrite("select column# from thetable where id = :id");
-       assertThat(rws.getSql()).isEqualTo("select column# from thetable where id = ?");
+        RewrittenStatement rws = rewrite("select column# from thetable where id = :id");
+        assertThat(rws.getSql()).isEqualTo("select column# from thetable where id = ?");
     }
 
     @Test


### PR DESCRIPTION
And create a concrete implementation of it, which is package-private accessible for internal JDBI components. This allows to restrict the amount of components which can change statement context's state, but at the same time to keep a public interface which allows to read the state. This also make statement contexts more testable because the use code which interacts with statement contexts can mock the interface.