### PR TITLE
Refactor HandlerFactory to allow for alternative method handler mappi…

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandlerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandlerFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizingAnnotation;
+
+public class DefaultMethodHandlerFactory implements HandlerFactory {
+    @Override
+    public Optional<Handler> buildHandler(Class<?> sqlObjectType, Method method) {
+        if (!method.isDefault()) {
+            return Optional.empty();
+        }
+
+        Stream.of(method.getAnnotations())
+                .map(Annotation::annotationType)
+                .filter(type -> type.isAnnotationPresent(SqlStatementCustomizingAnnotation.class))
+                .findFirst()
+                .ifPresent(type -> {
+                    throw new IllegalStateException(String.format(
+                            "Default method %s.%s has @%s annotation. Statement customizing annotations don't " +
+                                    "work on default methods.",
+                            sqlObjectType.getSimpleName(),
+                            method.getName(),
+                            type.getSimpleName()));
+                });
+
+        for (Parameter parameter : method.getParameters()) {
+            Stream.of(parameter.getAnnotations())
+                    .map(Annotation::annotationType)
+                    .filter(type -> type.isAnnotationPresent(SqlStatementCustomizingAnnotation.class))
+                    .findFirst()
+                    .ifPresent(type -> {
+                        throw new IllegalStateException(String.format(
+                                "Default method %s.%s parameter %s has @%s annotation. Statement customizing " +
+                                        "annotations don't work on default methods.",
+                                sqlObjectType.getSimpleName(),
+                                method.getName(),
+                                parameter.getName(),
+                                type.getSimpleName()));
+                    });
+        }
+
+        return Optional.of(new DefaultMethodHandler(method));
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerFactory.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
 
 /**
  * Creates Handler objects for methods annotated with a specific SQL method annotation, which satisfy the contract of
@@ -28,5 +29,5 @@ public interface HandlerFactory {
      * @param sqlObjectType the SQL Object type
      * @param method        the method
      */
-    Handler buildHandler(Class<?> sqlObjectType, Method method);
+    Optional<Handler> buildHandler(Class<?> sqlObjectType, Method method);
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handlers.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handlers.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.jdbi.v3.core.config.JdbiConfig;
+
+import static org.jdbi.v3.core.internal.JdbiStreams.toStream;
+
+/**
+ * Registry for {@link HandlerFactory handler factories}, which produce {@link Handler handlers} for SQL object methods.
+ * By default, a factory is registered for default methods ({@link DefaultMethodHandlerFactory}) and for methods annotated
+ * with SQL annotations such as {@code @SqlUpdate} or {@code SqlQuery}. Clients may register additional factories to provide
+ * support for other use cases. In the case that two or more registered factories would support a particular SQL object
+ * method, the last-registered factory takes precedence.
+ */
+public class Handlers implements JdbiConfig<Handlers> {
+    private final List<HandlerFactory> factories = new CopyOnWriteArrayList<>();
+
+    public Handlers() {
+        register(new DefaultMethodHandlerFactory());
+        register(new SqlMethodHandlerFactory());
+    }
+
+    private Handlers(Handlers that) {
+        factories.addAll(that.factories);
+    }
+
+    /**
+     * Registers the given handler factory with the registry.
+     * @param factory the factory to register
+     * @return this
+     */
+    public Handlers register(HandlerFactory factory) {
+        factories.add(0, factory);
+        return this;
+    }
+
+    public Optional<Handler> findFor(Class<?> sqlObjectType, Method method) {
+        return factories.stream()
+                .flatMap(factory -> toStream(factory.buildHandler(sqlObjectType, method)))
+                .findFirst();
+    }
+
+    @Override
+    public Handlers createCopy() {
+        return new Handlers(this);
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotation.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotation.java
@@ -25,8 +25,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.ANNOTATION_TYPE)
 public @interface SqlMethodAnnotation {
     /**
-     * Factory class that produces {@link Handler} instances for methods annotated with the associated annotation.
-     * Must have a zero-argument constructor.
+     * Handler class for methods annotated with the associated annotation.
+     * Must have a public no-arg, {@code (Method method)}, or
+     * {@code (Class<?> sqlObjectType, Method method)} constructor.
      */
-    Class<? extends HandlerFactory> value();
+    Class<? extends Handler> value();
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodHandlerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodHandlerFactory.java
@@ -55,7 +55,7 @@ public class SqlMethodHandlerFactory implements HandlerFactory {
                 .map(type -> type.getAnnotation(SqlMethodAnnotation.class))
                 .map(a -> buildHandler(a.value(), sqlObjectType, method))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException(String.format(
+                .<IllegalStateException>orElseThrow(() -> new IllegalStateException(String.format(
                         "Method %s.%s must be default or be annotated with a SQL method annotation.",
                         sqlObjectType.getSimpleName(),
                         method.getName()))));

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodHandlerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodHandlerFactory.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+public class SqlMethodHandlerFactory implements HandlerFactory {
+    @Override
+    public Optional<Handler> buildHandler(Class<?> sqlObjectType, Method method) {
+        List<Class<?>> sqlMethodAnnotations = Stream.of(method.getAnnotations())
+                .map(Annotation::annotationType)
+                .filter(type -> type.isAnnotationPresent(SqlMethodAnnotation.class))
+                .collect(toList());
+
+        if (sqlMethodAnnotations.isEmpty()) {
+            return Optional.empty();
+        }
+
+        if (sqlMethodAnnotations.size() > 1) {
+            throw new IllegalStateException(
+                    String.format("Mutually exclusive annotations on method %s.%s: %s",
+                            sqlObjectType.getName(),
+                            method.getName(),
+                            sqlMethodAnnotations));
+        }
+
+        if (method.isDefault()) {
+            throw new IllegalStateException(String.format(
+                    "Default method %s.%s has @%s annotation. " +
+                            "SQL object methods may be default, or have a SQL method annotation, but not both.",
+                    sqlObjectType.getSimpleName(),
+                    method.getName(),
+                    sqlMethodAnnotations.get(0).getSimpleName()));
+        }
+
+        return Optional.of(sqlMethodAnnotations.stream()
+                .map(type -> type.getAnnotation(SqlMethodAnnotation.class))
+                .map(a -> buildHandler(a.value(), sqlObjectType, method))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(String.format(
+                        "Method %s.%s must be default or be annotated with a SQL method annotation.",
+                        sqlObjectType.getSimpleName(),
+                        method.getName()))));
+    }
+
+    private Handler buildHandler(Class<? extends Handler> handlerType, Class<?> sqlObjectType, Method method) {
+        try {
+            return handlerType.getConstructor(Class.class, Method.class).newInstance(sqlObjectType, method);
+        } catch (InvocationTargetException e) {
+            throw toUnchecked(e.getCause());
+        } catch (ReflectiveOperationException e) {
+            // fall-through
+        }
+
+        try {
+            return handlerType.getConstructor(Method.class).newInstance(method);
+        } catch (InvocationTargetException e) {
+            throw toUnchecked(e.getCause());
+        } catch (ReflectiveOperationException e) {
+            // fall-through
+        }
+
+        try {
+            return handlerType.getConstructor().newInstance();
+        } catch (InvocationTargetException e) {
+            throw toUnchecked(e.getCause());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Handler class " + handlerType + " cannot be instantiated. " +
+                    "Expected a constructor with parameters (Class, Method), (Method), or ().", e);
+        }
+    }
+
+    private RuntimeException toUnchecked(Throwable t) {
+        if (t instanceof RuntimeException) {
+            return (RuntimeException) t;
+        }
+
+        return new RuntimeException(t);
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/Bind.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/Bind.java
@@ -36,7 +36,8 @@ import org.jdbi.v3.sqlobject.internal.ParameterUtil;
 @SqlStatementCustomizingAnnotation(Bind.Factory.class)
 public @interface Bind
 {
-    static final String NO_VALUE = "";
+    String NO_VALUE = "";
+
     /**
      * The name to bind the argument to. If omitted, the name of the annotated parameter is used. It is an
      * error to omit the name when there is no parameter naming information in your class files.
@@ -53,7 +54,7 @@ public @interface Bind
                                                                   Parameter param,
                                                                   int index) {
             Bind b = (Bind) annotation;
-            String nameFromAnnotation = b == null ? "" : b.value();
+            String nameFromAnnotation = b == null ? NO_VALUE : b.value();
             final String name = ParameterUtil.getParameterName(b, nameFromAnnotation, param);
 
             return (stmt, arg) -> {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlBatch.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlBatch.java
@@ -31,14 +31,11 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.internal.IterableLike;
 import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.result.ResultBearing;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.result.ResultIterator;
 import org.jdbi.v3.core.statement.PreparedBatch;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
-import org.jdbi.v3.sqlobject.Handler;
-import org.jdbi.v3.sqlobject.HandlerFactory;
 import org.jdbi.v3.sqlobject.SingleValue;
 import org.jdbi.v3.sqlobject.SqlMethodAnnotation;
 import org.jdbi.v3.sqlobject.UnableToCreateSqlObjectException;
@@ -59,7 +56,7 @@ import org.jdbi.v3.sqlobject.UnableToCreateSqlObjectException;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-@SqlMethodAnnotation(SqlBatch.Factory.class)
+@SqlMethodAnnotation(SqlBatch.Impl.class)
 public @interface SqlBatch {
     /**
      * @return the SQL string (or name)
@@ -72,20 +69,13 @@ public @interface SqlBatch {
      */
     boolean transactional() default true;
 
-    class Factory implements HandlerFactory {
-        @Override
-        public Handler buildHandler(Class<?> sqlObjectType, Method method) {
-            return new BatchHandler(sqlObjectType, method);
-        }
-    }
-
-    class BatchHandler extends CustomizingStatementHandler<PreparedBatch> {
+    class Impl extends CustomizingStatementHandler<PreparedBatch> {
         private final SqlBatch sqlBatch;
         private final ChunkSizeFunction batchChunkSize;
         private final Function<PreparedBatch, ResultIterator<?>> batchIntermediate;
         private final ResultReturner magic;
 
-        BatchHandler(Class<?> sqlObjectType, Method method) {
+        public Impl(Class<?> sqlObjectType, Method method) {
             super(sqlObjectType, method);
 
             this.sqlBatch = method.getAnnotation(SqlBatch.class);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlCall.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlCall.java
@@ -24,8 +24,6 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.statement.Call;
 import org.jdbi.v3.core.statement.OutParameters;
-import org.jdbi.v3.sqlobject.Handler;
-import org.jdbi.v3.sqlobject.HandlerFactory;
 import org.jdbi.v3.sqlobject.SqlMethodAnnotation;
 
 /**
@@ -33,21 +31,14 @@ import org.jdbi.v3.sqlobject.SqlMethodAnnotation;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-@SqlMethodAnnotation(SqlCall.Factory.class)
+@SqlMethodAnnotation(SqlCall.Impl.class)
 public @interface SqlCall {
     String value() default "";
 
-    class Factory implements HandlerFactory {
-        @Override
-        public Handler buildHandler(Class<?> sqlObjectType, Method method) {
-            return new CallHandler(sqlObjectType, method);
-        }
-    }
-
-    class CallHandler extends CustomizingStatementHandler<Call> {
+    class Impl extends CustomizingStatementHandler<Call> {
         private final boolean returnOutParams;
 
-        CallHandler(Class<?> sqlObjectType, Method method) {
+        public Impl(Class<?> sqlObjectType, Method method) {
             super(sqlObjectType, method);
 
             Type returnType = GenericTypes.resolveType(method.getGenericReturnType(), sqlObjectType);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlQuery.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlQuery.java
@@ -24,8 +24,6 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.sqlobject.Handler;
-import org.jdbi.v3.sqlobject.HandlerFactory;
 import org.jdbi.v3.sqlobject.SqlMethodAnnotation;
 
 /**
@@ -33,7 +31,7 @@ import org.jdbi.v3.sqlobject.SqlMethodAnnotation;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-@SqlMethodAnnotation(SqlQuery.Factory.class)
+@SqlMethodAnnotation(SqlQuery.Impl.class)
 public @interface SqlQuery {
     /**
      * The query (or query name if using a statement locator) to be executed. The default value will use
@@ -44,17 +42,10 @@ public @interface SqlQuery {
      */
     String value() default "";
 
-    class Factory implements HandlerFactory {
-        @Override
-        public Handler buildHandler(Class<?> sqlObjectType, Method method) {
-            return new QueryHandler(sqlObjectType, method);
-        }
-    }
-
-    class QueryHandler extends CustomizingStatementHandler<Query> {
+    class Impl extends CustomizingStatementHandler<Query> {
         private final ResultReturner magic;
 
-        QueryHandler(Class<?> sqlObjectType, Method method) {
+        public Impl(Class<?> sqlObjectType, Method method) {
             super(sqlObjectType, method);
             this.magic = ResultReturner.forMethod(sqlObjectType, method);
         }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlUpdate.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlUpdate.java
@@ -26,8 +26,6 @@ import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.result.ResultBearing;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.statement.Update;
-import org.jdbi.v3.sqlobject.Handler;
-import org.jdbi.v3.sqlobject.HandlerFactory;
 import org.jdbi.v3.sqlobject.SqlMethodAnnotation;
 import org.jdbi.v3.sqlobject.UnableToCreateSqlObjectException;
 
@@ -36,7 +34,7 @@ import org.jdbi.v3.sqlobject.UnableToCreateSqlObjectException;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-@SqlMethodAnnotation(SqlUpdate.Factory.class)
+@SqlMethodAnnotation(SqlUpdate.Impl.class)
 public @interface SqlUpdate {
     /**
      * The sql (or statement name if using a statement locator) to be executed. The default value will use
@@ -47,17 +45,10 @@ public @interface SqlUpdate {
      */
     String value() default "";
 
-    class Factory implements HandlerFactory {
-        @Override
-        public Handler buildHandler(Class<?> sqlObjectType, Method method) {
-            return new UpdateHandler(sqlObjectType, method);
-        }
-    }
-
-    class UpdateHandler extends CustomizingStatementHandler<Update> {
+    class Impl extends CustomizingStatementHandler<Update> {
         private final Function<Update, Object> returner;
 
-        UpdateHandler(Class<?> sqlObjectType, Method method) {
+        public Impl(Class<?> sqlObjectType, Method method) {
             super(sqlObjectType, method);
 
             boolean isGetGeneratedKeys = method.isAnnotationPresent(GetGeneratedKeys.class);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
@@ -16,10 +16,9 @@ package org.jdbi.v3.sqlobject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.reflect.Method;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.extension.HandleSupplier;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
@@ -66,12 +65,12 @@ public class TestSqlMethodAnnotations
     }
 
     @Retention(RetentionPolicy.RUNTIME)
-    @SqlMethodAnnotation(Foo.Factory.class)
+    @SqlMethodAnnotation(Foo.Impl.class)
     public @interface Foo {
-        class Factory implements HandlerFactory {
+        class Impl implements Handler {
             @Override
-            public Handler buildHandler(Class<?> sqlObjectType, Method method) {
-                return (obj, args, handle) -> "foo";
+            public Object invoke(Object target, Object[] args, HandleSupplier handle) throws Exception {
+                return "foo";
             }
         }
     }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecoratingAnnotations.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecoratingAnnotations.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.junit.Before;
@@ -182,15 +183,13 @@ public class TestSqlMethodDecoratingAnnotations {
     }
 
     @Retention(RetentionPolicy.RUNTIME)
-    @SqlMethodAnnotation(CustomSqlMethod.Factory.class)
+    @SqlMethodAnnotation(CustomSqlMethod.Impl.class)
     public @interface CustomSqlMethod {
-        class Factory implements HandlerFactory {
+        class Impl implements Handler {
             @Override
-            public Handler buildHandler(Class<?> sqlObjectType, Method method) {
-                return (obj, args, handle) -> {
-                    invoked("method");
-                    return null;
-                };
+            public Object invoke(Object target, Object[] args, HandleSupplier handle) throws Exception {
+                invoked("method");
+                return null;
             }
         }
     }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseCustomHandlerFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseCustomHandlerFactory.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.config;
+
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.Something;
+import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.sqlobject.Handler;
+import org.jdbi.v3.sqlobject.HandlerFactory;
+import org.jdbi.v3.sqlobject.Handlers;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.transaction.Transaction;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestUseCustomHandlerFactory {
+    @Rule
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private Handle handle;
+
+    @Before
+    public void setUp() throws Exception {
+        Jdbi db = dbRule.getJdbi();
+
+        HandlerFactory defaultHandlerFactory = new HandlerFactory() {
+
+            @Override
+            public Optional<Handler> buildHandler(Class<?> sqlObjectType, Method method) {
+                return getImplementation(sqlObjectType, method).map(m ->
+                        (Handler) (target, args, handle) -> m.invoke(null, Stream.concat(Stream.of(target), Stream.of(args)).toArray())
+                );
+            }
+
+            private Optional<Method> getImplementation(Class<?> type, Method method) {
+                return Stream.of(type.getClasses())
+                        .filter(c -> c.getSimpleName().equals("DefaultImpls"))
+                        .flatMap(c -> Stream.of(c.getMethods()).filter(m -> m.getName().equals(method.getName())))
+                        .findAny();
+            }
+        };
+
+
+        db.configure(Handlers.class, c -> c.register(defaultHandlerFactory));
+        handle = db.open();
+    }
+
+    @Test
+    public void shouldUseConfiguredDefaultHandler() throws Exception {
+        SomethingDao h = handle.attach(SomethingDao.class);
+        Something s = h.insertAndFind(new Something(1, "Joy"));
+        assertThat(s.getName()).isEqualTo("Joy");
+    }
+
+
+    @RegisterRowMapper(SomethingMapper.class)
+    public interface SomethingDao {
+        @SqlUpdate("insert into something (id, name) values (:id, :name)")
+        void insert(@BindBean Something s);
+
+        @SqlQuery("select id, name from something where id = :id")
+        Something findById(@Bind("id") int id);
+
+        @Transaction
+        Something insertAndFind(Something s);
+
+        class DefaultImpls {
+            public static Something insertAndFind(SomethingDao dao, Something s) {
+                dao.insert(s);
+                return dao.findById(s.getId());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
…ng strategies.

I'm submitting this as an alternative to PR #754 (which would add a config property for a "default" method handler as an alternative to existing default method handler).

However I believe the approach in this commit is a better choice long-term, as it allows clients to override the out-of-the-box behavior for any method,
rather than only being able to swap out the "fall-back" method handler.

The public API changes are modest:

* [BREAKING CHANGE] Change HandlerFactory to return `Optional<Handler>` instead of `Handler`
* [BREAKING CHANGE] Change semantics of `@SqlMethodAnnotation`: `value()` returns a handler type instead of handler factory type.
  * The handler type must have a public no-arg, (Method), or (Class, Method) constructor.
* Add Handlers registry with last-registered-wins semantics like our other registries
* Refactor SqlObjectFactory toi use the Handlers registry.
  * Existing logic was moved out to SqlMethodHandlerFactory and DefaultMethodHandlerFactory, which are registered out of the box.

To do
* [x] Needs tests to exercise custom `HandlerFactory`s that can override the default behavior

CC @aharin