### PR TITLE
Document how to use Map<K,V> collectors

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
@@ -15,9 +15,6 @@ package org.jdbi.v3.core.config;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;
-
-import org.jdbi.v3.core.statement.SqlParser;
-import org.jdbi.v3.core.statement.TimingCollector;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.array.SqlArrayArgumentStrategy;
@@ -31,11 +28,14 @@ import org.jdbi.v3.core.extension.Extensions;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.core.mapper.ColumnMappers;
+import org.jdbi.v3.core.mapper.MapEntryMappers;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.RowMappers;
-import org.jdbi.v3.core.statement.TemplateEngine;
+import org.jdbi.v3.core.statement.SqlParser;
 import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.core.statement.TemplateEngine;
+import org.jdbi.v3.core.statement.TimingCollector;
 
 /**
  * A type with access to access and modify arbitrary Jdbi configuration.
@@ -134,6 +134,26 @@ public interface Configurable<This> {
      */
     default This setSqlArrayArgumentStrategy(SqlArrayArgumentStrategy strategy) {
         return configure(SqlArrayTypes.class, c -> c.setArgumentStrategy(strategy));
+    }
+
+    /**
+     * Convenience method for {@code getConfig(MapEntryMappers.class).setKeyColumn(keyColumn)}
+     *
+     * @param keyColumn the key column name
+     * @return this
+     */
+    default This setMapKeyColumn(String keyColumn) {
+        return configure(MapEntryMappers.class, c -> c.setKeyColumn(keyColumn));
+    }
+
+    /**
+     * Convenience method for {@code getConfig(MapEntryMappers.class).setValueColumn(valueColumn)}
+     *
+     * @param valueColumn the value column name
+     * @return this
+     */
+    default This setMapValueColumn(String valueColumn) {
+        return configure(MapEntryMappers.class, c -> c.setValueColumn(valueColumn));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMapper.java
@@ -13,7 +13,6 @@
  */
 package org.jdbi.v3.core.mapper;
 
-import static java.util.Objects.requireNonNull;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 import static org.jdbi.v3.core.generic.GenericTypes.resolveType;
 

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -15,6 +15,7 @@
 :projecthome: https://github.com/jdbi/jdbi
 :exampledir: ../test/java/jdbi/doc
 :coreexampledir: ../../../core/src/test/java/org/jdbi/v3/core/mapper
+:guavaexampledir: ../../../guava/src/test/java/org/jdbi/v3/guava
 :sqlobjectexampledir: ../../../sqlobject/src/test/java/org/jdbi/v3/sqlobject
 
 ////
@@ -706,12 +707,75 @@ TODO:
 
 ===== Map.Entry mapping
 
-TODO:
+Out of the box, Jdbi registers a `RowMapper<Map.Entry<K,V>>`. Since each row in
+the result set is a `Map.Entry<K,V>`, the entire result set can be easily
+collected into a `Map<K,V>` (or Guava's `Multimap<K,V>`).
 
-* Demonstrate collectInfo(new GenericType<Map<Key,Value>>(){})
-* Key and value are row types (e.g. one-to-many entities)
-* Key is a column, value is a row type (e.g. index by id)
-* Key is a column, value is a column (e.g. accessing a config table)
+NOTE: A mapper must be registered for both the key and value type.
+
+Join rows can be gathered into a map result by specifying the generic map
+signature:
+
+[source,java,indent=0]
+----
+include::{coreexampledir}/MapEntryMapperTest.java[tags=joinRow]
+----
+
+In the preceding example, the `User` mapper uses a "u" column name prefix, and
+the `Phone` mapper uses "p". Since each mapper only reads columns with the
+expected prefix, the respective `id` columns are unambiguous.
+
+A unique index (e.g. by ID column) can be obtained by setting the key column
+name:
+
+[source,java,indent=0]
+----
+include::{coreexampledir}/MapEntryMapperTest.java[tags=uniqueIndex]
+----
+
+Set both the key and value column names to gather a two-column query into a map
+result:
+
+[source,java,indent=0]
+----
+include::{coreexampledir}/MapEntryMapperTest.java[tags=keyValue]
+----
+
+All the above examples assume a one-to-one key/value relationship. What if
+there is a one-to-many relationship?
+
+Google Guava provides a `Multimap` type, which supports mapping multiple
+values per key.
+
+First, follow the instructions in the <<Google Guava>> section to install
+`GuavaPlugin` into Jdbi.
+
+Then, simply ask for a `Multimap` instead of a `Map`:
+
+[source,java,indent=0]
+----
+include::{guavaexampledir}/MultimapEntryMapperTest.java[tags=joinRow]
+----
+
+The `collectInto()` method is worth explaining. When you call it, several things
+happen behind the scenes:
+
+* Consult the `JdbiCollectors` registry to obtain a
+  link:{jdbidocs}/core/collector/CollectorFactory.html[CollectorFactory^] which
+  supports the given container type.
+* Next, ask that `CollectorFactory` to extract the element type from the
+  container type signature. In the above example, the element type of
+  `Multimap<User,Phone>` is `Map.Entry<User,Phone>`.
+* Obtain a mapper for that element type from the mapping registry.
+* Obtain a link:{jdkdocs}/java/util/stream/Collector.html[Collector^] for the
+  container type from the `CollectorFactory`.
+* Finally, return `map(elementMapper).collect(collector)`.
+
+NOTE: If the lookup for the collector factory, element type, or element mapper
+fails, an exception is thrown.
+
+Jdbi can be enhanced to support arbitrary container types. See
+<<JdbiCollector>> for more information.
 
 === SQL Arrays
 
@@ -1424,11 +1488,62 @@ TODO: provide examples
 * Return type is Map<String,Object>, but we're selecting an hstore column from
   a single row.
 
+===== Map<K,V> Results
+
+SQL Object methods may return `Map<K,V>` types (see <<Map.Entry mapping>> in
+the Core API). In this scenario, each row is mapped to a `Map.Entry<K,V>`,
+and the entries for each row are collected into a single `Map` instance.
+
+NOTE: A mapper must be registered for both the key and value types.
+
+Gather master/detail join rows into a map, simply by registering mappers
+for the key and value types.
+
+[source,java,indent=0]
+----
+include::{sqlobjectexampledir}/TestReturningMap.java[tags=joinRow]
+----
+
+In the preceding example, the `User` mapper uses a "u" column name prefix, and
+the `Phone` mapper uses "p". Since each mapper only reads the column with the
+expected prefix, the respective `id` columns are unambigous.
+
+A unique index (e.g. by ID column) can be obtains by setting the key column
+name:
+
+[source,java,indent=0]
+----
+include::{sqlobjectexampledir}/TestReturningMap.java[tags=uniqueIndex]
+----
+
+Set both the key and value column names to gather a two-column query into a map
+result:
+
+[source,java,indent=0]
+----
+include::{sqlobjectexampledir}/TestReturningMap.java[tags=keyValue]
+----
+
+All of the above examples assume a one-to-one key/value relationship.
+
+What if there is a one-to-many relationship? Google Guava provides a `Multimap`
+type, which supports mapping multiple values per key.
+
+First, follow the instructions in the <<Google Guava>> section to install
+`GuavaPlugin`.
+
+Then, simply specify a `Multimap` return type instead of `Map`:
+
+[source,java,indent=0]
+----
+include::{sqlobjectexampledir}/TestReturningMap.java[tags=joinRowMultimap]
+----
+
 ==== @SqlUpdate
 
 TODO:
 
-* By default supports voice, int/long (update count), or boolean (update count
+* By default supports void, int/long (update count), or boolean (update count
   > 0) return types
 * Or use @GetGeneratedKeys annotation to return generated keys. e.g. return an
   id column value obtained from a sequence.
@@ -2162,7 +2277,7 @@ TODO:
 JdbiPlugin may be used to perform bulk configuration
 TODO
 
-=== JdbiCollectors registry
+=== JdbiCollector
 
 TODO:
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningMap.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningMap.java
@@ -65,10 +65,12 @@ public class TestReturningMap {
         @SqlUpdate("insert into config (key, value) values (:key, :value)")
         void insert(String key, String value);
 
+        // tag::keyValue[]
         @SqlQuery("select key, value from config")
         @KeyColumn("key")
         @ValueColumn("value")
         Map<String, String> getAll();
+        // end::keyValue[]
     }
 
     @Test
@@ -97,10 +99,12 @@ public class TestReturningMap {
         @SqlBatch("insert into user (id, name) values (:id, :name)")
         void insert(@BindBean User... users);
 
+        // tag::uniqueIndex[]
         @SqlQuery("select * from user")
         @KeyColumn("id")
         @RegisterConstructorMapper(User.class)
         Map<Integer, User> getAll();
+        // end::uniqueIndex[]
     }
 
     @Test
@@ -158,17 +162,21 @@ public class TestReturningMap {
         @SqlBatch("insert into phone (id, user_id, phone) values (:id, :userId, :phone)")
         void insertPhone(int userId, @BindBean Phone... phones);
 
+        // tag::joinRow[]
         @SqlQuery("select u.id u_id, u.name u_name, p.id p_id, p.phone p_phone " +
                 "from user u left join phone p on u.id = p.user_id")
         @RegisterConstructorMapper(value = User.class, prefix = "u")
         @RegisterConstructorMapper(value = Phone.class, prefix = "p")
         Map<User, Phone> getMap();
+        // end::joinRow[]
 
+        // tag::joinRowMultimap[]
         @SqlQuery("select u.id u_id, u.name u_name, p.id p_id, p.phone p_phone " +
                 "from user u left join phone p on u.id = p.user_id")
         @RegisterConstructorMapper(value = User.class, prefix = "u")
         @RegisterConstructorMapper(value = Phone.class, prefix = "p")
         Multimap<User, Phone> getMultimap();
+        // end::joinRowMultimap[]
 
     }
 


### PR DESCRIPTION
Addresses #774 

Adds documentation for `Map<K,V>` result types for both Core and SQL Object.

Also added two convenience methods to `Configurable`: `setMapKeyColumn(String)` and `setMapValueColumn(String)`.

@stevenschlansker or @arteam, could one of you please review?