### PR TITLE
ResultReturner refactor

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/collector/ArrayBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/ArrayBuilder.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.collector;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+
+class ArrayBuilder {
+    Class<?> componentType;
+    List<Object> list = new ArrayList<>();
+
+    ArrayBuilder(Class<?> componentType) {
+        this.componentType = componentType;
+    }
+
+    public void add(Object element) {
+        list.add(element);
+    }
+
+    public Object build() {
+        Object array = Array.newInstance(componentType, list.size());
+        for (int i = 0; i < list.size(); i++) {
+            Array.set(array, i, list.get(i));
+        }
+        return array;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/collector/ArrayCollectorFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/ArrayCollectorFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.collector;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.stream.Collector;
+
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
+
+class ArrayCollectorFactory implements CollectorFactory {
+    @Override
+    public boolean accepts(Type containerType) {
+        return getErasedType(containerType).isArray();
+    }
+
+    @Override
+    public Optional<Type> elementType(Type containerType) {
+        return Optional.ofNullable(getErasedType(containerType).getComponentType());
+    }
+
+    @Override
+    public Collector<?, ?, ?> build(Type containerType) {
+        Class<?> componentType = getErasedType(containerType).getComponentType();
+        return Collector.of(
+                () -> new ArrayBuilder(componentType),
+                ArrayBuilder::add,
+                (left, right) -> {
+                    left.list.addAll(right.list);
+                    return left;
+                },
+                ArrayBuilder::build);
+    }
+
+}

--- a/core/src/main/java/org/jdbi/v3/core/collector/BuiltInCollectorFactories.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/BuiltInCollectorFactories.java
@@ -43,6 +43,7 @@ public class BuiltInCollectorFactories
                 fromSupplier(List.class, Collectors::toList),
                 fromSupplier(Set.class, Collectors::toSet),
                 fromSupplier(SortedSet.class, () -> Collectors.toCollection(TreeSet::new)),
+                new ArrayCollectorFactory(),
                 new OptionalCollectorFactory()
             );
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/CustomizingStatementHandler.java
@@ -16,12 +16,14 @@ package org.jdbi.v3.sqlobject.statement;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.extension.HandleSupplier;
+import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.SqlStatement;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.sqlobject.Handler;
@@ -179,5 +181,20 @@ abstract class CustomizingStatementHandler<StatementType extends SqlStatement<St
     Method getMethod()
     {
         return method;
+    }
+
+    static RowMapper<?> rowMapperFor(GetGeneratedKeys ggk, Type returnType)
+    {
+        if (GetGeneratedKeys.DefaultMapper.class.equals(ggk.value())) {
+            return new GetGeneratedKeys.DefaultMapper(returnType, ggk.columnName());
+        }
+        else {
+            try {
+                return ggk.value().getConstructor().newInstance();
+            }
+            catch (Exception e) {
+                throw new UnableToCreateStatementException("Unable to instantiate row mapper for statement", e, null);
+            }
+        }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlBatch.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlBatch.java
@@ -99,7 +99,7 @@ public @interface SqlBatch {
                 magic = ResultReturner.forOptionalReturn(sqlObjectType, method);
             } else {
                 magic = ResultReturner.forMethod(sqlObjectType, method);
-                final Function<StatementContext, RowMapper<?>> mapper = ctx -> ResultReturner.rowMapperFor(getGeneratedKeys, magic.elementType(ctx));
+                final Function<StatementContext, RowMapper<?>> mapper = ctx -> rowMapperFor(getGeneratedKeys, magic.elementType(ctx));
                 if (getGeneratedKeys.columnName().isEmpty()) {
                     batchIntermediate = batch -> batch.executeAndReturnGeneratedKeys().map(mapper.apply(batch.getContext())).iterator();
                 } else {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlUpdate.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlUpdate.java
@@ -66,7 +66,7 @@ public @interface SqlUpdate {
             if (isGetGeneratedKeys) {
                 final ResultReturner magic = ResultReturner.forMethod(sqlObjectType, method);
                 final GetGeneratedKeys ggk = method.getAnnotation(GetGeneratedKeys.class);
-                final RowMapper<?> mapper = ResultReturner.rowMapperFor(ggk, returnType);
+                final RowMapper<?> mapper = rowMapperFor(ggk, returnType);
 
                 this.returner = update -> {
                     String columnName = ggk.columnName();


### PR DESCRIPTION
* Remove ArrayResultReturner in favor of ArrayCollectorFactory in core
* Move rowMapperType method to CustomizingStatementHandler
* Rename method parameters (bearer -> iterable)

Addresses #601 (Evaluate SqlObject hardcoding of types)

We have ResultReturners hardcoded for several categories of return type.

I believe each of them is appropriate at the SqlObject level, except for Array, which this PR promotes to core as ArrayResultReturner.

All the other ResultReturners fall into two categories:
1. The return type is a core object that exists before the Collector comes into play, or represents the result as a whole rather than a series of elements that can be collected.
2. The return type has special semantics in SqlObject, where using a collector makes no sense

* `void` - specific to SqlObject, nothing to collect
* `ResultIterable` - comes before the collector
* `Iterator` - comes before the collector (the stream itself comes from this iterator)
* `Stream` - comes before the collector
* `@SingleValue` - SqlObject-specific exception that avoids using a collector