### PR TITLE
Remove pom.xml <developers> section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,34 +50,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <developers>
-        <developer>
-            <id>brianm</id>
-            <name>Brian McCallister</name>
-            <email>brianm@skife.org</email>
-        </developer>
-        <developer>
-            <id>martint</id>
-            <name>Martin Traverso</name>
-        </developer>
-        <developer>
-            <id>hgschmie</id>
-            <name>Henning Schmiedehausen</name>
-        </developer>
-        <developer>
-            <id>arosien</id>
-            <name>Adam Rosien</name>
-        </developer>
-        <developer>
-            <id>tomdz</id>
-            <name>Thomas Dudziak</name>
-        </developer>
-        <developer>
-            <id>stevenschlansker</id>
-            <name>Steven Schlansker</name>
-        </developer>
-    </developers>
-
     <properties>
         <project.build.targetJdk>1.8</project.build.targetJdk>
         <basepom.maven.version>3.2.5</basepom.maven.version>


### PR DESCRIPTION
It's a little out of date.

I don't want to diminish past contributions,
but we don't keep this up to date, and I feel
it doesn't add much value.

So the most fair resolution seems to be to delete it :)