### PR TITLE
WIP draft of JdbiTemplate based plugin

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -3589,7 +3589,9 @@ public interface UserDao {
 === Spring
 
 This module provides `JdbiFactoryBean`, a factory bean which sets up a `Jdbi`
-singleton.
+singleton. Furthermore a `JdbiOperations` interface is provided together with
+a `JdbiTemplate` class following Spring's `*Operations` <- `*Template` pattern.
+The latter is the prefered way to set up Jdbi in Java config as seen below.
 
 To use this module, add a Maven dependency:
 
@@ -3707,6 +3709,33 @@ Global defined attributes may be configured on the factory bean:
   </property>
 </bean>
 ----
+
+==== Java Config
+
+If you want a fast setup similar to Spring's JdbcTemplate you can use the following:
+
+[source,java]
+----
+@Configuration
+@EnableTransactionManagement
+public class Config {
+
+    ...
+
+    @Bean
+    public Jdbi jdbi(DataSource dataSource) {
+        return Jdbi.create(dataSource);
+    }
+
+    @Bean
+    public JdbiOperations jdbiOperations(Jdbi jdbi) {
+        return new JdbiTemplate(jdbi);
+    }
+}
+----
+
+Now `JdbiOperations` or `JdbiTemplate` can be injected and are ready to use
+with `@Transactional`.
 
 === StringTemplate 4
 

--- a/spring4/src/main/java/org/jdbi/v3/spring4/HandleHolder.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/HandleHolder.java
@@ -14,17 +14,23 @@
 package org.jdbi.v3.spring4;
 
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.springframework.transaction.support.ResourceHolderSupport;
 
 public class HandleHolder extends ResourceHolderSupport {
 
     private final Handle handle;
 
+    private TransactionIsolationLevel transactionLevelForRelease;
+
     public HandleHolder(Handle handle) {
         this.handle = handle;
     }
 
     public void release() {
+        if (transactionLevelForRelease != null) {
+            handle.setTransactionIsolation(transactionLevelForRelease);
+        }
         handle.close();
     }
 
@@ -34,5 +40,9 @@ public class HandleHolder extends ResourceHolderSupport {
 
     public boolean isTransactionActive() {
         return handle.isInTransaction();
+    }
+
+    public void setTransactionLevelForRelease(TransactionIsolationLevel transactionLevelForRelease) {
+        this.transactionLevelForRelease = transactionLevelForRelease;
     }
 }

--- a/spring4/src/main/java/org/jdbi/v3/spring4/HandleHolder.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/HandleHolder.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.spring4;
+
+import org.jdbi.v3.core.Handle;
+import org.springframework.transaction.support.ResourceHolderSupport;
+
+public class HandleHolder extends ResourceHolderSupport {
+
+    private final Handle handle;
+
+    public HandleHolder(Handle handle) {
+        this.handle = handle;
+    }
+
+    public void release() {
+        handle.close();
+    }
+
+    public Handle getHandle() {
+        return handle;
+    }
+
+    public boolean isTransactionActive() {
+        return handle.isInTransaction();
+    }
+}

--- a/spring4/src/main/java/org/jdbi/v3/spring4/HandleHolderSynchronization.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/HandleHolderSynchronization.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.spring4;
+
+import org.jdbi.v3.core.Jdbi;
+import org.springframework.transaction.support.ResourceHolderSynchronization;
+
+public class HandleHolderSynchronization extends ResourceHolderSynchronization<HandleHolder, Jdbi> {
+
+    public HandleHolderSynchronization(HandleHolder handleHolder, Jdbi resourceKey) {
+        super(handleHolder, resourceKey);
+    }
+
+    @Override
+    protected void releaseResource(HandleHolder handleHolder, Jdbi resourceKey) {
+        handleHolder.release();
+    }
+
+    @Override
+    protected boolean shouldReleaseBeforeCompletion() {
+        return false;
+    }
+
+}

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiOperations.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiOperations.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.spring4;
+
+import org.jdbi.v3.core.HandleCallback;
+import org.jdbi.v3.core.HandleConsumer;
+import org.jdbi.v3.core.Jdbi;
+
+/**
+ * similar to {@link JdbiOperations} this class defines the basic Jdbi operations that should be used in a Spring environment.
+ * <p>
+ * implemented by {@link JdbiTemplate}
+ */
+public interface JdbiOperations {
+
+    /**
+     * like {@link Jdbi#withHandle(HandleCallback)} but respects springs transactions
+     */
+    <R, X extends Exception> R withHandle(HandleCallback<R, X> callback) throws X;
+
+    /**
+     * like {@link Jdbi#useHandle(HandleConsumer)} but respects springs transactions
+     */
+    default <X extends Exception> void useHandle(HandleConsumer<X> callback) throws X {
+        withHandle(h -> {
+            callback.useHandle(h);
+            return null;
+        });
+    }
+
+}

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTemplate.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTemplate.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.spring4;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.HandleCallback;
+import org.jdbi.v3.core.Jdbi;
+
+/**
+ * Spring template for querying with Jdbi. This class is transaction aware and respects spring's
+ * {@link org.springframework.transaction.annotation.Transactional}
+ */
+public class JdbiTemplate implements JdbiOperations {
+
+    private final Jdbi jdbi;
+
+    public JdbiTemplate(Jdbi jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    /**
+     * like {@link Jdbi#withHandle(HandleCallback)} but respects springs transactions
+     */
+    @Override
+    public <R, X extends Exception> R withHandle(HandleCallback<R, X> callback) throws X {
+        Handle h = JdbiUtil.getHandle(jdbi);
+        R result = callback.withHandle(h);
+        // close if not in transaction
+        JdbiUtil.closeIfNeeded(h);
+        return result;
+    }
+
+    /**
+     * @return the underlying Jdbi instance
+     */
+    public Jdbi getJdbi() {
+        return jdbi;
+    }
+}

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTemplate.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTemplate.java
@@ -35,10 +35,11 @@ public class JdbiTemplate implements JdbiOperations {
     @Override
     public <R, X extends Exception> R withHandle(HandleCallback<R, X> callback) throws X {
         Handle h = JdbiUtil.getHandle(jdbi);
-        R result = callback.withHandle(h);
-        // close if not in transaction
-        JdbiUtil.closeIfNeeded(h);
-        return result;
+        try {
+            return callback.withHandle(h);
+        } finally {
+            JdbiUtil.closeIfNeeded(h);
+        }
     }
 
     /**

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTransactionManager.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTransactionManager.java
@@ -54,7 +54,7 @@ public class JdbiTransactionManager extends AbstractPlatformTransactionManager
 
     @Override
     protected boolean isExistingTransaction(Object transaction) throws TransactionException {
-        final HandleHolder resource = getBoundResource();
+        final HandleHolder resource = ((JdbiTransactionObject) transaction).getHandleHolder();
         return resource != null && resource.isTransactionActive();
     }
 
@@ -138,6 +138,12 @@ public class JdbiTransactionManager extends AbstractPlatformTransactionManager
         } catch (org.jdbi.v3.core.transaction.TransactionException ex) {
             throw new TransactionSystemException("Could not roll back Jdbi transaction", ex);
         }
+    }
+
+    @Override
+    protected void doSetRollbackOnly(DefaultTransactionStatus status) throws TransactionException {
+        JdbiTransactionObject transaction = (JdbiTransactionObject) status.getTransaction();
+        transaction.getHandleHolder().setRollbackOnly();
     }
 
     @Override

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTransactionManager.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTransactionManager.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.spring4;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
@@ -74,10 +75,12 @@ public class JdbiTransactionManager extends AbstractPlatformTransactionManager
 
             handleHolder.setSynchronizedWithTransaction(true);
             handle = handleHolder.getHandle();
+            TransactionIsolationLevel currentIsolationLevel = handle.getTransactionIsolationLevel();
 
             handle.begin();
 
             if (definition.getIsolationLevel() != TransactionDefinition.ISOLATION_DEFAULT) {
+                handleHolder.setTransactionLevelForRelease(currentIsolationLevel);
                 handle.setTransactionIsolation(definition.getIsolationLevel());
             }
 

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTransactionManager.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTransactionManager.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.spring4;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.springframework.transaction.CannotCreateTransactionException;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+import org.springframework.transaction.support.ResourceTransactionManager;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * {@link org.springframework.transaction.PlatformTransactionManager}
+ * implementation for Jdbi. Instead of Datasource/Connections this implementation
+ * operated directly on Jdbi-native concepts such as {@link Jdbi} and {@link Handle}
+ */
+public class JdbiTransactionManager extends AbstractPlatformTransactionManager
+        implements ResourceTransactionManager {
+
+    // transient and serialUID to make findbugs happy
+    private static final long serialVersionUID = 1L;
+    private final transient Jdbi jdbi;
+
+    public JdbiTransactionManager(Jdbi jdbi) {
+        this.jdbi = jdbi;
+        this.setNestedTransactionAllowed(true);
+    }
+
+    @Override
+    protected Object doGetTransaction() throws TransactionException {
+        final HandleHolder resource = getBoundResource();
+        return new JdbiTransactionObject(resource);
+    }
+
+    private HandleHolder getBoundResource() {
+        return (HandleHolder) TransactionSynchronizationManager.getResource(this.jdbi);
+    }
+
+    @Override
+    protected boolean isExistingTransaction(Object transaction) throws TransactionException {
+        final HandleHolder resource = getBoundResource();
+        return resource != null && resource.isTransactionActive();
+    }
+
+    @Override
+    protected void doBegin(Object transaction, TransactionDefinition definition) throws TransactionException {
+        JdbiTransactionObject txObject = (JdbiTransactionObject) transaction;
+
+        HandleHolder handleHolder = txObject.getHandleHolder();
+        Handle handle = null;
+        boolean openedNew = false;
+
+        try {
+            if (handleHolder == null) {
+                Handle opened = jdbi.open();
+                handleHolder = new HandleHolder(opened);
+                openedNew = true;
+            }
+
+            handleHolder.setSynchronizedWithTransaction(true);
+            handle = handleHolder.getHandle();
+
+            handle.begin();
+
+            if (definition.getIsolationLevel() != TransactionDefinition.ISOLATION_DEFAULT) {
+                handle.setTransactionIsolation(definition.getIsolationLevel());
+            }
+
+            int timeout = determineTimeout(definition);
+            if (timeout != TransactionDefinition.TIMEOUT_DEFAULT) {
+                handleHolder.setTimeoutInSeconds(timeout);
+            }
+
+            txObject.setHandleHolder(handleHolder);
+
+            if (openedNew) {
+                TransactionSynchronizationManager.bindResource(jdbi, handleHolder);
+            }
+        } catch (Throwable ex) {
+            if (openedNew && handle != null) {
+                handle.close();
+                txObject.setHandleHolder(null);
+                if (TransactionSynchronizationManager.hasResource(jdbi)) {
+                    TransactionSynchronizationManager.unbindResource(jdbi);
+                }
+            }
+            throw new CannotCreateTransactionException("Could not open Jdbi Connection for transaction", ex);
+        }
+    }
+
+    @Override
+    protected void prepareSynchronization(DefaultTransactionStatus status, TransactionDefinition definition) {
+        super.prepareSynchronization(status, definition);
+
+        if (status.isNewSynchronization()) {
+            HandleHolder holder = getBoundResource();
+            TransactionSynchronizationManager.registerSynchronization(new HandleHolderSynchronization(holder, jdbi));
+        }
+    }
+
+    @Override
+    protected void doCommit(DefaultTransactionStatus status) {
+        JdbiTransactionObject txObject = (JdbiTransactionObject) status.getTransaction();
+        Handle h = txObject.getHandleHolder().getHandle();
+
+        try {
+            h.commit();
+        } catch (org.jdbi.v3.core.transaction.TransactionException ex) {
+            throw new TransactionSystemException("Could not commit Jdbi transaction", ex);
+        }
+    }
+
+    @Override
+    protected void doRollback(DefaultTransactionStatus status) {
+        JdbiTransactionObject txObject = (JdbiTransactionObject) status.getTransaction();
+        Handle h = txObject.getHandleHolder().getHandle();
+
+        try {
+            h.rollback();
+        } catch (org.jdbi.v3.core.transaction.TransactionException ex) {
+            throw new TransactionSystemException("Could not roll back Jdbi transaction", ex);
+        }
+    }
+
+    @Override
+    public Object getResourceFactory() {
+        return jdbi;
+    }
+
+    @Override
+    protected Object doSuspend(Object transaction) {
+        JdbiTransactionObject txObject = (JdbiTransactionObject) transaction;
+        final HandleHolder suspendedHolder = txObject.getHandleHolder();
+        txObject.setHandleHolder(null);
+        return suspendedHolder;
+    }
+
+    @Override
+    protected void doResume(Object transaction, Object suspendedResources) {
+        JdbiTransactionObject txObject = (JdbiTransactionObject) transaction;
+        txObject.setHandleHolder((HandleHolder) suspendedResources);
+    }
+}

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTransactionObject.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiTransactionObject.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.spring4;
+
+import org.springframework.transaction.CannotCreateTransactionException;
+import org.springframework.transaction.SavepointManager;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionSystemException;
+
+/**
+ * savepoint capable jdbi transaction wrapper
+ */
+public class JdbiTransactionObject implements SavepointManager {
+
+    private static final String JDBI_SAVEPOINT_BASENAME = "JDBI_SAVEPOINT_";
+
+    private int nextSavePointNumber = 0;
+    private HandleHolder handleHolder;
+
+    public JdbiTransactionObject(HandleHolder handleHolder) {
+        this.handleHolder = handleHolder;
+    }
+
+    @Override
+    public Object createSavepoint() throws TransactionException {
+        String savePointName = JDBI_SAVEPOINT_BASENAME + nextSavePointNumber++;
+        try {
+            handleHolder.getHandle().savepoint(savePointName);
+        } catch (org.jdbi.v3.core.transaction.TransactionException ex) {
+            throw new CannotCreateTransactionException("savepoint could not be created", ex);
+        }
+
+        return savePointName;
+    }
+
+    @Override
+    public void rollbackToSavepoint(Object savepoint) throws TransactionException {
+        if (!(savepoint instanceof String)) {
+            throw new IllegalArgumentException("unhandleable savepoint: " + savepoint);
+        }
+
+        try {
+            handleHolder.getHandle().rollbackToSavepoint((String) savepoint);
+        } catch (org.jdbi.v3.core.transaction.TransactionException ex) {
+            throw new TransactionSystemException("savepoint could be rolled back", ex);
+        }
+    }
+
+    @Override
+    public void releaseSavepoint(Object savepoint) throws TransactionException {
+        if (!(savepoint instanceof String)) {
+            throw new IllegalArgumentException("unhandleable savepoint: " + savepoint);
+        }
+
+        try {
+            handleHolder.getHandle().release((String) savepoint);
+        } catch (org.jdbi.v3.core.transaction.TransactionException ex) {
+            // no-op since {@link org.springframework.transaction.support.AbstractTransactionStatus#rollbackToHeldSavepoint}
+            // releases immediately after rollback -> jdbi throws exception
+            // see org.springframework.jdbc.datasource.JdbcTransactionObjectSupport#releaseSavepoint
+        }
+    }
+
+    public HandleHolder getHandleHolder() {
+        return handleHolder;
+    }
+
+    public void setHandleHolder(HandleHolder handleHolder) {
+        this.handleHolder = handleHolder;
+    }
+}

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiUtil.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiUtil.java
@@ -55,7 +55,11 @@ public class JdbiUtil
     {
         if (UNMANAGED_HANDLES.contains(handle))
         {
-            handle.close();
+            try {
+                handle.close();
+            } finally {
+                UNMANAGED_HANDLES.remove(handle);
+            }
         }
     }
 }

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiUtil.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiUtil.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.spring4;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Utility for working with Jdbi and Spring transaction bound resources
@@ -85,6 +85,7 @@ public class JdbiUtil
         @Override
         public void beforeCompletion()
         {
+            handle.close();
             TRANSACTIONAL_HANDLES.remove(handle);
             TransactionSynchronizationManager.unbindResource(db);
         }

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiUtil.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiUtil.java
@@ -85,9 +85,13 @@ public class JdbiUtil
         @Override
         public void beforeCompletion()
         {
-            handle.close();
             TRANSACTIONAL_HANDLES.remove(handle);
             TransactionSynchronizationManager.unbindResource(db);
+        }
+
+        @Override
+        public void afterCompletion(int status) {
+            handle.close();
         }
     }
 }

--- a/spring4/src/test/java/org/jdbi/v3/spring4/TemplateUsingService.java
+++ b/spring4/src/test/java/org/jdbi/v3/spring4/TemplateUsingService.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.spring4;
+
+import org.jdbi.v3.core.HandleConsumer;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+public class TemplateUsingService {
+    private final JdbiOperations jdbiOperations;
+
+    public TemplateUsingService(JdbiOperations jdbiOperations) {
+        this.jdbiOperations = jdbiOperations;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void inPropagationRequired(HandleConsumer<?> fn) throws Exception {
+        jdbiOperations.useHandle(fn);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void inRequiresNew(HandleConsumer<?> fn) throws Exception {
+        jdbiOperations.useHandle(fn);
+    }
+
+    @Transactional(propagation = Propagation.NESTED)
+    public void inNested(HandleConsumer<?> fn) throws Exception {
+        jdbiOperations.useHandle(fn);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_UNCOMMITTED)
+    public void inRequiresNewReadUncommitted(HandleConsumer<?> fn) throws Exception {
+        jdbiOperations.useHandle(fn);
+    }
+
+}

--- a/spring4/src/test/java/org/jdbi/v3/spring4/TestJdbiTemplate.java
+++ b/spring4/src/test/java/org/jdbi/v3/spring4/TestJdbiTemplate.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.spring4;
+
+import org.jdbi.v3.core.Jdbi;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {TestJdbiTemplate.Config.class})
+public class TestJdbiTemplate {
+
+    @Autowired
+    private JdbiOperations jdbiOps;
+
+    @Test
+    public void testJdbiOps() {
+        assertThat(jdbiOps).isNotNull().isInstanceOf(JdbiTemplate.class);
+    }
+
+    @Configuration
+    @EnableTransactionManagement
+    public static class Config {
+
+        @Bean
+        public DataSource dataSource() {
+            return new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2).build();
+        }
+
+        @Bean
+        public Jdbi jdbi(DataSource dataSource) {
+            return Jdbi.create(dataSource);
+        }
+
+        @Bean
+        public JdbiOperations jdbiOperations(Jdbi jdbi) {
+            return new JdbiTemplate(jdbi);
+        }
+
+    }
+}


### PR DESCRIPTION
This PR addresses #983 but also #987 

The idea is to follow springs conventions as closely as possible and expose a narrow interface that, similar to springs JdbcOperations, solely relies on the framework for transaction management.

If this draft is approved I will add tests and better documentation.

Also it can be considered to make `JdbiUtil` non-public.

Furthermore I was thinking of supporting spring boot which uses a lot more classpath magic to even avoid writing java config