### PR TITLE
Use public fields as well as getters for 'bindBean'

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/BeanPropertyArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/BeanPropertyArguments.java
@@ -20,7 +20,6 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
@@ -108,15 +107,22 @@ public class BeanPropertyArguments implements NamedArgumentFinder
             {
                 for (Field field : bean.getClass().getFields())
                 {
-                    if (Modifier.isPublic(field.getModifiers()) && field.getName().equals(propertyName))
+                    if (field.getName().equals(propertyName))
                     {
                         Object fieldValue = field.get(bean);
-                        Optional<Argument> argument = ctx.findArgumentFor(field.getGenericType(), fieldValue);
+                        Type fieldType = field.getGenericType();
+                        Optional<Argument> argument = ctx.findArgumentFor(fieldType, fieldValue);
 
-                        if (argument.isPresent())
+                        if (!argument.isPresent())
                         {
-                            return argument;
+                            throw new UnableToCreateStatementException(
+                                    String.format("No argument factory registered for type [%s] for field [%s] on [%s]",
+                                            fieldType,
+                                            propertyName,
+                                            bean), ctx);
                         }
+
+                        return argument;
                     }
                 }
             }

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -1464,7 +1464,8 @@ In SQL Object (but not in Core), you can qualify a bound map with a prefix:
 void insert(@BindMap("user") Map<String, ?> map);
 ----
 
-You can bind from the properties of a Java Bean:
+You can bind from the properties or public fields of a Java Bean
+(properties are prioritized if both are present):
 
 [source,java]
 ----

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindBean.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindBean.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Target;
 import org.jdbi.v3.sqlobject.customizer.internal.BindBeanFactory;
 
 /**
- * Binds the properties of a JavaBean to a SQL statement.
+ * Binds the properties and public fields of a JavaBean to a SQL statement.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER})
@@ -29,7 +29,7 @@ import org.jdbi.v3.sqlobject.customizer.internal.BindBeanFactory;
 public @interface BindBean
 {
     /**
-     * Prefix to apply to each bean property name. If specified, properties will be bound as
+     * Prefix to apply to each bean property/field name. If specified, properties will be bound as
      * {@code prefix.propertyName}.
      *
      * @return the prefix

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindBean.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindBean.java
@@ -95,21 +95,21 @@ public class TestBindBean {
 
         dao.insert(new Bean(1, ValueType.valueOf("foo"), "fooField", "fooGetter"));
         assertThat(dao.getById(1)).extracting(Bean::getId, Bean::getValueType, bean -> bean.fromField, Bean::getFromGetter)
-                .containsExactly(1, ValueType.valueOf("foo"), "fooField", Bean.PREFIX + "fooGetter");
+                .containsExactly(1, ValueType.valueOf("foo"), "fooField", "fooGetter");
     }
 
     public static class Bean {
-        public static final String PREFIX = "prefix-";
         private int id;
         private ValueType valueType;
         public String fromField;
-        public String fromGetter;
+        public final String fromGetter = "ACCESSED FROM FIELD";
+        private String actuallyFromGetter;
 
         public Bean(int id, ValueType valueType, String fromField, String fromGetter) {
             this.id = id;
             this.valueType = valueType;
             this.fromField = fromField;
-            this.fromGetter = fromGetter;
+            this.actuallyFromGetter = fromGetter;
         }
 
         public int getId() {
@@ -121,10 +121,7 @@ public class TestBindBean {
         }
 
         public String getFromGetter() {
-            if(!fromGetter.startsWith(PREFIX)) {
-                return PREFIX + fromGetter;
-            }
-            return fromGetter;
+            return actuallyFromGetter;
         }
     }
 


### PR DESCRIPTION
Fixed #895.

I added the tests to the existing "value type factory" tests as the actual `@BindBean` tests are using the `Something` class that's defined somewhere else and is used by a bunch of other tests (and the table is created... somewhere else, not sure how this works tbh). I can clean this up if you want.

EDIT: Forgot to mention that I'll update the documentation once these changes are approved.