### PR TITLE
Extract row-or-column mapper failback into its own config class

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,6 +1,17 @@
 3.0.0-beta4 (in development)
   - [breaking] ResultSetMapper -> ResultSetScanner; reducing overloaded 'Mapper'
   - PreparedBatch: throw an exception if you try to add() an empty binding
+  - [breaking] Removed column mapper fallback behavior from
+    StatementContext.findRowMapperFor() and RowMappers.findFor(), in favor or new
+    StatementContext.findMapperFor() and Mappers.findFor() methods. Previously,
+    findRowMapperFor() would first consult the RowMappers registry, then the
+    ColumnMappers registry if no RowMapper was registered for a given type. Thus:
+    - StatementContext.findMapperFor(...) or Mappers.findFor() may return a row mapper or
+      a first-column mapper.
+    - StatementContext.findRowMapperFor(...) or RowMappers.findFor() returns only row
+      mappers
+    - StatementContext.findColumnMapperFor(...) or ColumnMappers.findFor() returns only
+      column mapper
 
 3.0.0-beta3
   - Added Kotlin extension methods to Jdbi class, to work around Kotlin's lack

--- a/core/src/main/java/org/jdbi/v3/core/mapper/JoinRowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/JoinRowMapper.java
@@ -41,14 +41,7 @@ public class JoinRowMapper implements RowMapper<JoinRow>
     public JoinRow map(ResultSet r, StatementContext ctx)
     throws SQLException
     {
-        final Map<Type, Object> entries = new HashMap<>(types.length);
-        for (Type type : types) {
-            entries.put(type, ctx.findRowMapperFor(type)
-                    .orElseThrow(() -> new IllegalArgumentException(
-                            "No row mapper registered for " + type))
-                    .map(r, ctx));
-        }
-        return new JoinRow(entries);
+        return specialize(r, ctx).map(r, ctx);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/mapper/Mappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/Mappers.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import static org.jdbi.v3.core.internal.JdbiOptionals.findFirstPresent;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.generic.GenericType;
+
+/**
+ * Configuration class for obtaining row or column mappers.
+ * <p>
+ * This configuration is merely a convenience class, and does not have any
+ * configuration of its own. All methods delegate to {@link RowMappers} or
+ * {@link ColumnMappers}.
+ */
+public class Mappers implements JdbiConfig<Mappers> {
+    private RowMappers rowMappers;
+    private ColumnMappers columnMappers;
+
+    public Mappers() {
+    }
+
+    @Override
+    public void setRegistry(ConfigRegistry registry) {
+        this.rowMappers = registry.get(RowMappers.class);
+        this.columnMappers = registry.get(ColumnMappers.class);
+    }
+
+    /**
+     * Obtain a mapper for the given type. If a row mapper is registered for the
+     * given type, it is returned. If a column mapper is registered for the
+     * given type, it is adapted into a row mapper, mapping the first column of
+     * the result set. If neither a row or column mapper is registered, empty is
+     * returned.
+     *
+     * @param <T>  the type of the mapper to find
+     * @param type the target type to map to
+     * @return a mapper for the given type, or empty if no row or column mapper
+     * is registered for the given type.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Optional<RowMapper<T>> findFor(Class<T> type) {
+        RowMapper<T> mapper = (RowMapper<T>) findFor((Type) type).orElse(null);
+        return Optional.ofNullable(mapper);
+    }
+
+    /**
+     * Obtain a mapper for the given type. If a row mapper is registered for the
+     * given type, it is returned. If a column mapper is registered for the
+     * given type, it is adapted into a row mapper, mapping the first column of
+     * the result set. If neither a row or column mapper is registered, empty is
+     * returned.
+     *
+     * @param <T>  the type of the mapper to find
+     * @param type the target type to map to
+     * @return a mapper for the given type, or empty if no row or column mapper
+     * is registered for the given type.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Optional<RowMapper<T>> findFor(GenericType<T> type) {
+        RowMapper<T> mapper = (RowMapper<T>) findFor(type.getType()).orElse(null);
+        return Optional.ofNullable(mapper);
+    }
+
+    /**
+     * Obtain a mapper for the given type. If a row mapper is registered for the
+     * given type, it is returned. If a column mapper is registered for the
+     * given type, it is adapted into a row mapper, mapping the first column of
+     * the result set. If neither a row or column mapper is registered, empty is
+     * returned.
+     *
+     * @param type the target type to map to
+     * @return a mapper for the given type, or empty if no row or column mapper
+     * is registered for the given type.
+     */
+    public Optional<RowMapper<?>> findFor(Type type) {
+        return findFirstPresent(
+                () -> rowMappers.findFor(type),
+                () -> columnMappers.findFor(type).map(SingleColumnMapper::new));
+    }
+
+    @Override
+    public Mappers createCopy() {
+        return new Mappers();
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMappers.java
@@ -13,7 +13,6 @@
  */
 package org.jdbi.v3.core.mapper;
 
-import static org.jdbi.v3.core.internal.JdbiOptionals.findFirstPresent;
 import static org.jdbi.v3.core.internal.JdbiStreams.toStream;
 
 import java.lang.reflect.Type;
@@ -131,12 +130,9 @@ public class RowMappers implements JdbiConfig<RowMappers> {
             return Optional.of(cached);
         }
 
-        Optional<RowMapper<?>> mapper = findFirstPresent(
-                () -> factories.stream()
-                        .flatMap(factory -> toStream(factory.build(type, registry)))
-                        .findFirst(),
-                () -> registry.get(ColumnMappers.class).findFor(type)
-                        .map(SingleColumnMapper::new));
+        Optional<RowMapper<?>> mapper = factories.stream()
+                .flatMap(factory -> toStream(factory.build(type, registry)))
+                .findFirst();
 
         mapper.ifPresent(m -> cache.put(type, m));
 

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
@@ -111,7 +111,7 @@ public interface ResultBearing {
      */
     default ResultIterable<?> mapTo(Type type) {
         return scanResultSet((supplier, ctx) -> {
-            RowMapper<?> mapper = ctx.findRowMapperFor(type)
+            RowMapper<?> mapper = ctx.findMapperFor(type)
                     .orElseThrow(() -> new UnsupportedOperationException("No mapper registered for type " + type));
             return ResultIterable.of(supplier, mapper, ctx);
         });
@@ -274,7 +274,7 @@ public interface ResultBearing {
                     .orElseThrow(() -> new NoSuchCollectorException("No collector registered for container type " + containerType));
             Type elementType = ctx.findElementTypeFor(containerType)
                     .orElseThrow(() -> new ElementTypeNotFoundException("Unknown element type for container type " + containerType));
-            RowMapper<?> mapper = ctx.findRowMapperFor(elementType)
+            RowMapper<?> mapper = ctx.findMapperFor(elementType)
                     .orElseThrow(() -> new UnsupportedOperationException("No mapper registered for element type " + elementType));
             return ResultIterable.of(rs, mapper, ctx).collect(collector);
         });

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -45,8 +45,8 @@ import org.jdbi.v3.core.argument.NamedArgumentFinder;
 import org.jdbi.v3.core.argument.NullArgument;
 import org.jdbi.v3.core.argument.ObjectArgument;
 import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.mapper.Mappers;
 import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.mapper.RowMappers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1415,20 +1415,20 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
     }
 
     @SuppressWarnings("unchecked")
-    <T> RowMapper<T> rowMapperForType(Class<T> type)
+    <T> RowMapper<T> mapperForType(Class<T> type)
     {
-        return (RowMapper<T>) rowMapperForType((Type) type);
+        return (RowMapper<T>) mapperForType((Type) type);
     }
 
     @SuppressWarnings("unchecked")
-    <T> RowMapper<T> rowMapperForType(GenericType<T> type)
+    <T> RowMapper<T> mapperForType(GenericType<T> type)
     {
-        return (RowMapper<T>) rowMapperForType(type.getType());
+        return (RowMapper<T>) mapperForType(type.getType());
     }
 
-    RowMapper<?> rowMapperForType(Type type)
+    RowMapper<?> mapperForType(Type type)
     {
-        return getConfig(RowMappers.class).findFor(type)
+        return getConfig(Mappers.class).findFor(type)
             .orElseThrow(() -> new UnsupportedOperationException("No mapper registered for " + type));
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
@@ -46,6 +46,7 @@ import org.jdbi.v3.core.extension.ExtensionMethod;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMappers;
+import org.jdbi.v3.core.mapper.Mappers;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMappers;
 
@@ -165,6 +166,41 @@ public class StatementContext implements Closeable
      */
     public Optional<SqlArrayType<?>> findSqlArrayTypeFor(Type elementType) {
         return getConfig(SqlArrayTypes.class).findFor(elementType);
+    }
+
+    /**
+     * Obtain a mapper for the given type in this context.
+     *
+     * @param <T> the type to map
+     * @param type the target type to map to
+     * @return a mapper for the given type, or empty if no row or column mappers
+     * is registered for the given type.
+     */
+    public <T> Optional<RowMapper<T>> findMapperFor(Class<T> type) {
+        return getConfig(Mappers.class).findFor(type);
+    }
+
+    /**
+     * Obtain a mapper for the given type in this context.
+     *
+     * @param <T> the type to map
+     * @param type the target type to map to
+     * @return a mapper for the given type, or empty if no row or column mappers
+     * is registered for the given type.
+     */
+    public <T> Optional<RowMapper<T>> findMapperFor(GenericType<T> type) {
+        return getConfig(Mappers.class).findFor(type);
+    }
+
+    /**
+     * Obtain a mapper for the given type in this context.
+     *
+     * @param type the target type to map to
+     * @return a mapper for the given type, or empty if no row or column mappers
+     * is registered for the given type.
+     */
+    public Optional<RowMapper<?>> findMapperFor(Type type) {
+        return getConfig(Mappers.class).findFor(type);
     }
 
     /**


### PR DESCRIPTION
This has come up as a problem before, but #890 finally brought it into focus.

Currently, `RowMappers.findFor(Type)` automatically fails over to `ColumnMappers.findFor(Type)` if no explicit row mappers are registered for a given type.

The problem is, this design makes it impossible to know for sure whether there is actually a row mapper registered for some type, or whether we are just getting a column mapper.

This is a particular problem for MapEntryMapper, since if you don't set the key or value column name, then that key or value _must_ be a row mapper.

This PR:
* Removes the failover behavior from `RowMappers`, and moves it to a new `Mappers` config class
* Adds new `findMapperFor(...)` methods to `StatementContext`. These complement the existing `findColumnMapperFor(...)` and `findRowMapperFor(...)` methods. The new method lacks either "row" or "column" in the name, so the idea is that the underlying mapper could be either one, whichever is registered.

I've audited all the places where `RowMappers.findFor` or `StatementContext.findRowMapperFor` were called, and updated some of them to call the new methods where appropriate.