### PR TITLE
Support mapping of `@Nested` properties in reflection mappers.

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,7 +1,9 @@
 3.0.0-rc2
   - Row and column mapper for Optional types
-  - Binding of nested attributes e.g. ":user.address.city" with @BindBean, @BindMethods,
-    and @BindFields.
+  - Binding of nested attributes e.g. ":user.address.city" with bindBean(), bindMethods(),
+    bindFields(), (and by extension, @BindBean, @BindMethods, and @BindFields).
+  - Mapping of nested attributes with BeanMapper, ConstructorMapper, and FieldMapper, using
+    the @Nested annotation.
 
 3.0.0-rc1
   - SQL Object methods may have a Consumer<T> instead of a return type. See

--- a/core/src/main/java/org/jdbi/v3/core/mapper/Nested.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/Nested.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Signals that the annotated element is a nested mapped type.
+ */
+@Retention(RUNTIME)
+@Target({PARAMETER, FIELD, METHOD})
+public @interface Nested {
+  /**
+   * The column name prefix for all members of the nested object. If unset,
+   * no column name prefix is applied.
+   */
+  String value() default "";
+}

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
+import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.findColumnIndex;
+
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -20,20 +22,20 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
 
-import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
+import org.jdbi.v3.core.mapper.SingleColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
 
 /**
  * A row mapper which maps the columns in a statement into a JavaBean. The default
@@ -95,7 +97,7 @@ public class BeanMapper<T> implements RowMapper<T>
     private final Class<T> type;
     private final String prefix;
     private final BeanInfo info;
-    private final ConcurrentMap<String, Optional<PropertyDescriptor>> descriptorByColumnCache = new ConcurrentHashMap<>();
+    private final Map<PropertyDescriptor, RowMapper<?>> nestedMappers = new ConcurrentHashMap<>();
 
     private BeanMapper(Class<T> type, String prefix)
     {
@@ -117,107 +119,74 @@ public class BeanMapper<T> implements RowMapper<T>
 
     @Override
     public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
-        List<Integer> columnNumbers = new ArrayList<>();
-        List<ColumnMapper<?>> mappers = new ArrayList<>();
-        List<PropertyDescriptor> properties = new ArrayList<>();
+        final List<String> columnNames = ReflectionMapperUtil.getColumnNames(rs);
 
-        ResultSetMetaData metadata = rs.getMetaData();
-        List<ColumnNameMatcher> columnNameMatchers = ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
+        final List<RowMapper<?>> mappers = new ArrayList<>();
+        final List<PropertyDescriptor> properties = new ArrayList<>();
 
-        for (int i = 1; i <= metadata.getColumnCount(); ++i) {
-            String name = metadata.getColumnLabel(i);
+        final List<ColumnNameMatcher> columnNameMatchers = ReflectionMapperUtil.getColumnNameMatchers(ctx);
 
-            if (prefix.length() > 0) {
-                if (name.length() > prefix.length() &&
-                        name.regionMatches(true, 0, prefix, 0, prefix.length())) {
-                    name = name.substring(prefix.length());
-                }
-                else {
-                    continue;
-                }
+        for (PropertyDescriptor descriptor : info.getPropertyDescriptors()) {
+            Nested anno = Stream.of(descriptor.getReadMethod(), descriptor.getWriteMethod())
+                .filter(Objects::nonNull)
+                .map(m -> m.getAnnotation(Nested.class))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
+            if (anno == null) {
+                String paramName = paramName(descriptor);
+
+                findColumnIndex(paramName, prefix, columnNames, columnNameMatchers, () -> debugName(descriptor))
+                    .ifPresent(index -> {
+                        Type type = descriptor.getReadMethod().getGenericReturnType();
+                        ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
+                            .orElse((r, n, c) -> r.getObject(n));
+
+                        mappers.add(new SingleColumnMapper<>(mapper, index + 1));
+                        properties.add(descriptor);
+                    });
+            } else {
+                RowMapper<?> nestedMapper = nestedMappers.computeIfAbsent(descriptor, d -> {
+                    String prefix = BeanMapper.this.prefix + anno.value();
+                    return BeanMapper.of(d.getPropertyType(), prefix);
+                }).specialize(rs, ctx);
+
+                mappers.add(nestedMapper);
+                properties.add(descriptor);
             }
-
-            final Optional<PropertyDescriptor> maybeDescriptor =
-                    descriptorByColumnCache.computeIfAbsent(name, n -> descriptorForColumn(n, columnNameMatchers));
-
-            if (!maybeDescriptor.isPresent()) {
-                continue;
-            }
-
-            final PropertyDescriptor descriptor = maybeDescriptor.get();
-            final Type type = descriptor.getReadMethod().getGenericReturnType();
-            final ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
-                    .orElse((r, n, c) -> r.getObject(n));
-
-            columnNumbers.add(i);
-            mappers.add(mapper);
-            properties.add(descriptor);
         }
 
-        if (columnNumbers.isEmpty() && metadata.getColumnCount() > 0) {
+        if (mappers.isEmpty() && columnNames.size() > 0) {
             throw new IllegalArgumentException(String.format("Mapping bean type %s " +
                     "didn't find any matching columns in result set", type));
         }
 
-        if (    ctx.getConfig(ReflectionMappers.class).isStrictMatching() &&
-                columnNumbers.size() != metadata.getColumnCount()) {
+        // TODO rethink strict matching in terms of nested row mappers
+        if (ctx.getConfig(ReflectionMappers.class).isStrictMatching()
+            && mappers.size() != columnNames.size()) {
             throw new IllegalArgumentException(String.format("Mapping bean type %s " +
                     "only matched properties for %s of %s columns", type,
-                    columnNumbers.size(), metadata.getColumnCount()));
+                mappers.size(), columnNames.size()));
         }
 
         return (r, c) -> {
-            T bean;
-            try {
-                bean = type.newInstance();
-            }
-            catch (Exception e) {
-                throw new IllegalArgumentException(String.format("A bean, %s, was mapped " +
-                        "which was not instantiable", type.getName()), e);
-            }
+            T bean = construct();
 
-            for (int i = 0; i < columnNumbers.size(); i++) {
-                int columnNumber = columnNumbers.get(i);
-                ColumnMapper<?> mapper = mappers.get(i);
+            for (int i = 0; i < mappers.size(); i++) {
+                RowMapper<?> mapper = mappers.get(i);
                 PropertyDescriptor property = properties.get(i);
 
-                Object value = mapper.map(r, columnNumber, ctx);
-                try {
-                    property.getWriteMethod().invoke(bean, value);
-                }
-                catch (IllegalAccessException e) {
-                    throw new IllegalArgumentException(String.format("Unable to access setter for " +
-                            "property, %s", property.getName()), e);
-                }
-                catch (InvocationTargetException e) {
-                    throw new IllegalArgumentException(String.format("Invocation target exception trying to " +
-                            "invoker setter for the %s property", property.getName()), e);
-                }
-                catch (NullPointerException e) {
-                    throw new IllegalArgumentException(String.format("No appropriate method to " +
-                            "write property %s", property.getName()), e);
-                }
+                Object value = mapper.map(r, ctx);
+
+                writeProperty(bean, property, value);
             }
 
             return bean;
         };
     }
 
-    private Optional<PropertyDescriptor> descriptorForColumn(String columnName,
-                                                             List<ColumnNameMatcher> columnNameMatchers)
-    {
-        for (PropertyDescriptor descriptor : info.getPropertyDescriptors()) {
-            String paramName = paramName(descriptor);
-            for (ColumnNameMatcher strategy : columnNameMatchers) {
-                if (strategy.columnNameMatches(columnName, paramName)) {
-                    return Optional.of(descriptor);
-                }
-            }
-        }
-        return Optional.empty();
-    }
-
-    private String paramName(PropertyDescriptor descriptor)
+    private static String paramName(PropertyDescriptor descriptor)
     {
         return Stream.of(descriptor.getReadMethod(), descriptor.getWriteMethod())
                 .filter(Objects::nonNull)
@@ -226,5 +195,37 @@ public class BeanMapper<T> implements RowMapper<T>
                 .map(ColumnName::value)
                 .findFirst()
                 .orElseGet(descriptor::getName);
+    }
+
+    private String debugName(PropertyDescriptor descriptor) {
+        return String.format("%s.%s", type.getSimpleName(), descriptor.getName());
+    }
+
+    private T construct() {
+        try {
+            return type.newInstance();
+        }
+        catch (Exception e) {
+            throw new IllegalArgumentException(String.format("A bean, %s, was mapped " +
+                "which was not instantiable", type.getName()), e);
+        }
+    }
+
+    private static void writeProperty(Object bean, PropertyDescriptor property, Object value) {
+        try {
+            property.getWriteMethod().invoke(bean, value);
+        }
+        catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(String.format("Unable to access setter for " +
+                "property, %s", property.getName()), e);
+        }
+        catch (InvocationTargetException e) {
+            throw new IllegalArgumentException(String.format("Invocation target exception trying to " +
+                "invoker setter for the %s property", property.getName()), e);
+        }
+        catch (NullPointerException e) {
+            throw new IllegalArgumentException(String.format("No appropriate method to " +
+                "write property %s", property.getName()), e);
+        }
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -13,21 +13,26 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
+import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.findColumnIndex;
+import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNameMatchers;
+import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNames;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
-import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
+import org.jdbi.v3.core.mapper.SingleColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
 
 /**
  * A row mapper which maps the columns in a statement into an object, using reflection
@@ -86,7 +91,7 @@ public class FieldMapper<T> implements RowMapper<T>
 
     private final Class<T> type;
     private final String prefix;
-    private final ConcurrentMap<String, Optional<Field>> fieldByNameCache = new ConcurrentHashMap<>();
+    private final Map<Field, RowMapper<?>> nestedMappers = new ConcurrentHashMap<>();
 
     private FieldMapper(Class<T> type, String prefix)
     {
@@ -101,105 +106,97 @@ public class FieldMapper<T> implements RowMapper<T>
 
     @Override
     public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
-        List<Integer> columnNumbers = new ArrayList<>();
-        List<ColumnMapper<?>> mappers = new ArrayList<>();
+        final List<String> columnNames = getColumnNames(rs);
+
+        List<RowMapper<?>> mappers = new ArrayList<>();
         List<Field> fields = new ArrayList<>();
 
-        ResultSetMetaData metadata = rs.getMetaData();
-        List<ColumnNameMatcher> columnNameMatchers = ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
+        List<ColumnNameMatcher> columnNameMatchers = getColumnNameMatchers(ctx);
 
-        for (int i = 1; i <= metadata.getColumnCount(); ++i) {
-            String name = metadata.getColumnLabel(i).toLowerCase();
+        for (Class<?> aType = type; aType != null; aType = aType.getSuperclass()) {
+            for (Field field : aType.getDeclaredFields()) {
+                Nested anno = field.getAnnotation(Nested.class);
+                if (anno == null) {
+                    findColumnIndex(paramName(field), prefix, columnNames, columnNameMatchers, () -> debugName(field))
+                        .ifPresent(index -> {
+                            Type type = field.getGenericType();
+                            ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
+                                .orElse((r, n, c) -> rs.getObject(n));
+                            mappers.add(new SingleColumnMapper(mapper, index + 1));
+                            fields.add(field);
+                        });
+                } else {
+                    RowMapper<?> mapper = nestedMappers.computeIfAbsent(field, f -> {
+                        String prefix = FieldMapper.this.prefix + anno.value();
+                        return FieldMapper.of(field.getType(), prefix);
+                    }).specialize(rs, ctx);
 
-            if (prefix.length() > 0) {
-                if (name.length() > prefix.length() &&
-                        name.regionMatches(true, 0, prefix, 0, prefix.length())) {
-                    name = name.substring(prefix.length());
-                }
-                else {
-                    continue;
+                    mappers.add(mapper);
+                    fields.add(field);
                 }
             }
-
-            Optional<Field> maybeField = fieldByNameCache.computeIfAbsent(name, n -> fieldByColumn(n, columnNameMatchers));
-
-            if (!maybeField.isPresent()) {
-                continue;
-            }
-
-            final Field field = maybeField.get();
-            final Type type = field.getGenericType();
-            final ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
-                    .orElse((r, n, c) -> r.getObject(n));
-
-            columnNumbers.add(i);
-            mappers.add(mapper);
-            fields.add(field);
         }
 
-        if (columnNumbers.isEmpty() && metadata.getColumnCount() > 0) {
+        if (mappers.isEmpty() && columnNames.size() > 0) {
             throw new IllegalArgumentException(String.format("Mapping fields for type %s " +
-                    "didn't find any matching columns in result set", type));
+                "didn't find any matching columns in result set", type));
         }
 
-        if (    ctx.getConfig(ReflectionMappers.class).isStrictMatching() &&
-                columnNumbers.size() != metadata.getColumnCount()) {
-            throw new IllegalArgumentException(String.format("Mapping fields for type %s " +
-                    "only matched properties for %s of %s columns", type,
-                    columnNumbers.size(), metadata.getColumnCount()));
+        // TODO rethink strict mapping in terms of nested row mappers
+        if (ctx.getConfig(ReflectionMappers.class).isStrictMatching() &&
+            mappers.size() != columnNames.size()) {
+            throw new IllegalArgumentException(String.format(
+                "Mapping fields for type %s only matched properties for %s of %s columns",
+                type,
+                mappers.size(),
+                columnNames.size()));
         }
-
 
         return (r, c) -> {
-            T obj;
-            try {
-                obj = type.newInstance();
-            }
-            catch (Exception e) {
-                throw new IllegalArgumentException(String.format("A type, %s, was mapped " +
-                        "which was not instantiable", type.getName()), e);
-            }
+            T obj = construct();
 
-            for (int i = 0; i < columnNumbers.size(); i++) {
-                int columnNumber = columnNumbers.get(i);
-                ColumnMapper<?> mapper = mappers.get(i);
+            for (int i = 0; i < mappers.size(); i++) {
+                RowMapper<?> mapper = mappers.get(i);
                 Field field = fields.get(i);
 
-                Object value = mapper.map(rs, columnNumber, ctx);
-                try {
-                    field.setAccessible(true);
-                    field.set(obj, value);
-                } catch (IllegalAccessException e) {
-                    throw new IllegalArgumentException(String.format("Unable to access " +
-                            "property, %s", field.getName()), e);
-                }
+                Object value = mapper.map(rs, ctx);
+                writeField(obj, field, value);
             }
+
             return obj;
         };
     }
 
-    private Optional<Field> fieldByColumn(String columnName, List<ColumnNameMatcher> columnNameMatchers)
-    {
-        Class<?> aClass = type;
-        while(aClass != null) {
-            for (Field field : aClass.getDeclaredFields()) {
-                String paramName = paramName(field);
-                for (ColumnNameMatcher strategy : columnNameMatchers) {
-                    if (strategy.columnNameMatches(columnName, paramName)) {
-                        return Optional.of(field);
-                    }
-                }
-            }
-            aClass = aClass.getSuperclass();
-        }
-        return Optional.empty();
-    }
-
-    private String paramName(Field field)
-    {
+    private static String paramName(Field field) {
         return Optional.ofNullable(field.getAnnotation(ColumnName.class))
                 .map(ColumnName::value)
                 .orElseGet(field::getName);
+    }
+
+    private String debugName(Field field) {
+        return String.format("%s.%s", type.getSimpleName(), field.getName());
+    }
+
+    private T construct() {
+        try {
+            return type.newInstance();
+        }
+        catch (Exception e) {
+            String message = String.format(
+                "A type, %s, was mapped which was not instantiable",
+                type.getName());
+            throw new IllegalArgumentException(message, e);
+        }
+    }
+
+    private void writeField(T obj, Field field, Object value) {
+        try {
+            field.setAccessible(true);
+            field.set(obj, value);
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(String.format("Unable to access " +
+                "property, %s", field.getName()), e);
+        }
     }
 }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper.reflect;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.function.Supplier;
+
+import org.jdbi.v3.core.statement.StatementContext;
+
+class ReflectionMapperUtil {
+  static List<String> getColumnNames(ResultSet rs) throws SQLException {
+    final ResultSetMetaData metadata = rs.getMetaData();
+    final int count = metadata.getColumnCount();
+    final List<String> columnNames = new ArrayList<>(count);
+
+    for (int i = 0; i < count; ++i) {
+      columnNames.add(metadata.getColumnLabel(i + 1).toLowerCase());
+    }
+
+    return columnNames;
+  }
+
+  static List<ColumnNameMatcher> getColumnNameMatchers(StatementContext ctx) {
+    return ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
+  }
+
+  static OptionalInt findColumnIndex(String paramName,
+                                     String columnPrefix,
+                                     List<String> columnNames,
+                                     List<ColumnNameMatcher> columnNameMatchers,
+                                     Supplier<String> debugName) {
+    OptionalInt result = OptionalInt.empty();
+
+    for (int i = 0; i < columnNames.size(); i++) {
+      String columnName = columnNames.get(i);
+
+      if (!columnPrefix.isEmpty()) {
+        if (columnName.length() > columnPrefix.length() &&
+            columnName.regionMatches(true, 0, columnPrefix, 0, columnPrefix.length())) {
+          columnName = columnName.substring(columnPrefix.length());
+        } else {
+          continue;
+        }
+      }
+
+      for (ColumnNameMatcher strategy : columnNameMatchers) {
+        if (strategy.columnNameMatches(columnName, paramName)) {
+          if (result.isPresent()) {
+            throw new IllegalArgumentException(String.format(
+                "'%s' (%s) matches multiple columns: '%s' (%d) and '%s' (%d)",
+                debugName.get(), paramName,
+                columnNames.get(result.getAsInt()), result.getAsInt(),
+                columnNames.get(i), i));
+          }
+
+          result = OptionalInt.of(i);
+          break;
+        }
+      }
+    }
+
+    return result;
+  }
+}

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
@@ -41,7 +41,6 @@ class ReflectionMapperUtil {
   }
 
   static OptionalInt findColumnIndex(String paramName,
-                                     String columnPrefix,
                                      List<String> columnNames,
                                      List<ColumnNameMatcher> columnNameMatchers,
                                      Supplier<String> debugName) {
@@ -49,15 +48,6 @@ class ReflectionMapperUtil {
 
     for (int i = 0; i < columnNames.size(); i++) {
       String columnName = columnNames.get(i);
-
-      if (!columnPrefix.isEmpty()) {
-        if (columnName.length() > columnPrefix.length() &&
-            columnName.regionMatches(true, 0, columnPrefix, 0, columnPrefix.length())) {
-          columnName = columnName.substring(columnPrefix.length());
-        } else {
-          continue;
-        }
-      }
 
       for (ColumnNameMatcher strategy : columnNameMatchers) {
         if (strategy.columnNameMatches(columnName, paramName)) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMappers.java
@@ -35,10 +35,12 @@ public class ReflectionMappers implements JdbiConfig<ReflectionMappers> {
         columnNameMatchers = Arrays.asList(
                 new CaseInsensitiveColumnNameMatcher(),
                 new SnakeCaseColumnNameMatcher());
+        strictMatching = false;
     }
 
     private ReflectionMappers(ReflectionMappers that) {
         columnNameMatchers = new ArrayList<>(that.columnNameMatchers);
+        strictMatching = that.strictMatching;
     }
 
     /**
@@ -68,6 +70,9 @@ public class ReflectionMappers implements JdbiConfig<ReflectionMappers> {
     /**
      * Throw an IllegalArgumentException if a the set of fields doesn't
      * match to columns exactly.
+     *
+     * Reflection mappers with prefixes will only check those columns that
+     * begin with the mapper's prefix.
      *
      * @param strictMatching whether to enable strict matching
      * @return this

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/SnakeCaseColumnNameMatcher.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/SnakeCaseColumnNameMatcher.java
@@ -21,7 +21,7 @@ package org.jdbi.v3.core.mapper.reflect;
 public class SnakeCaseColumnNameMatcher implements ColumnNameMatcher {
     @Override
     public boolean columnNameMatches(String columnName, String javaName) {
-        return columnName.replace("_", "").equalsIgnoreCase(javaName);
+        return columnName.replace("_", "").equalsIgnoreCase(javaName.replace("_", ""));
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper.reflect;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,6 +67,21 @@ public class ConstructorMapperTest {
         assertThat(bean.i).isEqualTo(2);
     }
 
+    static class ConstructorBean {
+        private final String s;
+        private final int i;
+
+        ConstructorBean(int some, String other, long constructor) {
+            throw new UnsupportedOperationException("You don't belong here!");
+        }
+
+        @JdbiConstructor
+        ConstructorBean(String s, int i) {
+            this.s = s;
+            this.i = i;
+        }
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testDuplicate() throws Exception {
         execute("SELECT i, s, s FROM bean");
@@ -83,6 +99,13 @@ public class ConstructorMapperTest {
         assertThat(nb.i).isEqualTo(3);
     }
 
+    static class NamedParameterBean {
+        final int i;
+        NamedParameterBean(@ColumnName("xyz") int i) {
+            this.i = i;
+        }
+    }
+
     @Test
     public void testConstructorProperties() throws Exception {
         final ConstructorPropertiesBean cpi = dbRule.getSharedHandle()
@@ -91,28 +114,6 @@ public class ConstructorMapperTest {
                 .findOnly();
         assertThat(cpi.s).isEqualTo("3");
         assertThat(cpi.i).isEqualTo(2);
-    }
-
-    static class ConstructorBean {
-        private final String s;
-        private final int i;
-
-        ConstructorBean(int some, String other, long constructor) {
-            throw new UnsupportedOperationException("You don't belong here!");
-        }
-
-        @JdbiConstructor
-        ConstructorBean(String s, int i) {
-            this.s = s;
-            this.i = i;
-        }
-    }
-
-    static class NamedParameterBean {
-        final int i;
-        NamedParameterBean(@ColumnName("xyz") int i) {
-            this.i = i;
-        }
     }
 
     static class ConstructorPropertiesBean {
@@ -128,6 +129,44 @@ public class ConstructorMapperTest {
         ConstructorPropertiesBean(String x, int y) {
             this.s = x;
             this.i = y;
+        }
+    }
+
+    @Test
+    public void nestedParameters() {
+        NestedBean result = dbRule.getSharedHandle()
+            .registerRowMapper(ConstructorMapper.factory(NestedBean.class))
+            .select("select s, i from bean")
+            .mapTo(NestedBean.class)
+            .findOnly();
+        assertThat(result.nested.s).isEqualTo("3");
+        assertThat(result.nested.i).isEqualTo(2);
+    }
+
+    static class NestedBean {
+        final ConstructorBean nested;
+
+        NestedBean(@Nested ConstructorBean nested) {
+            this.nested = nested;
+        }
+    }
+
+    @Test
+    public void nestedPrefixParameters() {
+        NestedPrefixBean result = dbRule.getSharedHandle()
+            .registerRowMapper(ConstructorMapper.factory(NestedPrefixBean.class))
+            .select("select i nested_i, s nested_s from bean")
+            .mapTo(NestedPrefixBean.class)
+            .findOnly();
+        assertThat(result.nested.s).isEqualTo("3");
+        assertThat(result.nested.i).isEqualTo(2);
+    }
+
+    static class NestedPrefixBean {
+        final ConstructorBean nested;
+
+        NestedPrefixBean(@Nested("nested") ConstructorBean nested) {
+            this.nested = nested;
         }
     }
 }

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -1106,6 +1106,60 @@ public User(@ColumnName("user_id") int id, String name) {
 }
 ----
 
+Nested constructor-injected types can be mapped using the `@Nested` annotation:
+
+[source,java]
+----
+public class User {
+  public User(int id,
+              String name,
+              @Nested Address address) {
+    ...
+  }
+}
+
+public class Address {
+  public Address(String street,
+                 String city,
+                 String state,
+                 String zip) {
+    ...
+  }
+}
+----
+
+[source,java]
+----
+handle.registerMapper(ConstructorMapper.factory(User.class));
+
+List<User> users = handle
+    .select("select id, name, street, city, state, zip from users")
+    .mapTo(User.class)
+    .list();
+----
+
+The `@Nested` annotation has an optional `value()` attribute, which can be used
+to apply a column name prefix to each nested constructor parameter:
+
+[source,java]
+----
+public User(int id,
+            String name,
+            @Nested("addr") Address address) {
+  ...
+}
+----
+
+[source,java]
+----
+handle.registerMapper(ConstructorMapper.factory(User.class));
+
+List<User> users = handle
+    .select("select id, name, addr_street, addr_city, addr_state, addr_zip from users")
+    .mapTo(User.class)
+    .list();
+----
+
 ===== BeanMapper
 
 We also provide basic support for mapping beans:
@@ -1155,6 +1209,64 @@ public class User {
 
 The `@ColumnName` annotation can be placed on either the getter or setter
 method.
+
+Nested Java Bean types can be mapped using the `@Nested` annotation:
+
+[source,java]
+----
+public class User {
+  private int id;
+  private String name;
+  private Address address;
+
+  ... (getters and setters)
+
+  @Nested // <1>
+  public Address getAddress() { ... }
+
+  public void setAddress(Address address) { ... }
+}
+
+public class Address {
+  private String street;
+  private String city;
+  private String state;
+  private String zip;
+
+  ... (getters and setters)
+}
+----
+<1> The `@Nested` annotation can be placed on either the getter or setter
+    method.
+
+[source,java]
+----
+handle.registerMapper(BeanMapper.factory(User.class));
+
+List<User> users = handle
+    .select("select id, name, street, city, state, zip from users")
+    .mapTo(User.class)
+    .list();
+----
+
+The `@Nested` annotation has an optional `value()` attribute, which can be used
+to apply a column name prefix to each nested bean property:
+
+[source,java]
+----
+@Nested("addr")
+public Address getAddress() { ... }
+----
+
+[source,java]
+----
+handle.registerMapper(BeanMapper.factory(User.class));
+
+List<User> users = handle
+    .select("select id, name, addr_street, addr_city, addr_state, addr_zip from users")
+    .mapTo(User.class)
+    .list();
+----
 
 ===== FieldMapper
 
@@ -1210,6 +1322,60 @@ public class User {
 
   public String name;
 }
+----
+
+Nested field-mapped types can be mapped using the `@Nested` annotation:
+
+[source,java]
+----
+public class User {
+  public int id;
+  public String name;
+
+  @Nested
+  public Address address;
+}
+
+public class Address {
+  public String street;
+  public String city;
+  public String state;
+  public String zip;
+}
+----
+
+[source,java]
+----
+handle.registerMapper(FieldMapper.factory(User.class));
+
+List<User> users = handle
+    .select("select id, name, street, city, state, zip from users")
+    .mapTo(User.class)
+    .list();
+----
+
+The `@Nested` annotation has an optional `value()` attribute, which can be used
+to apply a column name prefix to each nested field:
+
+[source,java]
+----
+public class User {
+  public int id;
+  public String name;
+
+  @Nested("addr")
+  public Address address;
+}
+----
+
+[source,java]
+----
+handle.registerMapper(FieldMapper.factory(User.class));
+
+List<User> users = handle
+    .select("select id, name, addr_street, addr_city, addr_state, addr_zip from users")
+    .mapTo(User.class)
+    .list();
 ----
 
 ////

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2560,8 +2560,8 @@ that begin with the prefix:
 public interface UserDao {
   @SqlQuery("select u.id u_id, u.name u_name, r.id r_id, r.name r_name " +
       "from users u left join roles r on u.role_id = r.id")
-  @RegisterBeanMapper(value = User.class, prefix = "u_")
-  @RegisterBeanMapper(value = Role.class, prefix = "r_")
+  @RegisterBeanMapper(value = User.class, prefix = "u")
+  @RegisterBeanMapper(value = Role.class, prefix = "r")
   Map<User,Role> getRolesPerUser();
 }
 ----
@@ -2596,8 +2596,8 @@ columns that begin with the prefix:
 public interface UserDao {
   @SqlQuery("select u.id u_id, u.name u_name, r.id r_id, r.name r_name " +
       "from users u left join roles r on u.role_id = r.id")
-  @RegisterConstructorMapper(value = User.class, prefix = "u_")
-  @RegisterConstructorMapper(value = Role.class, prefix = "r_")
+  @RegisterConstructorMapper(value = User.class, prefix = "u")
+  @RegisterConstructorMapper(value = Role.class, prefix = "r")
   Map<User,Role> getRolesPerUser();
 }
 ----
@@ -2632,8 +2632,8 @@ that begin with the prefix:
 public interface UserDao {
   @SqlQuery("select u.id u_id, u.name u_name, r.id r_id, r.name r_name " +
       "from users u left join roles r on u.role_id = r.id")
-  @RegisterFieldMapper(value = User.class, prefix = "u_")
-  @RegisterFieldMapper(value = Role.class, prefix = "r_")
+  @RegisterFieldMapper(value = User.class, prefix = "u")
+  @RegisterFieldMapper(value = Role.class, prefix = "r")
   Map<User,Role> getRolesPerUser();
 }
 ----


### PR DESCRIPTION
Fixes #949 

Introduces the `@Nested` annotation, per #949.

Updates BeanMapper, ConstructorMapper, and FieldMapper to honor the `@Nested` annotation on accessors, constructor parameters, and fields (respectively).

Refactors some common elements of the three mappers out to a package private utility class.

Note: With this feature, the "strict checking" config option of `ReflectionMappers` probably needs to be revisited. We might possibly even want to remove strict check v3 if we can't reconcile its semantics when nested properties are involved.