### PR TITLE
Move CollectorFactory from core to sqlobject

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
@@ -23,8 +23,6 @@ import org.jdbi.v3.core.array.SqlArrayArgumentStrategy;
 import org.jdbi.v3.core.array.SqlArrayType;
 import org.jdbi.v3.core.array.SqlArrayTypeFactory;
 import org.jdbi.v3.core.array.SqlArrayTypes;
-import org.jdbi.v3.core.collector.CollectorFactory;
-import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.extension.ExtensionFactory;
 import org.jdbi.v3.core.extension.Extensions;
 import org.jdbi.v3.core.mapper.ColumnMapper;
@@ -154,16 +152,6 @@ public interface Configurable<This> {
      */
     default This registerArrayType(SqlArrayTypeFactory factory) {
         return configure(SqlArrayTypes.class, c -> c.register(factory));
-    }
-
-    /**
-     * Convenience method for {@code getConfig(JdbiCollectors.class).register(factory)}
-     *
-     * @param factory collector factory
-     * @return this
-     */
-    default This registerCollector(CollectorFactory factory) {
-        return configure(JdbiCollectors.class, c -> c.register(factory));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collector;
 
 import org.jdbi.v3.core.CloseException;
 import org.jdbi.v3.core.Handle;
@@ -38,7 +37,6 @@ import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.array.SqlArrayArgumentStrategy;
 import org.jdbi.v3.core.array.SqlArrayType;
 import org.jdbi.v3.core.array.SqlArrayTypes;
-import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.core.extension.ExtensionMethod;
@@ -219,26 +217,6 @@ public class StatementContext implements Closeable
      */
     public <T> Optional<RowMapper<T>> findRowMapperFor(GenericType<T> type) {
         return getConfig(RowMappers.class).findFor(type);
-    }
-
-    /**
-     * Obtain a collector for the given type.
-     *
-     * @param containerType the container type.
-     * @return a Collector for the given container type, or empty null if no collector is registered for the given type.
-     */
-    public Optional<Collector<?,?,?>> findCollectorFor(Type containerType) {
-        return getConfig(JdbiCollectors.class).findFor(containerType);
-    }
-
-    /**
-     * Returns the element type for the given container type.
-     *
-     * @param containerType the container type.
-     * @return the element type for the given container type, if available.
-     */
-    public Optional<Type> findElementTypeFor(Type containerType) {
-        return getConfig(JdbiCollectors.class).findElementTypeFor(containerType);
     }
 
     StatementContext setRawSql(String rawSql)

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -35,6 +35,11 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-sqlobject</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/guava/src/main/java/org/jdbi/v3/guava/GuavaCollectors.java
+++ b/guava/src/main/java/org/jdbi/v3/guava/GuavaCollectors.java
@@ -21,7 +21,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.stream.Collector;
 
-import org.jdbi.v3.core.collector.CollectorFactory;
+import org.jdbi.v3.sqlobject.collector.CollectorFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableCollection;

--- a/guava/src/main/java/org/jdbi/v3/guava/GuavaPlugin.java
+++ b/guava/src/main/java/org/jdbi/v3/guava/GuavaPlugin.java
@@ -17,13 +17,14 @@ import com.google.auto.service.AutoService;
 
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jdbi.v3.sqlobject.collector.JdbiCollectors;
 
 @AutoService(JdbiPlugin.class)
 public class GuavaPlugin implements JdbiPlugin {
     @Override
     public void customizeJdbi(Jdbi jdbi) {
         jdbi.registerArgument(GuavaArguments.factory());
-        jdbi.registerCollector(GuavaCollectors.factory());
+        jdbi.getConfig(JdbiCollectors.class).register(GuavaCollectors.factory());
         jdbi.registerColumnMapper(GuavaMappers.columnFactory());
     }
 }

--- a/guava/src/test/java/org/jdbi/v3/guava/TestCollectorFactory.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestCollectorFactory.java
@@ -11,8 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.sqlobject;
-
+package org.jdbi.v3.guava;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.guava.api.Assertions.assertThat;
@@ -22,11 +21,11 @@ import java.util.SortedSet;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
-import org.jdbi.v3.guava.GuavaCollectors;
-import org.jdbi.v3.sqlobject.config.RegisterCollectorFactory;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.collector.RegisterCollectorFactory;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -73,12 +73,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-jexl</artifactId>
             <scope>test</scope>

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/BuiltInCollectorFactories.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/BuiltInCollectorFactories.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.collector;
+package org.jdbi.v3.sqlobject.collector;
 
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/CollectorFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/CollectorFactory.java
@@ -11,13 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.collector;
+package org.jdbi.v3.sqlobject.collector;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.stream.Collector;
-
-import org.jdbi.v3.core.statement.StatementContext;
 
 /**
  * Factory for building Collectors to assemble containers of elements.
@@ -35,7 +33,7 @@ public interface CollectorFactory {
      * @param containerType the container type
      *
      * @return the container element type if it can be discovered through reflection; empty otherwise.
-     * @see StatementContext#findElementTypeFor(Type)
+     * @see JdbiCollectors#findElementTypeFor(Type)
      */
     Optional<Type> elementType(Type containerType);
 
@@ -44,7 +42,6 @@ public interface CollectorFactory {
      *
      * @return a {@link Collector} for the given container type.
      *
-     * @see StatementContext#findCollectorFor(Type)
      * @see JdbiCollectors#findFor(Type)
      */
     Collector<?, ?, ?> build(Type containerType);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/JdbiCollectors.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/JdbiCollectors.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.collector;
+package org.jdbi.v3.sqlobject.collector;
 
 import java.lang.reflect.Type;
 import java.util.List;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/OptionalBuilder.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/OptionalBuilder.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.collector;
+package org.jdbi.v3.sqlobject.collector;
 
 import java.util.Optional;
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/OptionalCollectorFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/OptionalCollectorFactory.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.collector;
+package org.jdbi.v3.sqlobject.collector;
 
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/RegisterCollectorFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/collector/RegisterCollectorFactory.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.sqlobject.config;
+package org.jdbi.v3.sqlobject.collector;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
@@ -23,10 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.Query;
-import org.jdbi.v3.core.collector.CollectorFactory;
+import org.jdbi.v3.sqlobject.config.ConfigurerFactory;
+import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation;
 
 /**
  * Used to register container mappers on the current {@link Query}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ResultReturner.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ResultReturner.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 
+import org.jdbi.v3.sqlobject.collector.JdbiCollectors;
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -150,7 +151,7 @@ abstract class ResultReturner
         @SuppressWarnings({ "unchecked", "rawtypes" })
         protected Object result(ResultIterable<?> bearer, StatementContext ctx)
         {
-            Collector collector = ctx.findCollectorFor(returnType).orElse(null);
+            Collector collector = ctx.getConfig(JdbiCollectors.class).findFor(returnType).orElse(null);
             if (collector != null) {
                 return bearer.collect(collector);
             }
@@ -161,7 +162,7 @@ abstract class ResultReturner
         protected Type elementType(StatementContext ctx)
         {
             // if returnType is not supported by a collector factory, assume it to be a single-value return type.
-            return ctx.findElementTypeFor(returnType).orElse(returnType);
+            return ctx.getConfig(JdbiCollectors.class).findElementTypeFor(returnType).orElse(returnType);
         }
     }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestInClauseExpansion.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestInClauseExpansion.java
@@ -18,8 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import com.google.common.collect.ImmutableSet;
-
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.customizer.BindList;
@@ -31,7 +29,7 @@ import org.junit.Test;
 public class TestInClauseExpansion
 {
     @Rule
-    public H2DatabaseRule db = new H2DatabaseRule().withPlugins(); // Guava
+    public H2DatabaseRule db = new H2DatabaseRule().withPlugins();
     private Handle handle;
 
     @Before
@@ -53,7 +51,7 @@ public class TestInClauseExpansion
     public interface DAO
     {
         @SqlQuery("select name from something where id in (<names>)")
-        ImmutableSet<String> findIdsForNames(@BindList List<Integer> names);
+        List<String> findIdsForNames(@BindList List<Integer> names);
     }
 
 }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPaging.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPaging.java
@@ -17,13 +17,10 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
-import org.jdbi.v3.guava.GuavaCollectors;
-import org.jdbi.v3.sqlobject.config.RegisterCollectorFactory;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
@@ -73,13 +70,12 @@ public class TestPaging
     }
 
     @RegisterRowMapper(SomethingMapper.class)
-    @RegisterCollectorFactory(GuavaCollectors.Factory.class)
     public interface Sql
     {
         @SqlBatch("insert into something (id, name) values (:id, :name)")
         int[] insert(@Bind("id") Iterable<Integer> ids, @Bind("name") Iterable<String> names);
 
         @SqlQuery("select id, name from something where id > :end_of_last_page order by id limit :size")
-        ImmutableList<Something> loadPage(@Bind("end_of_last_page") int last, @Bind("size") int size);
+        List<Something> loadPage(@Bind("end_of_last_page") int last, @Bind("size") int size);
     }
 }


### PR DESCRIPTION
I think this is a better home for `CollectorFactory` and friends.

I had to make guava depend on sqlobject, which required moving a test from sqlobject to guava to avoid a circular dependency.