### PR TITLE
MapMapper: use LinkedHashMap to preserve column ordering

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -10,6 +10,7 @@
     array attributes.
   - [breaking] Moved and renamed MapEntryMapper.Config to top-level class
     MapEntryMappers
+  - MapMapper preserves column ordering, #848
 
 3.0.0-beta1
   - [breaking] Refactored SqlStatementCustomizerFactory.createForParameter(...)

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
@@ -16,7 +16,7 @@ package org.jdbi.v3.core.mapper;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -72,7 +72,7 @@ public class MapMapper implements RowMapper<Map<String, Object>>
         }
 
         return (r, c) -> {
-            Map<String, Object> row = new HashMap<>(columnCount);
+            Map<String, Object> row = new LinkedHashMap<>(columnCount);
 
             for (int i = 1; i <= columnCount; i++) {
                 row.put(columnNames[i], rs.getObject(i));

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
@@ -20,12 +20,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
 import com.google.common.collect.Maps;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.result.NoResultsException;
@@ -379,5 +381,19 @@ public class TestQueries
         expectedException.expect(NoResultsException.class);
 
         h.select("insert into something (id, name) values (?, ?)", 1, "hello").mapToMap().list();
+    }
+
+    @Test
+    public void testMapMapperOrdering() throws Exception
+    {
+        h.execute("insert into something (id, name) values (?, ?)", 1, "hello");
+        h.execute("insert into something (id, name) values (?, ?)", 2, "world");
+
+        List<Map<String, Object>> rs = h.createQuery("select id, name from something")
+                              .mapToMap()
+                              .list();
+
+        assertThat(rs).hasSize(2);
+        assertThat(rs).hasOnlyElementsOfType(LinkedHashMap.class);
     }
 }


### PR DESCRIPTION
Fixes #848