### PR TITLE
Refactor GetGeneratedKeys

### DIFF
--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec mvn clean deploy -Ppublish-docs
+exec mvn clean deploy -Ppublish-docs,oracle

--- a/oracle12/src/test/java/org/jdbi/v3/oracle12/TestGetGeneratedKeysOracle.java
+++ b/oracle12/src/test/java/org/jdbi/v3/oracle12/TestGetGeneratedKeysOracle.java
@@ -54,7 +54,7 @@ public class TestGetGeneratedKeysOracle {
 
     public interface DAO {
         @SqlUpdate("insert into something (name, id) values (:name, something_id_sequence.nextval)")
-        @GetGeneratedKeys(columnName = "id", value = OracleGeneratedKeyMapper.class)
+        @GetGeneratedKeys("id")
         long insert(@Bind("name") String name);
 
         @SqlQuery("select name from something where id = :it")

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/CustomizingStatementHandler.java
@@ -16,7 +16,6 @@ package org.jdbi.v3.sqlobject.statement;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.lang.reflect.Type;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -183,18 +182,14 @@ abstract class CustomizingStatementHandler<StatementType extends SqlStatement<St
         return method;
     }
 
-    static RowMapper<?> rowMapperFor(GetGeneratedKeys ggk, Type returnType)
+    static RowMapper<?> rowMapperFor(UseRowMapper annotation)
     {
-        if (GetGeneratedKeys.DefaultMapper.class.equals(ggk.value())) {
-            return new GetGeneratedKeys.DefaultMapper(returnType, ggk.columnName());
+        Class<? extends RowMapper<?>> mapperClass = annotation.value();
+        try {
+            return mapperClass.getConstructor().newInstance();
         }
-        else {
-            try {
-                return ggk.value().getConstructor().newInstance();
-            }
-            catch (Exception e) {
-                throw new UnableToCreateStatementException("Unable to instantiate row mapper for statement", e, null);
-            }
+        catch (Exception e) {
+            throw new UnableToCreateStatementException("Could not create mapper " + mapperClass.getName(), e, null);
         }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/GetGeneratedKeys.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/GetGeneratedKeys.java
@@ -17,51 +17,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.reflect.Type;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
-import org.jdbi.v3.core.mapper.ColumnMapper;
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.mapper.SingleColumnMapper;
-import org.jdbi.v3.core.statement.StatementContext;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 public @interface GetGeneratedKeys {
-    Class<? extends RowMapper<?>> value() default DefaultMapper.class;
-
-    String columnName() default "";
-
-    class DefaultMapper implements RowMapper<Object> {
-        private final Type returnType;
-        private final String columnName;
-
-        DefaultMapper(Type returnType, String columnName) {
-            this.returnType = returnType;
-            this.columnName = columnName;
-        }
-
-        @Override
-        public Object map(ResultSet rs, StatementContext ctx) throws SQLException {
-            return rowMapperFor(ctx).map(rs, ctx);
-        }
-
-        @Override
-        public RowMapper<Object> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
-            return rowMapperFor(ctx).specialize(rs, ctx);
-        }
-
-        @SuppressWarnings("unchecked")
-        private RowMapper<Object> rowMapperFor(StatementContext ctx) {
-            ColumnMapper<Object> columnMapper = (ColumnMapper<Object>) ctx.findColumnMapperFor(returnType).orElse(null);
-            if (columnMapper != null) {
-                return "".equals(columnName)
-                        ? new SingleColumnMapper<>(columnMapper, 1)
-                        : new SingleColumnMapper<>(columnMapper, columnName);
-            }
-            return (RowMapper<Object>) ctx.findRowMapperFor(returnType)
-                    .orElseThrow(() -> new IllegalStateException("No column or row mapper for " + returnType));
-        }
-    }
+    /**
+     * Column names of the generated key(s) from a SQL statement.
+     */
+    String[] value() default {};
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ResultReturner.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ResultReturner.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.result.ResultIterable;
-import org.jdbi.v3.core.result.ResultBearing;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.sqlobject.SingleValue;
 
@@ -33,17 +32,6 @@ import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
  */
 abstract class ResultReturner
 {
-    /**
-     * Given a {@link ResultBearing}, map to the element
-     * type and construct the result container.
-     * @param r the ResultBearing
-     * @return the filled result container
-     */
-    public Object map(ResultBearing r, StatementContext ctx)
-    {
-        return result(r.mapTo(elementType(ctx)), ctx);
-    }
-
     /**
      * If the return type is {@code void}, swallow results.
      * @param extensionType

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/UseRowMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/UseRowMapper.java
@@ -13,26 +13,18 @@
  */
 package org.jdbi.v3.sqlobject.statement;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.reflect.Method;
 
 import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.result.ResultBearing;
-import org.jdbi.v3.core.statement.UnableToCreateStatementException;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizer;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizingAnnotation;
 
 /**
  * Used to specify specific row mapper on a query method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-@SqlStatementCustomizingAnnotation(UseRowMapper.Factory.class)
 public @interface UseRowMapper
 {
     /**
@@ -40,22 +32,4 @@ public @interface UseRowMapper
      * @return the class of row mapper to use.
      */
     Class<? extends RowMapper<?>> value();
-
-    class Factory implements SqlStatementCustomizerFactory
-    {
-        @Override
-        public SqlStatementCustomizer createForMethod(Annotation annotation, Class<?> sqlObjectType, Method method) {
-            final UseRowMapper mapperAnnotation = (UseRowMapper) annotation;
-            RowMapper<?> mapper;
-            try {
-                mapper = mapperAnnotation.value().newInstance();
-            } catch (InstantiationException | IllegalAccessException e) {
-                throw new UnableToCreateStatementException("Could not create mapper " + mapperAnnotation.value().getName(), e, null);
-            }
-
-            final ResultReturner returner = ResultReturner.forMethod(sqlObjectType, method);
-            return q -> q.getConfig(SqlObjectStatementConfiguration.class)
-                    .setReturner(() -> returner.result(((ResultBearing) q).map(mapper), q.getContext()));
-        }
-    }
 }


### PR DESCRIPTION
Addresses #694 

* Remove GetGeneratedKeys.value(): Class<? extends RowMapper> in favor of @UseRowMapper
* Rename GetGeneratedKeys.columnName() to value(), and change it from String to String[] (multiple column names)

After looking into it, I got rid of the `UseRowMapper.Factory` annotation handler. It turns out that `SqlBatch` was already doing its own custom handling, and `SqlUpdate` needed to implement its own custom handling too. So I inlined it into the `SqlQuery` handler.