### PR TITLE
added support for option mapping

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -3804,6 +3804,7 @@ The Vavr Plugin offers deep integration of *Jdbi* with the Vavr functional libra
   will be used as default implementation.
   For interface types a sensible default implementation will be used
   (e.q. `List<T>` for `Seq<T>`).
+* Columns can be mapped into Vavr's `Option<T>` type.
 * Tuple projections for *Jdbi*! Yey! Vavr offers Tuples up to a maximum arity of 8.
   you can map your query results e.g. to `Tuple3<Integer, String, Long>`.
   If you select more columns than the arity of the projection the columns
@@ -3854,8 +3855,16 @@ handle.createQuery("select name from users")
 ----
 
 This works for all the collection types supported. For the nested value
-row and column mappers already installed in *Jdbi* will be used. The plugin
-will obey configured key and value columns for `Map<K, V>` return types.
+row and column mappers already installed in *Jdbi* will be used.
+Therefore the following would work and can make sense if the column is nullable:
+
+[source,java]
+----
+handle.createQuery("select middle_name from users") // nulls incoming!
+        .collectInto(new GenericType<Seq<Option<String>>>() {});
+----
+
+The plugin will obey configured key and value columns for `Map<K, V>` return types.
 
 Last but not least we can now project simple queries to Vavr tuples like that:
 

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrOptionMapper.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrOptionMapper.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.vavr;
+
+import io.vavr.control.Option;
+import org.jdbi.v3.core.generic.GenericTypes;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.ColumnMapperFactory;
+import org.jdbi.v3.core.mapper.NoSuchMapperException;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.lang.reflect.Type;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
+
+public class VavrOptionMapper<T> implements ColumnMapper<Option<T>> {
+
+    private final Type type;
+
+    private VavrOptionMapper(Type type) {
+        this.type = type;
+    }
+
+    public static ColumnMapper<?> of(Type type) {
+        return new VavrOptionMapper(type);
+    }
+
+    public static ColumnMapperFactory factory() {
+        return (type, config) -> {
+            Class<?> rawType = getErasedType(type);
+            if (rawType == Option.class) {
+                return Optional.of(VavrOptionMapper.of(type));
+            }
+            return Optional.empty();
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Option<T> map(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+        final ColumnMapper<?> mapper = ctx.findColumnMapperFor(
+                GenericTypes.findGenericParameter(type, Option.class)
+                        .orElseThrow(() -> new NoSuchMapperException("No mapper for raw Option type")))
+                .orElseThrow(() -> new NoSuchMapperException("No mapper for type " + type + " nested in Option"));
+
+        return (Option<T>) Option.of(mapper.map(r, columnNumber, ctx));
+    }
+
+}

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrOptionMapper.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrOptionMapper.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 
-public class VavrOptionMapper<T> implements ColumnMapper<Option<T>> {
+class VavrOptionMapper<T> implements ColumnMapper<Option<T>> {
 
     private final Type nestedType;
 

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrPlugin.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrPlugin.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Type;
  *  <li>supports vavr collections via {@link org.jdbi.v3.core.result.ResultBearing#collectInto(Type)} call</li>
  *  <li>supports key-value mappings of a tuple result (implicitly used by map collectors)</li>
  *  <li>supports tuple projection</li>
+ *  <li>supports column mapping for {@link io.vavr.control.Option}</li>
  * </ul>
  */
 public class VavrPlugin implements JdbiPlugin {

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrPlugin.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrPlugin.java
@@ -34,5 +34,6 @@ public class VavrPlugin implements JdbiPlugin {
         jdbi.registerCollector(new VavrCollectorFactory());
         jdbi.registerRowMapper(new VavrTupleRowMapperFactory());
         jdbi.registerArgument(new VavrValueArgumentFactory());
+        jdbi.registerColumnMapper(VavrOptionMapper.factory());
     }
 }

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrTupleRowMapperFactory.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrTupleRowMapperFactory.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 import static org.jdbi.v3.core.generic.GenericTypes.resolveType;
 
-public class VavrTupleRowMapperFactory implements RowMapperFactory {
+class VavrTupleRowMapperFactory implements RowMapperFactory {
 
     @Override
     public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrValueArgumentFactory.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrValueArgumentFactory.java
@@ -34,7 +34,7 @@ import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
  * <p>
  * if there is no such value (Try-Failed, Either-Left...) a "null" value will be applied as argument value
  */
-public class VavrValueArgumentFactory implements ArgumentFactory {
+class VavrValueArgumentFactory implements ArgumentFactory {
 
     @Override
     public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.vavr;
+
+import io.vavr.collection.Set;
+import io.vavr.control.Option;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestVavrOptionMapperWithDB {
+
+    @Rule
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins();
+
+    @Before
+    public void addData() {
+        Handle handle = dbRule.openHandle();
+        handle.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
+        handle.createUpdate("insert into something (id) values (2)").execute();
+    }
+
+    @Test
+    public void testOptionMapped_shouldSucceed() throws SQLException {
+        final Set<Option<String>> result = dbRule.getSharedHandle()
+                .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
+                .createQuery("select name from something")
+                .collectInto(new GenericType<Set<Option<String>>>() {});
+
+        assertThat(result).hasSize(2);
+        assertThat(result).contains(Option.none(), Option.of("eric"));
+    }
+
+    @Test
+    public void testOptionMappedWithinObjectIfPresent_shouldContainValue() throws SQLException {
+        final SomethingWithOption result = dbRule.getSharedHandle()
+                .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
+                .createQuery("select id, name from something where id = 1")
+                .mapTo(SomethingWithOption.class)
+                .findOnly();
+
+        assertThat(result.getName()).isInstanceOf(Option.class);
+        assertThat(result.getName().get()).isEqualToIgnoringCase("eric");
+    }
+
+    @Test
+    public void testOptionWithinObjectIfMissing_shouldBeNone() throws SQLException {
+        final SomethingWithOption result = dbRule.getSharedHandle()
+                .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
+                .createQuery("select id, name from something where id = 2")
+                .mapTo(SomethingWithOption.class)
+                .findOnly();
+
+        assertThat(result.getName()).isInstanceOf(Option.class);
+        assertThat(result.getName().getOrNull()).isNull();
+    }
+
+    public static class SomethingWithOption {
+        private int id;
+        private Option<String> name;
+
+        public SomethingWithOption(int id, Option<String> name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Option<String> getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SomethingWithOption that = (SomethingWithOption) o;
+
+            if (id != that.id) return false;
+            return name != null ? name.equals(that.name) : that.name == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = id;
+            result = 31 * result + (name != null ? name.hashCode() : 0);
+            return result;
+        }
+    }
+
+
+}

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
@@ -55,19 +55,20 @@ public class TestVavrOptionMapperWithDB {
     @Test
     public void testOptionMappedWithoutGenericParameter_shouldFail() throws SQLException {
         assertThatThrownBy(() -> dbRule.getSharedHandle()
+                .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
                 .createQuery("select name from something")
                 .collectInto(new GenericType<Set<Option>>() {}))
-                .isInstanceOf(NoSuchMapperException.class);
+                .isInstanceOf(NoSuchMapperException.class)
+                .hasMessageContaining("raw");
     }
-
 
     @Test
     public void testOptionMappedWithoutNestedMapper_shouldFail() throws SQLException {
         assertThatThrownBy(() -> dbRule.getSharedHandle()
-                .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
                 .createQuery("select id, name from something")
                 .collectInto(new GenericType<Set<Option<SomethingWithOption>>>() {}))
-                .isInstanceOf(NoSuchMapperException.class);
+                .isInstanceOf(NoSuchMapperException.class)
+                .hasMessageContaining("nested");
     }
 
     @Test


### PR DESCRIPTION
using my plugin in real world development I realized that a critical column mapper was missing - the one for `Option`.

this is the code i use to work around that, "inspired" by the builtin OptionalMapper