### PR TITLE
Add HandlerDecorators registry, so e.g. JDBI-agnostic annotations can…

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorator.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
  * @see SqlMethodDecoratingAnnotation
  * @see HandlerDecorators
  */
+@FunctionalInterface
 public interface HandlerDecorator {
     /**
      * Decorates the {@link Handler} to add or substitute behavior on the given SQL Object method. Implementations may

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorator.java
@@ -16,19 +16,20 @@ package org.jdbi.v3.sqlobject;
 import java.lang.reflect.Method;
 
 /**
- * Creates Handler decorator objects for methods annotated with a specific SQL method <em>decorating</em> annotation,
- * which satisfy the contract of that annotation.
+ * Decorates Handler objects with additional behavior.
  *
  * @see SqlMethodDecoratingAnnotation
+ * @see HandlerDecorators
  */
 public interface HandlerDecorator {
     /**
-     * Decorates a {@link Handler} to add or substitute behavior on the given SQL Object method.
+     * Decorates the {@link Handler} to add or substitute behavior on the given SQL Object method. Implementations may
+     * alternatively return the base handler, e.g. if the conditions for applying a particular decoration are not met.
      *
      * @param base          the base handler to decorate
      * @param sqlObjectType the SQL Object type
-     * @param method        the decorated method
-     * @return the decorated handler.
+     * @param method        the method to be decorated
+     * @return the base handle, or a decorated handler (depending on the decorator implementation).
      */
     Handler decorateHandler(Handler base, Class<?> sqlObjectType, Method method);
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorators.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorators.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.jdbi.v3.core.config.JdbiConfig;
+
+/**
+ * Registry for {@link HandlerDecorator handler decorators}. Decorators may modify or augment the behavior of a method
+ * Handler in some way. Out of the box, a decorator is registered which applies decorations for any
+ * {@link SqlMethodDecoratingAnnotation decorating annotations} present on a SQL method. For example, using the
+ * {@link org.jdbi.v3.sqlobject.transaction.Transaction} annotation will cause a SQL method to be executed within a
+ * transaction. Decorators are applied in the order registered, from innermost to outermost: the last registered
+ * decorator will be the outermost decorator around the method handler.
+ */
+public class HandlerDecorators implements JdbiConfig<HandlerDecorators> {
+    private final List<HandlerDecorator> decorators = new CopyOnWriteArrayList<>();
+
+    public HandlerDecorators() {
+        register(new SqlMethodAnnotatedHandlerDecorator());
+    }
+
+    private HandlerDecorators(HandlerDecorators that) {
+        decorators.addAll(that.decorators);
+    }
+
+    /**
+     * Registers the given handler decorator with the registry.
+     *
+     * @param decorator the decorator to register
+     * @return this
+     */
+    public HandlerDecorators register(HandlerDecorator decorator) {
+        decorators.add(decorator);
+        return this;
+    }
+
+    /**
+     * Applies all registered decorators to the given handler
+     *
+     * @param base          the base handler
+     * @param sqlObjectType the SQL object type
+     * @param method        the SQL method to be decorated
+     * @return the decorated handler
+     */
+    public Handler applyDecorators(Handler base, Class<?> sqlObjectType, Method method) {
+        Handler handler = base;
+        for (HandlerDecorator decorator : decorators) {
+            handler = decorator.decorateHandler(handler, sqlObjectType, method);
+        }
+        return handler;
+    }
+
+    @Override
+    public HandlerDecorators createCopy() {
+        return new HandlerDecorators(this);
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotatedHandlerDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotatedHandlerDecorator.java
@@ -46,9 +46,7 @@ public class SqlMethodAnnotatedHandlerDecorator implements HandlerDecorator {
                 .map(e -> e.getAnnotation(DecoratorOrder.class))
                 .filter(Objects::nonNull)
                 .findFirst()
-                .ifPresent(order -> {
-                    annotationTypes.sort(createDecoratorComparator(order).reversed());
-                });
+                .ifPresent(order -> annotationTypes.sort(createDecoratorComparator(order).reversed()));
 
         List<HandlerDecorator> decorators = annotationTypes.stream()
                 .map(type -> type.getAnnotation(SqlMethodDecoratingAnnotation.class))
@@ -65,22 +63,18 @@ public class SqlMethodAnnotatedHandlerDecorator implements HandlerDecorator {
     private Comparator<Class<? extends Annotation>> createDecoratorComparator(DecoratorOrder order) {
         List<Class<? extends Annotation>> ordering = Arrays.asList(order.value());
 
-        ToIntFunction<Class<? extends Annotation>> indexOf = type -> {
+        return Comparator.comparingInt(type -> {
             int index = ordering.indexOf(type);
             return index == -1 ? ordering.size() : index;
-        };
-
-        return Comparator.comparingInt(indexOf::applyAsInt);
+        });
     }
 
     private static HandlerDecorator buildDecorator(Class<? extends HandlerDecorator> decoratorClass) {
-        HandlerDecorator decorator;
         try {
-            decorator = decoratorClass.getConstructor().newInstance();
+            return decoratorClass.getConstructor().newInstance();
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Decorator class " + decoratorClass + "cannot be instantiated", e);
         }
-        return decorator;
     }
 
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotatedHandlerDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotatedHandlerDecorator.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import static java.util.stream.Collectors.toList;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.ToIntFunction;
+import java.util.stream.Stream;
+
+/**
+ * Applies decorations to method handlers, according to any {@link SqlMethodDecoratingAnnotation decorating annotations}
+ * present on the method. If multiple decorating annotations are present, the order of application can be controlled
+ * using the {@link DecoratorOrder} annotation.
+ * <p>
+ * This decorator is registered out of the box.
+ * </p>
+ */
+public class SqlMethodAnnotatedHandlerDecorator implements HandlerDecorator {
+    @Override
+    public Handler decorateHandler(Handler base, Class<?> sqlObjectType, Method method) {
+        Handler handler = base;
+
+        List<Class<? extends Annotation>> annotationTypes = Stream.of(method.getAnnotations())
+                .map(Annotation::annotationType)
+                .filter(type -> type.isAnnotationPresent(SqlMethodDecoratingAnnotation.class))
+                .collect(toList());
+
+        Stream.of(method, sqlObjectType)
+                .map(e -> e.getAnnotation(DecoratorOrder.class))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .ifPresent(order -> {
+                    annotationTypes.sort(createDecoratorComparator(order).reversed());
+                });
+
+        List<HandlerDecorator> decorators = annotationTypes.stream()
+                .map(type -> type.getAnnotation(SqlMethodDecoratingAnnotation.class))
+                .map(a -> buildDecorator(a.value()))
+                .collect(toList());
+
+        for (HandlerDecorator decorator : decorators) {
+            handler = decorator.decorateHandler(handler, sqlObjectType, method);
+        }
+
+        return handler;
+    }
+
+    private Comparator<Class<? extends Annotation>> createDecoratorComparator(DecoratorOrder order) {
+        List<Class<? extends Annotation>> ordering = Arrays.asList(order.value());
+
+        ToIntFunction<Class<? extends Annotation>> indexOf = type -> {
+            int index = ordering.indexOf(type);
+            return index == -1 ? ordering.size() : index;
+        };
+
+        return Comparator.comparingInt(indexOf::applyAsInt);
+    }
+
+    private static HandlerDecorator buildDecorator(Class<? extends HandlerDecorator> decoratorClass) {
+        HandlerDecorator decorator;
+        try {
+            decorator = decoratorClass.getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Decorator class " + decoratorClass + "cannot be instantiated", e);
+        }
+        return decorator;
+    }
+
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -14,7 +14,6 @@
 package org.jdbi.v3.sqlobject;
 
 import static java.util.Collections.synchronizedMap;
-import static java.util.stream.Collectors.toList;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
@@ -24,14 +23,10 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.function.BiConsumer;
-import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -78,7 +73,10 @@ public class SqlObjectFactory implements ExtensionFactory {
      */
     @Override
     public <E> E attach(Class<E> extensionType, HandleSupplier handle) {
-        Map<Method, Handler> handlers = methodHandlersFor(extensionType, handle.getConfig(Handlers.class));
+        Map<Method, Handler> handlers = methodHandlersFor(
+                extensionType,
+                handle.getConfig(Handlers.class),
+                handle.getConfig(HandlerDecorators.class));
 
         ConfigRegistry instanceConfig = handle.getConfig().createCopy();
         forEachConfigurer(extensionType, (configurer, annotation) ->
@@ -92,7 +90,7 @@ public class SqlObjectFactory implements ExtensionFactory {
                         invocationHandler));
     }
 
-    private Map<Method, Handler> methodHandlersFor(Class<?> sqlObjectType, Handlers registry) {
+    private Map<Method, Handler> methodHandlersFor(Class<?> sqlObjectType, Handlers registry, HandlerDecorators decorators) {
         return handlersCache.computeIfAbsent(sqlObjectType, type -> {
             final Map<Method, Handler> handlers = new HashMap<>();
 
@@ -107,68 +105,21 @@ public class SqlObjectFactory implements ExtensionFactory {
             } catch (IllegalStateException expected) { } // optional implementation
 
             for (Method method : sqlObjectType.getMethods()) {
-                handlers.computeIfAbsent(method, m -> buildMethodHandler(sqlObjectType, m, registry));
+                handlers.computeIfAbsent(method, m -> buildMethodHandler(sqlObjectType, m, registry, decorators));
             }
 
             return handlers;
         });
     }
 
-    private Handler buildMethodHandler(Class<?> sqlObjectType, Method method, Handlers handlers) {
+    private Handler buildMethodHandler(Class<?> sqlObjectType, Method method, Handlers handlers, HandlerDecorators decorators) {
         Handler handler = handlers.findFor(sqlObjectType, method)
                 .orElseThrow(() -> new IllegalStateException(String.format(
                         "Method %s.%s must be default or be annotated with a SQL method annotation.",
                         sqlObjectType.getSimpleName(),
                         method.getName())));
 
-        return addDecorators(handler, sqlObjectType, method);
-    }
-
-    private Handler addDecorators(Handler handler, Class<?> sqlObjectType, Method method) {
-        List<Class<? extends Annotation>> annotationTypes = Stream.of(method.getAnnotations())
-                .map(Annotation::annotationType)
-                .filter(type -> type.isAnnotationPresent(SqlMethodDecoratingAnnotation.class))
-                .collect(toList());
-
-        Stream.of(method, sqlObjectType)
-                .map(e -> e.getAnnotation(DecoratorOrder.class))
-                .filter(Objects::nonNull)
-                .findFirst()
-                .ifPresent(order -> {
-                    annotationTypes.sort(createDecoratorComparator(order).reversed());
-                });
-
-        List<HandlerDecorator> decorators = annotationTypes.stream()
-                .map(type -> type.getAnnotation(SqlMethodDecoratingAnnotation.class))
-                .map(a -> buildDecorator(a.value()))
-                .collect(toList());
-
-        for (HandlerDecorator decorator : decorators) {
-            handler = decorator.decorateHandler(handler, sqlObjectType, method);
-        }
-
-        return handler;
-    }
-
-    private Comparator<Class<? extends Annotation>> createDecoratorComparator(DecoratorOrder order) {
-        List<Class<? extends Annotation>> ordering = Arrays.asList(order.value());
-
-        ToIntFunction<Class<? extends Annotation>> indexOf = type -> {
-            int index = ordering.indexOf(type);
-            return index == -1 ? ordering.size() : index;
-        };
-
-        return Comparator.comparingInt(indexOf::applyAsInt);
-    }
-
-    private static HandlerDecorator buildDecorator(Class<? extends HandlerDecorator> decoratorClass) {
-        HandlerDecorator decorator;
-        try {
-            decorator = decoratorClass.getConstructor().newInstance();
-        } catch (ReflectiveOperationException e) {
-            throw new IllegalStateException("Decorator class " + decoratorClass + "cannot be instantiated", e);
-        }
-        return decorator;
+        return decorators.applyDecorators(handler, sqlObjectType, method);
     }
 
     private static Map<Method, Handler> handlerEntry(Handler handler, Class<?> klass, String methodName, Class<?>... parameterTypes) {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecorators.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecorators.java
@@ -105,7 +105,7 @@ public class TestSqlMethodDecorators {
 
         handle.attach(Dao.class).orderedFooBar();
 
-        assertThat(invocations.get()).contains("custom", "foo", "bar");
+        assertThat(invocations.get()).containsExactly("custom", "foo", "bar", "method");
     }
 
     @Test
@@ -114,7 +114,7 @@ public class TestSqlMethodDecorators {
 
         handle.attach(Dao.class).orderedFooBar();
 
-        assertThat(invocations.get()).contains("foo", "bar");
+        assertThat(invocations.get()).containsExactly("foo", "bar", "method");
     }
 
     static void invoked(String value) {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecorators.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecorators.java
@@ -21,16 +21,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-
+import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
-import org.jdbi.v3.core.Handle;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class TestSqlMethodDecoratingAnnotations {
+public class TestSqlMethodDecorators {
     @Rule
     public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
 
@@ -93,6 +92,29 @@ public class TestSqlMethodDecoratingAnnotations {
         dao.abortingDecorator();
 
         assertThat(invocations.get()).containsExactly("foo", "abort");
+    }
+
+    @Test
+    public void testRegisteredDecorator() {
+        handle.getConfig(HandlerDecorators.class).register(
+                (base, sqlObjectType, method) ->
+                        (obj, args, handle) -> {
+                            invoked("custom");
+                            return base.invoke(obj, args, handle);
+                        });
+
+        handle.attach(Dao.class).orderedFooBar();
+
+        assertThat(invocations.get()).contains("custom", "foo", "bar");
+    }
+
+    @Test
+    public void testRegisteredDecoratorReturnsBase() {
+        handle.getConfig(HandlerDecorators.class).register((base, sqlObjectType, method) -> base);
+
+        handle.attach(Dao.class).orderedFooBar();
+
+        assertThat(invocations.get()).contains("foo", "bar");
     }
 
     static void invoked(String value) {


### PR DESCRIPTION
… have decorator behavior attached to them

Fixes #771 

To do:

* [x] Add proof of concept tests demonstrating how third-party annotations that have nothing to do with JDBI can have behavior attached to them.