### PR TITLE
Forbid mixing named and positional parameters in SQL statements.

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/rewriter/ColonPrefixStatementRewriter.java
+++ b/core/src/main/java/org/jdbi/v3/core/rewriter/ColonPrefixStatementRewriter.java
@@ -70,12 +70,12 @@ public class ColonPrefixStatementRewriter implements StatementRewriter {
                     b.append(t.getText());
                     break;
                 case NAMED_PARAM:
-                    stmt.addNamedParamAt(t.getText().substring(1));
+                    stmt.addNamedParam(t.getText().substring(1));
                     b.append("?");
                     break;
                 case POSITIONAL_PARAM:
                     b.append("?");
-                    stmt.addPositionalParamAt();
+                    stmt.addPositionalParam();
                     break;
                 case ESCAPED_TEXT:
                     b.append(t.getText().substring(1));
@@ -85,7 +85,7 @@ public class ColonPrefixStatementRewriter implements StatementRewriter {
             }
             t = lexer.nextToken();
         }
-        stmt.sql = b.toString();
+        stmt.setParsedSql(b.toString());
         return stmt;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/rewriter/HashPrefixStatementRewriter.java
+++ b/core/src/main/java/org/jdbi/v3/core/rewriter/HashPrefixStatementRewriter.java
@@ -67,12 +67,12 @@ public class HashPrefixStatementRewriter implements StatementRewriter {
                     b.append(t.getText());
                     break;
                 case NAMED_PARAM:
-                    stmt.addNamedParamAt(t.getText().substring(1));
+                    stmt.addNamedParam(t.getText().substring(1));
                     b.append("?");
                     break;
                 case POSITIONAL_PARAM:
                     b.append("?");
-                    stmt.addPositionalParamAt();
+                    stmt.addPositionalParam();
                     break;
                 case ESCAPED_TEXT:
                     b.append(t.getText().substring(1));
@@ -82,7 +82,7 @@ public class HashPrefixStatementRewriter implements StatementRewriter {
             }
             t = lexer.nextToken();
         }
-        stmt.sql = b.toString();
+        stmt.setParsedSql(b.toString());
         return stmt;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/rewriter/InternalRewrittenStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/rewriter/InternalRewrittenStatement.java
@@ -13,15 +13,16 @@
  */
 package org.jdbi.v3.core.rewriter;
 
-import static org.jdbi.v3.core.internal.JdbiOptionals.findFirstPresent;
+import static org.jdbi.v3.core.rewriter.ParsedStatement.POSITIONAL_PARAM;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.Optional;
+import java.util.List;
 
