### PR TITLE
Statement execution - increase flexibility around reducing, improve cleanup

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Batch.java
+++ b/core/src/main/java/org/jdbi/v3/core/Batch.java
@@ -126,7 +126,7 @@ public class Batch extends BaseStatement
             }
         }
         finally {
-            cleanup();
+            close();
         }
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/Call.java
@@ -110,7 +110,7 @@ public class Call extends SqlStatement<Call>
             return out;
         }
         finally {
-            cleanup();
+            close();
         }
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/GeneratedKeys.java
+++ b/core/src/main/java/org/jdbi/v3/core/GeneratedKeys.java
@@ -75,7 +75,7 @@ public class GeneratedKeys<T> implements ResultBearing<T>
         if (results == null) {
             return new EmptyResultIterator<>();
         }
-        return new ResultSetResultIterator<>(mapper, jdbiStatement, stmt, results, context);
+        return new ResultSetResultIterator<>(mapper, results, context);
     }
 
 }

--- a/core/src/main/java/org/jdbi/v3/core/GeneratedKeys.java
+++ b/core/src/main/java/org/jdbi/v3/core/GeneratedKeys.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.jdbi.v3.core.exception.ResultSetException;
+import org.jdbi.v3.core.exception.UnableToExecuteStatementException;
 import org.jdbi.v3.core.mapper.RowMapper;
 
 /**
@@ -29,7 +30,6 @@ public class GeneratedKeys<T> implements ResultBearing<T>
 {
     private final RowMapper<T>             mapper;
     private final SqlStatement<?>          jdbiStatement;
-    private final Statement                stmt;
     private final ResultSet                results;
     private final StatementContext         context;
 
@@ -49,7 +49,6 @@ public class GeneratedKeys<T> implements ResultBearing<T>
     {
         this.mapper = mapper;
         this.jdbiStatement = jdbiStatement;
-        this.stmt = stmt;
         try {
             this.results = stmt.getGeneratedKeys();
         } catch (SQLException e) {
@@ -78,4 +77,13 @@ public class GeneratedKeys<T> implements ResultBearing<T>
         return new ResultSetResultIterator<>(mapper, results, context);
     }
 
+    @Override
+    public <R> R execute(StatementExecutor<T, R> executor)
+    {
+        try {
+            return executor.execute(mapper, results, context);
+        } catch (SQLException e) {
+            throw new UnableToExecuteStatementException(e, context);
+        }
+    }
 }

--- a/core/src/main/java/org/jdbi/v3/core/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/PreparedBatch.java
@@ -202,7 +202,7 @@ public class PreparedBatch extends SqlStatement<PreparedBatch>
         finally {
             try {
                 if (!generateKeys) {
-                    cleanup();
+                    close();
                 }
             }
             finally {

--- a/core/src/main/java/org/jdbi/v3/core/Query.java
+++ b/core/src/main/java/org/jdbi/v3/core/Query.java
@@ -66,8 +66,6 @@ public class Query<ResultType> extends SqlStatement<Query<ResultType>> implement
         final PreparedStatement stmt = internalExecute();
         try {
             return new ResultSetResultIterator<>(mapper,
-                    Query.this,
-                    stmt,
                     stmt.getResultSet(),
                     getContext());
         } catch (SQLException e) {

--- a/core/src/main/java/org/jdbi/v3/core/ResultSetAccumulator.java
+++ b/core/src/main/java/org/jdbi/v3/core/ResultSetAccumulator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * A {@link ResultSetAccumulator} repeatedly combines rows
+ * from the given {@code ResultSet} to produce a single
+ * result.  {@code jdbi} will advance the {@code ResultSet} between
+ * each method invocation, so don't call {@link ResultSet#next()} please.
+ */
+@FunctionalInterface
+public interface ResultSetAccumulator<T>
+{
+    /**
+     * Extract a single row from the result set, and combine it with the
+     * accumulator to produce a result.
+     * @param in the previous object
+     * @param rs the ResultSet, please do not advance it
+     * @param ctx the statement context
+     * @return the accumulated value
+     * @throws SQLException in the face of grave danger
+     */
+    T apply(T in, ResultSet rs, StatementContext ctx) throws SQLException;
+}

