### PR TITLE
Include jdbi3-vavr in generated javadoc

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -85,6 +85,10 @@
         <artifactId>jdbi3-stringtemplate4</artifactId>
       </dependency>
       <dependency>
+        <groupId>org.jdbi</groupId>
+        <artifactId>jdbi3-vavr</artifactId>
+      </dependency>
+      <dependency>
           <groupId>org.jetbrains</groupId>
           <artifactId>annotations</artifactId>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,11 @@
                 <artifactId>jdbi3-stringtemplate4</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-vavr</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Fixes #942. Adds vavr javadoc to generated site. I already republished the rc1 docs with this.