### PR TITLE
Support '@Nested' in KotlinMapper

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
@@ -14,7 +14,6 @@
 package org.jdbi.v3.core.mapper.reflect;
 
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.findColumnIndex;
-import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNameMatchers;
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNames;
 
 import java.beans.BeanInfo;
@@ -122,7 +121,8 @@ public class BeanMapper<T> implements RowMapper<T>
     @Override
     public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         final List<String> columnNames = getColumnNames(rs);
-        final List<ColumnNameMatcher> columnNameMatchers = getColumnNameMatchers(ctx);
+        final List<ColumnNameMatcher> columnNameMatchers =
+                ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
         final List<String> unmatchedColumns = new ArrayList<>(columnNames);
 
         RowMapper<T> result = specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns);

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -15,7 +15,6 @@ package org.jdbi.v3.core.mapper.reflect;
 
 import static org.jdbi.v3.core.mapper.reflect.JdbiConstructors.findConstructorFor;
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.findColumnIndex;
-import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNameMatchers;
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNames;
 
 import java.beans.ConstructorProperties;
@@ -152,7 +151,8 @@ public class ConstructorMapper<T> implements RowMapper<T>
     @Override
     public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         final List<String> columnNames = getColumnNames(rs);
-        final List<ColumnNameMatcher> columnNameMatchers = getColumnNameMatchers(ctx);
+        final List<ColumnNameMatcher> columnNameMatchers =
+                ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
         final List<String> unmatchedColumns = new ArrayList<>(columnNames);
 
         RowMapper<T> mapper = specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns);

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -14,7 +14,6 @@
 package org.jdbi.v3.core.mapper.reflect;
 
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.findColumnIndex;
-import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNameMatchers;
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNames;
 
 import java.lang.reflect.Field;
@@ -107,7 +106,8 @@ public class FieldMapper<T> implements RowMapper<T>
     @Override
     public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         final List<String> columnNames = getColumnNames(rs);
-        final List<ColumnNameMatcher> columnNameMatchers = getColumnNameMatchers(ctx);
+        final List<ColumnNameMatcher> columnNameMatchers =
+                ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
         final List<String> unmatchedColumns = new ArrayList<>(columnNames);
 
         RowMapper<T> mapper = specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns);

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
@@ -21,9 +21,17 @@ import java.util.List;
 import java.util.OptionalInt;
 import java.util.function.Supplier;
 
