### PR TITLE
Add support for binding multiple columns in an in clause.

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -1226,9 +1226,9 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * Examples:
      * <pre>
      *
-     * List&lt;Things&gt; thingsToSearchBy = ...
+     * List&lt;ThingKey&gt; thingKeys = ...
      * List&lt;Thing&gt; things = handle.createQuery("select * from things where (id, foo) in (&lt;thingKeys&gt;)")
-     *     .bindBeanList("thingKeys", thingsToSearchBy)
+     *     .bindBeanList("thingKeys", thingKeys, Arrays.asList("id", "foo"))
      *     .mapTo(Contact.class)
      *     .list();
      * </pre>
@@ -1237,7 +1237,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * @param values list of values that will be comma-spliced into the defined attribute value.
      * @param propertyNames list of properties that will be invoked on the values.
      * @return this
-     * @throws IllegalArgumentException if the list is empty.
+     * @throws IllegalArgumentException if the list of values or properties is empty.
      */
     public final This bindBeanList(String key, List<?> values, List<String> propertyNames) {
         if (values.isEmpty()) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -1238,8 +1238,9 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * @param propertyNames list of properties that will be invoked on the values.
      * @return this
      * @throws IllegalArgumentException if the list of values or properties is empty.
+     * @throws UnableToCreateStatementException If a property can't be found on an value or we can't find a Argument for it.
      */
-    public final This bindBeanList(String key, List<?> values, List<String> propertyNames) {
+    public final This bindBeanList(String key, List<?> values, List<String> propertyNames) throws UnableToCreateStatementException {
         if (values.isEmpty()) {
             throw new IllegalArgumentException(
                     getClass().getSimpleName() + ".bindBeanList was called with no values.");
@@ -1268,7 +1269,9 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
                 String propertyName = propertyNames.get(propertyIndex);
                 String name = "__" + key + "_" + valueIndex + "_" + propertyName;
                 names.append(':').append(name);
-                bind(name, beanProperties.find(propertyName).get());
+                Argument argument = beanProperties.find(propertyName)
+                        .orElseThrow(() -> new UnableToCreateStatementException("Unable to get " + propertyName + " argument for " + bean, getContext()));
+                bind(name, argument);
             }
             names.append(")");
         }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBindBeanList.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBindBeanList.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.mapper.reflect.FieldMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class TestBindBeanList {
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule();
+
+    private Handle handle;
+
+    @Before
+    public void setUp() {
+        handle = db.getSharedHandle();
+        handle.registerRowMapper(FieldMapper.of(Thing.class));
+        handle.execute("create table thing (id identity primary key, foo varchar(50), bar varchar(50), baz varchar(50))");
+        handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 1, "foo1", "bar1", "baz1");
+        handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 2, "foo2", "bar2", "baz2");
+        handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 3, "foo3", "bar3", "baz3");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void bindBeanListWithNoValues() throws Exception {
+        handle.createQuery("select id, foo from thing where (foo, bar) in (<keys>)")
+                .bindBeanList("keys", Collections.emptyList(), Arrays.asList("foo", "bar"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void bindBeanListWithNoProperties() throws Exception {
+        ThingKey thingKey = new ThingKey("a", "b");
+        handle.createQuery("select id, foo from thing where (foo, bar) in (<keys>)")
+                .bindBeanList("keys", Collections.singletonList(thingKey), Collections.emptyList());
+    }
+
+    @Test
+    public void happyPath() {
+        ThingKey thing1Key = new ThingKey("foo1", "bar1");
+        ThingKey thing3Key = new ThingKey("foo3", "bar3");
+
+        List<Thing> list = handle.createQuery("select id, foo from thing where (foo, bar) in (<keys>)")
+                .bindBeanList("keys", Arrays.asList(thing1Key, thing3Key), Arrays.asList("foo", "bar"))
+                .mapTo(Thing.class)
+                .list();
+        assertThat(list)
+                .extracting(Thing::getId, Thing::getFoo, Thing::getBar, Thing::getBaz)
+                .containsExactly(
+                        tuple(1, "foo1", null, null),
+                        tuple(3, "foo3", null, null));
+    }
+
+    public static class ThingKey {
+        public String foo;
+        public String bar;
+
+        public ThingKey(String foo, String bar) {
+            this.foo = foo;
+            this.bar = bar;
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public String getBar() {
+            return bar;
+        }
+    }
+
+    public static class Thing {
+        public int id;
+        public String foo;
+        public String bar;
+        public String baz;
+
+        public int getId() {
+            return id;
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public String getBar() {
+            return bar;
+        }
+
+        public String getBaz() {
+            return baz;
+        }
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindBeanList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindBeanList.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.customizer;
+
+import org.jdbi.v3.sqlobject.internal.ParameterUtil;
+
+import java.lang.annotation.*;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Binds each property for each value in the annotated {@link Iterable} or array/varargs argument,
+ * and defines a named attribute as a comma-separated list of each bound parameter name.
+ *
+ * Used to create query similar to:
+ * select * from things where (id, name) in ((1,'abc'),(2,'def'),(3,'ghi'))
+ *
+ * <p>
+ * <pre>
+ * &#64;SqlQuery("select * from things where (id, name) in (&lt;keys&gt;)")
+ * List&lt;Thing&gt; getThings(@BindBeanList(value = "keys", propertyNames = {"id", "name"}) ThingKey... thingKeys)
+ * </pre>
+ * <p>
+ * <p>
+ * Throws IllegalArgumentException if the argument is not an array or Iterable.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@SqlStatementCustomizingAnnotation(BindBeanList.Factory.class)
+public @interface BindBeanList {
+    /**
+     * The attribute name to define. If omitted, the name of the annotated parameter is used. It is an error to omit
+     * the name when there is no parameter naming information in your class files.
+     *
+     * @return the attribute name.
+     */
+    String value() default "";
+
+    /**
+     * The list of properties to invoke on each element in the argument
+     *
+     * @return the property names
+     */
+    String[] propertyNames();
+
+    final class Factory implements SqlStatementCustomizerFactory {
+        @Override
+        public SqlStatementCustomizer createForParameter(Annotation annotation,
+                                                         Class<?> sqlObjectType,
+                                                         Method method,
+                                                         Parameter param,
+                                                         int index,
+                                                         Object arg) {
+            final BindBeanList bindBeanList = (BindBeanList) annotation;
+            final String name = ParameterUtil.getParameterName(bindBeanList, bindBeanList.value(), param);
+
+            if (arg == null) {
+                throw new IllegalArgumentException("argument is null; null was explicitly forbidden on BindBeanList");
+            }
+
+            List<Object> list = new ArrayList<>();
+            for (Iterator<?> iter = BindListUtil.toIterator(arg); iter.hasNext(); ) {
+                list.add(iter.next());
+            }
+
+            return stmt -> stmt.bindBeanList(name, list, Arrays.asList(bindBeanList.propertyNames()));
+        }
+
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindBeanList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindBeanList.java
@@ -15,7 +15,11 @@ package org.jdbi.v3.sqlobject.customizer;
 
 import org.jdbi.v3.sqlobject.internal.ParameterUtil;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -18,16 +18,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.jdbi.v3.core.internal.ReflectionArrayIterator;
 import org.jdbi.v3.sqlobject.internal.ParameterUtil;
 
 /**
@@ -74,7 +70,7 @@ public @interface BindList {
             final BindList bindList = (BindList) annotation;
             final String name = ParameterUtil.getParameterName(bindList, bindList.value(), param);
 
-            if (arg == null || Util.isEmpty(arg)) {
+            if (arg == null || BindListUtil.isEmpty(arg)) {
                 switch (bindList.onEmpty()) {
                     case VOID:
                         return stmt -> stmt.define(name, "");
@@ -90,62 +86,13 @@ public @interface BindList {
             }
 
             List<Object> list = new ArrayList<>();
-            for (Iterator<?> iter = Util.toIterator(arg); iter.hasNext();) {
+            for (Iterator<?> iter = BindListUtil.toIterator(arg); iter.hasNext();) {
                 list.add(iter.next());
             }
 
             return stmt -> stmt.bindList(name, list);
         }
 
-    }
-
-    final class Util {
-        private Util() {
-        }
-
-        static Iterator<?> toIterator(final Object obj) {
-            if (obj == null) {
-                throw new IllegalArgumentException("cannot make iterator of null");
-            }
-
-            if (obj instanceof Iterable) {
-                return ((Iterable<?>) obj).iterator();
-            }
-
-            if (obj.getClass().isArray()) {
-                if (obj instanceof Object[]) {
-                    return Arrays.asList((Object[]) obj).iterator();
-                } else {
-                    return ReflectionArrayIterator.of(obj);
-                }
-            }
-
-            throw new IllegalArgumentException(getTypeWarning(obj.getClass()));
-        }
-
-        static boolean isEmpty(final Object obj) {
-            if (obj == null) {
-                throw new IllegalArgumentException("cannot determine emptiness of null");
-            }
-
-            if (obj instanceof Collection) {
-                return ((Collection<?>)obj).isEmpty();
-            }
-
-            if (obj instanceof Iterable) {
-                return !((Iterable<?>)obj).iterator().hasNext();
-            }
-
-            if (obj.getClass().isArray()) {
-                return Array.getLength(obj) == 0;
-            }
-
-            throw new IllegalArgumentException(getTypeWarning(obj.getClass()));
-        }
-
-        private static String getTypeWarning(final Class<?> type) {
-            return "argument must be one of the following: Iterable, or an array/varargs (primitive or complex type); was " + type.getName() + " instead";
-        }
     }
 
     /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindListUtil.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindListUtil.java
@@ -1,0 +1,57 @@
+package org.jdbi.v3.sqlobject.customizer;
+
+import org.jdbi.v3.core.internal.ReflectionArrayIterator;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+final class BindListUtil {
+    private BindListUtil() {
+    }
+
+    static Iterator<?> toIterator(final Object obj) {
+        if (obj == null) {
+            throw new IllegalArgumentException("cannot make iterator of null");
+        }
+
+        if (obj instanceof Iterable) {
+            return ((Iterable<?>) obj).iterator();
+        }
+
+        if (obj.getClass().isArray()) {
+            if (obj instanceof Object[]) {
+                return Arrays.asList((Object[]) obj).iterator();
+            } else {
+                return ReflectionArrayIterator.of(obj);
+            }
+        }
+
+        throw new IllegalArgumentException(getTypeWarning(obj.getClass()));
+    }
+
+    static boolean isEmpty(final Object obj) {
+        if (obj == null) {
+            throw new IllegalArgumentException("cannot determine emptiness of null");
+        }
+
+        if (obj instanceof Collection) {
+            return ((Collection<?>) obj).isEmpty();
+        }
+
+        if (obj instanceof Iterable) {
+            return !((Iterable<?>) obj).iterator().hasNext();
+        }
+
+        if (obj.getClass().isArray()) {
+            return Array.getLength(obj) == 0;
+        }
+
+        throw new IllegalArgumentException(getTypeWarning(obj.getClass()));
+    }
+
+    private static String getTypeWarning(final Class<?> type) {
+        return "argument must be one of the following: Iterable, or an array/varargs (primitive or complex type); was " + type.getName() + " instead";
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindListUtil.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindListUtil.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jdbi.v3.sqlobject.customizer;
 
 import org.jdbi.v3.core.internal.ReflectionArrayIterator;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/BindListUtilTest.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/BindListUtilTest.java
@@ -28,44 +28,44 @@ public class BindListUtilTest
     @Test(expected = IllegalArgumentException.class)
     public void testObjectToIterator()
     {
-        BindList.Util.toIterator(new Object());
+        BindListUtil.toIterator(new Object());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testOtherClassToIterator()
     {
-        BindList.Util.toIterator("bla"); // or any other kind of object that isn't a java.lang.Object
+        BindListUtil.toIterator("bla"); // or any other kind of object that isn't a java.lang.Object
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPrimitiveToIterator()
     {
-        BindList.Util.toIterator(1);
+        BindListUtil.toIterator(1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIteratorToIterator()
     {
-        BindList.Util.toIterator(new ArrayList<Object>().iterator());
+        BindListUtil.toIterator(new ArrayList<>().iterator());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullToIterator()
     {
-        BindList.Util.toIterator(null);
+        BindListUtil.toIterator(null);
     }
 
     @Test
     public void testEmptyArrayToIterator()
     {
-        final Object[] out = toArray(BindList.Util.toIterator(new int[]{}));
+        final Object[] out = toArray(BindListUtil.toIterator(new int[]{}));
         assertThat(out).isEmpty();
     }
 
     @Test
     public void testEmptyListToIterator()
     {
-        final Object[] out = toArray(BindList.Util.toIterator(new ArrayList<Integer>()));
+        final Object[] out = toArray(BindListUtil.toIterator(new ArrayList<Integer>()));
         assertThat(out).isEmpty();
     }
 
@@ -76,7 +76,7 @@ public class BindListUtilTest
         in.add("1");
         in.add("2");
 
-        final Object[] out = toArray(BindList.Util.toIterator(in));
+        final Object[] out = toArray(BindListUtil.toIterator(in));
 
         assertThat(out).containsExactly("1", "2");
     }
@@ -88,7 +88,7 @@ public class BindListUtilTest
         in.add("1");
         in.add("2");
 
-        final Object[] out = toArray(BindList.Util.toIterator(in));
+        final Object[] out = toArray(BindListUtil.toIterator(in));
 
         assertThat(out).containsExactly("1", "2");
     }
@@ -109,7 +109,7 @@ public class BindListUtilTest
             }
         };
 
-        final Object[] out = toArray(BindList.Util.toIterator(in));
+        final Object[] out = toArray(BindListUtil.toIterator(in));
 
         assertThat(out).containsExactly("1", "2");
     }
@@ -119,7 +119,7 @@ public class BindListUtilTest
     {
         final String[] in = new String[]{"1", "2"};
 
-        final Object[] out = toArray(BindList.Util.toIterator(in));
+        final Object[] out = toArray(BindListUtil.toIterator(in));
 
         assertThat(out).containsExactly("1", "2");
     }
@@ -129,7 +129,7 @@ public class BindListUtilTest
     {
         final int[] in = new int[]{1, 2};
 
-        final Object[] out = toArray(BindList.Util.toIterator(in));
+        final Object[] out = toArray(BindListUtil.toIterator(in));
 
         assertThat(out).containsExactly(1, 2);
     }
@@ -147,25 +147,25 @@ public class BindListUtilTest
     @Test
     public void testIsEmptyPrimitiveArray()
     {
-        assertThat(BindList.Util.isEmpty(new int[]{1, 2, 3})).isFalse();
+        assertThat(BindListUtil.isEmpty(new int[]{1, 2, 3})).isFalse();
     }
 
     @Test
     public void testIsEmptyEmptyPrimitiveArray()
     {
-        assertThat(BindList.Util.isEmpty(new int[]{})).isTrue();
+        assertThat(BindListUtil.isEmpty(new int[]{})).isTrue();
     }
 
     @Test
     public void testIsEmptyObjectArray()
     {
-        assertThat(BindList.Util.isEmpty(new Object[]{"1", "2", "3"})).isFalse();
+        assertThat(BindListUtil.isEmpty(new Object[]{"1", "2", "3"})).isFalse();
     }
 
     @Test
     public void testIsEmptyEmptyObjectArray()
     {
-        assertThat(BindList.Util.isEmpty(new Object[]{})).isTrue();
+        assertThat(BindListUtil.isEmpty(new Object[]{})).isTrue();
     }
 
     @Test
@@ -176,30 +176,30 @@ public class BindListUtilTest
         in.add("2");
         in.add("3");
 
-        assertThat(BindList.Util.isEmpty(in)).isFalse();
+        assertThat(BindListUtil.isEmpty(in)).isFalse();
     }
 
     @Test
     public void testIsEmptyEmptyList()
     {
-        assertThat(BindList.Util.isEmpty(new ArrayList<String>())).isTrue();
+        assertThat(BindListUtil.isEmpty(new ArrayList<String>())).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsEmptyObject()
     {
-        BindList.Util.isEmpty(new Object());
+        BindListUtil.isEmpty(new Object());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsEmptyPrimitive()
     {
-        BindList.Util.isEmpty(5);
+        BindListUtil.isEmpty(5);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIsEmptyNull()
     {
-        BindList.Util.isEmpty(null);
+        BindListUtil.isEmpty(null);
     }
 }

--- a/stringtemplate3/src/test/java/org/jdbi/v3/sqlobject/BindBeanListTest.java
+++ b/stringtemplate3/src/test/java/org/jdbi/v3/sqlobject/BindBeanListTest.java
@@ -37,6 +37,8 @@ public class BindBeanListTest
 {
     private static Handle handle;
 
+    private static List<Something> expectedSomethings;
+
     @ClassRule
     public static final H2DatabaseRule db = new H2DatabaseRule();
 
@@ -53,6 +55,8 @@ public class BindBeanListTest
 
         // "control group" element that should *not* be returned by the queries
         handle.execute("insert into something(id, name) values(3, '3')");
+
+        expectedSomethings = Arrays.asList(new Something(1, "1"), new Something(2, "2"));
     }
 
     @AfterClass
@@ -72,7 +76,7 @@ public class BindBeanListTest
                 new SomethingKey(1, "1"),
                 new SomethingKey(2, "2"));
 
-        assertThat(out).hasSize(2);
+        assertThat(out).hasSameElementsAs(expectedSomethings);
     }
 
     @UseStringTemplateStatementRewriter
@@ -93,7 +97,7 @@ public class BindBeanListTest
                 new SomethingKey(1, "1"),
                 new SomethingKey(2, "2"));
 
-        assertThat(out).hasSize(2);
+        assertThat(out).hasSameElementsAs(expectedSomethings);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -138,7 +142,7 @@ public class BindBeanListTest
                 new SomethingKey(1, "1"),
                 new SomethingKey(2, "2"));
 
-        assertThat(out).hasSize(2);
+        assertThat(out).hasSameElementsAs(expectedSomethings);
     }
 
     @UseStringTemplateStatementRewriter
@@ -159,7 +163,7 @@ public class BindBeanListTest
                 new SomethingKey(2, "2"))
                 .iterator());
 
-        assertThat(out).hasSize(2);
+        assertThat(out).hasSameElementsAs(expectedSomethings);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/stringtemplate3/src/test/java/org/jdbi/v3/sqlobject/BindBeanListTest.java
+++ b/stringtemplate3/src/test/java/org/jdbi/v3/sqlobject/BindBeanListTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.Something;
+import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.sqlobject.customizer.BindBeanList;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.stringtemplate3.UseStringTemplateStatementRewriter;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BindBeanListTest
+{
+    private static Handle handle;
+
+    @ClassRule
+    public static final H2DatabaseRule db = new H2DatabaseRule();
+
+    @BeforeClass
+    public static void init()
+    {
+        final Jdbi dbi = db.getJdbi();
+        dbi.installPlugin(new SqlObjectPlugin());
+        dbi.registerRowMapper(new SomethingMapper());
+        handle = dbi.open();
+
+        handle.execute("insert into something(id, name) values(1, '1')");
+        handle.execute("insert into something(id, name) values(2, '2')");
+
+        // "control group" element that should *not* be returned by the queries
+        handle.execute("insert into something(id, name) values(3, '3')");
+    }
+
+    @AfterClass
+    public static void exit()
+    {
+        handle.close();
+    }
+
+    //
+
+    @Test
+    public void testSomethingWithExplicitAttributeName()
+    {
+        final SomethingWithExplicitAttributeName s = handle.attach(SomethingWithExplicitAttributeName.class);
+
+        final List<Something> out = s.get(
+                new SomethingKey(1, "1"),
+                new SomethingKey(2, "2"));
+
+        assertThat(out).hasSize(2);
+    }
+
+    @UseStringTemplateStatementRewriter
+    public interface SomethingWithExplicitAttributeName {
+        @SqlQuery("select id, name from something where (id, name) in (<keys>)")
+        List<Something> get(@BindBeanList(value = "keys", propertyNames = {"id", "name"})
+                                    SomethingKey... blarg);
+    }
+
+    //
+
+    @Test
+    public void testSomethingByVarargsWithVarargs()
+    {
+        final SomethingByVarargs s = handle.attach(SomethingByVarargs.class);
+
+        final List<Something> out = s.get(
+                new SomethingKey(1, "1"),
+                new SomethingKey(2, "2"));
+
+        assertThat(out).hasSize(2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSomethingByVarargsWithEmptyVarargs()
+    {
+        final SomethingByVarargs s = handle.attach(SomethingByVarargs.class);
+
+        final List<Something> out = s.get();
+    }
+
+    @UseStringTemplateStatementRewriter
+    public interface SomethingByVarargs
+    {
+        @SqlQuery("select id, name from something where (id, name) in (<keys>)")
+        List<Something> get(@BindBeanList(propertyNames = {"id", "name"}) SomethingKey... keys);
+    }
+
+    //
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSomethingByArrayWithNull()
+    {
+        final SomethingByArray s = handle.attach(SomethingByArray.class);
+
+        s.get(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSomethingByArrayWithEmptyArray()
+    {
+        final SomethingByArray s = handle.attach(SomethingByArray.class);
+
+        s.get(new SomethingKey[]{});
+    }
+
+    @Test
+    public void testSomethingByArrayWithNonEmptyArray()
+    {
+        final SomethingByVarargs s = handle.attach(SomethingByVarargs.class);
+
+        final List<Something> out = s.get(
+                new SomethingKey(1, "1"),
+                new SomethingKey(2, "2"));
+
+        assertThat(out).hasSize(2);
+    }
+
+    @UseStringTemplateStatementRewriter
+    private interface SomethingByArray
+    {
+        @SqlQuery("select id, name from something where (id, name) in (<keys>)")
+        List<Something> get(@BindBeanList(propertyNames = {"id", "name"}) SomethingKey[] keys);
+    }
+
+    //
+
+    @Test
+    public void testSomethingByIterableWithIterable()
+    {
+        final SomethingByIterable s = handle.attach(SomethingByIterable.class);
+
+        final List<Something> out = s.get(() -> Arrays.asList(new SomethingKey(1, "1"),
+                new SomethingKey(2, "2"))
+                .iterator());
+
+        assertThat(out).hasSize(2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSomethingByIterableWithEmptyIterable()
+    {
+        final SomethingByIterable s = handle.attach(SomethingByIterable.class);
+
+        final List<Something> out = s.get(new ArrayList<>());
+
+        assertThat(out).isEmpty();
+    }
+
+    @UseStringTemplateStatementRewriter
+    public interface SomethingByIterable
+    {
+        @SqlQuery("select id, name from something where (id, name) in (<keys>)")
+        List<Something> get(@BindBeanList(propertyNames = {"id", "name"}) Iterable<SomethingKey> keys);
+    }
+
+    //
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSomethingByIterator()
+    {
+        final SomethingByIterator s = handle.attach(SomethingByIterator.class);
+
+        s.get(Arrays.asList(new SomethingKey(1, "1"),
+                new SomethingKey(2, "2")).iterator());
+    }
+
+    @UseStringTemplateStatementRewriter
+    public interface SomethingByIterator
+    {
+        @SqlQuery("select id, name from something where (id, name) in (<keys>)")
+        List<Something> get(@BindBeanList(propertyNames = {"id", "name"}) Iterator<SomethingKey> keys);
+    }
+
+    public static class SomethingKey {
+        private int id;
+        private String name;
+
+        SomethingKey(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/stringtemplate3/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate3/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -39,6 +39,8 @@ public class BindListTest
 {
     private static Handle handle;
 
+    private static List<Something> expectedSomethings;
+
     @ClassRule
     public static final H2DatabaseRule db = new H2DatabaseRule();
 
@@ -55,6 +57,8 @@ public class BindListTest
 
         // "control group" element that should *not* be returned by the queries
         handle.execute("insert into something(id, name) values(3, '3')");
+
+        expectedSomethings = Arrays.asList(new Something(1, "1"), new Something(2, "2"));
     }
 
     @AfterClass
@@ -72,7 +76,7 @@ public class BindListTest
 
         final List<Something> out = s.get(1, 2);
 
-        assertThat(out).hasSize(2);
+        assertThat(out).hasSameElementsAs(expectedSomethings);
     }
 
     @UseStringTemplateStatementRewriter
@@ -91,7 +95,7 @@ public class BindListTest
 
         final List<Something> out = s.get(1, 2);
 
-        assertThat(out).hasSize(2);
+        assertThat(out).hasSameElementsAs(expectedSomethings);
     }
 
     @UseStringTemplateStatementRewriter
@@ -110,7 +114,7 @@ public class BindListTest
 
         final List<Something> out = s.get(new int[]{1, 2});
 
-        assertThat(out).hasSize(2);
+        assertThat(out).hasSameElementsAs(expectedSomethings);
     }
 
     @Test
@@ -172,16 +176,14 @@ public class BindListTest
     {
         final SomethingByIterableHandleDefault s = handle.attach(SomethingByIterableHandleDefault.class);
 
-        final List<Something> out = s.get(new Iterable<Integer>()
-        {
+        final List<Something> out = s.get(new Iterable<Integer>() {
             @Override
-            public Iterator<Integer> iterator()
-            {
+            public Iterator<Integer> iterator() {
                 return Arrays.asList(1, 2).iterator();
             }
         });
 
-        assertThat(out).hasSize(2);
+        assertThat(out).hasSameElementsAs(expectedSomethings);
     }
 
     @Test
@@ -189,7 +191,7 @@ public class BindListTest
     {
         final SomethingByIterableHandleDefault s = handle.attach(SomethingByIterableHandleDefault.class);
 
-        final List<Something> out = s.get(new ArrayList<Integer>());
+        final List<Something> out = s.get(new ArrayList<>());
 
         assertThat(out).isEmpty();
     }
@@ -208,7 +210,7 @@ public class BindListTest
     {
         final SomethingByIterableHandleThrow s = handle.attach(SomethingByIterableHandleThrow.class);
 
-        s.get(new ArrayList<Integer>());
+        s.get(new ArrayList<>());
     }
 
     @UseStringTemplateStatementRewriter


### PR DESCRIPTION
BindBeanList allows you to create queries similar to:
`select * from things where (key1, key2) in ((1,2),(3,4))`

This is useful to finding rows that match a list of tuples.

Notes:
1) I believe this is the same issue as https://groups.google.com/forum/#!topic/jdbi/AiJvndhLNk8
2) There is an unsafe `Optional.get` in `SqlStatement.bindBeanList`. I'm not sure what to do if it's empty. Happy to hear suggestions.