### PR TITLE
Bug fix: SQL method with primitive result throws NPE if query returns no rows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,22 @@
 Hi! Welcome to JDBI.
 
-We're glad you're thinking about contributing to the projects.
+We're glad you're thinking about contributing to the project.
 
 Here's a few pointers to help you get set up:
+
+# Enable `-parameters` compiler flag in your IDE:
+
+Most of our SQL Object tests rely on SQL method parameter names. However by default, `javac` does not compile these
+parameter names into `.class` files. Thus, in order for unit tests to pass, the compiler must be configured to output
+parameter names.
+
+## IntelliJ
+
+* File -> Settings
+* Build, Execution, Deployment -> Compiler -> Java Compiler
+* Additional command-line parameters: `-parameters`
+* Click Apply, then OK.
+* Build -> Rebuild Project
 
 # Setting up your machine to build `jdbi3-oracle`
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ResultReturner.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ResultReturner.java
@@ -167,7 +167,7 @@ abstract class ResultReturner
             if (collector != null) {
                 return bearer.collect(collector);
             }
-            return bearer.findFirst().map(Object.class::cast).orElseGet(() -> DefaultResult.forType(returnType));
+            return checkResult(bearer.findFirst().orElse(null), returnType);
         }
 
         @Override
@@ -190,7 +190,7 @@ abstract class ResultReturner
         @Override
         protected Object result(ResultIterable<?> bearer, StatementContext ctx)
         {
-            return bearer.findFirst().map(Object.class::cast).orElseGet(() -> DefaultResult.forType(returnType));
+            return checkResult(bearer.findFirst().orElse(null), returnType);
         }
 
         @Override
@@ -200,32 +200,11 @@ abstract class ResultReturner
         }
     }
 
