### PR TITLE
Shade core dependencies: antlr, expiringmap, and guava

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -196,7 +196,8 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <include>org.antlr:antlr-runtime</include>
+                                    <include>antlr:*</include>
+                                    <include>org.antlr:*</include>
                                     <include>com.google.guava:guava</include>
                                     <include>net.jodah:expiringmap</include>
                                 </includes>
@@ -206,7 +207,11 @@
                             <minimizeJar>true</minimizeJar>
                             <relocations>
                                 <relocation>
-                                    <pattern>org.antlr.runtime</pattern>
+                                    <pattern>org.antlr</pattern>
+                                    <shadedPattern>org.jdbi.v3.core.shaded.org.antlr</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>antlr</pattern>
                                     <shadedPattern>org.jdbi.v3.core.shaded.antlr</shadedPattern>
                                 </relocation>
 
@@ -223,7 +228,7 @@
                                     <shadedPattern>org.jdbi.v3.core.shaded.expiringmap</shadedPattern>
                                 </relocation>
                             </relocations>
-                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadeSourcesContent>true</shadeSourcesContent>
                         </configuration>
                     </execution>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,7 +46,7 @@
     </licenses>
 
     <dependencies>
-        <dependency>
+        <dependency> <!-- shaded -->
             <groupId>org.antlr</groupId>
             <artifactId>antlr-runtime</artifactId>
         </dependency>
@@ -67,12 +67,12 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
+        <dependency> <!-- shaded -->
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
 
-        <dependency>
+        <dependency> <!-- shaded -->
             <groupId>net.jodah</groupId>
             <artifactId>expiringmap</artifactId>
         </dependency>
@@ -184,7 +184,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- XXX: disable shading because it doesn't do Java 8 yet...
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -199,24 +198,47 @@
                                 <includes>
                                     <include>org.antlr:antlr-runtime</include>
                                     <include>com.google.guava:guava</include>
+                                    <include>net.jodah:expiringmap</include>
                                 </includes>
                             </artifactSet>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <createSourcesJar>true</createSourcesJar>
+                            <minimizeJar>true</minimizeJar>
                             <relocations>
                                 <relocation>
                                     <pattern>org.antlr.runtime</pattern>
-                                    <shadedPattern>org.jdbi.v3.org.antlr.runtime</shadedPattern>
+                                    <shadedPattern>org.jdbi.v3.core.shaded.antlr</shadedPattern>
                                 </relocation>
 
                                 <relocation>
-                                    <pattern>com.google.guava</pattern>
-                                    <shadedPattern>org.jdbi.v3.com.google.guava</shadedPattern>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.jdbi.v3.core.shaded.guava</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.thirdparty</pattern> <!-- packaged with guava -->
+                                    <shadedPattern>org.jdbi.v3.core.shaded.guava.thirdparty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.jodah.expiringmap</pattern>
+                                    <shadedPattern>org.jdbi.v3.core.shaded.expiringmap</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <shadeSourcesContent>true</shadeSourcesContent>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            -->
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>dependency-management-maven-plugin</artifactId>
+                <configuration>
+                    <requireManagement> <!-- can't control these in dependency-reduced pom produced by shade plugin -->
+                        <allowVersions>true</allowVersions>
+                        <allowExclusions>true</allowExclusions>
+                    </requireManagement>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Fixes #264 

Shading brings up the core JAR size from ~260K to ~1.4M.

Most of this comes from Guava, which weighs in at 2.5M. The shade plugin's tree shaking reduces this to just the 1.1M of classes that are transitively reachable through JDBI.