### PR TITLE
Move statement-specific config from SqlStatements back into StatementContext

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
@@ -18,7 +18,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.function.Supplier;
 
-import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**
@@ -78,11 +77,10 @@ public class ResultProducers {
      */
     public static ResultProducer<ResultBearing> returningGeneratedKeys(String... generatedKeyColumnNames) {
         return (supplier, ctx) -> {
-            SqlStatements cfg = ctx.getConfig(SqlStatements.class);
-            cfg.setReturningGeneratedKeys(true);
+            ctx.setReturningGeneratedKeys(true);
 
             if (generatedKeyColumnNames.length > 0) {
-                cfg.setGeneratedKeysColumnNames(generatedKeyColumnNames);
+                ctx.setGeneratedKeysColumnNames(generatedKeyColumnNames);
             }
 
             return ResultBearing.of(getGeneratedKeys(supplier, ctx), ctx);

--- a/core/src/main/java/org/jdbi/v3/core/statement/DefaultStatementBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/DefaultStatementBuilder.java
@@ -44,15 +44,14 @@ public class DefaultStatementBuilder implements StatementBuilder
     @Override
     public PreparedStatement create(Connection conn, String sql, StatementContext ctx) throws SQLException
     {
-        SqlStatements cfg = ctx.getConfig(SqlStatements.class);
-        if (cfg.isReturningGeneratedKeys()) {
-            String[] columnNames = cfg.getGeneratedKeysColumnNames();
+        if (ctx.isReturningGeneratedKeys()) {
+            String[] columnNames = ctx.getGeneratedKeysColumnNames();
             if (columnNames != null && columnNames.length > 0) {
                 return conn.prepareStatement(sql, columnNames);
             }
             return conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
         }
-        else if (cfg.isConcurrentUpdatable()) {
+        else if (ctx.isConcurrentUpdatable()) {
             return conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
         }
         else {

--- a/core/src/main/java/org/jdbi/v3/core/statement/Query.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Query.java
@@ -133,7 +133,7 @@ public class Query extends SqlStatement<Query> implements ResultBearing
      * @return the modified query
      */
     public Query concurrentUpdatable() {
-        getConfig(SqlStatements.class).setConcurrentUpdatable(true);
+        getContext().setConcurrentUpdatable(true);
         return this;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -13,7 +13,6 @@
  */
 package org.jdbi.v3.core.statement;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,10 +26,6 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     private StatementRewriter statementRewriter;
     private TimingCollector timingCollector;
 
-    private boolean returningGeneratedKeys;
-    private String[] generatedKeysColumnNames = new String[0];
-    private boolean concurrentUpdatable;
-
     public SqlStatements() {
         attributes = new ConcurrentHashMap<>();
         statementRewriter = new ColonPrefixStatementRewriter();
@@ -41,9 +36,6 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
         this.attributes = new ConcurrentHashMap<>(that.attributes);
         this.statementRewriter = that.statementRewriter;
         this.timingCollector = that.timingCollector;
-        this.returningGeneratedKeys = that.returningGeneratedKeys;
-        this.generatedKeysColumnNames = that.generatedKeysColumnNames;
-        this.concurrentUpdatable = that.concurrentUpdatable;
     }
 
     /**
@@ -120,74 +112,6 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     public SqlStatements setTimingCollector(TimingCollector timingCollector) {
         this.timingCollector = timingCollector == null ? TimingCollector.NOP_TIMING_COLLECTOR : timingCollector;
         return this;
-    }
-
-    /**
-     * Sets whether the current statement returns generated keys.
-     * @param b return generated keys?
-     */
-    public void setReturningGeneratedKeys(boolean b)
-    {
-        if (isConcurrentUpdatable() && b) {
-            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
-                    + "updatable and is returning generated keys.");
-        }
-        this.returningGeneratedKeys = b;
-    }
-
-    /**
-     * @return whether the statement being generated is expected to return generated keys.
-     */
-    public boolean isReturningGeneratedKeys()
-    {
-        return returningGeneratedKeys || generatedKeysColumnNames.length > 0;
-    }
-
-    /**
-     * @return the generated key column names, if any
-     */
-    public String[] getGeneratedKeysColumnNames()
-    {
-        return Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
-    }
-
-    /**
-     * Set the generated key column names.
-     * @param generatedKeysColumnNames the generated key column names
-     */
-    public void setGeneratedKeysColumnNames(String[] generatedKeysColumnNames)
-    {
-        this.generatedKeysColumnNames = Arrays.copyOf(generatedKeysColumnNames, generatedKeysColumnNames.length);
-    }
-
-    /**
-     * Return if the statement should be concurrent updatable.
-     *
-     * If this returns true, the concurrency level of the created ResultSet will be
-     * {@link java.sql.ResultSet#CONCUR_UPDATABLE}, otherwise the result set is not updatable,
-     * and will have concurrency level {@link java.sql.ResultSet#CONCUR_READ_ONLY}.
-     *
-     * @return if the statement generated should be concurrent updatable.
-     */
-    public boolean isConcurrentUpdatable() {
-        return concurrentUpdatable;
-    }
-
-    /**
-     * Set the context to create a concurrent updatable result set.
-     *
-     * This cannot be combined with {@link #isReturningGeneratedKeys()}, only
-     * one option may be selected. It does not make sense to combine these either, as one
-     * applies to queries, and the other applies to updates.
-     *
-     * @param concurrentUpdatable if the result set should be concurrent updatable.
-     */
-    public void setConcurrentUpdatable(final boolean concurrentUpdatable) {
-        if (concurrentUpdatable && isReturningGeneratedKeys()) {
-            throw new IllegalArgumentException("Cannot create a result set that is concurrent "
-                    + "updatable and is returning generated keys.");
-        }
-        this.concurrentUpdatable = concurrentUpdatable;
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/v3/core/statement/StatementContextTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/StatementContextTest.java
@@ -29,19 +29,17 @@ public class StatementContextTest {
     @Test(expected = IllegalArgumentException.class)
     public void testShouldNotBeAbleToCombineGeneratedKeysAndConcurrentUpdatable() throws Exception {
         final StatementContext context = StatementContextAccess.createContext();
-        final SqlStatements cfg = context.getConfig(SqlStatements.class);
 
-        cfg.setReturningGeneratedKeys(true);
-        cfg.setConcurrentUpdatable(true);
+        context.setReturningGeneratedKeys(true);
+        context.setConcurrentUpdatable(true);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testShouldNotBeAbleToCombineConcurrentUpdatableAndGeneratedKeys() throws Exception {
         final StatementContext context = StatementContextAccess.createContext();
-        final SqlStatements cfg = context.getConfig(SqlStatements.class);
 
-        cfg.setConcurrentUpdatable(true);
-        cfg.setReturningGeneratedKeys(true);
+        context.setConcurrentUpdatable(true);
+        context.setReturningGeneratedKeys(true);
     }
 
     private static class Foo {


### PR DESCRIPTION
Per https://github.com/jdbi/jdbi/pull/648#issuecomment-271463707:

> One thing has been nagging me: I'm not sure I like putting statement-specific settings into JdbiConfig classes. In my mind, this invites users to set config at that Jdbi or Handle level that is inappropriate to share between statements, e.g. SqlStatements.setGeneratedKeysColumnNames or setConcurrentUpdatable. It may have been a mistake to move that out of StatementContext. (And I acknowledge that it was originally my suggestion--sorry for the waste of time)

I think we were probably better off with `StatementContext` holding statement-specific properties instead of `SqlStatements`:
* `returningGeneratedKeys`
* `generatedKeysColumnNames`
* `concurrentUpdatable`

@arteam @stevenschlansker What do you think about this change?