### PR TITLE
Tests demonstrating NoViableAltException is fixed

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
@@ -115,4 +115,11 @@ public class TestClasspathSqlLocator {
         assertThat(findSqlOnClasspath(getClass(), "test-locate-by-custom-name"))
                 .contains("select 1");
     }
+
+    @Test
+    public void testColonInComment() throws Exception {
+        // Used to throw exception in SQL statement lexer
+        // see https://github.com/jdbi/jdbi/issues/748
+        findSqlOnClasspath(getClass(), "test-colon-in-comment");
+    }
 }

--- a/core/src/test/java/org/jdbi/v3/core/rewriter/TestColonStatementRewriter.java
+++ b/core/src/test/java/org/jdbi/v3/core/rewriter/TestColonStatementRewriter.java
@@ -166,4 +166,10 @@ public class TestColonStatementRewriter
         String sql = "select 1 /* ' \" <foo> */";
         assertThat(rewrite(sql).getSql()).isEqualTo(sql);
     }
+
+    @Test
+    public void testColonInComment() throws Exception {
+        String sql = "/* comment with : colons :: inside it */ select 1";
+        assertThat(rewrite(sql).getSql()).isEqualTo(sql);
+    }
 }

--- a/core/src/test/resources/org/jdbi/v3/core/locator/TestClasspathSqlLocator/test-colon-in-comment.sql
+++ b/core/src/test/resources/org/jdbi/v3/core/locator/TestClasspathSqlLocator/test-colon-in-comment.sql
@@ -1,0 +1,17 @@
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+/* block comment with : colon :: inside */
+-- inline comment with : colon :: inside
+SELECT 1.007 AS column_name WHERE :left = :right;


### PR DESCRIPTION
Addresses #748.

Putting a colon in comments used to trigger a NoViableAltException in the lexer. New tests show this is fixed in v3.

@stevenschlansker or @arteam please review