### PR TITLE
Rename ResultSetMapper to ResultSetScanner

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,7 @@
-3.0.0-beta3 (in development)
+3.0.0-beta4 (in development)
+  - [breaking] ResultSetMapper -> ResultSetScanner; reducing overloaded 'Mapper'
+
+3.0.0-beta3
   - Added Kotlin extension methods to Jdbi class, to work around Kotlin's lack
     of support for exception transparency: withHandleUnchecked,
     useHandleUnchecked, inTransactionUnchecked, useTransactionUnchecked,

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultSetScanner.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultSetScanner.java
@@ -20,16 +20,19 @@ import java.util.function.Supplier;
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**
- * Maps result sets to objects.
+ * Scan over rows of result sets, mapping and collecting the rows to a result type.
+ * Unlike the Row and ColumnMappers, this interface lets you control the ResultSet
+ * scrolling - the implementation should {@link ResultSet#next()} over rows it wants to consider.
  *
- * @param <T> the mapped type
- * @see org.jdbi.v3.core.result.ResultBearing#mapResultSet(ResultSetMapper)
+ * @param <T> the collected result type
+ * @see org.jdbi.v3.core.result.ResultBearing#scanResultSet(ResultSetScanner)
  */
 @FunctionalInterface
-public interface ResultSetMapper<T> {
+public interface ResultSetScanner<T> {
     /**
-     * Maps the lazily-supplied result set into an object. The result set is not opened (and typically, the statement
-     * the result came from is not executed) until {@code resultSetSupplier.get()} is called.
+     * Scans the lazily-supplied result set into a result. The ResultSet is not produced
+     * (and typically, the statement the result came from is not executed) until
+     * {@code resultSetSupplier.get()} is called.
      * <p>
      * Implementors that call {@code resultSetSupplier.get()} must ensure that the statement context is closed, to
      * ensure that database resources are freed:
@@ -52,5 +55,5 @@ public interface ResultSetMapper<T> {
      * @return the mapped result
      * @throws SQLException if anything goes wrong
      */
-    T mapResultSet(Supplier<ResultSet> resultSetSupplier, StatementContext ctx) throws SQLException;
+    T scanResultSet(Supplier<ResultSet> resultSetSupplier, StatementContext ctx) throws SQLException;
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -28,7 +28,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.result.ResultBearing;
 import org.jdbi.v3.core.result.ResultIterator;
 import org.jdbi.v3.core.result.ResultProducer;
-import org.jdbi.v3.core.result.ResultSetMapper;
+import org.jdbi.v3.core.result.ResultSetScanner;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,8 +58,8 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
     }
 
     @Override
-    public <R> R mapResultSet(ResultSetMapper<R> mapper) {
-        return execute(returningResults()).mapResultSet(mapper);
+    public <R> R scanResultSet(ResultSetScanner<R> mapper) {
+        return execute(returningResults()).scanResultSet(mapper);
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/Query.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Query.java
@@ -21,7 +21,7 @@ import java.sql.Statement;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.result.ResultBearing;
 import org.jdbi.v3.core.result.ResultProducer;
-import org.jdbi.v3.core.result.ResultSetMapper;
+import org.jdbi.v3.core.result.ResultSetScanner;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
 
 /**
@@ -56,8 +56,8 @@ public class Query extends SqlStatement<Query> implements ResultBearing
     }
 
     @Override
-    public <R> R mapResultSet(ResultSetMapper<R> mapper) {
-        return execute(returningResults()).mapResultSet(mapper);
+    public <R> R scanResultSet(ResultSetScanner<R> mapper) {
+        return execute(returningResults()).scanResultSet(mapper);
     }
 
     /**

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -909,6 +909,19 @@ single remains, and then return that.
 
 TODO: example
 
+===== ResultSetScanner
+
+The *ResultSetScanner* interface accepts a lazily-provided *ResultSet*
+and produces the result Jdbi returns from statement execution.
+
+Most of the above operations are implemented in terms of *ResultSetScanner*.
+The Scanner has ownership of the ResultSet and may advance or seek it.
+
+The return value ends up being the final result of statement execution.
+
+Most users should prefer using the higher level result collectors described above,
+but someone's gotta do the dirty work.
+
 ==== Joins
 
 Joining multiple tables together is a very common database task. It is also


### PR DESCRIPTION
The name 'mapper' is already used for a different concept

cc @mikebell90

Fixes #889 