### PR TITLE
Add a check for mistyped named parameters

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -13,10 +13,11 @@
  */
 package org.jdbi.v3.core.statement;
 
+import org.jdbi.v3.core.argument.Argument;
+
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
-import org.jdbi.v3.core.argument.Argument;
 
 class ArgumentBinder {
     static void bind(ParsedParameters parameters, Binding binding, PreparedStatement statement, StatementContext context) {
@@ -43,6 +44,11 @@ class ArgumentBinder {
     }
 
     private static void bindNamed(List<String> parameterNames, Binding binding, PreparedStatement statement, StatementContext context) {
+        if (parameterNames.isEmpty() && !binding.isEmpty()) {
+            throw new UnableToExecuteStatementException(
+                    String.format("Unable to execute. The query doesn't have named parameters, but provided binding '%s'.", binding),
+                    context);
+        }
         for (int i = 0; i < parameterNames.size(); i++) {
             String param = parameterNames.get(i);
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMistypedNamedParameter.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMistypedNamedParameter.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class TestMistypedNamedParameter {
+
+    @Rule
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private Dao dao;
+
+    @Before
+    public void setUp() throws Exception {
+        dao = dbRule.getSharedHandle().attach(Dao.class);
+        dbRule.getSharedHandle().useTransaction(h -> {
+            h.execute("insert into something (id, name) values (1, 'Alice')");
+            h.execute("insert into something (id, name) values (2, 'Bob')");
+            h.execute("insert into something (id, name) values (3, 'Charles')");
+        });
+    }
+
+    @Test
+    public void testWarnAboutUnmatchedBinding() throws Exception {
+        assertThatExceptionOfType(UnableToExecuteStatementException.class)
+                .isThrownBy(() -> dao.deleteSomething(2))
+                .satisfies(e -> assertThat(e.getMessage())
+                        .startsWith("Unable to execute. The query doesn't have named parameters, but provided binding"));
+    }
+
+
+    @RegisterRowMapper(SomethingMapper.class)
+    public interface Dao {
+
+        @SqlUpdate("delete from something where id = id")
+        void deleteSomething(@Bind("id") int id);
+    }
+}


### PR DESCRIPTION
It's very easy to mistype an SQL query and use a column name instead of a naming parameters. For example, `DELETE FROM users WHERE id=id` instead of `DELETE FROM users WHERE id=:id`. Unfortunately, this query is a valid SQL query and a DBMS will happily execute it. Such mistake is very easy to make, relatively hard to catch with a unit test and can lead to a disaster in production.

It would be great if JDBI could detect situations when the user added a binding, but the query doesn't have any named parameters.