### PR TITLE
Instruct Eclipse to not build asciidoc

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -138,6 +138,33 @@
                         </excludes>
                     </configuration>
                 </plugin>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                  <groupId>org.eclipse.m2e</groupId>
+                  <artifactId>lifecycle-mapping</artifactId>
+                  <version>1.0.0</version>
+                  <configuration>
+                    <lifecycleMappingMetadata>
+                      <pluginExecutions>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>
+                              asciidoctor-maven-plugin
+                            </artifactId>
+                            <versionRange>[1.5.3,)</versionRange>
+                            <goals>
+                              <goal>process-asciidoc</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore></ignore>
+                          </action>
+                        </pluginExecution>
+                      </pluginExecutions>
+                    </lifecycleMappingMetadata>
+                  </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
There's no plugin for it so this just causes build errors.
No effect in other environments.