### PR TITLE
Specializing row mappers

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/GeneratedKeys.java
+++ b/core/src/main/java/org/jdbi/v3/core/GeneratedKeys.java
@@ -74,7 +74,13 @@ public class GeneratedKeys<T> implements ResultBearing<T>
         if (results == null) {
             return new EmptyResultIterator<>(context);
         }
-        return new ResultSetResultIterator<>(mapper, results, context);
+
+        try {
+            return new ResultSetResultIterator<>(mapper, results, context);
+        }
+        catch (SQLException e) {
+            throw new UnableToExecuteStatementException(e, context);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/ResultSetResultIterator.java
+++ b/core/src/main/java/org/jdbi/v3/core/ResultSetResultIterator.java
@@ -33,9 +33,9 @@ class ResultSetResultIterator<Type> implements ResultIterator<Type>
 
     ResultSetResultIterator(RowMapper<Type> mapper,
                             ResultSet results,
-                            StatementContext context)
+                            StatementContext context) throws SQLException
     {
-        this.mapper = mapper;
+        this.mapper = mapper.memoize(results, context);
         this.context = context;
         this.results = results;
 

--- a/core/src/main/java/org/jdbi/v3/core/ResultSetResultIterator.java
+++ b/core/src/main/java/org/jdbi/v3/core/ResultSetResultIterator.java
@@ -35,7 +35,7 @@ class ResultSetResultIterator<Type> implements ResultIterator<Type>
                             ResultSet results,
                             StatementContext context) throws SQLException
     {
-        this.mapper = mapper.memoize(results, context);
+        this.mapper = mapper.specialize(results, context);
         this.context = context;
         this.results = results;
 

--- a/core/src/main/java/org/jdbi/v3/core/RowView.java
+++ b/core/src/main/java/org/jdbi/v3/core/RowView.java
@@ -79,7 +79,7 @@ public class RowView
 
         RowMapper<?> mapper = ctx.findRowMapperFor(type)
                 .orElseThrow(() -> new UnableToExecuteStatementException("No row mapper for " + type, ctx))
-                .memoize(rs, ctx);
+                .specialize(rs, ctx);
         rowMappers.put(type, mapper);
 
         return mapper;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/JoinRowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/JoinRowMapper.java
@@ -85,13 +85,13 @@ public class JoinRowMapper implements RowMapper<JoinRowMapper.JoinRow>
     }
 
     @Override
