### PR TITLE
Make postgres plugin an SPI plugin, plus other plugin cleanup

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -61,10 +61,6 @@
         <artifactId>jdbi3-guava</artifactId>
       </dependency>
       <dependency>
-        <groupId>com.google.auto.service</groupId>
-        <artifactId>auto-service</artifactId>
-      </dependency>
-      <dependency>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-jodatime2</artifactId>
       </dependency>
@@ -121,7 +117,6 @@
                         <!-- Don't care, just want javadocs -->
                         <ignoredDependencies>
                             <ignoredDependency>org.jdbi:*</ignoredDependency>
-                            <ignoredDependency>com.google.auto.service:auto-service</ignoredDependency>
                         </ignoredDependencies>
                     </configuration>
                 </plugin>

--- a/docs/src/test/java/jdbi/doc/GeneratedKeysTest.java
+++ b/docs/src/test/java/jdbi/doc/GeneratedKeysTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
-import org.jdbi.v3.postgres.PostgresJdbiPlugin;
+import org.jdbi.v3.postgres.PostgresPlugin;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
@@ -32,7 +32,7 @@ public class GeneratedKeysTest {
     @Rule
     public PgDatabaseRule db = new PgDatabaseRule()
         .withPlugin(new SqlObjectPlugin())
-        .withPlugin(new PostgresJdbiPlugin());
+        .withPlugin(new PostgresPlugin());
     private Jdbi dbi;
 
     @Before

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -40,11 +40,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.auto.service</groupId>
-            <artifactId>auto-service</artifactId>
-            <optional>true</optional>
-        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>

--- a/guava/src/main/java/org/jdbi/v3/guava/GuavaPlugin.java
+++ b/guava/src/main/java/org/jdbi/v3/guava/GuavaPlugin.java
@@ -13,12 +13,9 @@
  */
 package org.jdbi.v3.guava;
 
-import com.google.auto.service.AutoService;
-
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 
-@AutoService(JdbiPlugin.class)
 public class GuavaPlugin implements JdbiPlugin {
     @Override
     public void customizeJdbi(Jdbi jdbi) {

--- a/guava/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
+++ b/guava/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
@@ -1,0 +1,1 @@
+org.jdbi.v3.guava.GuavaPlugin

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -47,11 +47,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.auto.service</groupId>
-            <artifactId>auto-service</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3</artifactId>
             <classifier>tests</classifier>

--- a/jodatime2/src/main/java/org/jdbi/v3/jodatime2/JodaTimePlugin.java
+++ b/jodatime2/src/main/java/org/jdbi/v3/jodatime2/JodaTimePlugin.java
@@ -13,12 +13,9 @@
  */
 package org.jdbi.v3.jodatime2;
 
-import com.google.auto.service.AutoService;
-
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 
-@AutoService(JdbiPlugin.class)
 public class JodaTimePlugin implements JdbiPlugin {
     @Override
     public void customizeJdbi(Jdbi jdbi) {

--- a/jodatime2/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
+++ b/jodatime2/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
@@ -1,0 +1,1 @@
+org.jdbi.v3.jodatime2.JodaTimePlugin

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -48,11 +48,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.auto.service</groupId>
-            <artifactId>auto-service</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3</artifactId>
             <classifier>tests</classifier>

--- a/jpa/src/main/java/org/jdbi/v3/jpa/JpaPlugin.java
+++ b/jpa/src/main/java/org/jdbi/v3/jpa/JpaPlugin.java
@@ -13,11 +13,9 @@
  */
 package org.jdbi.v3.jpa;
 
-import com.google.auto.service.AutoService;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 
-@AutoService(JdbiPlugin.class)
 public class JpaPlugin implements JdbiPlugin {
     @Override
     public void customizeJdbi(Jdbi jdbi) {

--- a/jpa/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
+++ b/jpa/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
@@ -1,0 +1,1 @@
+org.jdbi.v3.jpa.JpaPlugin

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>9.4.1208</version>
+                <version>9.4.1212</version>
             </dependency>
 
             <dependency>
@@ -338,12 +338,6 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-guava</artifactId>
                 <version>3.1.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.auto.service</groupId>
-                <artifactId>auto-service</artifactId>
-                <version>1.0-rc2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 
-public class PostgresJdbiPlugin implements JdbiPlugin {
+public class PostgresPlugin implements JdbiPlugin {
     @Override
     public void customizeJdbi(Jdbi jdbi) {
         jdbi.registerArgument(new TypedEnumArgumentFactory());

--- a/postgres/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
+++ b/postgres/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
@@ -1,0 +1,1 @@
+org.jdbi.v3.postgres.PostgresPlugin

--- a/postgres/src/test/java/org/jdbi/v3/postgres/PostgresDbRule.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/PostgresDbRule.java
@@ -38,7 +38,7 @@ public class PostgresDbRule implements TestRule {
             @Override
             public void evaluate() throws Throwable {
                 db = Jdbi.create(pg.getEmbeddedPostgres().getDatabase("postgres", "postgres"))
-                        .installPlugin(new PostgresJdbiPlugin())
+                        .installPlugin(new PostgresPlugin())
                         .installPlugin(new SqlObjectPlugin());
                 h = db.open();
 

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestInetAddressPg.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestInetAddressPg.java
@@ -18,7 +18,7 @@ import org.jdbi.v3.core.argument.TestInetAddressH2;
 
 public class TestInetAddressPg extends TestInetAddressH2
 {
-    { db = new PgDatabaseRule().withPlugin(new PostgresJdbiPlugin()); }
+    { db = new PgDatabaseRule().withPlugin(new PostgresPlugin()); }
 
     @Override
     protected String getInetType()

--- a/postgres/src/test/java/org/jdbi/v3/sqlobject/TestBatchGeneratedKeys.java
+++ b/postgres/src/test/java/org/jdbi/v3/sqlobject/TestBatchGeneratedKeys.java
@@ -22,7 +22,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
-import org.jdbi.v3.postgres.PostgresJdbiPlugin;
+import org.jdbi.v3.postgres.PostgresPlugin;
 import org.jdbi.v3.sqlobject.statement.BatchChunkSize;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -39,7 +39,7 @@ public class TestBatchGeneratedKeys
     @Rule
     public PgDatabaseRule db = new PgDatabaseRule()
             .withPlugin(new SqlObjectPlugin())
-            .withPlugin(new PostgresJdbiPlugin());
+            .withPlugin(new PostgresPlugin());
     private Handle handle;
     private UsesBatching b;
 


### PR DESCRIPTION
* Rename PostgresJdbiPlugin to PostgresPlugin, to agree with other plugin names.
* Add SPI file for PostgresPlugin--somehow we overlooked this one
* Remove auto-service dependency in favor of manual SPI files.
* Upgrade Postgres JDBC dependency to latest