### PR TITLE
@SingleValue for prepared batch parameters

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgument.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgument.java
@@ -16,10 +16,13 @@ package org.jdbi.v3.core.array;
 import java.lang.reflect.Array;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.jdbi.v3.core.StatementContext;
 import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.util.ReflectionArrayIterator;
 
 class SqlArrayArgument<T> implements Argument {
 
@@ -29,11 +32,12 @@ class SqlArrayArgument<T> implements Argument {
     @SuppressWarnings("unchecked")
     SqlArrayArgument(SqlArrayType<T> arrayType, Object newArray) {
         this.typeName = arrayType.getTypeName();
-        int length = Array.getLength(newArray);
-        this.array = new Object[length];
-        for (int i = 0; i < length; i++) {
-            array[i] = arrayType.convertArrayElement((T) Array.get(newArray, i));
-        }
+
+        List<Object> elements = new ArrayList<>(
+                newArray.getClass().isArray() ? Array.getLength(newArray) : 10);
+        ReflectionArrayIterator.of(newArray).forEachRemaining(
+                e -> elements.add(arrayType.convertArrayElement((T) e)));
+        array = elements.toArray();
     }
 
     SqlArrayArgument(SqlArrayType<T> arrayType, Collection<T> list) {

--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgumentFactory.java
@@ -24,18 +24,17 @@ import org.jdbi.v3.core.util.GenericTypes;
 
 public class SqlArrayArgumentFactory implements ArgumentFactory {
     @Override
-    @SuppressWarnings("unchecked")
     public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
         Class<?> erasedType = GenericTypes.getErasedType(type);
         if (erasedType.isArray()) {
             Class<?> elementType = erasedType.getComponentType();
             return config.findSqlArrayTypeFor(elementType)
-                    .map(arrayType -> new SqlArrayArgument(arrayType, value));
+                    .map(arrayType -> new SqlArrayArgument<>(arrayType, value));
         }
         if (Collection.class.isAssignableFrom(erasedType)) {
             return GenericTypes.findGenericParameter(type, Collection.class)
                     .flatMap(config::findSqlArrayTypeFor)
-                    .map(arrayType -> new SqlArrayArgument(arrayType, (Collection) value));
+                    .map(arrayType -> new SqlArrayArgument<>(arrayType, (Collection<?>) value));
         }
         return Optional.empty();
     }

--- a/core/src/main/java/org/jdbi/v3/core/util/ReflectionArrayIterator.java
+++ b/core/src/main/java/org/jdbi/v3/core/util/ReflectionArrayIterator.java
@@ -17,8 +17,6 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import com.google.common.base.Verify;
-
 /**
  * Implements Iterator for unidentified arrays that have been cast to Object. Note that its elements will be returned as Object, primitives included (will be autoboxed).
  */
@@ -88,9 +86,11 @@ public class ReflectionArrayIterator implements Iterator<Object>
         }
 
         Class<? extends Object> klass = iterable.getClass();
-        Verify.verify(klass.isArray(), "'%s' not an iterable", klass);
-        if (klass.getComponentType().isPrimitive())
-        {
+        if(!klass.isArray()) {
+            throw new IllegalArgumentException(String.format("'%s' not an iterable", klass));
+        }
+
+        if (klass.getComponentType().isPrimitive()) {
             return new ReflectionArrayIterator(iterable);
         }
         return Arrays.asList((Object[])iterable).iterator();

--- a/core/src/main/java/org/jdbi/v3/core/vendor/H2DatabasePlugin.java
+++ b/core/src/main/java/org/jdbi/v3/core/vendor/H2DatabasePlugin.java
@@ -24,5 +24,6 @@ public class H2DatabasePlugin implements JdbiPlugin {
     public void customizeJdbi(Jdbi jdbi) {
         jdbi.setSqlArrayArgumentStrategy(SqlArrayArgumentStrategy.OBJECT_ARRAY);
         jdbi.registerArrayType(UUID.class, "uuid");
+        jdbi.registerArrayType(int.class, "integer");
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/util/ReflectionArrayIteratorTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/util/ReflectionArrayIteratorTest.java
@@ -11,13 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.sqlobject.customizers;
+package org.jdbi.v3.core.util;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Iterator;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
 
 public class ReflectionArrayIteratorTest
 {
@@ -40,7 +40,7 @@ public class ReflectionArrayIteratorTest
     @Test(expected = ArrayIndexOutOfBoundsException.class)
     public void testOverflow()
     {
-        final Iterator it = new ReflectionArrayIterator(new int[]{1});
+        final Iterator<?> it = new ReflectionArrayIterator(new int[]{1});
 
         assertThat(it.hasNext()).isTrue();
         assertThat(it.next()).isEqualTo(1);
@@ -51,7 +51,7 @@ public class ReflectionArrayIteratorTest
     @Test(expected = ArrayIndexOutOfBoundsException.class)
     public void testOverflowOnEmpty()
     {
-        final Iterator it = new ReflectionArrayIterator(new int[]{});
+        final Iterator<?> it = new ReflectionArrayIterator(new int[]{});
 
         it.next();
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultObjectBinder.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultObjectBinder.java
@@ -36,7 +36,7 @@ class DefaultObjectBinder implements BinderFactory<Bind, Object>
 
             Type type = param.getParameterizedType();
 
-            if (q instanceof PreparedBatchPart) {
+            if (q instanceof PreparedBatchPart && !param.isAnnotationPresent(SingleValue.class)) {
                 Class<?> erasedType = GenericTypes.getErasedType(type);
                 if (Iterable.class.isAssignableFrom(erasedType)) {
                     type = GenericTypes.findGenericParameter(type, Iterable.class).get();

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SingleValue.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SingleValue.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
  * should be treated as a single element.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.PARAMETER })
 public @interface SingleValue {
 
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/BindList.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import org.jdbi.v3.core.util.ReflectionArrayIterator;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizerFactory;
 import org.jdbi.v3.sqlobject.SqlStatementCustomizingAnnotation;
@@ -113,7 +114,7 @@ public @interface BindList {
                 if (obj instanceof Object[]) {
                     return Arrays.asList((Object[]) obj).iterator();
                 } else {
-                    return new ReflectionArrayIterator(obj);
+                    return ReflectionArrayIterator.of(obj);
                 }
             }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizers/BindList.java
@@ -127,11 +127,11 @@ public @interface BindList {
             }
 
             if (obj instanceof Collection) {
-                return ((Collection)obj).isEmpty();
+                return ((Collection<?>)obj).isEmpty();
             }
 
             if (obj instanceof Iterable) {
-                return !((Iterable)obj).iterator().hasNext();
+                return !((Iterable<?>)obj).iterator().hasNext();
             }
 
             if (obj.getClass().isArray()) {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatchingSingleValue.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatchingSingleValue.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import static java.util.Arrays.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.jdbi.v3.core.H2DatabaseRule;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.vendor.H2DatabasePlugin;
+import org.jdbi.v3.sqlobject.customizers.BatchChunkSize;
+import org.jdbi.v3.sqlobject.customizers.RegisterConstructorMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestBatchingSingleValue
+{
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule().withPlugin(new SqlObjectPlugin()).withPlugin(new H2DatabasePlugin());
+    private Handle handle;
+    private SingleValueBatching b;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        handle = db.getSharedHandle();
+        handle.execute("create table batching (id integer, values array)");
+        b = handle.attach(SingleValueBatching.class);
+    }
+
+
+    @Test
+    public void testSingleValueArray() throws Exception
+    {
+        final int[] ids = IntStream.range(0, 10).toArray();
+        final int[] values = IntStream.range(50, 60).toArray();
+
+        b.insertValues(ids, values);
+
+        assertThat(b.select()).containsExactly(
+                stream(ids)
+                    .mapToObj(id -> new BatchingRow(id, values))
+                    .toArray(BatchingRow[]::new));
+    }
+
+    @BatchChunkSize(4)
+    @RegisterConstructorMapper(BatchingRow.class)
+    public interface SingleValueBatching
+    {
+        @SqlBatch("insert into batching (id, values) values (:id, :values)")
+        int[] insertValues(int[] ids, @SingleValue int[] values);
+
+        @SqlQuery("select id, values from batching order by id asc")
+        List<BatchingRow> select();
+    }
+
+    public static class BatchingRow
+    {
+        final int id;
+        final int[] values;
+
+        public BatchingRow(int id, int[] values)
+        {
+            this.id = id;
+            this.values = values;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj instanceof BatchingRow)
+            {
+                BatchingRow other = (BatchingRow) obj;
+                return id == other.id && Arrays.equals(values, other.values);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return id ^ Arrays.hashCode(values);
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("%s %s", id, Arrays.toString(values));
+        }
+    }
+}


### PR DESCRIPTION
Also increases use of `ReflectionArrayIterator` so you can bind e.g. `int[]` without hitting a nasty `ClassCastException`.