--- a/core/src/main/java/org/jdbi/v3/core/RowView.java
+++ b/core/src/main/java/org/jdbi/v3/core/RowView.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.lang.reflect.Type;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.exception.UnableToExecuteStatementException;
+import org.jdbi.v3.core.util.GenericType;
+
+/**
+ * A RowView is an accessor for {@code ResultSet} that uses
+ * {@code RowMapper} or {@code ColumnMapper} to extract values.
+ * It is not valid outside the scope of the method that receives it.
+ */
+public class RowView
+{
+    private final StatementContext ctx;
+    private final ResultSet rs;
+
+    RowView(ResultSet rs, StatementContext ctx)
+    {
+        this.rs = rs;
+        this.ctx = ctx;
+    }
+
+    /**
+     * Use a row mapper to extract a type from the current ResultSet row.
+     */
+    public <T> T getRow(Class<T> rowType)
+    {
+        return rowType.cast(getRow((Type) rowType));
+    }
+
+    /**
+     * Use a row mapper to extract a type from the current ResultSet row.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getRow(GenericType<T> rowType)
+    {
+        return (T) getRow(rowType.getType());
+    }
+
+    /**
+     * Use a row mapper to extract a type from the current ResultSet row.
+     */
+    public Object getRow(Type type)
+    {
+        try {
+            return ctx.findRowMapperFor(type)
+                    .orElseThrow(() -> new UnableToExecuteStatementException("No row mapper for " + type, ctx))
+                    .map(rs, ctx);
+        } catch (SQLException e) {
+            throw new UnableToExecuteStatementException(e, ctx);
+        }
+    }
+
+    /**
+     * Use a column mapper to extract a type from the current ResultSet row.
+     */
+    public <T> T getColumn(String column, Class<T> type)
+    {
+        return type.cast(getColumn(column, (Type) type));
+    }
+    /**
+     * Use a column mapper to extract a type from the current ResultSet row.
+     */
+    public <T> T getColumn(int column, Class<T> type)
+    {
+        return type.cast(getColumn(column, (Type) type));
+    }
+
+    /**
+     * Use a column mapper to extract a type from the current ResultSet row.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getColumn(String column, GenericType<T> type)
+    {
+        return (T) getColumn(column, type.getType());
+    }
+    /**
+     * Use a column mapper to extract a type from the current ResultSet row.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getColumn(int column, GenericType<T> type)
+    {
+        return (T) getColumn(column, type.getType());
+    }
+
+    /**
+     * Use a column mapper to extract a type from the current ResultSet row.
+     */
+    public Object getColumn(String column, Type type)
+    {
+        try {
+            return ctx.findColumnMapperFor(type)
+                    .orElseThrow(() -> new UnableToExecuteStatementException("No column mapper for " + type, ctx))
+                    .map(rs, column, ctx);
+        } catch (SQLException e) {
+            throw new UnableToExecuteStatementException(e, ctx);
+        }
+    }
+
+    /**
+     * Use a column mapper to extract a type from the current ResultSet row.
+     */
+    public Object getColumn(int column, Type type)
+    {
+        try {
+            return ctx.findColumnMapperFor(type)
+                    .orElseThrow(() -> new UnableToExecuteStatementException("No column mapper for " + type, ctx))
+                    .map(rs, column, ctx);
+        } catch (SQLException e) {
+            throw new UnableToExecuteStatementException(e, ctx);
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/StatementContext.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.Closeable;
 import java.lang.reflect.Type;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -36,7 +37,7 @@ import org.jdbi.v3.core.mapper.RowMapper;
  * DISCLAIMER: The class is not intended to be extended. The final modifier is absent to allow
  * mock tools to create a mock object of this class in the user code.
  */
-public class StatementContext
+public class StatementContext implements Closeable
 {
     private final JdbiConfig config;
     private final ExtensionMethod extensionMethod;
@@ -228,8 +229,15 @@ public class StatementContext
         return binding;
     }
 
-    Cleanables getCleanables() {
+    Cleanables getCleanables()
+    {
         return cleanables;
+    }
+
+    @Override
+    public void close()
+    {
+        cleanables.close();
     }
 
     public ExtensionMethod getExtensionMethod()

--- a/core/src/main/java/org/jdbi/v3/core/StatementExecutor.java
+++ b/core/src/main/java/org/jdbi/v3/core/StatementExecutor.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+
+/**
+ * A StatementExecutor generates the mapped results of a {@link SqlStatement},
+ * potentially wrapped in a container object.
+ */
+@FunctionalInterface
+interface StatementExecutor<T, R>
+{
+    /**
+     * Produce a statement result.
+     * @param mapper the mapper the user's code told you to use
+     * @param rs the result set
+     * @param ctx the statement context
+     * @return an object of the type your caller expects
+     * @throws SQLException sadness
+     */
+    R execute(RowMapper<T> mapper, ResultSet rs, StatementContext ctx) throws SQLException;
+}

--- a/core/src/main/java/org/jdbi/v3/core/Update.java
+++ b/core/src/main/java/org/jdbi/v3/core/Update.java
@@ -54,7 +54,7 @@ public class Update extends SqlStatement<Update>
             throw new UnableToExecuteStatementException("Could not get update count", e, getContext());
         }
         finally {
-            cleanup();
+            close();
         }
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementCustomizer.java
@@ -42,12 +42,4 @@ public interface StatementCustomizer
      * @throws SQLException go ahead and percolate it for jDBI to handle
      */
     default void afterExecution(PreparedStatement stmt, StatementContext ctx) throws SQLException { }
-
-    /**
-     * Invoked at cleanup time to clean resources used by this statement.
-     *
-     * @param ctx Statement context associated with the statement being customized
-     * @throws SQLException go ahead and percolate it for jDBI to handle
-     */
-    default void cleanup(StatementContext ctx) throws SQLException { }
 }

--- a/core/src/test/java/org/jdbi/v3/core/TestReducing.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestReducing.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestReducing
+{
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule();
+
+    @Before
+    public void setUp()
+    {
+        Handle h = db.getSharedHandle();
+        h.execute("CREATE TABLE something_location (id int, location varchar)");
+        h.execute("INSERT INTO something (id, name) VALUES (1, 'tree')");
+        h.execute("INSERT INTO something (id, name) VALUES (2, 'apple')");
+        h.execute("INSERT INTO something_location (id, location) VALUES (1, 'outside')");
+        h.execute("INSERT INTO something_location (id, location) VALUES (2, 'tree')");
+        h.execute("INSERT INTO something_location (id, location) VALUES (2, 'pie')");
+        h.registerRowMapper(new SomethingMapper());
+    }
+
+    @Test
+    public void testLeftJoinRowView() throws Exception
+    {
+        Map<Integer, SomethingWithLocations> result = db.getSharedHandle()
+            .createQuery("SELECT something.id, name, location FROM something NATURAL JOIN something_location")
+            .reduceRows(new HashMap<Integer, SomethingWithLocations>(), (map, rr) -> {
+                map.computeIfAbsent(rr.getColumn("id", Integer.class),
+                        id -> new SomethingWithLocations(rr.getRow(Something.class)))
+                    .locations.add(rr.getColumn("location", String.class));
+                return map;
+            });
+
+        assertThat(result).hasSize(2)
+            .containsEntry(1, new SomethingWithLocations(new Something(1, "tree")).at("outside"))
+            .containsEntry(2, new SomethingWithLocations(new Something(2, "apple")).at("tree").at("pie"));
+    }
+
+    @Test
+    public void testLeftJoinResultSet() throws Exception
+    {
+        Map<Integer, SomethingWithLocations> result = db.getSharedHandle()
+            .createQuery("SELECT something.id, name, location FROM something NATURAL JOIN something_location")
+            .reduceResultSet(new HashMap<Integer, SomethingWithLocations>(), (map, rs, ctx) -> {
+                final String name = rs.getString("name");
+                map.computeIfAbsent(rs.getInt("id"),
+                        id -> new SomethingWithLocations(new Something(id, name)))
+                    .at(rs.getString("location"));
+                return map;
+            });
+
+        assertThat(result).hasSize(2)
+            .containsEntry(1, new SomethingWithLocations(new Something(1, "tree")).at("outside"))
+            .containsEntry(2, new SomethingWithLocations(new Something(2, "apple")).at("tree").at("pie"));
+    }
+
+    static class SomethingWithLocations
+    {
+        final Something something;
+        final List<String> locations = new ArrayList<>();
+
+        SomethingWithLocations(Something something)
+        {
+            this.something = something;
+        }
+
+        SomethingWithLocations at(String where)
+        {
+            locations.add(where);
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (!(other instanceof SomethingWithLocations))
+            {
+                return false;
+            }
+            SomethingWithLocations o = (SomethingWithLocations)other;
+            return o.something.equals(something) && o.locations.equals(locations);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return something.hashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("Something %s with locations %s", something, locations);
+        }
+    }
+}


### PR DESCRIPTION
StatementExecutor: allow customization of how jdbi runs a statement
ResultBearing: change main `iterator()` interface to instead use `execute(StatementExecutor)`
ReduceRow: introduce a jdbi "view" over a `ResultSet`
ResultBearing: introduce `reduceRows` and `reduceResultSet`
ResultSetResultIterator: simplify interface greatly by removing unused parameters

fixes #526 