### PR TITLE
PreparedBatch: throw an exception if you add() a batch with no bindings at all

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,6 @@
 3.0.0-beta4 (in development)
   - [breaking] ResultSetMapper -> ResultSetScanner; reducing overloaded 'Mapper'
+  - PreparedBatch: throw an exception if you try to add() an empty binding
 
 3.0.0-beta3
   - Added Kotlin extension methods to Jdbi class, to work around Kotlin's lack

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -205,7 +205,12 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
      */
     public PreparedBatch add()
     {
-        bindings.add(getBinding());
+        final Binding currentBinding = getBinding();
+        if (currentBinding.isEmpty()) {
+            throw new IllegalStateException("Attempt to add() a empty batch, you probably didn't mean to do this "
+                    + "- call add() *after* setting batch parameters");
+        }
+        bindings.add(currentBinding);
         getContext().setBinding(new Binding());
         return this;
     }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBatch.java
@@ -42,4 +42,12 @@ public class TestBatch
         List<Something> r = h.createQuery("select * from something order by id").mapToBean(Something.class).list();
         assertThat(r).hasSize(3);
     }
+
+    @Test(expected=IllegalStateException.class)
+    public void testEmptyBatchThrows() throws Exception {
+        try (Handle h = dbRule.openHandle()) {
+            final PreparedBatch b = h.prepareBatch("insert into something (id, name) values (?, ?)");
+            b.add(); // No parameters written yet
+        }
+    }
 }


### PR DESCRIPTION
reported by @mikebell90