### PR TITLE
Fix Postgres error when binding null UUID

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/Argument.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/Argument.java
@@ -34,5 +34,5 @@ public interface Argument
      * @param ctx the statement context
      * @throws SQLException if anything goes wrong
      */
-    void apply(final int position, PreparedStatement statement, StatementContext ctx) throws SQLException;
+    void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException;
 }

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
@@ -50,6 +50,7 @@ public class PostgresPlugin implements JdbiPlugin {
         db.registerArgument(new PeriodArgumentFactory());
         db.registerArgument(new InetArgumentFactory());
         db.registerArgument(new HStoreArgumentFactory());
+        db.registerArgument(new UUIDArgumentFactory());
 
         db.registerArrayType(int.class, "integer");
         db.registerArrayType(Integer.class, "integer");

--- a/postgres/src/main/java/org/jdbi/v3/postgres/UUIDArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/UUIDArgumentFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.postgres;
+
+import java.sql.Types;
+import java.util.UUID;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+public class UUIDArgumentFactory extends AbstractArgumentFactory<UUID> {
+    public UUIDArgumentFactory() {
+        super(Types.OTHER);
+    }
+
+    @Override
+    protected Argument build(UUID value, ConfigRegistry config) {
+        return (i, stmt, ctx) -> stmt.setObject(i, value);
+    }
+}


### PR DESCRIPTION
Built-in argument factory in core uses wrong SQL type (`Types.VARCHAR`) with nulls. Postgres expects `Types.OTHER`.

Also added tests for array usage.