### PR TITLE
Allow setting null key / value column name when mapping map entries.

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMappers.java
@@ -47,7 +47,7 @@ public class MapEntryMappers implements JdbiConfig<MapEntryMappers>, MapEntryCon
      */
     @Override
     public MapEntryMappers setKeyColumn(String keyColumn) {
-        this.keyColumn = requireNonNull(keyColumn);
+        this.keyColumn = keyColumn;
         return this;
     }
 
@@ -66,7 +66,7 @@ public class MapEntryMappers implements JdbiConfig<MapEntryMappers>, MapEntryCon
      */
     @Override
     public MapEntryMappers setValueColumn(String valueColumn) {
-        this.valueColumn = requireNonNull(valueColumn);
+        this.valueColumn = valueColumn;
         return this;
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/KeyColumnImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/KeyColumnImpl.java
@@ -25,6 +25,7 @@ public class KeyColumnImpl implements Configurer {
     @Override
     public void configureForMethod(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType, Method method) {
         KeyColumn keyColumn = (KeyColumn) annotation;
-        registry.get(MapEntryMappers.class).setKeyColumn(keyColumn.value());
+        String name = keyColumn.value();
+        registry.get(MapEntryMappers.class).setKeyColumn(name.isEmpty() ? null : name);
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/ValueColumnImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/ValueColumnImpl.java
@@ -25,6 +25,7 @@ public class ValueColumnImpl implements Configurer {
     @Override
     public void configureForMethod(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType, Method method) {
         ValueColumn valueColumn = (ValueColumn) annotation;
-        registry.get(MapEntryMappers.class).setValueColumn(valueColumn.value());
+        String name = valueColumn.value();
+        registry.get(MapEntryMappers.class).setValueColumn(name.isEmpty() ? null : name);
     }
 }


### PR DESCRIPTION
Identified this design bug while reviewing #890.

I can't think of a scenario where someone would want to do this, but to be on the safe side: it's possible that someone could set the map key / value column names at e.g. the Jdbi or Handle level, and need to override it back to null at the statement level (e.g. when the key or value is row-mapped instead of column-mapped).

This PR removes the null check that we put in originally.