-    static class DefaultResult {
-        public static Object forType(Type type) {
-            Class<?> clazz = getErasedType(type);
-            if (clazz.isPrimitive()) {
-                if (clazz.equals(boolean.class)) {
-                    return false;
-                } else if (clazz.equals(byte.class)) {
-                    return (byte) 0;
-                } else if (clazz.equals(short.class)) {
-                    return (short) 0;
-                } else if (clazz.equals(int.class)) {
-                    return 0;
-                } else if (clazz.equals(long.class)) {
-                    return 0L;
-                } else if (clazz.equals(char.class)) {
-                    return (char) 0;
-                } else if (clazz.equals(float.class)) {
-                    return 0f;
-                } else if (clazz.equals(double.class)) {
-                    return 0d;
-                } else {
-                    throw new UnsupportedOperationException("Unsupported primitive return type " + clazz);
-                }
-            }
-            return null;
+    private static Object checkResult(Object result, Type type) {
+        if (result == null && getErasedType(type).isPrimitive()) {
+            throw new IllegalStateException("SQL method returns primitive " + type + ", but statement returned no results");
         }
+        return result;
     }
 
     static class ResultIterableResultReturner extends ResultReturner

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPrimitiveQueryResult.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPrimitiveQueryResult.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPrimitiveQueryResult
+{
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    PrimitiveDao dao;
+
+    @Before
+    public void setUp() {
+      dao = db.getSharedHandle().attach(PrimitiveDao.class);
+      dao.insert(1, "foo");
+    }
+
+    @Test
+    public void testBoolean() {
+        assertThat(dao.getBoolean(1)).isTrue();
+        assertThat(dao.getBoolean(2)).isFalse();
+    }
+
+    @Test
+    public void testByte() {
+        assertThat(dao.getByte(1)).isEqualTo((byte) 1);
+        assertThat(dao.getByte(2)).isEqualTo((byte) 0);
+    }
+
+    @Test
+    public void testChar() {
+        assertThat(dao.getChar(1)).isEqualTo('a');
+        assertThat(dao.getChar(2)).isEqualTo('\0');
+    }
+
+    @Test
+    public void testShort() {
+        assertThat(dao.getShort(1)).isEqualTo((short) 1);
+        assertThat(dao.getShort(2)).isEqualTo((short) 0);
+    }
+
+    @Test
+    public void testInt() {
+        assertThat(dao.getInt(1)).isEqualTo(1);
+        assertThat(dao.getInt(2)).isEqualTo(0);
+    }
+
+    @Test
+    public void testLong() {
+        assertThat(dao.getLong(1)).isEqualTo(1L);
+        assertThat(dao.getLong(2)).isEqualTo(0L);
+    }
+
+    @Test
+    public void testFloat() {
+        assertThat(dao.getFloat(1)).isEqualTo(1f);
+        assertThat(dao.getFloat(2)).isEqualTo(0f);
+    }
+
+    @Test
+    public void testDouble() {
+        assertThat(dao.getDouble(1)).isEqualTo(1d);
+        assertThat(dao.getDouble(2)).isEqualTo(0d);
+    }
+
+    public interface PrimitiveDao {
+        @SqlUpdate("insert into something(id, name) values (:id, :name)")
+        void insert(int id, String name);
+
+        @SqlQuery("select 1 from something where id = :id")
+        boolean getBoolean(int id);
+
+        @SqlQuery("select 1 from something where id = :id")
+        byte getByte(int id);
+
+        @SqlQuery("select 'a' from something where id = :id")
+        char getChar(int id);
+
+        @SqlQuery("select 1 from something where id = :id")
+        short getShort(int id);
+
+        @SqlQuery("select 1 from something where id = :id")
+        int getInt(int id);
+
+        @SqlQuery("select 1 from something where id = :id")
+        long getLong(int id);
+
+        @SqlQuery("select 1 from something where id = :id")
+        float getFloat(int id);
+
+        @SqlQuery("select 1 from something where id = :id")
+        double getDouble(int id);
+    }
+}

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPrimitiveQueryResult.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPrimitiveQueryResult.java
@@ -19,6 +19,7 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,6 +27,9 @@ public class TestPrimitiveQueryResult
 {
     @Rule
     public H2DatabaseRule db = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     PrimitiveDao dao;
 
@@ -38,49 +42,65 @@ public class TestPrimitiveQueryResult
     @Test
     public void testBoolean() {
         assertThat(dao.getBoolean(1)).isTrue();
-        assertThat(dao.getBoolean(2)).isFalse();
+
+        exception.expect(IllegalStateException.class);
+        dao.getBoolean(2);
     }
 
     @Test
     public void testByte() {
         assertThat(dao.getByte(1)).isEqualTo((byte) 1);
-        assertThat(dao.getByte(2)).isEqualTo((byte) 0);
+
+        exception.expect(IllegalStateException.class);
+        dao.getByte(2);
     }
 
     @Test
     public void testChar() {
         assertThat(dao.getChar(1)).isEqualTo('a');
-        assertThat(dao.getChar(2)).isEqualTo('\0');
+
+        exception.expect(IllegalStateException.class);
+        dao.getChar(2);
     }
 
     @Test
     public void testShort() {
         assertThat(dao.getShort(1)).isEqualTo((short) 1);
-        assertThat(dao.getShort(2)).isEqualTo((short) 0);
+
+        exception.expect(IllegalStateException.class);
+        dao.getShort(2);
     }
 
     @Test
     public void testInt() {
         assertThat(dao.getInt(1)).isEqualTo(1);
-        assertThat(dao.getInt(2)).isEqualTo(0);
+
+        exception.expect(IllegalStateException.class);
+        dao.getInt(2);
     }
 
     @Test
     public void testLong() {
         assertThat(dao.getLong(1)).isEqualTo(1L);
-        assertThat(dao.getLong(2)).isEqualTo(0L);
+
+        exception.expect(IllegalStateException.class);
+        dao.getLong(2);
     }
 
     @Test
     public void testFloat() {
         assertThat(dao.getFloat(1)).isEqualTo(1f);
-        assertThat(dao.getFloat(2)).isEqualTo(0f);
+
+        exception.expect(IllegalStateException.class);
+        dao.getFloat(2);
     }
 
     @Test
     public void testDouble() {
         assertThat(dao.getDouble(1)).isEqualTo(1d);
-        assertThat(dao.getDouble(2)).isEqualTo(0d);
+
+        exception.expect(IllegalStateException.class);
+        dao.getDouble(2);
     }
 
     public interface PrimitiveDao {


### PR DESCRIPTION
Also added some documentation on `-parameters` compiler flag to `CONTRIBUTING.md`.