-    public RowMapper<JoinRow> memoize(ResultSet r, StatementContext ctx) throws SQLException {
+    public RowMapper<JoinRow> specialize(ResultSet r, StatementContext ctx) throws SQLException {
         RowMapper[] mappers = new RowMapper[types.length];
         for (int i = 0; i < types.length; i++) {
             Type type = types[i];
             mappers[i] = ctx.findRowMapperFor(type)
                     .orElseThrow(() -> new IllegalArgumentException("No row mapper registered for " + type))
-                    .memoize(r, ctx);
+                    .specialize(r, ctx);
         }
 
         return (rs, context) -> {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
@@ -41,6 +41,8 @@ public interface RowMapper<T>
      * Returns an equivalent row mapper, optimized for the given result set. Overriding this method is optional--the
      * default implementation returns {@code this}. Implementors might choose to override this method to improve
      * performance, e.g. by mapping result columns once for the whole result set, instead of for every row.
+     * <p>
+     * The returned mapper should <em>only</em> be used to map values from the given result set.
      *
      * @param rs  the result set to specialize over
      * @param ctx the statement context to specialize over

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
@@ -38,16 +38,17 @@ public interface RowMapper<T>
     T map(ResultSet rs, StatementContext ctx) throws SQLException;
 
     /**
-     * Returns a row mapper instance with the details of the result set memoized for performance. Overriding this
-     * method is optional--the default implementation simply returns {@code this}.
+     * Returns an equivalent row mapper, optimized for the given result set. Overriding this method is optional--the
+     * default implementation returns {@code this}. Implementors might choose to override this method to improve
+     * performance, e.g. by mapping result columns once for the whole result set, instead of for every row.
      *
-     * @param rs  the result set to memoize over
-     * @param ctx the statement context to memoize over
-     * @return a row mapper equivalent to this one, possibly memoized.
+     * @param rs  the result set to specialize over
+     * @param ctx the statement context to specialize over
+     * @return a row mapper equivalent to this one, possibly specialized.
      * @throws SQLException if anything goes wrong go ahead and let this percolate, jDBI will handle it
      * @see org.jdbi.v3.core.mapper.reflect.BeanMapper for an example of memoization.
      */
-    default RowMapper<T> memoize(ResultSet rs, StatementContext ctx) throws SQLException {
+    default RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         return this;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
@@ -41,17 +41,17 @@ public interface RowMapper<T>
      * Returns a specialized row mapper, optimized for the given result set.
      * <p>
      * Before mapping the result set from a SQL statement, JDBI will first call this method to obtain a specialized
-     * instance. The returned mapper will then be used for each row in the result set, and discarded.
+     * instance. The returned mapper will then be used to map the result set rows, and discarded.
      * <p>
      * Implementing this method is optional; the default implementation returns {@code this}. Implementors might choose
-     * to override this method to improve performance, e.g. by mapping result columns once for the whole result set,
-     * and not for every row.
+     * to override this method to improve performance, e.g. by matching up column names to properties once for the
+     * entire result set, rather than repeating the process for every row.
      *
      * @param rs  the result set to specialize over
      * @param ctx the statement context to specialize over
      * @return a row mapper equivalent to this one, possibly specialized.
      * @throws SQLException if anything goes wrong go ahead and let this percolate, jDBI will handle it
-     * @see org.jdbi.v3.core.mapper.reflect.BeanMapper for an example of memoization.
+     * @see org.jdbi.v3.core.mapper.reflect.BeanMapper for an example of specialization.
      */
     default RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         return this;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
@@ -38,11 +38,14 @@ public interface RowMapper<T>
     T map(ResultSet rs, StatementContext ctx) throws SQLException;
 
     /**
-     * Returns an equivalent row mapper, optimized for the given result set. Overriding this method is optional--the
-     * default implementation returns {@code this}. Implementors might choose to override this method to improve
-     * performance, e.g. by mapping result columns once for the whole result set, instead of for every row.
+     * Returns a specialized row mapper, optimized for the given result set.
      * <p>
-     * The returned mapper should <em>only</em> be used to map values from the given result set.
+     * Before mapping the result set from a SQL statement, JDBI will first call this method to obtain a specialized
+     * instance. The returned mapper will then be used for each row in the result set, and discarded.
+     * <p>
+     * Implementing this method is optional; the default implementation returns {@code this}. Implementors might choose
+     * to override this method to improve performance, e.g. by mapping result columns once for the whole result set,
+     * and not for every row.
      *
      * @param rs  the result set to specialize over
      * @param ctx the statement context to specialize over

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
@@ -16,8 +16,8 @@ package org.jdbi.v3.core.mapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.StatementContext;
 import org.jdbi.v3.core.Query;
+import org.jdbi.v3.core.StatementContext;
 
 /**
  * Used with a {@link Query#map(RowMapper)} call to specify
@@ -30,10 +30,24 @@ public interface RowMapper<T>
      * Map the row the result set is at when passed in. This method should not cause the result
      * set to advance, allow jDBI to do that, please.
      *
-     * @param r the result set being iterated
+     * @param rs the result set being iterated
      * @param ctx the statement context
      * @return the value to return for this row
      * @throws SQLException if anything goes wrong go ahead and let this percolate, jDBI will handle it
      */
-    T map(ResultSet r, StatementContext ctx) throws SQLException;
+    T map(ResultSet rs, StatementContext ctx) throws SQLException;
+
+    /**
+     * Returns a row mapper instance with the details of the result set memoized for performance. Overriding this
+     * method is optional--the default implementation simply returns {@code this}.
+     *
+     * @param rs  the result set to memoize over
+     * @param ctx the statement context to memoize over
+     * @return a row mapper equivalent to this one, possibly memoized.
+     * @throws SQLException if anything goes wrong go ahead and let this percolate, jDBI will handle it
+     * @see org.jdbi.v3.core.mapper.reflect.BeanMapper for an example of memoization.
+     */
+    default RowMapper<T> memoize(ResultSet rs, StatementContext ctx) throws SQLException {
+        return this;
+    }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
@@ -100,11 +100,11 @@ public class BeanMapper<T> implements RowMapper<T>
 
     @Override
     public T map(ResultSet rs, StatementContext ctx) throws SQLException {
-        return memoize(rs, ctx).map(rs, ctx);
+        return specialize(rs, ctx).map(rs, ctx);
     }
 
     @Override
-    public RowMapper<T> memoize(ResultSet rs, StatementContext ctx) throws SQLException {
+    public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         List<Integer> columnNumbers = new ArrayList<>();
         List<ColumnMapper<?>> mappers = new ArrayList<>();
         List<PropertyDescriptor> properties = new ArrayList<>();

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Type;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -98,17 +99,15 @@ public class BeanMapper<T> implements RowMapper<T>
     }
 
     @Override
-    public T map(ResultSet rs, StatementContext ctx)
-        throws SQLException
-    {
-        T bean;
-        try {
-            bean = type.newInstance();
-        }
-        catch (Exception e) {
-            throw new IllegalArgumentException(String.format("A bean, %s, was mapped " +
-                                                             "which was not instantiable", type.getName()), e);
-        }
+    public T map(ResultSet rs, StatementContext ctx) throws SQLException {
+        return memoize(rs, ctx).map(rs, ctx);
+    }
+
+    @Override
+    public RowMapper<T> memoize(ResultSet rs, StatementContext ctx) throws SQLException {
+        List<Integer> columnNumbers = new ArrayList<>();
+        List<ColumnMapper<?>> mappers = new ArrayList<>();
+        List<PropertyDescriptor> properties = new ArrayList<>();
 
         ResultSetMetaData metadata = rs.getMetaData();
         List<ColumnNameMatcher> columnNameMatchers = ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
@@ -135,35 +134,49 @@ public class BeanMapper<T> implements RowMapper<T>
 
             final PropertyDescriptor descriptor = maybeDescriptor.get();
             final Type type = descriptor.getReadMethod().getGenericReturnType();
-            final Object value;
-            final Optional<ColumnMapper<?>> mapper = ctx.findColumnMapperFor(type);
+            final ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
+                    .orElse((r, n, c) -> r.getObject(n));
 
-            if (mapper.isPresent()) {
-                value = mapper.get().map(rs, i, ctx);
-            }
-            else {
-                value = rs.getObject(i);
-            }
-
-            try
-            {
-                descriptor.getWriteMethod().invoke(bean, value);
-            }
-            catch (IllegalAccessException e) {
-                throw new IllegalArgumentException(String.format("Unable to access setter for " +
-                                                                 "property, %s", name), e);
-            }
-            catch (InvocationTargetException e) {
-                throw new IllegalArgumentException(String.format("Invocation target exception trying to " +
-                                                                 "invoker setter for the %s property", name), e);
-            }
-            catch (NullPointerException e) {
-                throw new IllegalArgumentException(String.format("No appropriate method to " +
-                                                                 "write property %s", name), e);
-            }
+            columnNumbers.add(i);
+            mappers.add(mapper);
+            properties.add(descriptor);
         }
 
-        return bean;
+        return (r, c) -> {
+            T bean;
+            try {
+                bean = type.newInstance();
+            }
+            catch (Exception e) {
+                throw new IllegalArgumentException(String.format("A bean, %s, was mapped " +
+                        "which was not instantiable", type.getName()), e);
+            }
+
+            for (int i = 0; i < columnNumbers.size(); i++) {
+                int columnNumber = columnNumbers.get(i);
+                ColumnMapper<?> mapper = mappers.get(i);
+                PropertyDescriptor property = properties.get(i);
+
+                Object value = mapper.map(r, columnNumber, ctx);
+                try {
+                    property.getWriteMethod().invoke(bean, value);
+                }
+                catch (IllegalAccessException e) {
+                    throw new IllegalArgumentException(String.format("Unable to access setter for " +
+                            "property, %s", property.getName()), e);
+                }
+                catch (InvocationTargetException e) {
+                    throw new IllegalArgumentException(String.format("Invocation target exception trying to " +
+                            "invoker setter for the %s property", property.getName()), e);
+                }
+                catch (NullPointerException e) {
+                    throw new IllegalArgumentException(String.format("No appropriate method to " +
+                            "write property %s", property.getName()), e);
+                }
+            }
+
+            return bean;
+        };
     }
 
     private Optional<PropertyDescriptor> descriptorForColumn(String columnName,

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -92,11 +92,11 @@ public class ConstructorMapper<T> implements RowMapper<T>
 
     @Override
     public T map(ResultSet rs, StatementContext ctx) throws SQLException {
-        return memoize(rs, ctx).map(rs, ctx);
+        return specialize(rs, ctx).map(rs, ctx);
     }
 
     @Override
-    public RowMapper<T> memoize(ResultSet rs, StatementContext ctx) throws SQLException {
+    public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         final ResultSetMetaData metadata = rs.getMetaData();
         final List<String> columnNames = new ArrayList<>(metadata.getColumnCount());
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Type;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,17 +83,15 @@ public class FieldMapper<T> implements RowMapper<T>
     }
 
     @Override
-    public T map(ResultSet rs, StatementContext ctx)
-            throws SQLException
-    {
-        T obj;
-        try {
-            obj = type.newInstance();
-        }
-        catch (Exception e) {
-            throw new IllegalArgumentException(String.format("A bean, %s, was mapped " +
-                    "which was not instantiable", type.getName()), e);
-        }
+    public T map(ResultSet rs, StatementContext ctx) throws SQLException {
+        return memoize(rs, ctx).map(rs, ctx);
+    }
+
+    @Override
+    public RowMapper<T> memoize(ResultSet rs, StatementContext ctx) throws SQLException {
+        List<Integer> columnNumbers = new ArrayList<>();
+        List<ColumnMapper<?>> mappers = new ArrayList<>();
+        List<Field> fields = new ArrayList<>();
 
         ResultSetMetaData metadata = rs.getMetaData();
         List<ColumnNameMatcher> columnNameMatchers = ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
@@ -118,28 +117,40 @@ public class FieldMapper<T> implements RowMapper<T>
 
             final Field field = maybeField.get();
             final Type type = field.getGenericType();
-            final Object value;
-            final Optional<ColumnMapper<?>> mapper = ctx.findColumnMapperFor(type);
+            final ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
+                    .orElse((r, n, c) -> r.getObject(n));
 
-            if (mapper.isPresent()) {
-                value = mapper.get().map(rs, i, ctx);
-            }
-            else {
-                value = rs.getObject(i);
-            }
-
-            try
-            {
-                field.setAccessible(true);
-                field.set(obj, value);
-            }
-            catch (IllegalAccessException e) {
-                throw new IllegalArgumentException(String.format("Unable to access " +
-                        "property, %s", name), e);
-            }
+            columnNumbers.add(i);
+            mappers.add(mapper);
+            fields.add(field);
         }
 
-        return obj;
+        return (r, c) -> {
+            T obj;
+            try {
+                obj = type.newInstance();
+            }
+            catch (Exception e) {
+                throw new IllegalArgumentException(String.format("A bean, %s, was mapped " +
+                        "which was not instantiable", type.getName()), e);
+            }
+
+            for (int i = 0; i < columnNumbers.size(); i++) {
+                int columnNumber = columnNumbers.get(i);
+                ColumnMapper<?> mapper = mappers.get(i);
+                Field field = fields.get(i);
+
+                Object value = mapper.map(rs, columnNumber, ctx);
+                try {
+                    field.setAccessible(true);
+                    field.set(obj, value);
+                } catch (IllegalAccessException e) {
+                    throw new IllegalArgumentException(String.format("Unable to access " +
+                            "property, %s", field.getName()), e);
+                }
+            }
+            return obj;
+        };
     }
 
     private Optional<Field> fieldByColumn(String columnName, List<ColumnNameMatcher> columnNameMatchers)

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -84,11 +84,11 @@ public class FieldMapper<T> implements RowMapper<T>
 
     @Override
     public T map(ResultSet rs, StatementContext ctx) throws SQLException {
-        return memoize(rs, ctx).map(rs, ctx);
+        return specialize(rs, ctx).map(rs, ctx);
     }
 
     @Override
-    public RowMapper<T> memoize(ResultSet rs, StatementContext ctx) throws SQLException {
+    public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         List<Integer> columnNumbers = new ArrayList<>();
         List<ColumnMapper<?>> mappers = new ArrayList<>();
         List<Field> fields = new ArrayList<>();

--- a/core/src/main/java/org/jdbi/v3/core/unstable/oracle/OracleReturning.java
+++ b/core/src/main/java/org/jdbi/v3/core/unstable/oracle/OracleReturning.java
@@ -137,7 +137,7 @@ public class OracleReturning<ResultType> implements StatementCustomizer
         }
         this.results = new ArrayList<>();
         try {
-            RowMapper<ResultType> mapper = this.mapper.memoize(rs, context);
+            RowMapper<ResultType> mapper = this.mapper.specialize(rs, context);
             while (rs.next()) {
                 results.add(mapper.map(rs, context));
             }

--- a/core/src/main/java/org/jdbi/v3/core/unstable/oracle/OracleReturning.java
+++ b/core/src/main/java/org/jdbi/v3/core/unstable/oracle/OracleReturning.java
@@ -137,6 +137,7 @@ public class OracleReturning<ResultType> implements StatementCustomizer
         }
         this.results = new ArrayList<>();
         try {
+            RowMapper<ResultType> mapper = this.mapper.memoize(rs, context);
             while (rs.next()) {
                 results.add(mapper.map(rs, context));
             }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultGeneratedKeyMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultGeneratedKeyMapper.java
@@ -37,8 +37,8 @@ class DefaultGeneratedKeyMapper implements RowMapper<Object> {
     }
 
     @Override
-    public RowMapper<Object> memoize(ResultSet rs, StatementContext ctx) throws SQLException {
-        return rowMapperFor(ctx).memoize(rs, ctx);
+    public RowMapper<Object> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
+        return rowMapperFor(ctx).specialize(rs, ctx);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Added method `RowMapper<T>.memoize(ResultSet, StatementContext): RowMapper<T>`.

This improves performance of mapping since the memoized mapper only scans the column names and performance column-to-(field/parameter/property) mapping and column mapper lookup once for the entire result set.

Audited all StatementExecutors, and all other callers of `RowMapper.map` to ensure that the row mapper is memoized once before parsing the result set.