### PR TITLE
PreparedBatch: update context binding for each batch

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -169,6 +169,7 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
 
             try {
                 for (Binding binding : bindings) {
+                    getContext().setBinding(binding);
                     ArgumentBinder.bind(parsedParameters, binding, stmt, getContext());
                     stmt.addBatch();
                 }


### PR DESCRIPTION
Otherwise, anyone who uses the context to print out debug information
(say an exception) just has an empty binding which is misleading.

cc @pennello