### PR TITLE
Make Handle.close() play nice with container managed transactions

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -49,6 +49,7 @@ public class Handle implements Closeable, Configurable<Handle>
 
     private final TransactionHandler transactions;
     private final Connection connection;
+    private final boolean forceEndTransactions;
 
     private ThreadLocal<ConfigRegistry> config;
     private ThreadLocal<ExtensionMethod> extensionMethod;
@@ -66,6 +67,7 @@ public class Handle implements Closeable, Configurable<Handle>
         this.config = ThreadLocal.withInitial(() -> config);
         this.extensionMethod = new ThreadLocal<>();
         this.statementBuilder = statementBuilder;
+        this.forceEndTransactions = !transactions.isInTransaction(this);
     }
 
     @Override
@@ -118,7 +120,7 @@ public class Handle implements Closeable, Configurable<Handle>
     public void close() {
         extensionMethod.remove();
         if (!closed) {
-            boolean wasInTransaction = isInTransaction();
+            boolean wasInTransaction = isInTransaction() && forceEndTransactions;
             if (wasInTransaction) {
                 rollback();
             }

--- a/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
+++ b/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
@@ -13,21 +13,25 @@
  */
 package org.jdbi.v3.core;
 
+import java.sql.Connection;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.DefaultStatementBuilder;
 import org.jdbi.v3.core.transaction.LocalTransactionHandler;
+import org.mockito.Mockito;
 
 /**
  * Utilities for testing jdbi internal classes.
  */
 public class HandleAccess {
     /**
-     * Create a handle with no connection,
+     * Create a handle with a fake connection,
      * useful for tests that do not actually hit
      * a database.
      */
     public static Handle createHandle() {
+        Connection fakeConnection = Mockito.mock(Connection.class);
+
         return new Handle(new ConfigRegistry(), new LocalTransactionHandler(),
-                new DefaultStatementBuilder(), null);
+                new DefaultStatementBuilder(), fakeConnection);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
 
@@ -156,6 +157,16 @@ public class TestClosingHandle
         }
         finally {
             assertThat(h.isClosed()).isTrue();
+        }
+    }
+
+    @Test
+    public void testCloseWithOpenContainerManagedTransaction() throws Exception {
+        try (Connection conn = dbRule.getConnectionFactory().openConnection()) {
+            conn.setAutoCommit(false); // open transaction
+
+            Handle handle = Jdbi.open(conn);
+            handle.close();
         }
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactionsAutoCommit.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactionsAutoCommit.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.transaction;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -63,7 +64,7 @@ public class TestTransactionsAutoCommit
 
         // expected behaviour chain:
         // 1. store initial auto-commit state
-        inOrder.verify(connection).getAutoCommit();
+        inOrder.verify(connection, atLeastOnce()).getAutoCommit();
 
         // 2. turn off auto-commit
         inOrder.verify(connection).setAutoCommit(false);


### PR DESCRIPTION
Fixes #881 