### PR TITLE
Add ResultBearing#list

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,6 @@
+3.0.0-beta5
+  - add ResultBearing#list as shorthand for mapToMap().list()
+
 3.0.0-beta4
   - [breaking] ResultSetMapper -> ResultSetScanner; reducing overloaded 'Mapper'
   - PreparedBatch: throw an exception if you try to add() an empty binding

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
@@ -30,6 +30,7 @@ import org.jdbi.v3.core.statement.StatementContext;
 import java.lang.reflect.Type;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -268,7 +269,7 @@ public interface ResultBearing {
      * @param containerType the container type into which results will be collected
      * @return a container into which result rows have been collected
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     default Object collectInto(Type containerType) {
         return scanResultSet((rs, ctx) -> {
             Collector collector = ctx.findCollectorFor(containerType)
@@ -279,5 +280,15 @@ public interface ResultBearing {
                     .orElseThrow(() -> new NoSuchMapperException("No mapper registered for element type " + elementType));
             return ResultIterable.of(rs, mapper, ctx).collect(collector);
         });
+    }
+
+    /**
+     * Shorthand for {@code mapToMap().list()}, a commonly combined operation.
+     * Note that in many cases it is preferable to define a result type and avoid
+     * using {@code Map}; usually both clarity and performance improve.
+     * @return the query results
+     */
+    default List<Map<String, Object>> list() {
+        return mapToMap().list();
     }
 }

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -541,11 +541,21 @@ LocalDate releaseDate = handle.createQuery(
     .findOnly();
 ----
 
+You can produce `Map<String, Object>` instances which map column name to value.
+Column names are converted to lowercase, as JDBC drivers have different and often confusing
+rules around case sensitivity.
+
+[source,java]
+----
+List<Map<String, Object>> maps = handle.createQuery(
+        "select title, release_date from films")
+    .list();  // or mapToMap() if you want collections other than List
+----
+
 TODO:
 
 * demonstrate providing a column mapper inline
 * demonstrate mapToBean()
-* demonstrate mapToMap()
 
 === Mappers
 


### PR DESCRIPTION
as suggested on v2 to v3 migration guide, can be useful for more dynamic languages or use cases