### PR TITLE
TransactionIsolationLevel: rename INVALID to UNKNOWN.

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/transaction/TransactionIsolationLevel.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/TransactionIsolationLevel.java
@@ -17,12 +17,13 @@ import java.sql.Connection;
 
 public enum TransactionIsolationLevel
 {
+    NONE(Connection.TRANSACTION_NONE),
     READ_UNCOMMITTED(Connection.TRANSACTION_READ_UNCOMMITTED),
     READ_COMMITTED(Connection.TRANSACTION_READ_COMMITTED),
     REPEATABLE_READ(Connection.TRANSACTION_REPEATABLE_READ),
-    NONE(Connection.TRANSACTION_NONE),
     SERIALIZABLE(Connection.TRANSACTION_SERIALIZABLE),
-    INVALID_LEVEL(Integer.MIN_VALUE);
+    /** The transaction isolation level wasn't specified or is unknown to jdbi. */
+    UNKNOWN(Integer.MIN_VALUE);
 
     private final int value;
 
@@ -43,7 +44,7 @@ public enum TransactionIsolationLevel
             case Connection.TRANSACTION_NONE: return NONE;
             case Connection.TRANSACTION_REPEATABLE_READ: return REPEATABLE_READ;
             case Connection.TRANSACTION_SERIALIZABLE: return SERIALIZABLE;
-            default: return INVALID_LEVEL;
+            default: return UNKNOWN;
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/Transaction.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/Transaction.java
@@ -42,7 +42,7 @@ public @interface Transaction {
     /**
      * @return the transaction isolation level.  If not specified, invoke with the default isolation level.
      */
-    TransactionIsolationLevel value() default TransactionIsolationLevel.INVALID_LEVEL;
+    TransactionIsolationLevel value() default TransactionIsolationLevel.UNKNOWN;
     /**
      * Set the connection readOnly property before the transaction starts, and restore it before it returns.
      * Databases may use this as a performance or concurrency hint.
@@ -63,7 +63,7 @@ public @interface Transaction {
                 if (h.isInTransaction()) {
                     // Already in transaction. The outermost @Transaction method determines the transaction isolation level.
                     TransactionIsolationLevel currentLevel = h.getTransactionIsolationLevel();
-                    if (currentLevel != isolation && isolation != TransactionIsolationLevel.INVALID_LEVEL) {
+                    if (currentLevel != isolation && isolation != TransactionIsolationLevel.UNKNOWN) {
                         throw new TransactionException("Tried to execute nested @Transaction(" + isolation + "), " +
                                 "but already running in a transaction with isolation level " + currentLevel + ".");
                     }
@@ -82,7 +82,7 @@ public @interface Transaction {
                 }
 
                 try {
-                    if (isolation == TransactionIsolationLevel.INVALID_LEVEL) {
+                    if (isolation == TransactionIsolationLevel.UNKNOWN) {
                         return h.inTransaction(callback);
                     } else {
                         return h.inTransaction(isolation, callback);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/TransactionIsolation.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/TransactionIsolation.java
@@ -43,7 +43,7 @@ import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizingAnnotation;
 public @interface TransactionIsolation
 {
 
-    TransactionIsolationLevel value() default TransactionIsolationLevel.INVALID_LEVEL;
+    TransactionIsolationLevel value() default TransactionIsolationLevel.UNKNOWN;
 
     class Factory implements SqlStatementCustomizerFactory
     {


### PR DESCRIPTION
fixes #695 

I chose this over `UNSPECIFIED` because it is specified, just not by us (it's either the driver or the db)