### PR TITLE
Developer guide section for `@SqlCall`. Make `@OutParameter` annotation repeatable.

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2178,11 +2178,40 @@ In the above example, each new row would get the same `varchar[]` value in the
 
 ==== @SqlCall
 
-TODO:
+Use the `@SqlCall` annotation to call stored procedures.
 
-* Use @OutParameter to register an output parameter. Multiple output parameters
-  are not yet supported.
-* Method may return null or OutParameters
+[source,java]
+----
+public interface AccountDao {
+  @SqlCall("{call suspend_account(:id)}")
+  void suspendAccount(@Bind("id") long accountId);
+}
+----
+
+`@SqlCall` methods can return `void`, or may return `OutParameters` if the
+stored procedure has any output parameters. Each output parameter must be
+registered with the `@OutParameter` annotation.
+
+[source,java]
+----
+public interface OrderDao {
+  @SqlCall("{call prepare_order_from_cart(:cartId, :orderId, :orderTotal)}")
+  @OutParameter(name = "orderId",    sqlType = java.sql.Types.BIGINT)
+  @OutParameter(name = "orderTotal", sqlType = java.sql.Types.DECIMAL)
+  OutParameters prepareOrderFromCart(@Bind("cartId") long cartId);
+}
+----
+
+Individual output parameters can be extracted from the
+link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] returned from
+the method:
+
+[source,java]
+----
+OutParameters outParams = orderDao.prepareOrderFromCart(cartId);
+long orderId = outParams.getLong("orderId");
+double orderTotal = outParams.getDouble("orderTotal");
+----
 
 ==== Automatic parameter naming
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/OutParameter.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/OutParameter.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject.customizer;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -38,6 +39,7 @@ import org.jdbi.v3.sqlobject.customizer.internal.OutParameterFactory;
 @SqlStatementCustomizingAnnotation(OutParameterFactory.class)
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(OutParameterList.class)
 public @interface OutParameter {
     String name();
     int sqlType();

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/OutParameterList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/OutParameterList.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.customizer;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.jdbi.v3.sqlobject.customizer.internal.OutParameterListFactory;
+
+@SqlStatementCustomizingAnnotation(OutParameterListFactory.class)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OutParameterList {
+    OutParameter[] value();
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/OutParameterListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/OutParameterListFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.customizer.internal;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import org.jdbi.v3.core.statement.Call;
+import org.jdbi.v3.sqlobject.customizer.OutParameter;
+import org.jdbi.v3.sqlobject.customizer.OutParameterList;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizer;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
+
+public class OutParameterListFactory implements SqlStatementCustomizerFactory {
+    @Override
+    public SqlStatementCustomizer createForMethod(Annotation annotation, Class<?> sqlObjectType, Method method) {
+        final OutParameterList outParams = (OutParameterList) annotation;
+
+        return stmt -> {
+            Call call = (Call) stmt;
+            for (OutParameter outParam : outParams.value()) {
+                call.registerOutParameter(outParam.name(), outParam.sqlType());
+            }
+        };
+    }
+}

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredMappersWork.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredMappersWork.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -102,25 +101,6 @@ public class TestRegisteredMappersWork
                     .mapTo(Bean.class) // uses annotation-registered mapper
                     .findFirst();
         }
-    }
-
-    void foo() throws Exception {
-        Jdbi jdbi = dbRule.getJdbi();
-        jdbi.useHandle(handle -> {
-            BeanMappingDao dao = handle.attach(BeanMappingDao.class);
-            TestColumnMappers.SomeBeanDao another = handle.attach(TestColumnMappers.SomeBeanDao.class);
-
-
-        });
-
-        BeanMappingDao dao = jdbi.onDemand(BeanMappingDao.class);
-        dao.useHandle(h -> {
-            TestColumnMappers.SomeBeanDao another = h.attach(TestColumnMappers.SomeBeanDao.class);
-            Bean foo = dao.findByName("foo");
-
-            foo.setColor("brown");
-            dao.insertBean(foo);
-        });
     }
 
     @Test


### PR DESCRIPTION
Fixes #727.
Fixes #815.