+import com.google.common.base.Joiner;
+import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.statement.Binding;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 
@@ -36,49 +37,55 @@ class InternalRewrittenStatement implements RewrittenStatement {
 
     @Override
     public void bind(Binding params, PreparedStatement statement) throws SQLException {
-        if (stmt.positionalOnly) {
-            // no named params, is easy
-            boolean finished = false;
-            for (int i = 0; !finished; ++i) {
-                final Optional<Argument> a = params.findForPosition(i);
-                if (a.isPresent()) {
-                    try {
-                        a.get().apply(i + 1, statement, this.context);
-                    } catch (SQLException e) {
-                        throw new UnableToExecuteStatementException(
-                                String.format("Exception while binding positional param at (0 based) position %d",
-                                        i), e, context);
-                    }
-                } else {
-                    finished = true;
-                }
-            }
+        if (stmt.isPositional()) {
+            bindPositional(params, statement);
         } else {
-            //List<String> named_params = stmt.params;
-            int i = 0;
-            for (String named_param : stmt.params) {
-                if ("*".equals(named_param)) {
-                    continue;
-                }
-                final int index = i;
-                Argument a = findFirstPresent(
-                        () -> params.findForName(named_param),
-                        () -> params.findForPosition(index))
-                        .orElseThrow(() -> {
-                            String msg = String.format("Unable to execute, no named parameter matches " +
-                                            "\"%s\" and no positional param for place %d (which is %d in " +
-                                            "the JDBC 'start at 1' scheme) has been set.",
-                                    named_param, index, index + 1);
-                            return new UnableToExecuteStatementException(msg, context);
-                        });
+            bindNamed(params, statement);
+        }
+    }
 
-                try {
-                    a.apply(i + 1, statement, this.context);
-                } catch (SQLException e) {
-                    throw new UnableToCreateStatementException(String.format("Exception while binding '%s'",
-                            named_param), e, context);
-                }
-                i++;
+    private void bindPositional(Binding params, PreparedStatement statement) {
+        int paramCount = stmt.getParams().size();
+        for (int i = 0; i < paramCount; i++) {
+            int index = i;
+            Argument a = params.findForPosition(i)
+                    .orElseThrow(() -> {
+                        String msg = String.format("Unable to execute, no positional parameter bound at position %s",
+                                index);
+                        return new UnableToExecuteStatementException(msg, context);
+                    });
+            try {
+                a.apply(i + 1, statement, this.context);
+            } catch (SQLException e) {
+                throw new UnableToExecuteStatementException(
+                        String.format("Exception while binding positional param at (0 based) position %d",
+                                i), e, context);
+            }
+        }
+    }
+
+    private void bindNamed(Binding params, PreparedStatement statement) {
+        List<String> paramList = stmt.getParams();
+
+        if (paramList.contains(POSITIONAL_PARAM)) {
+            String msg = "Cannot mix named and positional parameters in a SQL statement: "
+                    + Joiner.on(", ").join(paramList);
+            throw new UnableToExecuteStatementException(msg, context);
+        }
+
+        for (int i = 0; i < paramList.size(); i++) {
+            String param = paramList.get(i);
+            Argument a = params.findForName(param)
+                    .orElseThrow(() -> {
+                        String msg = String.format("Unable to execute, no named parameter matches \"%s\".", param);
+                        return new UnableToExecuteStatementException(msg, context);
+                    });
+
+            try {
+                a.apply(i + 1, statement, this.context);
+            } catch (SQLException e) {
+                throw new UnableToCreateStatementException(String.format("Exception while binding '%s'",
+                        param), e, context);
             }
         }
     }

--- a/core/src/main/java/org/jdbi/v3/core/rewriter/ParsedStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/rewriter/ParsedStatement.java
@@ -17,20 +17,34 @@ import java.util.ArrayList;
 import java.util.List;
 
 class ParsedStatement {
-    String sql;
-    boolean positionalOnly = true;
+    static final String POSITIONAL_PARAM = "?";
+
+    private String parsedSql;
+    private boolean positional = true;
     List<String> params = new ArrayList<>();
 
-    void addNamedParamAt(String name) {
-        positionalOnly = false;
+    String getParsedSql() {
+        return parsedSql;
+    }
+
+    void setParsedSql(String parsedSql) {
+        this.parsedSql = parsedSql;
+    }
+
+    boolean isPositional() {
+        return positional;
+    }
+
+    void addNamedParam(String name) {
+        positional = false;
         params.add(name);
     }
 
-    void addPositionalParamAt() {
-        params.add("*");
+    void addPositionalParam() {
+        params.add(POSITIONAL_PARAM);
     }
 
-    String getParsedSql() {
-        return sql;
+    List<String> getParams() {
+        return params;
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
@@ -48,9 +48,9 @@ public class TestClasspathSqlLocator {
     }
 
     @Test
-    public void testNamedPositionalNamedParamsInPrepared() throws Exception {
+    public void testPositionalParamsInPrepared() throws Exception {
         Handle h = dbRule.openHandle();
-        h.insert(findSqlOnClasspath("insert-id-name"), 3, "Tip");
+        h.insert(findSqlOnClasspath("insert-id-name-positional"), 3, "Tip");
         assertThat(h.select("select name from something").mapTo(String.class).list()).hasSize(1);
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
@@ -118,7 +118,7 @@ public class TestPreparedBatch
     public void testPositionalBinding() throws Exception
     {
         Handle h = dbRule.openHandle();
-        PreparedBatch b = h.prepareBatch("insert into something (id, name) values (:id, :name)");
+        PreparedBatch b = h.prepareBatch("insert into something (id, name) values (?, ?)");
 
         b.bind(0, 0).bind(1, "Keith").add().execute();
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
@@ -155,7 +155,7 @@ public class TestQueries
                         .mapToBean(Something.class)
                         .list())
                 .isInstanceOf(UnableToExecuteStatementException.class)
-                .hasMessageContaining("no named parameter matches \"name\"");
+                .hasMessageContaining("no named parameter matches 'name'");
     }
 
     @Test
@@ -171,7 +171,7 @@ public class TestQueries
                         .mapToBean(Something.class)
                         .list())
                 .isInstanceOf(UnableToExecuteStatementException.class)
-                .hasMessageContaining("no named parameter matches \"name\"");
+                .hasMessageContaining("no named parameter matches 'name'");
     }
 
     @Test(expected = UnableToExecuteStatementException.class)

--- a/core/src/test/resources/insert-id-name-positional.sql
+++ b/core/src/test/resources/insert-id-name-positional.sql
@@ -1,0 +1,15 @@
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into something(id, name) values (?, ?)

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
@@ -170,7 +170,7 @@ public class TestSqlArrays {
         CopyOnWriteArrayList<UUID> fetchUuidCopyOnWriteArrayList();
 
         @SqlUpdate(U_INSERT)
-        void insertUuidList(List<UUID> u);
+        void insertUuidList(List<UUID> uuids);
 
         @SqlQuery(I_SELECT)
         @SingleValue
@@ -195,7 +195,7 @@ public class TestSqlArrays {
         List<Integer> fetchIntList();
 
         @SqlUpdate(I_INSERT)
-        void insertIntList(List<Integer> u);
+        void insertIntList(List<Integer> ints);
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatchingSingleValue.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatchingSingleValue.java
@@ -66,7 +66,7 @@ public class TestBatchingSingleValue
     public interface SingleValueBatching
     {
         @SqlBatch("insert into batching (id, values) values (:id, :values)")
-        int[] insertValues(int[] ids, @SingleValue int[] values);
+        int[] insertValues(int[] id, @SingleValue int[] values);
 
         @SqlQuery("select id, values from batching order by id asc")
         List<BatchingRow> select();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGetGeneratedKeysHsqlDb.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGetGeneratedKeysHsqlDb.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.jdbi.v3.core.Jdbi;
-import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -43,14 +42,14 @@ public class TestGetGeneratedKeysHsqlDb {
     public interface DAO {
         @SqlUpdate("insert into something (name) values (:name)")
         @GetGeneratedKeys
-        long insert(@Bind String name);
+        long insert(String name);
 
-        @SqlBatch("insert into something (name) values(:name)")
+        @SqlBatch("insert into something (name) values(:names)")
         @GetGeneratedKeys
-        int[] insert(@Bind List<String> names);
+        int[] insert(List<String> names);
 
         @SqlQuery("select name from something where id = :id")
-        String findNameById(@Bind long id);
+        String findNameById(long id);
     }
 
     @Test


### PR DESCRIPTION
Addresses #500.

In a nutshell: if a named parameter didn't match up with e.g. the method parameter name, JDBI would attempt to match on a positional param. This could have very unexpected results if e.g. the method arguments aren't in the same order as the query.

I'm rather surprised how many of our existing tests relied on this. :grimacing: 

This PR adds the following restrictions:
- A SQL statement must use _either_ named parameters, or positional parameters. Using both in the same statement will throw an exception.
- A statement with positional parameters will only used position-bound arguments.
- A statement with named parameters will only use name-bound arguments.

You can still bind both positional and named, but the statement will only use one category of bindings or the other.