### PR TITLE
Add the abilty to have SqlObject methods accept a Consumer<T>

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2820,6 +2820,18 @@ If you like StringTemplate, the <<StringTemplate 4>> module also provides a
 SqlLocator, which can load SQL templates from StringTemplate 4 files on the
 classpath.
 
+=== Consumer Methods
+
+As a special case, you may provide a `Consumer<T>` argument in addition to other bound parameters.
+The provided consumer is executed once for each row in the result set.
+The static type of parameter T determines the row type.
+
+[source,java]
+----
+@SqlQuery("select id, name from users")
+void forEachUser(Consumer<User> consumer);
+----
+
 === Default Methods
 
 Occasionally a use case comes up where SQL Method annotations don't fit. In

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindFactory.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlObjectStatementConfiguration.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlObjectStatementConfiguration.java
@@ -20,12 +20,14 @@ import org.jdbi.v3.core.config.JdbiConfig;
 public class SqlObjectStatementConfiguration implements JdbiConfig<SqlObjectStatementConfiguration>
 {
     private Supplier<Object> returner;
+    private Object[] args;
 
     public SqlObjectStatementConfiguration() { }
 
     private SqlObjectStatementConfiguration(SqlObjectStatementConfiguration other)
     {
         this.returner = other.returner;
+        this.args = other.args;
     }
 
     @Override
@@ -39,5 +41,13 @@ public class SqlObjectStatementConfiguration implements JdbiConfig<SqlObjectStat
 
     Supplier<Object> getReturner() {
         return returner;
+    }
+
+    void setArgs(Object[] args) {
+        this.args = args;
+    }
+
+    Object[] getArgs() {
+        return args;
     }
 }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConsumer.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConsumer.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jdbi.v3.core.Something;
+import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.statement.UseRowMapper;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestConsumer
+{
+    @Rule
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    @Test
+    public void testReturnStream() throws Exception {
+        Something one = new Something(3, "foo");
+        Something two = new Something(4, "bar");
+        Something thr = new Something(5, "baz");
+
+        Spiffy dao = dbRule.getJdbi().open().attach(Spiffy.class);
+        dao.insert(one);
+        dao.insert(thr);
+        dao.insert(two);
+
+        List<Something> results = new ArrayList<>();
+        dao.forEach(results::add);
+        assertThat(results).containsExactly(thr, two, one);
+    }
+
+    public interface Spiffy
+    {
+        @SqlQuery("select id, name from something order by id desc")
+        @UseRowMapper(SomethingMapper.class)
+        void forEach(Consumer<Something> consumer);
+
+        @SqlUpdate("insert into something (id, name) values (:id, :name)")
+        void insert(@BindBean Something something);
+    }
+}


### PR DESCRIPTION
This is handy when you want only a side effect.  You could already
do this with Stream or Iterable's forEach, but then you end up
owning a Closeable you don't really care for