### PR TITLE
Clean up StatementContext

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
@@ -18,6 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.function.Supplier;
 
+import org.jdbi.v3.core.statement.StatementConfiguration;
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**
@@ -77,10 +78,11 @@ public class ResultProducers {
      */
     public static ResultProducer<ResultSetIterable> returningGeneratedKeys(String... generatedKeyColumnNames) {
         return (supplier, ctx) -> {
-            ctx.setReturningGeneratedKeys(true);
+            StatementConfiguration cfg = ctx.getConfig(StatementConfiguration.class);
+            cfg.setReturningGeneratedKeys(true);
 
             if (generatedKeyColumnNames.length > 0) {
-                ctx.setGeneratedKeysColumnNames(generatedKeyColumnNames);
+                cfg.setGeneratedKeysColumnNames(generatedKeyColumnNames);
             }
 
             return ResultSetIterable.of(getGeneratedKeys(supplier, ctx), ctx);

--- a/core/src/main/java/org/jdbi/v3/core/statement/DefaultStatementBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/DefaultStatementBuilder.java
@@ -44,14 +44,15 @@ public class DefaultStatementBuilder implements StatementBuilder
     @Override
     public PreparedStatement create(Connection conn, String sql, StatementContext ctx) throws SQLException
     {
-        if (ctx.isReturningGeneratedKeys()) {
-            String[] columnNames = ctx.getGeneratedKeysColumnNames();
+        StatementConfiguration cfg = ctx.getConfig(StatementConfiguration.class);
+        if (cfg.isReturningGeneratedKeys()) {
+            String[] columnNames = cfg.getGeneratedKeysColumnNames();
             if (columnNames != null && columnNames.length > 0) {
                 return conn.prepareStatement(sql, columnNames);
             }
             return conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
         }
-        else if (ctx.isConcurrentUpdatable()) {
+        else if (cfg.isConcurrentUpdatable()) {
             return conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
         }
         else {

--- a/core/src/main/java/org/jdbi/v3/core/statement/Query.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Query.java
@@ -136,7 +136,7 @@ public class Query extends SqlStatement<Query> implements ResultBearing, ResultS
      * @return the modified query
      */
     public Query concurrentUpdatable() {
-        getContext().setConcurrentUpdatable(true);
+        getConfig(StatementConfiguration.class).setConcurrentUpdatable(true);
         return this;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementConfiguration.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementConfiguration.java
@@ -1,0 +1,102 @@
+package org.jdbi.v3.core.statement;
+
+import java.util.Arrays;
+
+import org.jdbi.v3.core.config.JdbiConfig;
+
+/**
+ * Contains configuration applied to Statements created by the {@code DefaultStatementBuilder}
+ * or your own {@link StatementBuilder} implementation.
+ */
+public class StatementConfiguration implements JdbiConfig<StatementConfiguration>
+{
+    private boolean  returningGeneratedKeys;
+    private String[] generatedKeysColumnNames;
+    private boolean  concurrentUpdatable;
+
+    StatementConfiguration() { }
+
+    StatementConfiguration(StatementConfiguration other)
+    {
+        this.returningGeneratedKeys = other.returningGeneratedKeys;
+        this.generatedKeysColumnNames = other.generatedKeysColumnNames.clone();
+        this.concurrentUpdatable = other.concurrentUpdatable;
+    }
+
+    @Override
+    public StatementConfiguration createCopy()
+    {
+        return new StatementConfiguration(this);
+    }
+
+    /**
+     * Control returning generated keys on created statements.
+     * @param b return generated keys?
+     */
+    public void setReturningGeneratedKeys(boolean b)
+    {
+        if (isConcurrentUpdatable() && b) {
+            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
+                    + "updatable and is returning generated keys.");
+        }
+        this.returningGeneratedKeys = b;
+    }
+
+    /**
+     * @return whether the statement being generated is expected to return generated keys.
+     */
+    public boolean isReturningGeneratedKeys()
+    {
+        return returningGeneratedKeys || generatedKeysColumnNames != null && generatedKeysColumnNames.length > 0;
+    }
+
+    /**
+     * @return the generated key column names, if any
+     */
+    public String[] getGeneratedKeysColumnNames()
+    {
+        if (generatedKeysColumnNames == null) {
+            return new String[0];
+        }
+        return Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
+    }
+
+    /**
+     * Set the generated key column names.
+     * @param generatedKeysColumnNames the generated key column names
+     */
+    public void setGeneratedKeysColumnNames(String[] generatedKeysColumnNames)
+    {
+        this.generatedKeysColumnNames = Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
+    }
+
+    /**
+     * Return if the statement should be concurrent updatable.
+     *
+     * If this returns true, the concurrency level of the created ResultSet will be
+     * {@link java.sql.ResultSet#CONCUR_UPDATABLE}, otherwise the result set is not updatable,
+     * and will have concurrency level {@link java.sql.ResultSet#CONCUR_READ_ONLY}.
+     *
+     * @return if the statement generated should be concurrent updatable.
+     */
+    public boolean isConcurrentUpdatable() {
+        return concurrentUpdatable;
+    }
+
+    /**
+     * Set the context to create a concurrent updatable result set.
+     *
+     * This cannot be combined with {@link #isReturningGeneratedKeys()}, only
+     * one option may be selected. It does not make sense to combine these either, as one
+     * applies to queries, and the other applies to updates.
+     *
+     * @param concurrentUpdatable if the result set should be concurrent updatable.
+     */
+    public void setConcurrentUpdatable(final boolean concurrentUpdatable) {
+        if (concurrentUpdatable && isReturningGeneratedKeys()) {
+            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
+                    + "updatable and is returning generated keys.");
+        }
+        this.concurrentUpdatable = concurrentUpdatable;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
@@ -23,7 +23,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -47,10 +46,10 @@ import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.RowMapper;
 
 /**
- * The statement context provides a means for passing client specific information through the
- * evaluation of a statement. The context is not used by jDBI internally, but will be passed
- * to all statement customizers. This makes it possible to parameterize the processing of
- * the tweakable parts of the statement processing cycle.
+ * The statement context provides access to statement-local configuration.
+ * Context is inherited from the parent {@link Handle} initially and changes will
+ * not outlive the statement.
+ * The context will be passed through most major jdbi APIs.
  *
  * DISCLAIMER: The class is not intended to be extended. The final modifier is absent to allow
  * mock tools to create a mock object of this class in the user code.
@@ -67,9 +66,6 @@ public class StatementContext implements Closeable
     private PreparedStatement statement;
     private Connection        connection;
     private Binding           binding = new Binding();
-    private boolean           returningGeneratedKeys;
-    private boolean           concurrentUpdatable;
-    private String[]          generatedKeysColumnNames;
 
     StatementContext() {
         this(new ConfigRegistry());
@@ -362,65 +358,5 @@ public class StatementContext implements Closeable
     public ExtensionMethod getExtensionMethod()
     {
         return extensionMethod;
-    }
-
-    public void setReturningGeneratedKeys(boolean b)
-    {
-        if (isConcurrentUpdatable() && b) {
-            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
-                    + "updatable and is returning generated keys.");
-        }
-        this.returningGeneratedKeys = b;
-    }
-
-    /**
-     * @return whether the statement being generated is expected to return generated keys.
-     */
-    public boolean isReturningGeneratedKeys()
-    {
-        return returningGeneratedKeys || generatedKeysColumnNames != null && generatedKeysColumnNames.length > 0;
-    }
-
-    public String[] getGeneratedKeysColumnNames()
-    {
-        if (generatedKeysColumnNames == null) {
-            return new String[0];
-        }
-        return Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
-    }
-
-    public void setGeneratedKeysColumnNames(String[] generatedKeysColumnNames)
-    {
-        this.generatedKeysColumnNames = Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
-    }
-
-    /**
-     * Return if the statement should be concurrent updatable.
-     *
-     * If this returns true, the concurrency level of the created ResultSet will be
-     * {@link java.sql.ResultSet#CONCUR_UPDATABLE}, otherwise the result set is not updatable,
-     * and will have concurrency level {@link java.sql.ResultSet#CONCUR_READ_ONLY}.
-     *
-     * @return if the statement generated should be concurrent updatable.
-     */
-    public boolean isConcurrentUpdatable() {
-        return concurrentUpdatable;
-    }
-
-    /**
-     * Set the context to create a concurrent updatable result set.
-     *
-     * This cannot be combined with {@link #isReturningGeneratedKeys()}, only
-     * one option may be selected. It does not make sense to combine these either, as one
-     * applies to queries, and the other applies to updates.
-     *
-     * @param concurrentUpdatable if the result set should be concurrent updatable.
-     */
-    public void setConcurrentUpdatable(final boolean concurrentUpdatable) {
-        if (concurrentUpdatable && isReturningGeneratedKeys()) {
-            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
-                    + "updatable and is returning generated keys.");
-        }
-        this.concurrentUpdatable = concurrentUpdatable;
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/StatementContextTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/StatementContextTest.java
@@ -13,17 +13,15 @@
  */
 package org.jdbi.v3.core.statement;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMappers;
-import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.core.statement.StatementContextAccess;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class StatementContextTest {
 
@@ -31,17 +29,19 @@ public class StatementContextTest {
     @Test(expected = IllegalArgumentException.class)
     public void testShouldNotBeAbleToCombineGeneratedKeysAndConcurrentUpdatable() throws Exception {
         final StatementContext context = StatementContextAccess.createContext();
+        final StatementConfiguration cfg = context.getConfig(StatementConfiguration.class);
 
-        context.setReturningGeneratedKeys(true);
-        context.setConcurrentUpdatable(true);
+        cfg.setReturningGeneratedKeys(true);
+        cfg.setConcurrentUpdatable(true);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testShouldNotBeAbleToCombineConcurrentUpdatableAndGeneratedKeys() throws Exception {
         final StatementContext context = StatementContextAccess.createContext();
+        final StatementConfiguration cfg = context.getConfig(StatementConfiguration.class);
 
-        context.setConcurrentUpdatable(true);
-        context.setReturningGeneratedKeys(true);
+        cfg.setConcurrentUpdatable(true);
+        cfg.setReturningGeneratedKeys(true);
     }
 
     private static class Foo {


### PR DESCRIPTION
StatementContext has StatementBuilder's information there.  Split it out into its own class.  Fixes #626 
