### PR TITLE
Support binding nested properties with bindBean, bindFields, and bindMethods

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,7 @@
 3.0.0-rc2
   - Row and column mapper for Optional types
+  - Binding of nested attributes e.g. ":user.address.city" with @BindBean, @BindMethods,
+    and @BindFields.
 
 3.0.0-rc1
   - SQL Object methods may have a Consumer<T> instead of a return type. See

--- a/core/src/main/java/org/jdbi/v3/core/argument/BeanPropertyArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/BeanPropertyArguments.java
@@ -38,10 +38,11 @@ import org.jdbi.v3.core.statement.UnableToCreateStatementException;
  */
 public class BeanPropertyArguments extends MethodReturnValueNamedArgumentFinder
 {
-    private static final Map<Class, Map<String, PropertyDescriptor>> CLASS_PROPERTY_DESCRIPTORS = ExpiringMap.builder()
+    private static final Map<Class<?>, Map<String, PropertyDescriptor>> CLASS_PROPERTY_DESCRIPTORS = ExpiringMap
+        .builder()
         .expiration(10, TimeUnit.MINUTES)
         .expirationPolicy(ExpirationPolicy.ACCESSED)
-        .entryLoader((Class type) -> {
+        .entryLoader((Class<?> type) -> {
             try {
                 BeanInfo info = Introspector.getBeanInfo(type);
                 return Stream.of(info.getPropertyDescriptors())

--- a/core/src/main/java/org/jdbi/v3/core/argument/MethodReturnValueNamedArgumentFinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/MethodReturnValueNamedArgumentFinder.java
@@ -18,8 +18,6 @@ import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.Optional;
 
 /**
  * Base {@link NamedArgumentFinder} implementation that can be used for bindings that use the return value
@@ -31,30 +29,15 @@ abstract class MethodReturnValueNamedArgumentFinder extends ObjectPropertyNamedA
      * @param prefix an optional prefix (we insert a '.' as a separator)
      * @param object the object to bind methods on
      */
-    protected MethodReturnValueNamedArgumentFinder(String prefix, Object object)
+    MethodReturnValueNamedArgumentFinder(String prefix, Object object)
     {
         super(prefix, object);
     }
 
-
-    protected Optional<Argument> getArgumentForMethod(Method method, StatementContext ctx)
-    {
+    Object invokeMethod(Method method, StatementContext ctx) {
         try
         {
-            Type propertyType = method.getGenericReturnType();
-            Object propertyValue = method.invoke(object);
-            Optional<Argument> argument = ctx.findArgumentFor(propertyType, propertyValue);
-
-            if (!argument.isPresent())
-            {
-                throw new UnableToCreateStatementException(
-                        String.format("No argument factory registered for type [%s] for method [%s] on [%s]",
-                                propertyType,
-                                method.getName(),
-                                object), ctx);
-            }
-
-            return argument;
+            return method.invoke(object);
         }
         catch (IllegalAccessException e)
         {

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
@@ -37,10 +37,10 @@ import org.jdbi.v3.core.statement.UnableToCreateStatementException;
  */
 public class ObjectFieldArguments extends ObjectPropertyNamedArgumentFinder
 {
-    private static final Map<Class, Map<String, Field>> CLASS_FIELDS = ExpiringMap.builder()
+    private static final Map<Class<?>, Map<String, Field>> CLASS_FIELDS = ExpiringMap.builder()
         .expiration(10, TimeUnit.MINUTES)
         .expirationPolicy(ExpirationPolicy.ACCESSED)
-        .entryLoader((Class type) ->
+        .entryLoader((Class<?> type) ->
             Stream.of(type.getFields())
                 .collect(toMap(Field::getName, Function.identity())))
         .build();

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
@@ -33,10 +33,10 @@ import java.util.stream.Stream;
  */
 public class ObjectMethodArguments extends MethodReturnValueNamedArgumentFinder
 {
-    private static final Map<Class, Map<String, Method>> CLASS_METHODS = ExpiringMap.builder()
+    private static final Map<Class<?>, Map<String, Method>> CLASS_METHODS = ExpiringMap.builder()
         .expiration(10, TimeUnit.MINUTES)
         .expirationPolicy(ExpirationPolicy.ACCESSED)
-        .entryLoader((Class type) ->
+        .entryLoader((Class<?> type) ->
             Stream.of(type.getMethods())
                 .filter(m -> m.getParameterCount() == 0)
                 .collect(toMap(Method::getName, Function.identity())))

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
@@ -13,41 +13,64 @@
  */
 package org.jdbi.v3.core.argument;
 
+import static java.util.stream.Collectors.toMap;
+
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
 import org.jdbi.v3.core.statement.StatementContext;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * Binds public methods with no parameters on a specified object.
  */
 public class ObjectMethodArguments extends MethodReturnValueNamedArgumentFinder
 {
+    private static final Map<Class, Map<String, Method>> CLASS_METHODS = ExpiringMap.builder()
+        .expiration(10, TimeUnit.MINUTES)
+        .expirationPolicy(ExpirationPolicy.ACCESSED)
+        .entryLoader((Class type) ->
+            Stream.of(type.getMethods())
+                .filter(m -> m.getParameterCount() == 0)
+                .collect(toMap(Method::getName, Function.identity())))
+        .build();
+
+    private final Map<String, Method> methods;
+
     /**
      * @param prefix an optional prefix (we insert a '.' as a separator)
      * @param object the object to bind functions on
      */
-    public ObjectMethodArguments(String prefix, Object object)
-    {
+    public ObjectMethodArguments(String prefix, Object object) {
         super(prefix, object);
+
+        this.methods = CLASS_METHODS.get(object.getClass());
     }
 
     @Override
-    Optional<Argument> find0(String name, StatementContext ctx)
-    {
-        if (name.startsWith(prefix))
-        {
-            String propertyName = name.substring(prefix.length());
+    Optional<TypedValue> getValue(String name, StatementContext ctx) {
+        Method method = methods.get(name);
 
-            for (Method method : object.getClass().getMethods())
-            {
-                if (method.getParameterCount() == 0 && method.getName().equals(propertyName))
-                {
-                    return getArgumentForMethod(method, ctx);
-                }
-            }
+        if (method == null) {
+            return Optional.empty();
         }
-        return Optional.empty();
+
+        Type type = method.getGenericReturnType();
+        Object value = invokeMethod(method, ctx);
+
+        return Optional.of(new TypedValue(type, value));
+    }
+
+    @Override
+    NamedArgumentFinder getNestedArgumentFinder(Object obj) {
+        return new ObjectMethodArguments(null, obj);
     }
 
     @Override

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -332,7 +332,7 @@ You can bind multiple arguments from properties of a Java Bean:
 ----
 Contact contact = new Contact();
 contact.setId(3);
-contact.withName("Cindy");
+contact.setName("Cindy");
 
 handle.createUpdate("insert into contacts (id, name) values (:id, :name)")
       .bindBean(contact)
@@ -390,9 +390,13 @@ handle.createUpdate("insert into documents (id, folder_id, name, contents) " +
       .execute();
 ----
 
+[NOTE]
+`bindBean()`, `bindFields()`, and `bindMethods()` may be used to bind nested
+properties, e.g. `:user.address.street`.
+
 [WARNING]
-Neither `bindMap()`, `bindMethods()`, `bindFields()`, nor `bindBean()` support
- binding of nested properties (e.g. `:user.address.street`).
+`bindMap()` does not bind nested properties--map keys are expected to exactly
+match the bound parameter name.
 
 ==== Custom Arguments
 
@@ -2136,10 +2140,13 @@ void insert(@BindBean("user") User user);
 //void insert(@BindMethods("user") User user);
 ----
 
+[NOTE]
+As in the Core API, `@BindBean`, `@BindFields`, and `@BindMethods` may be used
+to bind nested properties, e.g. `:user.address.street`.
+
 [WARNING]
-As in the Core API, neither `@BindMap`, `@BindBean`, `@BindFields`, nor
-`@BindMethods` support binding of nested properties
-(e.g. `:user.address.street`).
+`@BindMap` does not bind nested properties--map keys are expected to exactly
+match the bound parameter name.
 
 ==== @SqlQuery
 


### PR DESCRIPTION
Fixes #395.
Fixes #122.

This required a pretty heavy refactor of `BeanPropertyArguments`, `ObjectFieldArguments`, `ObjectMethodArguments`, and their superclasses.

In addition to the goal of supporting nested bindings, this PR:

* Introduces some caching of class members / property descriptors, to speed up binding and reduce redundant introspection.
* Hides some protected methods that should have been package private

@stevenschlansker or @arteam would you please review?

Putting this in the post v3 release milestone so we don't hold up release. If you think it's ready to go now, I'm fine with merging and including it in v3.