### PR TITLE
SQL Arrays: if no static element type is available (e.g. List<?>), try guessing rather than just failing.

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -7,6 +7,7 @@
   - [breaking] Moved JoinRowMapper.JoinRow class to top-level class
   - [breaking] Modified @Register* annotations to be repeatable, instead of using
     array attributes.
+  - array binder now guesses type based on first element of untyped collections, rather than passing
 
 3.0.0-beta1
   - [breaking] Refactored SqlStatementCustomizerFactory.createForParameter(...)

--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgumentFactory.java
@@ -47,8 +47,12 @@ public class SqlArrayArgumentFactory implements ArgumentFactory {
                     .map(arrayType -> new SqlArrayArgument<>(arrayType, value));
         }
 
-        return GenericTypes.findGenericParameter(type, Collection.class)
-                .flatMap(lookup)
+        final Collection<?> collection = (Collection<?>) value;
+        // If there's no static type, guess based on the first element
+        final Type eltType = GenericTypes.findGenericParameter(type, Collection.class)
+            .orElse(collection.isEmpty() ? String.class : collection.iterator().next().getClass());
+
+        return lookup.apply(eltType)
                 .map(arrayType -> new SqlArrayArgument<>(arrayType, (Collection<?>) value));
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/array/TestH2CollectionArgument.java
+++ b/core/src/test/java/org/jdbi/v3/core/array/TestH2CollectionArgument.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.array;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.UUID;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.Test;
+
+public class TestH2CollectionArgument {
+
+    private void init(Jdbi db) {
+        db.registerArrayType(Integer.class, "int");
+        db.registerArrayType(String.class, "varchar");
+    }
+
+    @Test
+    public void testErasedCollectionBind() {
+        Jdbi db = Jdbi.create("jdbc:hsqldb:mem:" + UUID.randomUUID());
+        init(db);
+
+        try (Handle handle = db.open()) {
+            handle.execute("create table player_stats (" +
+                    "name varchar(64) primary key, " +
+                    "seasons varchar(36) array, " +
+                    "points int array)");
+            handle.createUpdate("insert into player_stats (name,seasons,points) values (?,?,?)")
+                    .bind(0, "Jack Johnson")
+                    .bind(1, Arrays.asList("2013-2014", "2014-2015", "2015-2016"))
+                    .bind(2, new HashSet<>(Arrays.asList(42, 51, 50)))
+                    .execute();
+
+            String[] seasons = handle.createQuery("select seasons from player_stats where name=:name")
+                    .bind("name", "Jack Johnson")
+                    .mapTo(String[].class)
+                    .findOnly();
+            assertThat(seasons).containsExactly("2013-2014", "2014-2015", "2015-2016");
+        }
+    }
+}


### PR DESCRIPTION
I'm not 100% sure of this change, but it's pretty frustrating to have `query.bind("foo", Collections.singleton("hi"))` fail even if you register all your array argument factories.

cc @strykerd