### PR TITLE
Make Duration/Period factories inherit AbstractArgumentFactory

### DIFF
--- a/postgres/src/main/java/org/jdbi/v3/postgres/DurationArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/DurationArgumentFactory.java
@@ -47,11 +47,7 @@ public class DurationArgumentFactory extends AbstractArgumentFactory<Duration> {
     }
 
     @Override
-    public Argument build( Duration value, ConfigRegistry config) {
-        if (null == value) {
-            return new NullArgument(Types.OTHER);
-        }
-        Duration duration = (Duration)value;
+    public Argument build(Duration duration, ConfigRegistry config) {
         final boolean isNegative = duration.isNegative();
         if (isNegative) {
             duration = duration.negated();

--- a/postgres/src/main/java/org/jdbi/v3/postgres/DurationArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/DurationArgumentFactory.java
@@ -13,16 +13,14 @@
  */
 package org.jdbi.v3.postgres;
 
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
-import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.NullArgument;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.postgresql.util.PGInterval;
 
-import java.lang.reflect.Type;
 import java.sql.Types;
 import java.time.Duration;
-import java.util.Optional;
 
 /**
  * Postgres version of argument factory for {@link Duration}.
@@ -42,14 +40,16 @@ import java.util.Optional;
  * The handling of the second is subject to revision in the future; for example, it would be reasonable to have a
  * configurable truncation option.
  */
-public class DurationArgumentFactory implements ArgumentFactory {
+public class DurationArgumentFactory extends AbstractArgumentFactory<Duration> {
+
+    public DurationArgumentFactory(){
+        super(Types.OTHER);
+    }
+
     @Override
-    public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
-        if (Duration.class != type) {
-            return Optional.empty();
-        }
+    public Argument build( Duration value, ConfigRegistry config) {
         if (null == value) {
-            return Optional.of(new NullArgument(Types.OTHER));
+            return new NullArgument(Types.OTHER);
         }
         Duration duration = (Duration)value;
         final boolean isNegative = duration.isNegative();
@@ -76,6 +76,6 @@ public class DurationArgumentFactory implements ArgumentFactory {
         if (isNegative) {
             interval.scale(-1);
         }
-        return Optional.of((i, p, cx) -> p.setObject(i, interval, Types.OTHER));
+        return (i, p, cx) -> p.setObject(i, interval, Types.OTHER);
     }
 }

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PeriodArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PeriodArgumentFactory.java
@@ -13,32 +13,32 @@
  */
 package org.jdbi.v3.postgres;
 
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
-import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.NullArgument;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.postgresql.util.PGInterval;
 
-import java.lang.reflect.Type;
 import java.sql.Types;
 import java.time.Period;
-import java.util.Optional;
 
 /**
  * Postgres version of argument factory for {@link Period}.
  */
-public class PeriodArgumentFactory implements ArgumentFactory {
+public class PeriodArgumentFactory extends AbstractArgumentFactory<Period> {
+
+    public PeriodArgumentFactory(){
+        super(Types.OTHER);
+    }
+
     @Override
-    public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
-        if (Period.class != type) {
-            return Optional.empty();
-        }
+    public Argument build(Period value, ConfigRegistry config) {
         if (null == value) {
-            return Optional.of(new NullArgument(Types.OTHER));
+            return new NullArgument(Types.OTHER);
         }
         final Period period = (Period)value;
         final PGInterval interval = new PGInterval(
                 period.getYears(), period.getMonths(), period.getDays(), 0, 0, 0);
-        return Optional.of((i, p, cx) -> p.setObject(i, interval, Types.OTHER));
+        return (i, p, cx) -> p.setObject(i, interval, Types.OTHER);
     }
 }

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PeriodArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PeriodArgumentFactory.java
@@ -32,13 +32,8 @@ public class PeriodArgumentFactory extends AbstractArgumentFactory<Period> {
     }
 
     @Override
-    public Argument build(Period value, ConfigRegistry config) {
-        if (null == value) {
-            return new NullArgument(Types.OTHER);
-        }
-        final Period period = (Period)value;
-        final PGInterval interval = new PGInterval(
-                period.getYears(), period.getMonths(), period.getDays(), 0, 0, 0);
+    public Argument build(Period period, ConfigRegistry config) {
+        PGInterval interval = new PGInterval(period.getYears(), period.getMonths(), period.getDays(), 0, 0, 0);
         return (i, p, cx) -> p.setObject(i, interval, Types.OTHER);
     }
 }


### PR DESCRIPTION
Doing so, we can avoid additional checks for confirming factory to the right type and make the factories more generic-friendly.

References #686