### PR TITLE
Generate javadocs for kotlin classes, release 3.0.0-beta1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-docs</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-docs</artifactId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-guava</artifactId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-guava</artifactId>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-jodatime2</artifactId>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-jodatime2</artifactId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-jpa</artifactId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-jpa</artifactId>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -12,14 +12,13 @@
 ~   See the License for the specific language governing permissions and
 ~   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-kotlin-sqlobject</artifactId>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-kotlin-sqlobject</artifactId>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -132,6 +132,18 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>javadocJar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -12,14 +12,13 @@
 ~   See the License for the specific language governing permissions and
 ~   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-kotlin</artifactId>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -131,6 +131,18 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>javadocJar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-kotlin</artifactId>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-oracle12</artifactId>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-oracle12</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.jdbi</groupId>
     <artifactId>jdbi3-parent</artifactId>
     <name>jdbi Parent</name>
-    <version>3.0.0-beta1-SNAPSHOT</version>
+    <version>3.0.0-beta1</version>
     <packaging>pom</packaging>
     <description>
         jDBI is designed to provide convenient tabular data access in
@@ -55,7 +55,7 @@
         <connection>scm:git:git://github.com/jdbi/jdbi.git</connection>
         <developerConnection>scm:git:git@github.com:jdbi/jdbi.git</developerConnection>
         <url>https://github.com/jdbi/jdbi/</url>
-        <tag>HEAD</tag>
+        <tag>v3.0.0-beta1</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.jdbi</groupId>
     <artifactId>jdbi3-parent</artifactId>
     <name>jdbi Parent</name>
-    <version>3.0.0-beta1</version>
+    <version>3.0.0-beta2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         jDBI is designed to provide convenient tabular data access in
@@ -55,7 +55,7 @@
         <connection>scm:git:git://github.com/jdbi/jdbi.git</connection>
         <developerConnection>scm:git:git@github.com:jdbi/jdbi.git</developerConnection>
         <url>https://github.com/jdbi/jdbi/</url>
-        <tag>v3.0.0-beta1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,14 @@
         </license>
     </licenses>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jcenter</id>
+            <name>JCenter</name>
+            <url>https://jcenter.bintray.com/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <scm>
         <connection>scm:git:git://github.com/jdbi/jdbi.git</connection>
         <developerConnection>scm:git:git@github.com:jdbi/jdbi.git</developerConnection>
@@ -60,6 +68,7 @@
         <dep.slf4j.version>1.7.21</dep.slf4j.version>
         <dep.kotlin.version>1.1.0</dep.kotlin.version>
         <dep.jetbrainsAnnotations.version>13.0</dep.jetbrainsAnnotations.version>
+        <dep.dokka.version>0.9.13</dep.dokka.version>
 
         <basepom.check.fail-all>true</basepom.check.fail-all>
 
@@ -157,6 +166,14 @@
               <excludes>
                 <exclude>src/build/*</exclude>
               </excludes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.jetbrains.dokka</groupId>
+            <artifactId>dokka-maven-plugin</artifactId>
+            <version>${dep.dokka.version}</version>
+            <configuration>
+              <jdkVersion>8</jdkVersion>
             </configuration>
           </plugin>
         </plugins>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-postgres</artifactId>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-postgres</artifactId>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-spring4</artifactId>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-spring4</artifactId>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-sqlobject</artifactId>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-sqlobject</artifactId>

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1-SNAPSHOT</version>
+        <version>3.0.0-beta1</version>
     </parent>
 
     <artifactId>jdbi3-stringtemplate4</artifactId>

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.0.0-beta1</version>
+        <version>3.0.0-beta2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-stringtemplate4</artifactId>


### PR DESCRIPTION
The last hurdle in the way of releasing another beta: the Sonatype OSS repository wants us to generate a javadoc jar for the kotlin artifacts.

Long term we should produce a kdoc which will give kotlin users a more Kotlin-idiomatic picture of the API. This PR just gets us over the release hurdle imposed by Sonatype.