-import org.jdbi.v3.core.statement.StatementContext;
-
+/**
+ * Utilities for reflective mappers.
+ */
 public class ReflectionMapperUtil {
+  /**
+   * Returns the name of all the columns present in the specified {@link ResultSet}
+   * @param rs  the {@link ResultSet} to get the column names of
+   * @return list of all the column names in {@code rs} (will contain duplicates if multiple columns have the same name)
+   * @throws SQLException See {@link ResultSet#getMetaData()}, {@link ResultSetMetaData#getColumnCount()},
+   * and {@link ResultSetMetaData#getColumnLabel(int)}
+   */
   public static List<String> getColumnNames(ResultSet rs) throws SQLException {
     final ResultSetMetaData metadata = rs.getMetaData();
     final int count = metadata.getColumnCount();
@@ -36,10 +44,14 @@ public class ReflectionMapperUtil {
     return columnNames;
   }
 
-  public static List<ColumnNameMatcher> getColumnNameMatchers(StatementContext ctx) {
-    return ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
-  }
-
+  /**
+   * Attempts to find the index of a specified column's mapped parameter in a list of column names
+   * @param paramName the name of the parameter to search for
+   * @param columnNames list of column names to search in
+   * @param columnNameMatchers  {@link ColumnNameMatcher}s to map {@code paramName} to the column names
+   * @param debugName name of the parameter to use for debugging purposes (ie: when throwing exceptions)
+   * @return {@link OptionalInt} with the found index, {@link OptionalInt#empty()} otherwise.
+   */
   public static OptionalInt findColumnIndex(String paramName,
                                      List<String> columnNames,
                                      List<ColumnNameMatcher> columnNameMatchers,

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
@@ -23,8 +23,8 @@ import java.util.function.Supplier;
 
 import org.jdbi.v3.core.statement.StatementContext;
 
-class ReflectionMapperUtil {
-  static List<String> getColumnNames(ResultSet rs) throws SQLException {
+public class ReflectionMapperUtil {
+  public static List<String> getColumnNames(ResultSet rs) throws SQLException {
     final ResultSetMetaData metadata = rs.getMetaData();
     final int count = metadata.getColumnCount();
     final List<String> columnNames = new ArrayList<>(count);
@@ -36,11 +36,11 @@ class ReflectionMapperUtil {
     return columnNames;
   }
 
-  static List<ColumnNameMatcher> getColumnNameMatchers(StatementContext ctx) {
+  public static List<ColumnNameMatcher> getColumnNameMatchers(StatementContext ctx) {
     return ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
   }
 
-  static OptionalInt findColumnIndex(String paramName,
+  public static OptionalInt findColumnIndex(String paramName,
                                      List<String> columnNames,
                                      List<ColumnNameMatcher> columnNameMatchers,
                                      Supplier<String> debugName) {

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
@@ -62,7 +62,7 @@ public interface ResultBearing {
 
     /**
      * Invokes the mapper with a result set supplier, and returns the value returned by the mapper.
-     * @param mapper result set mapper
+     * @param mapper result set scanner
      * @param <R> result type returned by the mapper.
      * @return the value returned by the mapper.
      */

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -3384,7 +3384,7 @@ Kotlin API documentation:
 
 ==== ResultSet mapping
 
-The *jdbi3-kotlin* plugin adds ResultSet mapping to Kotlin data classes. It
+The *jdbi3-kotlin* plugin adds mapping to Kotlin data classes. It
 supports data classes where all fields are present in the constructor as well
 as classes with writable properties. Any fields not present in the constructor
 will be set after the constructor call. The mapper supports nullable types. It
@@ -3408,7 +3408,7 @@ Then install the plugin into your `Jdbi` instance:
 jdbi.installPlugin(KotlinPlugin());
 ----
 
-Result set mapper also supports `@ColumnName` annotation that allows to specify
+The Kotlin mapper also supports `@ColumnName` annotation that allows to specify
 name for a property or parameter explicitly, as well as the `@Nested` annotation
 that allows mapping nested Kotlin objects.
 

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -3409,7 +3409,8 @@ jdbi.installPlugin(KotlinPlugin());
 ----
 
 Result set mapper also supports `@ColumnName` annotation that allows to specify
-name for a property or parameter explicitly.
+name for a property or parameter explicitly, as well as the `@Nested` annotation
+that allows mapping nested Kotlin objects.
 
 If you load all Jdbi plugins via `Jdbi.installPlugins()` this plugin will be
 discovered and registered automatically. Otherwise, you can attach it using

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,15 +1,17 @@
-Kotlin ResultSet mapper for Jdbi
+Kotlin RowMapper for Jdbi
 ================================
 
-This plugin adds ResultSet mapping to Kotlin classes anywhere a ResultSet is used.
+This plugin adds mapping to Kotlin classes anywhere a ResultSet is used.
 
-ResultSet mapping supports data classes where all fields are present in the constructor as well as classes with 
-writable properties. Any fields not present in the constructor will be set after the constructor call.
-The mapper supports nullable types.  It also uses default parameter values in 
-the constructor if the parameter type is not nullable and the value absent in the result set.
+It supports data classes where all fields are present in the constructor as well
+as classes with writable properties. Any fields not present in the constructor
+will be set after the constructor call. The mapper supports nullable types. It
+also uses default parameter values in the constructor if the parameter type is
+not nullable and the value absent in the result set.
 
-Result set mapper also supports `@ColumnName` annotation that allows to specify name for a property or parameter explicitly.
-
+The Kotlin mapper also supports the `@ColumnName` annotation that allows to specify
+name for a property or parameter explicitly, as well as the `@Nested` annotation
+that allows mapping nested Kotlin objects.
 
 ### Usage:
 
@@ -19,20 +21,19 @@ Otherwise, you can attach the plugin using `Jdbi.installPlugin(KotlinPlugin())`.
 
 An example from the test class:
 
-```
-    data class Thing(val id: Int, val name: String,
+```kotlin
+    data class IdAndName(val id: Int, val name: String)
+    data class Thing(@Nested val idAndName: IdAndName,
                      val nullable: String?,
                      val nullableDefaultedNull: String? = null,
                      val nullableDefaultedNotNull: String? = "not null",
                      val defaulted: String = "default value")
 
      @Test fun testFindById() {
-    
-            val qry = db.sharedHandle.createQuery("select id, name from something where id = :id")
-            val things: List<Thing> = qry.bind("id", brian.id).mapTo<Thing>().list()
-            assertEquals(1, things.size)
-            assertEquals(brian, things[0])
-    
+        val qry = db.sharedHandle.createQuery("select id, name from something where id = :id")
+        val things: List<Thing> = qry.bind("id", brian.idAndName.id).mapTo<Thing>().list()
+        assertEquals(1, things.size)
+        assertEquals(brian, things[0])
      } 
 ```
 
@@ -45,7 +46,7 @@ Allowing code like:
 
 ```
 val qry = handle.createQuery("select id, name from something where id = :id")
-val things = qry.bind("id", brian.id).mapTo<Thing>.list()
+val things = qry.bind("id", brian.idAndName.id).mapTo<Thing>.list()
 ```
 
 and for using a Sequence that is auto closed:

--- a/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinMapper.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinMapper.kt
@@ -51,7 +51,7 @@ class KotlinMapper(clazz: Class<*>, private val prefix: String = "") : RowMapper
 
     override fun specialize(rs: ResultSet, ctx: StatementContext): RowMapper<Any> {
         val columnNames = getColumnNames(rs)
-        val columnNameMatchers = getColumnNameMatchers(ctx)
+        val columnNameMatchers = ctx.getConfig(ReflectionMappers::class.java).columnNameMatchers
         val unmatchedColumns = columnNames.toMutableSet()
 
         val mapper = specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns)
@@ -117,8 +117,7 @@ class KotlinMapper(clazz: Class<*>, private val prefix: String = "") : RowMapper
                     .orElseThrow({
                         IllegalArgumentException(
                                 "Constructor '${constructor.name}' parameter '$parameterName' has no column in the result set. " +
-                                        "Verify that the Java compiler is configured to emit parameter names, " +
-                                        "that your result set has the columns expected, or annotate the " +
+                                        "Verify that your result set has the columns expected, or annotate the " +
                                         "parameter names explicitly with @ColumnName"
                         )
                     })
@@ -136,8 +135,6 @@ class KotlinMapper(clazz: Class<*>, private val prefix: String = "") : RowMapper
                         unmatchedColumns.remove(columnNames[columnIndex])
                     }
         } else {
-            //TODO: Support for nested non-kotlin types?
-
             val nestedPrefix = prefix + nested.value
 
             nestedMappers
@@ -177,8 +174,6 @@ class KotlinMapper(clazz: Class<*>, private val prefix: String = "") : RowMapper
                         unmatchedColumns.remove(columnNames[columnIndex])
                     }
         } else {
-            //TODO: Support for nested non-kotlin types?
-
             val nestedPrefix = prefix + nested.value
 
             nestedPropertyMappers

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinMapperTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinMapperTest.kt
@@ -60,11 +60,6 @@ class KotlinMapperTest {
         assertThat(result).isEqualTo(expected)
     }
 
-    @Test
-    fun shouldUseSecondOccurrenceOfColumnWhenMultipleColumnsWithSameNameArePresent() {
-        TODO("Pretty sure this test isn't necessary anymore since we're using regular 'findColumnIndex', please confirm")
-    }
-
     data class DataClassWithAnnotatedParameter(val id: Int, @ColumnName("first") val n: String)
 
     @Test

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinMapperTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinMapperTest.kt
@@ -1,169 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jdbi.v3.core.kotlin
 
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
 import org.assertj.core.api.Assertions.assertThat
-import org.jdbi.v3.core.HandleAccess
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.mapper.Nested
 import org.jdbi.v3.core.mapper.reflect.ColumnName
-import org.jdbi.v3.core.statement.StatementContextAccess
+import org.jdbi.v3.core.rule.H2DatabaseRule
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
-import java.sql.ResultSet
-import java.sql.ResultSetMetaData
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
 
 class KotlinMapperTest {
+    @Rule
+    @JvmField
+    val mockitoRule: MockitoRule = MockitoJUnit.rule()
 
+    @Rule
+    @JvmField
+    val dbRule: H2DatabaseRule = H2DatabaseRule().withPlugin(KotlinPlugin())
 
-    val resultSet = mock<ResultSet>()
-    val resultSetMetaData = mock<ResultSetMetaData>()
-    val ctx = StatementContextAccess.createContext(HandleAccess.createHandle())
-
-    private data class DataClassWithOnlyPrimaryConstructor(val id: Int, val name: String)
+    private lateinit var handle: Handle
 
     @Before
-    fun setUpMocks() {
-        whenever(resultSet.metaData).thenReturn(resultSetMetaData)
+    fun setup() {
+        handle = dbRule.sharedHandle
+        handle.execute("CREATE TABLE the_things(id integer, first text)")
+        handle.execute("CREATE TABLE the_other_things(id integer, other text)")
     }
 
-    @Test fun testDataClassWithOnlyPrimaryConstructor() {
+    data class DataClassWithOnlyPrimaryConstructor(val id: Int, val first: String)
 
-        val mapper = KotlinMapper(DataClassWithOnlyPrimaryConstructor::class.java)
-        mockColumns("id", "name")
+    @Test
+    fun testDataClassWithOnlyPrimaryConstructor() {
+        val expected = DataClassWithOnlyPrimaryConstructor(1, "does this work?")
 
-        whenever(resultSet.getInt(1)).thenReturn(1)
-        whenever(resultSet.getString(2)).thenReturn("one")
-        whenever(resultSet.wasNull()).thenReturn(false)
+        handle.createUpdate("INSERT INTO the_things(id, first) VALUES(:id, :first)")
+                .bindBean(expected)
+                .execute()
 
-        val thing = mapper.map(resultSet, ctx)
+        val result = handle.createQuery("SELECT * from the_things")
+                .mapTo<DataClassWithOnlyPrimaryConstructor>()
+                .single()
 
-        assertThat(thing).isEqualToComparingFieldByField(DataClassWithOnlyPrimaryConstructor(1, "one"))
-
+        assertThat(result).isEqualTo(expected)
     }
 
-    @Test fun shouldUseSecondOccurrenceOfColumnWhenMultipleColumnsWithSameNameArePresent() {
-
-        val mapper = KotlinMapper(DataClassWithOnlyPrimaryConstructor::class.java)
-        mockColumns("id", "name", "name")
-
-        whenever(resultSet.getInt(1)).thenReturn(1)
-        whenever(resultSet.getString(2)).thenReturn("one")
-        whenever(resultSet.getString(3)).thenReturn("two")
-        whenever(resultSet.wasNull()).thenReturn(false)
-
-        val thing = mapper.map(resultSet, ctx)
-
-        assertThat(thing).isEqualToComparingFieldByField(DataClassWithOnlyPrimaryConstructor(1, "two"))
-
+    @Test
+    fun shouldUseSecondOccurrenceOfColumnWhenMultipleColumnsWithSameNameArePresent() {
+        TODO("Pretty sure this test isn't necessary anymore since we're using regular 'findColumnIndex', please confirm")
     }
 
-    private data class DataClassWithAnnotatedParameter(val id: Int, @ColumnName("name") val n: String)
+    data class DataClassWithAnnotatedParameter(val id: Int, @ColumnName("first") val n: String)
 
-    @Test fun testDataClassWithAnnotatedParameter() {
+    @Test
+    fun testDataClassWithAnnotatedParameter() {
+        val expected = DataClassWithAnnotatedParameter(1, "does this work?")
 
-        val mapper = KotlinMapper(DataClassWithAnnotatedParameter::class.java)
-        mockColumns("id", "name")
+        handle.createUpdate("INSERT INTO the_things(id, first) VALUES(:id, :first)")
+                .bind("id", expected.id)
+                .bind("first", expected.n)
+                .execute()
 
-        whenever(resultSet.getInt(1)).thenReturn(1)
-        whenever(resultSet.getString(2)).thenReturn("one")
-        whenever(resultSet.wasNull()).thenReturn(false)
+        val result = handle.createQuery("SELECT * from the_things")
+                .mapTo<DataClassWithAnnotatedParameter>()
+                .single()
 
-        val thing = mapper.map(resultSet, ctx)
-
-        assertThat(thing).isEqualToComparingFieldByField(DataClassWithAnnotatedParameter(1, "one"))
-
+        assertThat(result).isEqualTo(expected)
     }
 
+    class ClassWithOnlyPrimaryConstructor(val id: Int, val first: String)
 
-    private class ClassWithOnlyPrimaryConstructor(val id: Int, val name: String)
+    @Test
+    fun testClassWithOnlyPrimaryConstructor() {
+        val expected = ClassWithOnlyPrimaryConstructor(1, "does this work?")
 
-    @Test fun testClassWithOnlyPrimaryConstructor() {
+        handle.createUpdate("INSERT INTO the_things(id, first) VALUES(:id, :first)")
+                .bindBean(expected)
+                .execute()
 
-        val mapper = KotlinMapper(ClassWithOnlyPrimaryConstructor::class.java)
-        mockColumns("id", "name")
+        val result = handle.createQuery("SELECT * from the_things")
+                .mapTo<ClassWithOnlyPrimaryConstructor>()
+                .single()
 
-        whenever(resultSet.getInt(1)).thenReturn(1)
-        whenever(resultSet.getString(2)).thenReturn("one")
-        whenever(resultSet.wasNull()).thenReturn(false)
-
-        val thing = mapper.map(resultSet, ctx)
-
-        assertThat(thing).isEqualToComparingFieldByField(ClassWithOnlyPrimaryConstructor(1, "one"))
-
+        assertThat(result)
+                .extracting("id", "first")
+                .containsExactly(expected.id, expected.first)
     }
 
-
-    private class ClassWithOnlySecondaryConstructor {
+    class ClassWithOnlySecondaryConstructor {
         val id: Int
-        val name: String
+        val first: String
 
-        constructor(id: Int, name: String) {
+        constructor(id: Int, first: String) {
             this.id = id
-            this.name = name
+            this.first = first
         }
     }
 
-    @Test fun testClassWithOnlySecondaryConstructor() {
+    @Test
+    fun testClassWithOnlySecondaryConstructor() {
+        val expected = ClassWithOnlySecondaryConstructor(1, "does this work?")
 
-        val mapper = KotlinMapper(ClassWithOnlySecondaryConstructor::class.java)
-        mockColumns("id", "name")
+        handle.createUpdate("INSERT INTO the_things(id, first) VALUES(:id, :first)")
+                .bindBean(expected)
+                .execute()
 
-        whenever(resultSet.getInt(1)).thenReturn(1)
-        whenever(resultSet.getString(2)).thenReturn("one")
-        whenever(resultSet.wasNull()).thenReturn(false)
+        val result = handle.createQuery("SELECT * from the_things")
+                .mapTo<ClassWithOnlySecondaryConstructor>()
+                .single()
 
-        val thing = mapper.map(resultSet, ctx)
-
-        assertThat(thing).isEqualToComparingFieldByField(ClassWithOnlySecondaryConstructor(1, "one"))
-
+        assertThat(result)
+                .extracting("id", "first")
+                .containsExactly(expected.id, expected.first)
     }
 
-    private class ClassWithWritableProperty(val id: Int, val name: String) {
-        var foo: String = "foo"
+    class ClassWithWritableProperty(val id: Int) {
+        lateinit var first: String
     }
 
-    @Test fun testClassWithWritableProperty() {
+    @Test
+    fun testClassWithWritableProperty() {
+        val expected = ClassWithWritableProperty(1)
+        expected.first = "does this work?"
 
-        val mapper = KotlinMapper(ClassWithWritableProperty::class.java)
-        mockColumns("id", "name", "foo")
+        handle.createUpdate("INSERT INTO the_things(id, first) VALUES(:id, :first)")
+                .bindBean(expected)
+                .execute()
 
-        whenever(resultSet.getInt(1)).thenReturn(1)
-        whenever(resultSet.getString(2)).thenReturn("one")
-        whenever(resultSet.getString(3)).thenReturn("bar")
-        whenever(resultSet.wasNull()).thenReturn(false)
+        val result = handle.createQuery("SELECT * from the_things")
+                .mapTo<ClassWithWritableProperty>()
+                .single()
 
-        val thing = mapper.map(resultSet, ctx)
-
-        assertThat(thing).isEqualToComparingFieldByField(ClassWithWritableProperty(1, "one").apply { foo = "bar" })
-
+        assertThat(result)
+                .extracting("id", "first")
+                .containsExactly(expected.id, expected.first)
     }
 
-    private class ClassWithAnnotatedWritableProperty(val id: Int, val name: String) {
-        @ColumnName("description")
-        var foo: String = "foo"
+    class ClassWithAnnotatedWritableProperty(val id: Int) {
+        @ColumnName("first")
+        lateinit var foo: String
     }
 
-    @Test fun testClassWithAnnotatedWritableProperty() {
+    @Test
+    fun testClassWithAnnotatedWritableProperty() {
+        val expected = ClassWithAnnotatedWritableProperty(1)
+        expected.foo = "does this work?"
 
-        val mapper = KotlinMapper(ClassWithAnnotatedWritableProperty::class.java)
-        mockColumns("id", "name", "description")
+        handle.createUpdate("INSERT INTO the_things(id, first) VALUES(:id, :first)")
+                .bind("id", expected.id)
+                .bind("first", expected.foo)
+                .execute()
 
-        whenever(resultSet.getInt(1)).thenReturn(1)
-        whenever(resultSet.getString(2)).thenReturn("one")
-        whenever(resultSet.getString(3)).thenReturn("bar")
-        whenever(resultSet.wasNull()).thenReturn(false)
+        val result = handle.createQuery("SELECT * from the_things")
+                .mapTo<ClassWithAnnotatedWritableProperty>()
+                .single()
 
-        val thing = mapper.map(resultSet, ctx)
-
-        assertThat(thing).isEqualToComparingFieldByField(ClassWithAnnotatedWritableProperty(1, "one").apply { foo = "bar" })
-
+        assertThat(result)
+                .extracting("id", "foo")
+                .containsExactly(expected.id, expected.foo)
     }
 
-    private fun mockColumns(vararg columns: String) {
-        whenever(resultSetMetaData.columnCount).thenReturn(columns.size)
-        for (i in columns.indices) {
-            whenever(resultSetMetaData.getColumnLabel(i + 1)).thenReturn(columns[i])
-            whenever(resultSet.findColumn(columns[i])).thenReturn(i + 1)
+    private data class TheNestedDataClass(val other: String)
+    private data class TheDataClass(val first: String, @Nested("nested_") val nested: TheNestedDataClass)
+
+    @Test
+    fun testDataClassWithNestedConstructorParameter() {
+        val expected = TheDataClass("something", TheNestedDataClass("something else"))
+
+        handle.createUpdate("INSERT INTO the_things(id, first) VALUES(1, :value)")
+                .bind("value", expected.first)
+                .execute()
+        handle.createUpdate("INSERT INTO the_other_things(id, other) VALUES(1, :other)")
+                .bind("other", expected.nested.other)
+                .execute()
+
+        val result = handle
+                .createQuery("SELECT a.first AS first, b.other AS nested_other FROM the_things a JOIN the_other_things b ON a.id = b.id")
+                .mapTo<TheDataClass>()
+                .single()
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    private class TheNestedClass() {
+        lateinit var other: String
+
+        constructor(other: String) : this() {
+            this.other = other
         }
     }
 
+    private class TheClass() {
+        @Nested("nested_")
+        lateinit var nested: TheNestedClass
+        lateinit var first: String
+
+        constructor(first: String, nested: TheNestedClass) : this() {
+            this.first = first
+            this.nested = nested
+        }
+    }
+
+    @Test
+    fun testClassWithNestedMemberProperty() {
+        val expected = TheClass("something", TheNestedClass("something else"))
+
+        handle.createUpdate("INSERT INTO the_things(id, first) VALUES(1, :value)")
+                .bind("value", expected.first)
+                .execute()
+        handle.createUpdate("INSERT INTO the_other_things(id, other) VALUES(1, :other)")
+                .bind("other", expected.nested.other)
+                .execute()
+
+        val result = handle
+                .createQuery("SELECT a.first AS first, b.other AS nested_other FROM the_things a JOIN the_other_things b ON a.id = b.id")
+                .mapTo<TheClass>()
+                .single()
+
+        assertThat(result)
+                .extracting("first", "nested.other")
+                .containsExactly(expected.first, expected.nested.other)
+    }
 }

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinPluginTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinPluginTest.kt
@@ -49,16 +49,6 @@ class KotlinPluginTest {
 
     }
 
-    @Test fun mapperShouldUseSecondColumnIfMultipleColumnsReturnedByResultSet() {
-
-        //finds records where name contains a given string, highlight matched substring using markdown syntax
-        val qry = db.sharedHandle.createQuery("select *, REGEXP_REPLACE(name, '(' || :match || ')', '*\$1*') as name from something where name  regexp :match")
-        val things: List<Thing> = qry.bind("match", "ria").mapTo<Thing>().list()
-        assertEquals(1, things.size)
-        assertEquals("B*ria*n", things.first().name)
-
-    }
-
     @Test fun testFindByIdWithNulls() {
 
         val qry = db.sharedHandle.createQuery(


### PR DESCRIPTION
Rewrote KotlinMapper to work like a combined 'ConstructorMapper' and
'BeanMapper' (as it's what it's doing anyway). This also adds support
for '@Nested' annotations in Kotlin.

Still a work in progress so don't merge right away, just creating the PR to get some feedback.

TODO:
- [x] Re-add support for nullable constructor parameters
- [x] ~Add support for nested non-kotlin classes?~
- [x] I'm pretty sure the 'shouldUseSecondOccurrenceOfColumnWhenMultipleColumnsWithSameNameArePresent' test isn't required anymore (as I'm using the reguler "findColumnIndex" used by other reflective mappers), can you guys confirm?