### PR TITLE
Remove Handler.invoke redundant parameter `method`

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BatchHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BatchHandler.java
@@ -107,13 +107,13 @@ class BatchHandler extends CustomizingStatementHandler
     }
 
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier h)
+    public Object invoke(Object target, Object[] args, HandleSupplier h)
     {
         final Handle handle = h.getHandle();
         final String sql = handle.getConfig().get(SqlObjects.class)
-                .getSqlLocator().locate(sqlObjectType, method);
+                .getSqlLocator().locate(sqlObjectType, getMethod());
         final int chunkSize = batchChunkSize.call(args);
-        final Iterator<Object[]> batchArgs = zipArgs(method, args);
+        final Iterator<Object[]> batchArgs = zipArgs(getMethod(), args);
 
         ResultIterator<Object> result = new ResultIterator<Object>() {
             ResultIterator<?> batchResult;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BeginHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BeginHandler.java
@@ -13,14 +13,12 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 
 class BeginHandler implements Handler
 {
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         handle.getHandle().begin();
         return null;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CallHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CallHandler.java
@@ -43,9 +43,9 @@ class CallHandler extends CustomizingStatementHandler
     }
 
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
-        String sql = handle.getConfig(SqlObjects.class).getSqlLocator().locate(sqlObjectType, method);
+        String sql = handle.getConfig(SqlObjects.class).getSqlLocator().locate(sqlObjectType, getMethod());
         Call call = handle.getHandle().createCall(sql);
         applyCustomizers(call, args);
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CommitHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CommitHandler.java
@@ -13,14 +13,12 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 
 class CommitHandler implements Handler
 {
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         handle.getHandle().commit();
         return null;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CreateSqlObjectHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/CreateSqlObjectHandler.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 import org.jdbi.v3.core.extension.Extensions;
 
@@ -28,7 +26,7 @@ class CreateSqlObjectHandler implements Handler
     }
 
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         return handle.getConfig(Extensions.class)
                 .findFactory(SqlObjectFactory.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandler.java
@@ -67,7 +67,7 @@ class DefaultMethodHandler implements Handler {
     }
 
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle) {
+    public Object invoke(Object target, Object[] args, HandleSupplier handle) {
         try {
             return methodHandle.bindTo(target).invokeWithArguments(args);
         } catch (RuntimeException | Error e) {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/EqualsHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/EqualsHandler.java
@@ -22,7 +22,7 @@ import org.jdbi.v3.core.HandleSupplier;
 class EqualsHandler implements Handler
 {
     @Override
-    public Object invoke(final Object target, Method method, final Object[] args, final HandleSupplier handle)
+    public Object invoke(final Object target, final Object[] args, final HandleSupplier handle)
     {
         // basic reference equals for now.
         return target == args[0];

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/FinalizeHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/FinalizeHandler.java
@@ -38,7 +38,7 @@ class FinalizeHandler implements Handler
     }
 
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         return null;
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GetHandleHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GetHandleHandler.java
@@ -13,14 +13,12 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 
 class GetHandleHandler implements Handler
 {
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         return handle.getHandle();
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handler.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 
 /**
@@ -25,11 +23,10 @@ public interface Handler {
      * Executes a SQL Object method, and returns the result.
      *
      * @param target the SQL Object instance being invoked
-     * @param method the method being invoked on the SQL Object.
      * @param args   the arguments that were passed to the method.
      * @param handle a (possibly lazy) Handle supplier.
      * @return the method return value, or null if the method has a void return type.
      * @throws Exception any exception thrown by the method.
      */
-    Object invoke(Object target, Method method, Object[] args, HandleSupplier handle) throws Exception;
+    Object invoke(Object target, Object[] args, HandleSupplier handle) throws Exception;
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HashCodeHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HashCodeHandler.java
@@ -36,7 +36,7 @@ class HashCodeHandler implements Handler
     }
 
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         return System.identityHashCode(target);
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/InTransactionHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/InTransactionHandler.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 import org.jdbi.v3.sqlobject.mixins.Transactional;
 
@@ -22,7 +20,7 @@ class InTransactionHandler implements Handler
 {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Object invoke(final Object target, Method method, Object[] args, HandleSupplier handle) throws Exception
+    public Object invoke(final Object target, Object[] args, HandleSupplier handle) throws Exception
     {
         final TransactionalCallback callback = (TransactionalCallback) args[0];
         return handle.getHandle().inTransaction(h -> callback.inTransaction(Transactional.class.cast(target)));

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/InTransactionWithIsolationLevelHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/InTransactionWithIsolationLevelHandler.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.jdbi.v3.sqlobject.mixins.Transactional;
@@ -23,7 +21,7 @@ class InTransactionWithIsolationLevelHandler implements Handler
 {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Object invoke(final Object target, Method method, Object[] args, HandleSupplier handle) throws Exception
+    public Object invoke(final Object target, Object[] args, HandleSupplier handle) throws Exception
     {
         final TransactionalCallback callback = (TransactionalCallback) args[1];
         final TransactionIsolationLevel level = (TransactionIsolationLevel) args[0];

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/QueryHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/QueryHandler.java
@@ -21,17 +21,19 @@ import org.jdbi.v3.core.Query;
 class QueryHandler extends CustomizingStatementHandler
 {
     private final Class<?> sqlObjectType;
+    private final Method method;
     private final ResultReturner magic;
 
     QueryHandler(Class<?> sqlObjectType, Method method, ResultReturner magic)
     {
         super(sqlObjectType, method);
         this.sqlObjectType = sqlObjectType;
+        this.method = method;
         this.magic = magic;
     }
 
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         String sql = handle.getConfig(SqlObjects.class).getSqlLocator().locate(sqlObjectType, method);
         Query<?> q = handle.getHandle().createQuery(sql);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ReleaseSavepointHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ReleaseSavepointHandler.java
@@ -13,14 +13,12 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 
 class ReleaseSavepointHandler implements Handler
 {
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         handle.getHandle().release(String.valueOf(args[0]));
         return null;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/RollbackHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/RollbackHandler.java
@@ -13,14 +13,12 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 
 class RollbackHandler implements Handler
 {
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         handle.getHandle().rollback();
         return null;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/RollbackSavepointHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/RollbackSavepointHandler.java
@@ -13,14 +13,12 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 
 class RollbackSavepointHandler implements Handler
 {
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         handle.getHandle().rollbackToSavepoint(String.valueOf(args[0]));
         return null;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SavepointHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SavepointHandler.java
@@ -13,14 +13,12 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.HandleSupplier;
 
 class SavepointHandler implements Handler
 {
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
         handle.getHandle().savepoint(String.valueOf(args[0]));
         return null;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -259,7 +259,7 @@ public class SqlObjectFactory implements ExtensionFactory {
                     factory.createForMethod(annotation, sqlObjectType, method).accept(methodConfig));
 
             return handle.invokeInContext(new ExtensionMethod(sqlObjectType, method), methodConfig,
-                    () -> handler.invoke(proxy, method, args == null ? NO_ARGS : args, handle));
+                    () -> handler.invoke(proxy, args == null ? NO_ARGS : args, handle));
         };
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ToStringHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/ToStringHandler.java
@@ -29,7 +29,7 @@ class ToStringHandler implements Handler
     }
 
     @Override
-    public Object invoke(final Object target, Method method, final Object[] args, final HandleSupplier handle)
+    public Object invoke(final Object target, final Object[] args, final HandleSupplier handle)
     {
         return className + '@' + Integer.toHexString(target.hashCode());
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/TransactionDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/TransactionDecorator.java
@@ -15,8 +15,6 @@ package org.jdbi.v3.sqlobject;
 
 import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.INVALID_LEVEL;
 
-import java.lang.reflect.Method;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleSupplier;
 import org.jdbi.v3.core.exception.TransactionException;
@@ -35,7 +33,7 @@ class TransactionDecorator implements Handler
     }
 
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle) throws Exception
+    public Object invoke(Object target, Object[] args, HandleSupplier handle) throws Exception
     {
         Handle h = handle.getHandle();
 
@@ -43,7 +41,7 @@ class TransactionDecorator implements Handler
             TransactionIsolationLevel currentLevel = h.getTransactionIsolationLevel();
             if (currentLevel == isolation || isolation == INVALID_LEVEL) {
                 // Already in transaction. The outermost @Transaction method determines the transaction isolation level.
-                return delegate.invoke(target, method, args, handle);
+                return delegate.invoke(target, args, handle);
             }
             else {
                 throw new TransactionException("Tried to execute nested @Transaction(" + isolation+ "), " +
@@ -51,7 +49,7 @@ class TransactionDecorator implements Handler
             }
         }
 
-        TransactionCallback<Object, Exception> callback = th -> delegate.invoke(target, method, args, handle);
+        TransactionCallback<Object, Exception> callback = th -> delegate.invoke(target, args, handle);
 
         if (isolation == INVALID_LEVEL) {
             return h.inTransaction(callback);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UpdateHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UpdateHandler.java
@@ -56,9 +56,9 @@ class UpdateHandler extends CustomizingStatementHandler
     }
 
     @Override
-    public Object invoke(Object target, Method method, Object[] args, HandleSupplier handle)
+    public Object invoke(Object target, Object[] args, HandleSupplier handle)
     {
-        String sql = handle.getConfig(SqlObjects.class).getSqlLocator().locate(sqlObjectType, method);
+        String sql = handle.getConfig(SqlObjects.class).getSqlLocator().locate(sqlObjectType, getMethod());
         Update update = handle.getHandle().createUpdate(sql);
         applyCustomizers(update, args);
         return this.returner.apply(update);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
@@ -69,7 +69,7 @@ public class TestSqlMethodAnnotations
         class Factory implements HandlerFactory {
             @Override
             public Handler buildHandler(Class<?> sqlObjectType, Method method) {
-                return (obj, m, args, handle) -> "foo";
+                return (obj, args, handle) -> "foo";
             }
         }
     }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecoratingAnnotations.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecoratingAnnotations.java
@@ -144,9 +144,9 @@ public class TestSqlMethodDecoratingAnnotations {
         class Factory implements HandlerDecorator {
             @Override
             public Handler decorateHandler(Handler base, Class<?> sqlObjectType, Method method) {
-                return (obj, m, args, handle) -> {
+                return (obj, args, handle) -> {
                     invoked("foo");
-                    return base.invoke(obj, m, args, handle);
+                    return base.invoke(obj, args, handle);
                 };
             }
         }
@@ -159,9 +159,9 @@ public class TestSqlMethodDecoratingAnnotations {
         class Factory implements HandlerDecorator {
             @Override
             public Handler decorateHandler(Handler base, Class<?> sqlObjectType, Method method) {
-                return (obj, m, args, handle) -> {
+                return (obj, args, handle) -> {
                     invoked("bar");
-                    return base.invoke(obj, m, args, handle);
+                    return base.invoke(obj, args, handle);
                 };
             }
         }
@@ -173,7 +173,7 @@ public class TestSqlMethodDecoratingAnnotations {
         class Factory implements HandlerDecorator {
             @Override
             public Handler decorateHandler(Handler base, Class<?> sqlObjectType, Method method) {
-                return (obj, m, args, handle) -> {
+                return (obj, args, handle) -> {
                     invoked("abort");
                     return null;
                 };
@@ -187,7 +187,7 @@ public class TestSqlMethodDecoratingAnnotations {
         class Factory implements HandlerFactory {
             @Override
             public Handler buildHandler(Class<?> sqlObjectType, Method method) {
-                return (obj, m, args, handle) -> {
+                return (obj, args, handle) -> {
                     invoked("method");
                     return null;
                 };


### PR DESCRIPTION
I'm kind of amazed I never recognized this before. The factory and handler `method` parameters were always colliding..