### PR TITLE
Fix how the @BindIn annotation deals with EmptyHandling.NULL when backed by a postgresql database

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
+++ b/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java
@@ -97,23 +97,6 @@ public @interface BindIn
                 size = Util.size(arg);
             }
 
-            if (size == 0)
-            {
-                switch (bindIn.onEmpty())
-                {
-                    case VOID:
-                        // output nothing - taken care of with size = 0
-                        break;
-                    case NULL:
-                        // output null - handle in Binder
-                        break;
-                    case THROW:
-                        throw new IllegalArgumentException("argument is empty; emptiness was explicitly forbidden on this instance of BindIn");
-                    default:
-                        throw new IllegalStateException(EmptyHandling.valueNotHandledMessage);
-                }
-            }
-
             final String key = bindIn.value();
 
             // generate and concat placeholders
@@ -126,6 +109,24 @@ public @interface BindIn
                 }
                 names.append(":__").append(key).append("_").append(i);
             }
+
+            if (size == 0)
+            {
+                switch (bindIn.onEmpty())
+                {
+                    case VOID:
+                        // output nothing - taken care of with size = 0
+                        break;
+                    case NULL:
+                        names.append((String) null); // force 'null' placeholder in IN clause
+                        break;
+                    case THROW:
+                        throw new IllegalArgumentException("argument is empty; emptiness was explicitly forbidden on this instance of BindIn");
+                    default:
+                        throw new IllegalStateException(EmptyHandling.valueNotHandledMessage);
+                }
+            }
+
             final String ns = names.toString();
 
             return new SqlStatementCustomizer()

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/BindInNullPostgresTest.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/BindInNullPostgresTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.Something;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+import org.skife.jdbi.v2.unstable.BindIn;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assume.assumeTrue;
+import static org.skife.jdbi.v2.unstable.BindIn.EmptyHandling.NULL;
+
+public class BindInNullPostgresTest {
+    private static Handle handle;
+
+    @BeforeClass
+    public static void isPostgresInstalled() {
+        assumeTrue(Boolean.parseBoolean(System.getenv("TRAVIS")));
+    }
+
+    @BeforeClass
+    public static void init() {
+        handle = new DBI("jdbc:postgresql:jdbi_test", "postgres", "").open();
+
+        handle.execute("create table something (id int primary key, name varchar(100))");
+        handle.execute("insert into something(id, name) values(1, null)");
+        handle.execute("insert into something(id, name) values(2, 'bla')");
+        handle.execute("insert into something(id, name) values(3, 'null')");
+        handle.execute("insert into something(id, name) values(4, '')");
+    }
+
+    @AfterClass
+    public static void exit() {
+        handle.execute("drop table something");
+        handle.close();
+    }
+
+    @Test
+    public void testSomethingByIterableHandleNullWithNull() {
+        final SomethingByIterableHandleNull s = handle.attach(SomethingByIterableHandleNull.class);
+
+        final List<Something> out = s.get(null);
+
+        Assert.assertEquals(0, out.size());
+    }
+
+    @Test
+    public void testSomethingByIterableHandleNullWithEmptyList() {
+        final SomethingByIterableHandleNull s = handle.attach(SomethingByIterableHandleNull.class);
+
+        final List<Something> out = s.get(new ArrayList<Object>());
+
+        Assert.assertEquals(0, out.size());
+    }
+
+    @UseStringTemplate3StatementLocator
+    private interface SomethingByIterableHandleNull {
+        @SqlQuery("select id, name from something where name in (<names>)")
+        List<Something> get(@BindIn(value = "names", onEmpty = NULL) Iterable<Object> ids);
+    }
+}

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/BindInNullTest.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/BindInNullTest.java
@@ -65,11 +65,6 @@ public class BindInNullTest
         handle.close();
     }
 
-    // TODO run the following 2 tests against a postgresql db
-    // due to queries being parameterized with ?, we can't really test that the query's final form contains "in (null)", i.e. that EmptyHandling.NULL works as intended on a db like postgresql that demands the "in (null)" syntax
-    // all we can test is that the query returns no rows, as specified by sql's general design
-    // h2 accepts either form without causing trouble
-
     @Test
     public void testSomethingByIterableHandleNullWithNull()
     {


### PR DESCRIPTION
Support for handling empty collections through the `@BindIn` annotation was introduced in 823c7b7e28100bab44d29f17c2e6023ae3f46d83. However, this functionality does not work on postgresql databases - postgresql demands the "in (null)" syntax, and despite the fact that [BindingFactory.Binder#build attempts to solve this problem](https://github.com/jdbi/jdbi/blob/master/src/main/java/org/skife/jdbi/v2/unstable/BindIn.java#L161-L164), it falls short of setting the appropriate attributes so that [StringTemplate3StatementLocator#locate](https://github.com/jdbi/jdbi/blob/master/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/StringTemplate3StatementLocator.java#L258-L266) works as intended. This fix is aimed squarely at injecting a placeholder `null` value into the `in` clause, instead of just `()`.

A couple of things to note:
1. This is my first time contributing to this code base, so comments / criticisms are more than welcome. Is there a cleaner way to solve the problem than the way I've solved it?
1. I didn't change the behavior if the input value is explicitly `null` as opposed to simply an empty collection - not entirely sure what the expected behavior is in this scenario.
1. I've gone ahead and added a postgresql test that fires only in the Travis build. Not sure what the best practice around this is. This test *does* fail in the case where my code changes around `BindIn` are removed.