### PR TITLE
Add configurable 'untyped null' argument

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.argument;
 import static org.jdbi.v3.core.internal.JdbiStreams.toStream;
 
 import java.lang.reflect.Type;
+import java.sql.Types;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -27,6 +28,7 @@ import org.jdbi.v3.core.config.JdbiConfig;
 public class Arguments implements JdbiConfig<Arguments> {
     private final List<ArgumentFactory> argumentFactories = new CopyOnWriteArrayList<>();
     private ConfigRegistry registry;
+    private Argument untypedNullArgument = new NullArgument(Types.OTHER);
 
     public Arguments() {
         register(BuiltInArgumentFactory.INSTANCE);
@@ -40,6 +42,7 @@ public class Arguments implements JdbiConfig<Arguments> {
 
     private Arguments(Arguments that) {
         argumentFactories.addAll(that.argumentFactories);
+        untypedNullArgument = that.untypedNullArgument;
     }
 
     public Arguments register(ArgumentFactory factory) {
@@ -58,6 +61,25 @@ public class Arguments implements JdbiConfig<Arguments> {
         return argumentFactories.stream()
                 .flatMap(factory -> toStream(factory.build(type, value, registry)))
                 .findFirst();
+    }
+
+    /**
+     * Configure the {@link Argument} to use when binding a null
+     * we don't have a type for.
+     * @param untypedNullArgument the argument to bind
+     */
+    public void setUntypedNullArgument(Argument untypedNullArgument) {
+        if (untypedNullArgument == null) {
+            throw new IllegalArgumentException("the Argument itself may not be null");
+        }
+        this.untypedNullArgument = untypedNullArgument;
+    }
+
+    /**
+     * @return the untyped null argument
+     */
+    public Argument getUntypedNullArgument() {
+        return untypedNullArgument;
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/argument/BuiltInArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/BuiltInArgumentFactory.java
@@ -146,7 +146,7 @@ public class BuiltInArgumentFactory implements ArgumentFactory {
         }
 
         return value == null
-                ? Optional.of(new NullArgument(Types.NULL))
+                ? Optional.of(config.get(Arguments.class).getUntypedNullArgument())
                 : Optional.empty();
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestMapArguments.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestMapArguments.java
@@ -21,7 +21,6 @@ import java.sql.Types;
 import java.util.Collections;
 import java.util.Map;
 
-import org.jdbi.v3.core.argument.MapArguments;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.StatementContextAccess;
 import org.junit.Rule;
@@ -55,6 +54,6 @@ public class TestMapArguments
         Map<String, Object> args = Collections.singletonMap("foo", null);
         new MapArguments(args, ctx).find("foo").get().apply(3, stmt, null);
 
-        verify(stmt).setNull(3, Types.NULL);
+        verify(stmt).setNull(3, Types.OTHER);
     }
 }


### PR DESCRIPTION
Fixes #299 (although customization per database vendor is not included)

Also changes default from `Types.NULL` to `Types.OTHER` because I think that's a more sensible default given the prior discussion.