### PR TITLE
H2 array integration improvements, support `Set<T>` types, bare configuration

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/CollectionColumnMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/CollectionColumnMapper.java
@@ -15,23 +15,23 @@ package org.jdbi.v3.core;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.List;
+import java.util.Collection;
 import java.util.function.Supplier;
 
 import org.jdbi.v3.core.mapper.ColumnMapper;
 
-class ListColumnMapper<T> implements ColumnMapper<List<T>> {
+class CollectionColumnMapper<T> implements ColumnMapper<Collection<T>> {
     private final ColumnMapper<T> elementMapper;
-    private final Supplier<List<T>> listSupplier;
+    private final Supplier<Collection<T>> collectionSupplier;
 
-    ListColumnMapper(ColumnMapper<T> elementMapper,
-                     Supplier<List<T>> listSupplier) {
+    CollectionColumnMapper(ColumnMapper<T> elementMapper,
+                     Supplier<Collection<T>> collectionSupplier) {
         this.elementMapper = elementMapper;
-        this.listSupplier = listSupplier;
+        this.collectionSupplier = collectionSupplier;
     }
 
     @Override
-    public List<T> map(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+    public Collection<T> map(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
         java.sql.Array array = r.getArray(columnNumber);
         try {
             return buildFromResultSet(array, ctx);
@@ -41,15 +41,15 @@ class ListColumnMapper<T> implements ColumnMapper<List<T>> {
         }
     }
 
-    private List<T> buildFromResultSet(java.sql.Array array, StatementContext ctx) throws SQLException {
-        List<T> list = listSupplier.get();
+    private Collection<T> buildFromResultSet(java.sql.Array array, StatementContext ctx) throws SQLException {
+        Collection<T> result = collectionSupplier.get();
 
         try (ResultSet rs = array.getResultSet()) {
             while (rs.next()) {
-                list.add(elementMapper.map(rs, 2, ctx));
+                result.add(elementMapper.map(rs, 2, ctx));
             }
         }
 
-        return list;
+        return result;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/ConfigOnlyExtension.java
+++ b/core/src/main/java/org/jdbi/v3/core/ConfigOnlyExtension.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import org.jdbi.v3.core.extension.ExtensionConfig;
+import org.jdbi.v3.core.extension.ExtensionFactory;
+
+class ConfigOnlyExtension<C extends ExtensionConfig<C>> implements ExtensionFactory<C>
+{
+    private final Class<C> configClass;
+
+    ConfigOnlyExtension(Class<C> configClass)
+    {
+        this.configClass = configClass;
+    }
+
+    @Override
+    public C createConfig() {
+        try {
+            return configClass.getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to instantiate " + configClass, e);
+        }
+    }
+
+    @Override
+    public boolean accepts(Class<?> extensionType) {
+        return extensionType == configClass;
+    }
+
+    @Override
+    public <E> E attach(Class<E> extensionType, C config, HandleSupplier handle) {
+        return extensionType.cast(config);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/ExtensionRegistry.java
+++ b/core/src/main/java/org/jdbi/v3/core/ExtensionRegistry.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import org.jdbi.v3.core.extension.ExtensionConfig;
 import org.jdbi.v3.core.extension.ExtensionFactory;

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -651,8 +651,14 @@ public class Handle implements Closeable
                 .orElseThrow(() -> new NoSuchExtensionException("Extension not found: " + extensionType));
     }
 
-    public <C extends ExtensionConfig<C>> void configureExtension(Class<C> configClass, Consumer<C> consumer) {
+    public <C extends ExtensionConfig<C>> Handle configureExtension(Class<C> configClass, Consumer<C> consumer) {
         config.extensionRegistry.configure(configClass, consumer);
+        return this;
+    }
+
+    public <C extends ExtensionConfig<C>> Handle configure(Class<C> configClass, Consumer<C> consumer) {
+        registerExtension(new ConfigOnlyExtension<C>(configClass));
+        return configureExtension(configClass, consumer);
     }
 
     public ExtensionMethod getExtensionMethod() {

--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -366,9 +366,16 @@ public class Jdbi
         return this;
     }
 
-    public <C extends ExtensionConfig<C>> Jdbi configureExtension(Class<C> configClass, Consumer<C> consumer) {
+    public <C extends ExtensionConfig<C>> Jdbi configureExtension(Class<C> configClass, Consumer<C> consumer)
+    {
         config.extensionRegistry.configure(configClass, consumer);
         return this;
+    }
+
+    public <C extends ExtensionConfig<C>> Jdbi configure(Class<C> configClass, Consumer<C> consumer)
+    {
+        registerExtension(new ConfigOnlyExtension<C>(configClass));
+        return configureExtension(configClass, consumer);
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -73,6 +73,13 @@ public class Jdbi
     {
         Objects.requireNonNull(connectionFactory, "null connectionFactory");
         this.connectionFactory = connectionFactory;
+
+        baseConfiguration();
+    }
+
+    private void baseConfiguration()
+    {
+        configure(SqlArrayConfiguration.class, c -> {});
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/SqlArrayArgument.java
+++ b/core/src/main/java/org/jdbi/v3/core/SqlArrayArgument.java
@@ -44,8 +44,18 @@ class SqlArrayArgument<T> implements Argument {
 
     @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException {
-        java.sql.Array sqlArray = statement.getConnection().createArrayOf(typeName, array);
-        ctx.getCleanables().add(sqlArray::free);
-        statement.setArray(position, sqlArray);
+        ArgumentStyle argumentStyle = ctx.findConfiguration(SqlArrayConfiguration.class).getArgumentStyle();
+        switch (argumentStyle) {
+        case SQL_ARRAY:
+            java.sql.Array sqlArray = statement.getConnection().createArrayOf(typeName, array);
+            ctx.getCleanables().add(sqlArray::free);
+            statement.setArray(position, sqlArray);
+            break;
+        case OBJECT_ARRAY:
+            statement.setObject(position, array);
+            break;
+        default:
+            throw new UnsupportedOperationException("Unknown array argument style " + argumentStyle);
+        }
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/SqlArrayArgument.java
+++ b/core/src/main/java/org/jdbi/v3/core/SqlArrayArgument.java
@@ -16,8 +16,9 @@ package org.jdbi.v3.core;
 import java.lang.reflect.Array;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.List;
+import java.util.Collection;
 
+import org.jdbi.v3.core.SqlArrayConfiguration.ArgumentStyle;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.SqlArrayType;
 
@@ -36,7 +37,7 @@ class SqlArrayArgument<T> implements Argument {
         }
     }
 
-    SqlArrayArgument(SqlArrayType<T> arrayType, List<T> list) {
+    SqlArrayArgument(SqlArrayType<T> arrayType, Collection<T> list) {
         this.typeName = arrayType.getTypeName();
         this.array = list.stream().map(arrayType::convertArrayElement).toArray();
     }

--- a/core/src/main/java/org/jdbi/v3/core/SqlArrayArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/SqlArrayArgumentFactory.java
@@ -14,7 +14,7 @@
 package org.jdbi.v3.core;
 
 import java.lang.reflect.Type;
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
 
 import org.jdbi.v3.core.argument.Argument;
@@ -23,7 +23,7 @@ import org.jdbi.v3.core.util.GenericTypes;
 
 class SqlArrayArgumentFactory implements ArgumentFactory {
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Optional<Argument> build(Type type, Object value, StatementContext ctx) {
         Class<?> erasedType = GenericTypes.getErasedType(type);
         if (erasedType.isArray()) {
@@ -31,10 +31,10 @@ class SqlArrayArgumentFactory implements ArgumentFactory {
             return ctx.findArrayTypeFor(elementType)
                     .map(arrayType -> new SqlArrayArgument<>(arrayType, value));
         }
-        if (List.class.isAssignableFrom(erasedType)) {
-            return GenericTypes.findGenericParameter(type, List.class)
+        if (Collection.class.isAssignableFrom(erasedType)) {
+            return GenericTypes.findGenericParameter(type, Collection.class)
                     .flatMap(ctx::findArrayTypeFor)
-                    .map(arrayType -> new SqlArrayArgument<>(arrayType, value));
+                    .map(arrayType -> new SqlArrayArgument<>(arrayType, (Collection) value));
         }
         return Optional.empty();
     }

--- a/core/src/main/java/org/jdbi/v3/core/SqlArrayArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/SqlArrayArgumentFactory.java
@@ -32,10 +32,22 @@ class SqlArrayArgumentFactory implements ArgumentFactory {
                     .map(arrayType -> new SqlArrayArgument<>(arrayType, value));
         }
         if (Collection.class.isAssignableFrom(erasedType)) {
-            return GenericTypes.findGenericParameter(type, Collection.class)
+            return guessElementType(type, (Collection<?>) value)
                     .flatMap(ctx::findArrayTypeFor)
                     .map(arrayType -> new SqlArrayArgument<>(arrayType, (Collection) value));
         }
         return Optional.empty();
+    }
+
+    private Optional<? extends Type> guessElementType(Type type, Collection<?> value) {
+        Optional<? extends Type> result = GenericTypes.findGenericParameter(type, Collection.class);
+        if (result.isPresent()) {
+            return result;
+        }
+        result = value.stream().map(Object::getClass).findFirst();
+        if (result.isPresent()) {
+            return result;
+        }
+        return Optional.of(Object.class);
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/SqlArrayArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/SqlArrayArgumentFactory.java
@@ -29,12 +29,12 @@ class SqlArrayArgumentFactory implements ArgumentFactory {
         if (erasedType.isArray()) {
             Class<?> elementType = erasedType.getComponentType();
             return ctx.findArrayTypeFor(elementType)
-                    .map(arrayType -> new SqlArrayArgument(arrayType, value));
+                    .map(arrayType -> new SqlArrayArgument<>(arrayType, value));
         }
         if (List.class.isAssignableFrom(erasedType)) {
             return GenericTypes.findGenericParameter(type, List.class)
                     .flatMap(ctx::findArrayTypeFor)
-                    .map(arrayType -> new SqlArrayArgument(arrayType, (List) value));
+                    .map(arrayType -> new SqlArrayArgument<>(arrayType, value));
         }
         return Optional.empty();
     }

--- a/core/src/main/java/org/jdbi/v3/core/SqlArrayConfiguration.java
+++ b/core/src/main/java/org/jdbi/v3/core/SqlArrayConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import org.jdbi.v3.core.extension.ExtensionConfig;
+
+public class SqlArrayConfiguration implements ExtensionConfig<SqlArrayConfiguration>
+{
+    public enum ArgumentStyle
+    {
+        SQL_ARRAY, OBJECT_ARRAY
+    }
+
+    private ArgumentStyle argumentStyle = ArgumentStyle.SQL_ARRAY;
+
+    public SqlArrayConfiguration() { }
+
+    SqlArrayConfiguration(SqlArrayConfiguration other) {
+        this.argumentStyle = other.argumentStyle;
+    }
+
+    public SqlArrayConfiguration withArgumentStyle(ArgumentStyle argumentStyle)
+    {
+        this.argumentStyle = argumentStyle;
+        return this;
+    }
+
+    public ArgumentStyle getArgumentStyle()
+    {
+        return argumentStyle;
+    }
+
+    @Override
+    public SqlArrayConfiguration createCopy()
+    {
+        return new SqlArrayConfiguration(this);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/SqlArrayMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/SqlArrayMapperFactory.java
@@ -15,11 +15,16 @@ package org.jdbi.v3.core;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 
@@ -28,17 +33,22 @@ import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.core.util.GenericTypes;
 
 class SqlArrayMapperFactory implements ColumnMapperFactory {
-    private final Map<Class<?>, Supplier<List<?>>> listSuppliers = new HashMap<>();
+    private final Map<Class<?>, Supplier<Collection<?>>> suppliers = new HashMap<>();
 
     SqlArrayMapperFactory() {
-        listSuppliers.put(List.class, ArrayList::new);
-        listSuppliers.put(ArrayList.class, ArrayList::new);
-        listSuppliers.put(LinkedList.class, LinkedList::new);
-        listSuppliers.put(CopyOnWriteArrayList.class, CopyOnWriteArrayList::new);
+        suppliers.put(List.class, ArrayList::new);
+        suppliers.put(ArrayList.class, ArrayList::new);
+        suppliers.put(LinkedList.class, LinkedList::new);
+        suppliers.put(CopyOnWriteArrayList.class, CopyOnWriteArrayList::new);
+
+        suppliers.put(Set.class, HashSet::new);
+        suppliers.put(HashSet.class, HashSet::new);
+        suppliers.put(LinkedHashSet.class, LinkedHashSet::new);
+        suppliers.put(TreeSet.class, TreeSet::new);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Optional<ColumnMapper<?>> build(Type type, StatementContext ctx) {
         final Class<?> erasedType = GenericTypes.getErasedType(type);
 
@@ -48,11 +58,11 @@ class SqlArrayMapperFactory implements ColumnMapperFactory {
                     .map(elementMapper -> new ArrayColumnMapper(elementMapper, elementType));
         }
 
-        Supplier<List<?>> supplier = listSuppliers.get(erasedType);
+        Supplier<Collection<?>> supplier = suppliers.get(erasedType);
         if (supplier != null) {
-            return GenericTypes.findGenericParameter(type, List.class)
+            return GenericTypes.findGenericParameter(type, Collection.class)
                     .flatMap(elementType -> elementTypeMapper(elementType, ctx))
-                    .map(elementMapper -> new ListColumnMapper(elementMapper, supplier));
+                    .map(elementMapper -> new CollectionColumnMapper(elementMapper, supplier));
         }
 
         return Optional.empty();

--- a/core/src/main/java/org/jdbi/v3/core/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/StatementContext.java
@@ -22,10 +22,12 @@ import java.sql.PreparedStatement;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collector;
 
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.SqlArrayType;
+import org.jdbi.v3.core.extension.ExtensionConfig;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.RowMapper;
 
@@ -153,6 +155,13 @@ public class StatementContext implements Closeable
      */
     public Optional<Collector<?, ?, ?>> findCollectorFor(Type type) {
         return config.collectorRegistry.findCollectorFor(type);
+    }
+
+    public <C extends ExtensionConfig<C>> C findConfiguration(Class<C> configType)
+    {
+        AtomicReference<C> result = new AtomicReference<>();
+        config.extensionRegistry.configure(configType, result::set);
+        return result.get();
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/vendor/H2DatabasePlugin.java
+++ b/core/src/main/java/org/jdbi/v3/core/vendor/H2DatabasePlugin.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.vendor;
+
+import java.util.UUID;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.SqlArrayConfiguration;
+import org.jdbi.v3.core.SqlArrayConfiguration.ArgumentStyle;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+public class H2DatabasePlugin implements JdbiPlugin
+{
+    @Override
+    public void customizeDbi(Jdbi dbi)
+    {
+        dbi.configure(SqlArrayConfiguration.class, c -> c.withArgumentStyle(ArgumentStyle.OBJECT_ARRAY));
+        dbi.registerArrayType(UUID.class, "uuid");
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/vendor/TestH2SqlArrays.java
+++ b/core/src/test/java/org/jdbi/v3/core/vendor/TestH2SqlArrays.java
@@ -35,6 +35,7 @@ public class TestH2SqlArrays {
     private static final GenericType<ArrayList<UUID>> UUID_ARRAYLIST = new GenericType<ArrayList<UUID>>() {};
     private static final GenericType<Set<UUID>> UUID_SET = new GenericType<Set<UUID>>() {};
     private static final GenericType<HashSet<UUID>> UUID_HASHSET = new GenericType<HashSet<UUID>>() {};
+    private static final GenericType<LinkedHashSet<UUID>> UUID_LINKEDHASHSET = new GenericType<LinkedHashSet<UUID>>() {};
 
     private static final String U_SELECT = "SELECT u FROM uuids";
     private static final String U_INSERT = "INSERT INTO uuids VALUES(:u)";
@@ -110,7 +111,7 @@ public class TestH2SqlArrays {
             h.createQuery(U_SELECT)
                 .mapTo(UUID_HASHSET)
                 .findOnly())
-            .containsExactly(testUuids);
+            .containsExactlyInAnyOrder(testUuids);
     }
 
     @Test
@@ -122,7 +123,7 @@ public class TestH2SqlArrays {
             .isEqualTo(1);
         assertThat(
             h.createQuery(U_SELECT)
-                .mapTo(UUID_SET)
+                .mapTo(UUID_LINKEDHASHSET)
                 .findOnly())
             .isInstanceOf(LinkedHashSet.class)
             .containsExactly(testUuids);

--- a/core/src/test/java/org/jdbi/v3/core/vendor/TestH2SqlArrays.java
+++ b/core/src/test/java/org/jdbi/v3/core/vendor/TestH2SqlArrays.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.vendor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.jdbi.v3.core.H2DatabaseRule;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.util.GenericType;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class TestH2SqlArrays {
+    private static final GenericType<List<UUID>> UUID_LIST = new GenericType<List<UUID>>() {};
+    private static final GenericType<ArrayList<UUID>> UUID_ARRAYLIST = new GenericType<ArrayList<UUID>>() {};
+    private static final GenericType<Set<UUID>> UUID_SET = new GenericType<Set<UUID>>() {};
+    private static final GenericType<HashSet<UUID>> UUID_HASHSET = new GenericType<HashSet<UUID>>() {};
+
+    private static final String U_SELECT = "SELECT u FROM uuids";
+    private static final String U_INSERT = "INSERT INTO uuids VALUES(:u)";
+
+    @ClassRule
+    public static H2DatabaseRule db = new H2DatabaseRule().withPlugin(new H2DatabasePlugin());
+
+    private Handle h;
+
+    @Before
+    public void setUp() {
+        h = db.getSharedHandle();
+        h.useTransaction((th, status) -> {
+            th.execute("DROP TABLE IF EXISTS uuids");
+            th.execute("CREATE TABLE uuids (u ARRAY)");
+        });
+    }
+
+    private final UUID[] testUuids = new UUID[] {
+        UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()
+    };
+
+    @Test
+    public void testUuidArray() throws Exception {
+        assertThat(
+            h.createUpdate(U_INSERT)
+                .bind("u", testUuids)
+                .execute())
+            .isEqualTo(1);
+        assertThat(
+            h.createQuery(U_SELECT)
+                .mapTo(UUID[].class)
+                .findOnly())
+            .containsExactly(testUuids);
+    }
+
+    @Test
+    public void testUuidList() throws Exception {
+        assertThat(
+            h.createUpdate(U_INSERT)
+                .bindByType("u", Arrays.asList(testUuids), UUID_LIST)
+                .execute())
+            .isEqualTo(1);
+        assertThat(
+            h.createQuery(U_SELECT)
+                .mapTo(UUID_LIST)
+                .findOnly())
+            .containsExactly(testUuids);
+    }
+
+    @Test
+    public void testUuidArrayList() throws Exception {
+        assertThat(
+            h.createUpdate(U_INSERT)
+                .bindByType("u", new ArrayList<>(Arrays.asList(testUuids)), UUID_LIST)
+                .execute())
+            .isEqualTo(1);
+        assertThat(
+            h.createQuery(U_SELECT)
+                .mapTo(UUID_ARRAYLIST)
+                .findOnly())
+            .containsExactly(testUuids);
+    }
+
+    @Test
+    public void testUuidHashSet() throws Exception {
+        assertThat(
+            h.createUpdate(U_INSERT)
+                .bindByType("u", new HashSet<>(Arrays.asList(testUuids)), UUID_SET)
+                .execute())
+            .isEqualTo(1);
+        assertThat(
+            h.createQuery(U_SELECT)
+                .mapTo(UUID_HASHSET)
+                .findOnly())
+            .containsExactly(testUuids);
+    }
+
+    @Test
+    public void testUuidLinkedHashSet() throws Exception {
+        assertThat(
+            h.createUpdate(U_INSERT)
+                .bindByType("u", new LinkedHashSet<>(Arrays.asList(testUuids)), UUID_SET)
+                .execute())
+            .isEqualTo(1);
+        assertThat(
+            h.createQuery(U_SELECT)
+                .mapTo(UUID_SET)
+                .findOnly())
+            .isInstanceOf(LinkedHashSet.class)
+            .containsExactly(testUuids);
+    }
+}


### PR DESCRIPTION
Three small changes in one:
- Support for configuring core features that aren't bound to an extension (RFC, do you like this?)
- Use that feature to support H2 array binding, introduce a plugin to configure it
- Add support for mapping `Set<T>` and friends
