### PR TITLE
Upgrade to Guava 21

### DIFF
--- a/guava/src/main/java/org/jdbi/v3/guava/GuavaCollectors.java
+++ b/guava/src/main/java/org/jdbi/v3/guava/GuavaCollectors.java
@@ -24,7 +24,6 @@ import java.util.stream.Collector;
 import org.jdbi.v3.core.collector.CollectorFactory;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -35,62 +34,12 @@ import com.google.common.collect.ImmutableSortedSet;
  * versions of the base Java collections.
  */
 public class GuavaCollectors {
-    /**
-     * @param <T> the element type collected.
-     *
-     * @return a collector into {@code ImmutableList<T>}
-     */
-    public static <T> Collector<T, ?, ImmutableList<T>> toImmutableList() {
-        return Collector.<T, ImmutableList.Builder<T>, ImmutableList<T>>of(
-                ImmutableList::builder,
-                ImmutableList.Builder::add,
-                GuavaCollectors::combineBuilders,
-                ImmutableList.Builder::build);
-    }
 
     /**
-     * @param <T> the element type collected.
-     *
-     * @return a collector into {@code ImmutableSet<T>}
+     * @return a {@code CollectorFactory} which knows how to create all supported Guava types
      */
-    public static <T> Collector<T, ?, ImmutableSet<T>> toImmutableSet() {
-        return Collector.<T, ImmutableSet.Builder<T>, ImmutableSet<T>>of(
-                ImmutableSet::builder,
-                ImmutableSet.Builder::add,
-                GuavaCollectors::combineBuilders,
-                ImmutableSet.Builder::build);
-    }
-
-    /**
-     * @param <T> the element type collected.
-     *
-     * @return a collector into {@code ImmutableSortedSet<T>}
-     */
-    public static <T extends Comparable<T>> Collector<T, ?, ImmutableSortedSet<T>> toImmutableSortedSet() {
-        return Collector.<T, ImmutableSortedSet.Builder<T>, ImmutableSortedSet<T>>of(
-                ImmutableSortedSet::naturalOrder,
-                ImmutableSortedSet.Builder::add,
-                GuavaCollectors::combineBuilders,
-                ImmutableSortedSet.Builder::build);
-    }
-
-    /**
-     * @param comparator the comparator for sorting set elements.
-     * @param <T> the element type collected.
-     *
-     * @return a collector into {@code ImmutableSortedSet<T>} using the given comparator for sorting
-     */
-    public static <T> Collector<T, ?, ImmutableSortedSet<T>> toImmutableSortedSet(Comparator<T> comparator) {
-        return Collector.<T, ImmutableSortedSet.Builder<T>, ImmutableSortedSet<T>> of(
-                () -> ImmutableSortedSet.orderedBy(comparator),
-                ImmutableSortedSet.Builder::add,
-                GuavaCollectors::combineBuilders,
-                ImmutableSortedSet.Builder::build);
-    }
-
-    private static <T, C extends ImmutableCollection.Builder<T>> C combineBuilders(C left, C right) {
-        left.addAll(right.build());
-        return left;
+    public static CollectorFactory factory() {
+        return new Factory();
     }
 
     /**
@@ -125,20 +74,13 @@ public class GuavaCollectors {
         }
     }
 
-    /**
-     * @return a {@code CollectorFactory} which knows how to create all supported Guava types
-     */
-    public static CollectorFactory factory() {
-        return new Factory();
-    }
-
     public static class Factory implements CollectorFactory {
 
         private static final Map<Class<?>, Collector<?, ?, ?>> collectors =
             ImmutableMap.<Class<?>, Collector<?, ?, ?>>builder()
-                .put(ImmutableList.class, toImmutableList())
-                .put(ImmutableSet.class, toImmutableSet())
-                .put(ImmutableSortedSet.class, toImmutableSortedSet())
+                .put(ImmutableList.class, ImmutableList.toImmutableList())
+                .put(ImmutableSet.class, ImmutableSet.toImmutableSet())
+                .put(ImmutableSortedSet.class, ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()))
                 .put(Optional.class, toOptional())
                 .build();
 

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
@@ -50,7 +50,7 @@ public class TestGuavaCollectors {
     public void immutableList() {
         ImmutableList<Integer> list = dbRule.getSharedHandle().createQuery("select intValue from something")
                 .mapTo(int.class)
-                .collect(GuavaCollectors.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
 
         assertThat(list).containsOnlyElementsOf(expected);
     }
@@ -59,7 +59,7 @@ public class TestGuavaCollectors {
     public void immutableSet() {
         ImmutableSet<Integer> set = dbRule.getSharedHandle().createQuery("select intValue from something")
                 .mapTo(int.class)
-                .collect(GuavaCollectors.toImmutableSet());
+                .collect(ImmutableSet.toImmutableSet());
 
         assertThat(set).containsOnlyElementsOf(expected);
     }
@@ -68,7 +68,7 @@ public class TestGuavaCollectors {
     public void immutableSortedSet() {
         ImmutableSortedSet<Integer> set = dbRule.getSharedHandle().createQuery("select intValue from something")
                 .mapTo(int.class)
-                .collect(GuavaCollectors.toImmutableSortedSet());
+                .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
 
         assertThat(set).containsExactlyElementsOf(expected);
     }
@@ -78,7 +78,7 @@ public class TestGuavaCollectors {
         Comparator<Integer> comparator = Comparator.<Integer>naturalOrder().reversed();
         ImmutableSortedSet<Integer> set = dbRule.getSharedHandle().createQuery("select intValue from something")
                 .mapTo(int.class)
-                .collect(GuavaCollectors.toImmutableSortedSet(comparator));
+                .collect(ImmutableSortedSet.toImmutableSortedSet(comparator));
 
         assertThat(set).containsExactlyElementsOf(expected.stream()
                 .sorted(comparator)

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>19.0</version>
+                <version>21.0</version>
             </dependency>
 
             <dependency>

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
@@ -74,7 +74,7 @@ public class TestCollectorFactory {
 
         ImmutableList<String> rs = h.createQuery("select name from something order by id")
                 .mapTo(String.class)
-                .collect(GuavaCollectors.toImmutableList());
+                .collect(ImmutableList.toImmutableList());
 
         assertThat(rs).containsExactly("Coda", "Brian");
     }


### PR DESCRIPTION
Guava 21 is a release which requires Java 8 and provide some additional features for computability between Guava and Java 8 collection frameworks. For instance, we can reuse collectors for immutable lists and sets. They are now provided by Guava itself. Unfortunately, it looks like we can't replace the collections that collects data to Guava's Optional. Guava provides an optional collectors, but it collects
data to Java8's Optional. A pity.

Guava 21 release notes: https://github.com/google/guava/wiki/Release21

Reference issue: #683 