### PR TITLE
Add unchecked extensions for `Jdbi` functions (#858)

### DIFF
--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -92,6 +92,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/Jdbi858Extensions.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/Jdbi858Extensions.kt
@@ -12,8 +12,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("unused")
-
 package org.jdbi.v3.core.kotlin
 
 import org.jdbi.v3.core.Handle
@@ -34,7 +32,7 @@ import org.jdbi.v3.core.transaction.TransactionIsolationLevel
 /**
  * Temporary extension function for [Jdbi.withHandle].
  *
- * This function WILL be deprecated when not needed anymore.
+ * This function WILL be deprecated and removed when not needed anymore.
  *
  * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
  * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
@@ -49,7 +47,7 @@ inline fun <R> Jdbi.withHandleUnchecked(crossinline block: (Handle) -> R): R {
 /**
  * Temporary extension function for [Jdbi.useHandle].
  *
- * This function WILL be deprecated when not needed anymore.
+ * This function WILL be deprecated and removed when not needed anymore.
  *
  * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
  * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
@@ -64,7 +62,7 @@ inline fun Jdbi.useHandleUnchecked(crossinline block: (Handle) -> Unit) {
 /**
  * Temporary extension function for [Jdbi.inTransaction].
  *
- * This function WILL be deprecated when not needed anymore.
+ * This function WILL be deprecated and removed when not needed anymore.
  *
  * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
  * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
@@ -79,7 +77,7 @@ inline fun <R> Jdbi.inTransactionUnchecked(crossinline block: (Handle) -> R): R 
 /**
  * Temporary extension function for [Jdbi.useTransaction].
  *
- * This function WILL be deprecated when not needed anymore.
+ * This function WILL be deprecated and removed when not needed anymore.
  *
  * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
  * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
@@ -94,7 +92,7 @@ inline fun Jdbi.useTransactionUnchecked(crossinline block: (Handle) -> Unit) {
 /**
  * Temporary extension function for [Jdbi.inTransaction].
  *
- * This function WILL be deprecated when not needed anymore.
+ * This function WILL be deprecated and removed when not needed anymore.
  *
  * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
  * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
@@ -109,7 +107,7 @@ inline fun <R> Jdbi.inTransactionUnchecked(level: TransactionIsolationLevel, cro
 /**
  * Temporary extension function for [Jdbi.useTransaction].
  *
- * This function WILL be deprecated when not needed anymore.
+ * This function WILL be deprecated and removed when not needed anymore.
  *
  * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
  * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
@@ -124,7 +122,7 @@ inline fun Jdbi.useTransactionUnchecked(level: TransactionIsolationLevel, crossi
 /**
  * Temporary extension function for [Jdbi.withExtension].
  *
- * This function WILL be deprecated when not needed anymore.
+ * This function WILL be deprecated and removed when not needed anymore.
  *
  * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
  * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
@@ -139,7 +137,7 @@ inline fun <E, R> Jdbi.withExtensionUnchecked(extensionType: Class<E>, crossinli
 /**
  * Temporary extension function for [Jdbi.useExtension].
  *
- * This function WILL be deprecated when not needed anymore.
+ * This function WILL be deprecated and removed when not needed anymore.
  *
  * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
  * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>

--- a/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/Jdbi858Extensions.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/Jdbi858Extensions.kt
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("unused")
+
+package org.jdbi.v3.core.kotlin
+
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.HandleCallback
+import org.jdbi.v3.core.HandleConsumer
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.extension.ExtensionCallback
+import org.jdbi.v3.core.extension.ExtensionConsumer
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel
+
+// The extensions in this file were created in response to these issues :
+// https://github.com/jdbi/jdbi/issues/858
+// https://youtrack.jetbrains.com/issue/KT-5464
+
+// These extensions are temporary and will be removed when Kotlin's type inference
+// is improved and this isn't an issue anymore.
+
+/**
+ * Temporary extension function for [Jdbi.withHandle].
+ *
+ * This function WILL be deprecated when not needed anymore.
+ *
+ * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
+ * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
+ * @see [Jdbi.withHandle]
+ */
+inline fun <R> Jdbi.withHandleUnchecked(crossinline block: (Handle) -> R): R {
+    return withHandle(HandleCallback<R, RuntimeException> { handle ->
+        block(handle)
+    })
+}
+
+/**
+ * Temporary extension function for [Jdbi.useHandle].
+ *
+ * This function WILL be deprecated when not needed anymore.
+ *
+ * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
+ * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
+ * @see [Jdbi.useHandle]
+ */
+inline fun Jdbi.useHandleUnchecked(crossinline block: (Handle) -> Unit) {
+    useHandle(HandleConsumer<RuntimeException> { handle ->
+        block(handle)
+    })
+}
+
+/**
+ * Temporary extension function for [Jdbi.inTransaction].
+ *
+ * This function WILL be deprecated when not needed anymore.
+ *
+ * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
+ * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
+ * @see [Jdbi.inTransaction]
+ */
+inline fun <R> Jdbi.inTransactionUnchecked(crossinline block: (Handle) -> R): R {
+    return inTransaction(HandleCallback<R, RuntimeException> { handle ->
+        block(handle)
+    })
+}
+
+/**
+ * Temporary extension function for [Jdbi.useTransaction].
+ *
+ * This function WILL be deprecated when not needed anymore.
+ *
+ * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
+ * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
+ * @see [Jdbi.useTransaction]
+ */
+inline fun Jdbi.useTransactionUnchecked(crossinline block: (Handle) -> Unit) {
+    useTransaction(HandleConsumer<RuntimeException> { handle ->
+        block(handle)
+    })
+}
+
+/**
+ * Temporary extension function for [Jdbi.inTransaction].
+ *
+ * This function WILL be deprecated when not needed anymore.
+ *
+ * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
+ * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
+ * @see [Jdbi.inTransaction]
+ */
+inline fun <R> Jdbi.inTransactionUnchecked(level: TransactionIsolationLevel, crossinline block: (Handle) -> R): R {
+    return inTransaction(level, HandleCallback<R, RuntimeException> { handle ->
+        block(handle)
+    })
+}
+
+/**
+ * Temporary extension function for [Jdbi.useTransaction].
+ *
+ * This function WILL be deprecated when not needed anymore.
+ *
+ * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
+ * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
+ * @see [Jdbi.useTransaction]
+ */
+inline fun Jdbi.useTransactionUnchecked(level: TransactionIsolationLevel, crossinline block: (Handle) -> Unit) {
+    useTransaction(level, HandleConsumer<RuntimeException> { handle ->
+        block(handle)
+    })
+}
+
+/**
+ * Temporary extension function for [Jdbi.withExtension].
+ *
+ * This function WILL be deprecated when not needed anymore.
+ *
+ * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
+ * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
+ * @see [Jdbi.withExtension]
+ */
+inline fun <E, R> Jdbi.withExtensionUnchecked(extensionType: Class<E>, crossinline callback: (E) -> R): R {
+    return withExtension(extensionType, ExtensionCallback<R, E, RuntimeException> { dao ->
+        callback(dao)
+    })
+}
+
+/**
+ * Temporary extension function for [Jdbi.useExtension].
+ *
+ * This function WILL be deprecated when not needed anymore.
+ *
+ * @see <a href="https://github.com/jdbi/jdbi/issues/858">Github issue</a>
+ * @see <a href="https://youtrack.jetbrains.com/issue/KT-5464">Kotlin issue</a>
+ * @see [Jdbi.useExtension]
+ */
+inline fun <E> Jdbi.useExtensionUnchecked(extensionType: Class<E>, crossinline callback: (E) -> Unit) {
+    useExtension(extensionType, ExtensionConsumer<E, RuntimeException> { dao ->
+        callback(dao)
+    })
+}

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/Jdbi858ExtensionsTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/Jdbi858ExtensionsTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jdbi.v3.core.kotlin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.rule.H2DatabaseRule
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel
+import org.jdbi.v3.sqlobject.statement.SqlQuery
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class Jdbi858ExtensionsTest {
+    interface FooDao {
+        @SqlQuery("SELECT ${Jdbi858ExtensionsTest.NAME_COLUMN} FROM ${Jdbi858ExtensionsTest.TABLE_NAME}")
+        fun getOnlyName(): String
+    }
+
+    @Rule @JvmField
+    val dbRule = H2DatabaseRule().withPlugins()
+
+    lateinit var jdbi: Jdbi
+
+    @Before fun setUp() {
+        jdbi = dbRule.jdbi
+
+        dbRule.openHandle().apply {
+            execute("CREATE TABLE $TABLE_NAME ($ID_COLUMN INTEGER PRIMARY KEY AUTO_INCREMENT, $NAME_COLUMN VARCHAR)")
+            execute("INSERT INTO $TABLE_NAME ($NAME_COLUMN) VALUES (?)", EXPECTED_NAME)
+        }
+    }
+
+    @Test fun testWithHandleUnchecked() {
+        val name = jdbi.withHandleUnchecked { handle ->
+            handle.createQuery("SELECT $NAME_COLUMN FROM $TABLE_NAME").mapTo(String::class.java).findOnly()
+        }
+
+        assertThat(name).isEqualTo(EXPECTED_NAME)
+    }
+
+    @Test fun testUseHandleUnchecked() {
+        jdbi.useHandleUnchecked { handle ->
+            val name = handle.createQuery("SELECT $NAME_COLUMN FROM $TABLE_NAME").mapTo(String::class.java).findOnly()
+
+            assertThat(name).isEqualTo(EXPECTED_NAME)
+        }
+    }
+
+    @Test fun testInTransactionUnchecked() {
+        val name = jdbi.inTransactionUnchecked { handle ->
+            handle.createQuery("SELECT $NAME_COLUMN FROM $TABLE_NAME").mapTo(String::class.java).findOnly()
+        }
+
+        assertThat(name).isEqualTo(EXPECTED_NAME)
+    }
+
+    @Test fun testUseTransactionUnchecked() {
+        jdbi.useTransactionUnchecked { handle ->
+            val name = handle.createQuery("SELECT $NAME_COLUMN FROM $TABLE_NAME").mapTo(String::class.java).findOnly()
+
+            assertThat(name).isEqualTo(EXPECTED_NAME)
+        }
+    }
+
+    @Test fun testInTransactionUncheckedWithLevel() {
+        val name = jdbi.inTransactionUnchecked(TransactionIsolationLevel.READ_COMMITTED) { handle ->
+            handle.createQuery("SELECT $NAME_COLUMN FROM $TABLE_NAME").mapTo(String::class.java).findOnly()
+        }
+
+        assertThat(name).isEqualTo(EXPECTED_NAME)
+    }
+
+    @Test fun testUseTransactionUncheckedWithLevel() {
+        jdbi.useTransactionUnchecked(TransactionIsolationLevel.READ_COMMITTED) { handle ->
+            val name = handle.createQuery("SELECT $NAME_COLUMN FROM $TABLE_NAME").mapTo(String::class.java).findOnly()
+
+            assertThat(name).isEqualTo(EXPECTED_NAME)
+        }
+    }
+
+    @Test fun testWithExtensionUnchecked() {
+        val name = jdbi.withExtensionUnchecked(FooDao::class.java) { dao ->
+            dao.getOnlyName()
+        }
+
+        assertThat(name).isEqualTo(EXPECTED_NAME)
+    }
+
+    @Test fun testUseExtensionUnchecked() {
+        jdbi.useExtensionUnchecked(FooDao::class.java) { dao ->
+            val name = dao.getOnlyName()
+
+            assertThat(name).isEqualTo(EXPECTED_NAME)
+        }
+    }
+
+    companion object {
+        const val EXPECTED_NAME = "Foo"
+        const val TABLE_NAME = "FOO"
+        const val ID_COLUMN = "id"
+        const val NAME_COLUMN = "name"
+    }
+}


### PR DESCRIPTION
These could eventually be removed when Kotlin's type inference allows us
to use the regular functions in `Jdbi`.

Unfortunately I wasn't able to use overloads in the `Jdbi` class directly or name those extensions the same as the regular 'checked' ones as type inference also failed on them...