### PR TITLE
Add row reducers

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/result/LinkedHashMapRowReducer.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/LinkedHashMapRowReducer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.result;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+/**
+ * A row reducer that uses {@link LinkedHashMap} (which preserves insertion order) as an
+ * accumulator, and returns {@code map.values().stream()} as the final result.
+ *
+ * <p>Implementors need only implement the {@link #accumulate(Object, RowView)} method.
+ *
+ * @param <K> the map key type--often the primary key type of {@code <V>}.
+ * @param <V> the map value type, and the result element type--often the "master" object in a
+ *     master/detail relation.
+ */
+public abstract class LinkedHashMapRowReducer<K, V> implements RowReducer<Map<K, V>, V> {
+  @Override
+  public Map<K, V> createAccumulator() {
+    return new LinkedHashMap<>();
+  }
+
+  @Override
+  public Stream<V> stream(Map<K, V> accumulator) {
+    return accumulator.values().stream();
+  }
+
+  public static <K, V> RowReducer<Map<K, V>, V> of(BiConsumer<Map<K, V>, RowView> acc) {
+    return new LinkedHashMapRowReducer<K, V>() {
+      @Override
+      public void accumulate(Map<K, V> accumulator, RowView rowView) {
+        acc.accept(accumulator, rowView);
+      }
+    };
+  }
+}

--- a/core/src/main/java/org/jdbi/v3/core/result/LinkedHashMapRowReducer.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/LinkedHashMapRowReducer.java
@@ -15,7 +15,6 @@ package org.jdbi.v3.core.result;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 /**
@@ -26,25 +25,17 @@ import java.util.stream.Stream;
  *
  * @param <K> the map key type--often the primary key type of {@code <V>}.
  * @param <V> the map value type, and the result element type--often the "master" object in a
- *     master/detail relation.
+ *            master/detail relation.
  */
-public abstract class LinkedHashMapRowReducer<K, V> implements RowReducer<Map<K, V>, V> {
-  @Override
-  public Map<K, V> container() {
-    return new LinkedHashMap<>();
-  }
+@FunctionalInterface
+public interface LinkedHashMapRowReducer<K, V> extends RowReducer<Map<K, V>, V> {
+    @Override
+    default Map<K, V> container() {
+        return new LinkedHashMap<>();
+    }
 
-  @Override
-  public Stream<V> stream(Map<K, V> container) {
-    return container.values().stream();
-  }
-
-  public static <K, V> RowReducer<?, V> of(BiConsumer<Map<K, V>, RowView> accumulator) {
-    return new LinkedHashMapRowReducer<K, V>() {
-      @Override
-      public void accumulate(Map<K, V> map, RowView rowView) {
-        accumulator.accept(map, rowView);
-      }
-    };
-  }
+    @Override
+    default Stream<V> stream(Map<K, V> container) {
+        return container.values().stream();
+    }
 }

--- a/core/src/main/java/org/jdbi/v3/core/result/LinkedHashMapRowReducer.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/LinkedHashMapRowReducer.java
@@ -19,8 +19,8 @@ import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 /**
- * A row reducer that uses {@link LinkedHashMap} (which preserves insertion order) as an
- * accumulator, and returns {@code map.values().stream()} as the final result.
+ * A row reducer that uses {@link LinkedHashMap} (which preserves insertion order) as a
+ * result container, and returns {@code map.values().stream()} as the final result.
  *
  * <p>Implementors need only implement the {@link #accumulate(Object, RowView)} method.
  *
@@ -30,20 +30,20 @@ import java.util.stream.Stream;
  */
 public abstract class LinkedHashMapRowReducer<K, V> implements RowReducer<Map<K, V>, V> {
   @Override
-  public Map<K, V> createAccumulator() {
+  public Map<K, V> container() {
     return new LinkedHashMap<>();
   }
 
   @Override
-  public Stream<V> stream(Map<K, V> accumulator) {
-    return accumulator.values().stream();
+  public Stream<V> stream(Map<K, V> container) {
+    return container.values().stream();
   }
 
-  public static <K, V> RowReducer<Map<K, V>, V> of(BiConsumer<Map<K, V>, RowView> acc) {
+  public static <K, V> RowReducer<?, V> of(BiConsumer<Map<K, V>, RowView> accumulator) {
     return new LinkedHashMapRowReducer<K, V>() {
       @Override
-      public void accumulate(Map<K, V> accumulator, RowView rowView) {
-        acc.accept(accumulator, rowView);
+      public void accumulate(Map<K, V> map, RowView rowView) {
+        accumulator.accept(map, rowView);
       }
     };
   }

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
@@ -193,6 +193,21 @@ public interface ResultBearing {
     }
 
     /**
+     * Reduce the result rows using a {@link Map Map&lt;K, V&gt;} as the
+     * result container.
+     *
+     * @param accumulator accumulator function which gathers data from each
+     *                    {@link RowView} into the result map.
+     * @param <K>         map key type
+     * @param <V>         map value type
+     * @return the stream of elements in the container's {@link Map#values()}
+     *         collection, in the order they were inserted.
+     */
+    default <K, V> Stream<V> reduceRows(BiConsumer<Map<K, V>, RowView> accumulator) {
+        return reduceRows((LinkedHashMapRowReducer<K, V>) accumulator::accept);
+    }
+
+    /**
      * Reduce the results.  Using a {@code BiFunction<U, RowView, U>}, repeatedly
      * combine query results until only a single value remains.
      *

--- a/core/src/main/java/org/jdbi/v3/core/result/RowReducer.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/RowReducer.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.result;
+
+import java.util.stream.Stream;
+
+/**
+ * Reduces row data from a {@link java.sql.ResultSet} into a stream of result
+ * elements. Useful for collapsing one-to-many joins.
+ *
+ * @param <A> the mutable accumulator type
+ * @param <R> result element type
+ * @see ResultBearing#reduceRows(RowReducer)
+ */
+public interface RowReducer<A, R> {
+  /**
+   * Returns a new accumulator in a "blank" state.
+   *
+   * @return a new accumulator.
+   */
+  A createAccumulator();
+
+  /**
+   * Folds the current row data into the accumulator.
+   *
+   * @param accumulator the accumulator
+   * @param rowView row view of the current row of the result set
+   */
+  void accumulate(A accumulator, RowView rowView);
+
+  /**
+   * Returns the final result from the accumulator as a stream of elements.
+   *
+   * @param accumulator the accumulator
+   * @return stream of result elements.
+   */
+  Stream<R> stream(A accumulator);
+}

--- a/core/src/main/java/org/jdbi/v3/core/result/RowReducer.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/RowReducer.java
@@ -19,31 +19,36 @@ import java.util.stream.Stream;
  * Reduces row data from a {@link java.sql.ResultSet} into a stream of result
  * elements. Useful for collapsing one-to-many joins.
  *
- * @param <A> the mutable accumulator type
+ * @param <C> mutable result container type
  * @param <R> result element type
  * @see ResultBearing#reduceRows(RowReducer)
  */
-public interface RowReducer<A, R> {
+public interface RowReducer<C, R> {
   /**
-   * Returns a new accumulator in a "blank" state.
+   * Returns a new, empty result container.
    *
-   * @return a new accumulator.
+   * @return a new result container.
    */
-  A createAccumulator();
+  C container();
 
   /**
-   * Folds the current row data into the accumulator.
+   * Accumulate data from the current row into the result container. Do not attempt
+   * to accumulate the {@link RowView} itself into the result container--it is only
+   * valid within the {@link RowReducer#accumulate(Object, RowView) accumulate()}
+   * method invocation. Instead, extract mapped types from the RowView by calling
+   * {@code RowView.getRow()} or {@code RowView.getColumn()} and store those values
+   * in the container.
    *
-   * @param accumulator the accumulator
-   * @param rowView row view of the current row of the result set
+   * @param container the result container
+   * @param rowView row view over the current result set row.
    */
-  void accumulate(A accumulator, RowView rowView);
+  void accumulate(C container, RowView rowView);
 
   /**
-   * Returns the final result from the accumulator as a stream of elements.
+   * Returns a stream of result elements from the result container.
    *
-   * @param accumulator the accumulator
+   * @param container the result container
    * @return stream of result elements.
    */
-  Stream<R> stream(A accumulator);
+  Stream<R> stream(C container);
 }

--- a/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
@@ -13,8 +13,8 @@
  */
 package org.jdbi.v3.core.result;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -91,11 +91,11 @@ public class TestReducing
     public void testReduceRows() {
         List<SomethingWithLocations> result = dbRule.getSharedHandle()
             .createQuery("SELECT something.id, name, location FROM something NATURAL JOIN something_location")
-            .reduceRows(LinkedHashMapRowReducer.<Integer, SomethingWithLocations>of((map, rv) ->
+            .<Integer, SomethingWithLocations>reduceRows((map, rv) ->
                 map.computeIfAbsent(rv.getColumn("id", Integer.class),
                                     id -> new SomethingWithLocations(rv.getRow(Something.class)))
                    .locations
-                   .add(rv.getColumn("location", String.class))))
+                   .add(rv.getColumn("location", String.class)))
             .collect(toList());
 
         assertThat(result).containsExactly(

--- a/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
@@ -14,11 +14,14 @@
 package org.jdbi.v3.core.result;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collector;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
@@ -47,14 +50,14 @@ public class TestReducing
     }
 
     @Test
-    public void testLeftJoinRowView() throws Exception
-    {
+    public void testReduceRowsWithSeed() {
         Map<Integer, SomethingWithLocations> result = dbRule.getSharedHandle()
             .createQuery("SELECT something.id, name, location FROM something NATURAL JOIN something_location")
             .reduceRows(new HashMap<Integer, SomethingWithLocations>(), (map, rr) -> {
                 map.computeIfAbsent(rr.getColumn("id", Integer.class),
                         id -> new SomethingWithLocations(rr.getRow(Something.class)))
-                    .locations.add(rr.getColumn("location", String.class));
+                   .locations
+                   .add(rr.getColumn("location", String.class));
                 return map;
             });
 
@@ -64,8 +67,44 @@ public class TestReducing
     }
 
     @Test
-    public void testLeftJoinResultSet() throws Exception
-    {
+    public void testCollectRows() {
+        Iterable<SomethingWithLocations> result = dbRule.getSharedHandle()
+            .createQuery("SELECT something.id, name, location FROM something NATURAL JOIN something_location")
+            .collectRows(Collector.<RowView, Map<Integer, SomethingWithLocations>, Iterable<SomethingWithLocations>>of(
+                    LinkedHashMap::new,
+                    (Map<Integer, SomethingWithLocations> map, RowView rv) ->
+                        map.computeIfAbsent(rv.getColumn("id", Integer.class),
+                                            id -> new SomethingWithLocations(rv.getRow(Something.class)))
+                           .locations
+                           .add(rv.getColumn("location", String.class)),
+                    (a, b) -> {
+                        throw new UnsupportedOperationException("shouldn't use combiner");
+                    },
+                    Map::values));
+
+        assertThat(result).containsExactly(
+            new SomethingWithLocations(new Something(1, "tree")).at("outside"),
+            new SomethingWithLocations(new Something(2, "apple")).at("tree").at("pie"));
+    }
+
+    @Test
+    public void testReduceRows() {
+        List<SomethingWithLocations> result = dbRule.getSharedHandle()
+            .createQuery("SELECT something.id, name, location FROM something NATURAL JOIN something_location")
+            .reduceRows(LinkedHashMapRowReducer.<Integer, SomethingWithLocations>of((map, rv) ->
+                map.computeIfAbsent(rv.getColumn("id", Integer.class),
+                                    id -> new SomethingWithLocations(rv.getRow(Something.class)))
+                   .locations
+                   .add(rv.getColumn("location", String.class))))
+            .collect(toList());
+
+        assertThat(result).containsExactly(
+            new SomethingWithLocations(new Something(1, "tree")).at("outside"),
+            new SomethingWithLocations(new Something(2, "apple")).at("tree").at("pie"));
+    }
+
+    @Test
+    public void testReduceResultSet() {
         Map<Integer, SomethingWithLocations> result = dbRule.getSharedHandle()
             .createQuery("SELECT something.id, name, location FROM something NATURAL JOIN something_location")
             .reduceResultSet(new HashMap<Integer, SomethingWithLocations>(), (map, rs, ctx) -> {

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -1694,7 +1694,7 @@ Jdbi provides a few different APIs for dealing with joined data.
 ===== ResultBearing.reduceRows()
 
 The
-link:{jdbidocs}/core/result/ResultBearing.html#reduceRows-U-java.util.function.BiFunction-[ResultBearing.reduceRows()^]
+link:{jdbidocs}/core/result/ResultBearing.html#reduceRows-U-java.util.function.BiFunction-["ResultBearing.reduceRows(U, BiFunction)"^]
 method accepts an accumulator seed value and a lambda function. For each row in
 the result set, Jdbi calls the lambda with the current accumulator value and a
 link:{jdbidocs}/core/result/RowView.html[RowView^] over the current row of the
@@ -1708,8 +1708,8 @@ List<Contact> contacts = handle.createQuery(SELECT_ALL)
     .registerRowMapper(BeanMapper.factory(Contact.class, "c"))
     .registerRowMapper(BeanMapper.factory(Phone.class, "p")) <1>
     .reduceRows(new LinkedHashMap<Long, Contact>(), // <2>
-                (acc, rowView) -> {
-      Contact contact = acc.computeIfAbsent( // <3>
+                (map, rowView) -> {
+      Contact contact = map.computeIfAbsent( // <3>
           rowView.getColumn("c_id", Long.class),
           id -> rowView.getRow(Contact.class));
 
@@ -1717,7 +1717,7 @@ List<Contact> contacts = handle.createQuery(SELECT_ALL)
         contact.addPhone(rowView.getRow(Phone.class));
       }
 
-      return acc; // <5>
+      return map; // <5>
     })
     .values() // <6>
     .stream()
@@ -1745,6 +1745,40 @@ List<Contact> contacts = handle.createQuery(SELECT_ALL)
     contact ID keys. So we call `Map.values()` to get a `Collection<Contact>`.
 <7> Collect the contacts into a `List<Contact>`.
 
+Alternatively, the
+link:{jdbidocs}/core/result/ResultBearing.html#reduceRows-org.jdbi.v3.core.result.RowReducer-[ResultBearing.reduceRows(RowReducer)^]
+variant accepts a link:{jdbidocs}/core/result/RowReducer.html[RowReducer^] and
+returns a stream of reduced elements.
+
+For simple master-detail joins, the abstract
+link:{jdbidocs}/core/result/LinkedHashMapRowReducer.html[LinkedHashMapRowReducer^]
+class makes it easy to reduce these joins into a stream of master elements.
+Adapting the example above:
+
+[source,java]
+----
+List<Contact> contacts = handle.createQuery(SELECT_ALL)
+    .registerRowMapper(BeanMapper.factory(Contact.class, "c"))
+    .registerRowMapper(BeanMapper.factory(Phone.class, "p"))
+    .reduceRows(LinkedHashMapRowReducer.<Long, Contact> of((map, rowView) -> { // <1>
+      Contact contact = map.computeIfAbsent(
+          rowView.getColumn("c_id", Long.class),
+          id -> rowView.getRow(Contact.class));
+
+      if (rowView.getColumn("p_id", Long.class) != null) {
+        contact.addPhone(rowView.getRow(Phone.class));
+      }
+      // <2>
+    })
+    .collect(toList()); // <3>
+----
+
+<1> The factory method
+    link:{jdbidocs}/core/result/LinkedHashMapRowReducer.html#of-java.util.function.BiConsumer-[LinkedHashMapRowReducer.of(BiConsumer)^]
+    needs only a `BiConsumer(Map<K,V>, RowView)`
+<2> No `return` statement needed. The same `map` is reused on every row.
+<3> This reduction produces a `Stream<Contact>`, and we can use any stream method
+
 You may be wondering about the `getRow()` and `getColumn()` calls to `rowView`.
 When you call `rowView.getRow(SomeType.class)`, `RowView` looks up the
 registered row mapper for `SomeType`, and uses it to map the current row to a
@@ -1762,25 +1796,15 @@ Optional<Contact> contact = handle.createQuery(SELECT_ONE)
     .bind("id", contactId)
     .registerRowMapper(BeanMapper.factory(Contact.class, "c"))
     .registerRowMapper(BeanMapper.factory(Phone.class, "p"))
-    .reduceRows(Optional.<Contact>empty(), // <1>
-                (acc, rowView) -> {
-      Contact contact = acc.orElseGet(() -> rowView.getRow(Contact.class)); // <2>
+    .reduceRows(LinkedHashMapRowReducer.<Long, Contact> of((map, rowView) -> {
+      Contact contact = map.orElseGet(() -> rowView.getRow(Contact.class));
 
       if (rowView.getColumn("p_id", Long.class) != null) {
         contact.addPhone(rowView.getRow(Phone.class));
       }
-
-      return Optional.of(contact); // <3>
-    });
+    })
+    .findFirst();
 ----
-
-<1> Use an empty link:{jdkdocs}/java/util/Optional.html[Optional<Contact>^]
-    as the accumulator seed. After the first row, the accumulator will be a
-    non-empty `Optional<Contact>`.
-<2> Load the `Contact` from the accumulator if we already have it; otherwise,
-    initialize it through the `RowView`.
-<3> Rewrap the `Contact` in an `Optional<Contact>`, to use for the accumulator
-    on the following rows.
 
 ===== ResultBearing.reduceResultSet()
 
@@ -2758,6 +2782,67 @@ Map<String, Object> getById(long userId);
 Do you use PostgreSQL's `hstore` columns? The <<PostgreSQL>> plugin provides an
 `hstore` to `Map<String, String>` column mapper. See
 <<PostgreSQL-hstore,hstore>> for more information.
+
+===== @UseRowReducer
+
+`@SqlQuery` methods that use join queries may reduce master-detail joins
+into one or more master-level objects. See <<ResultBearing.reduceRows()>> for
+an introduction to row reducers.
+
+Consider a filesystem metaphor with folders and documents. In the join, we'll
+prefix folder columns with `f_` and document columns with `d_`.
+
+[source,java]
+----
+@RegisterBeanMapper(value = Folder.class, prefix = "f") // <1>
+@RegisterBeanMapper(value = Document.class, prefix = "d")
+public interface DocumentDao {
+    @SqlQuery("select " +
+            "f.id f_id, f.name f_name, " +
+            "d.id d_id, d.name d_name, d.contents d_contents " +
+            "from folders f left join documents d " +
+            "on f.id = d.folder_id " +
+            "where f.id = :folderId" +
+            "order by d.name")
+    @UseRowReducer(FolderDocReducer.class) // <2>
+    Optional<Folder> getFolder(int folderId); // <3>
+
+    @SqlQuery("select " +
+            "f.id f_id, f.name f_name, " +
+            "d.id d_id, d.name d_name, d.contents d_contents " +
+            "from folders f left join documents d " +
+            "on f.id = d.folder_id " +
+            "order by f.name, d.name")
+    @UseRowReducer(FolderDocReducer.class) // <2>
+    List<Folder> listFolders(); // <3>
+
+    class FolderDocReducer extends LinkedHashMapRowReducer<Integer, Folder> { // <4>
+        @Override
+        public void accumulate(Map<Integer, Folder> map, RowView rowView) {
+            Folder f = map.computeIfAbsent(rowView.getColumn("f_id", Integer.class), // <2>
+                                           id -> rowView.getRow(Folder.class));
+
+            if (rowView.getColumn("d_id", Integer.class) != null) { // <3>
+                f.getDocuments().add(rowView.getRow(Document.class));
+            }
+        }
+    }
+}
+----
+<1> In this example, we register the folder and document mappers with a
+    prefix, so that each mapper only looks at the columns with that prefix.
+    These mappers are used indirectly by the row reducer in the
+    `getRow(Folder.class)` and `getRow(Document.class)` calls.
+<2> Annotate the method with `@UseRowReducer`, and specify the `RowReducer`
+    implementation class.
+<3> The same `RowReducer` implementation may be used for both single- and
+    multi-master-record queries.
+<4> link:{jdbidocs}/core/result/LinkedHashMapRowReducer.html[LinkedHashMapRowReducer^]
+    is an abstract `RowReducer` implementation that uses a `LinkedHashMap` as the result
+    container, and returns the `values()` collection as the result.
+<5> Get the `Folder` for this row from the map by ID, or create it if not in the map.
+<6> Confirm this row has a document (this _is_ a left join) before mapping a document
+    and adding it to the folder.
 
 ==== @SqlBatch
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/UseRowReducer.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/UseRowReducer.java
@@ -18,19 +18,19 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.result.RowReducer;
 
 /**
- * Used to specify specific row mapper on a query method. Mutually exclusive
- * with {@link UseRowReducer}.
+ * Used to specify a row reducer on a result-bearing method. Mutually exclusive
+ * with {@link UseRowMapper}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-public @interface UseRowMapper
+public @interface UseRowReducer
 {
     /**
-     * The class implementing {@link RowMapper}. It must have a no-arg constructor.
-     * @return the class of row mapper to use.
+     * The class implementing {@link RowReducer}. It must have a no-arg constructor.
+     * @return the class of row reducer to use.
      */
-    Class<? extends RowMapper<?>> value();
+    Class<? extends RowReducer<?, ?>> value();
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.result.RowReducer;
 import org.jdbi.v3.core.statement.SqlStatement;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
@@ -41,6 +42,7 @@ import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizingAnnotation;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
 import org.jdbi.v3.sqlobject.statement.ParameterCustomizerFactory;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 
 /**
  * Base handler for annotations' implementation classes.
@@ -186,6 +188,16 @@ abstract class CustomizingStatementHandler<StatementType extends SqlStatement<St
         }
         catch (Exception e) {
             throw new UnableToCreateStatementException("Could not create mapper " + mapperClass.getName(), e, null);
+        }
+    }
+
+    static RowReducer<?, ?> rowReducerFor(UseRowReducer annotation) {
+        Class<? extends RowReducer<?, ?>> reducerClass = annotation.value();
+        try {
+            return reducerClass.getConstructor().newInstance();
+        }
+        catch (Exception e) {
+            throw new UnableToCreateStatementException("Could not create reducer " + reducerClass.getName(), e, null);
         }
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/MapToFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/MapToFactory.java
@@ -42,7 +42,7 @@ public class MapToFactory implements SqlStatementCustomizerFactory {
             }
             ResultReturner returner = ResultReturner.forMethod(sqlObjectType, method);
             stmt.getConfig(SqlObjectStatementConfiguration.class).setReturner(
-                    () -> returner.result(((ResultBearing) stmt).mapTo(typeArg), stmt.getContext()));
+                    () -> returner.mappedResult(((ResultBearing) stmt).mapTo(typeArg), stmt.getContext()));
         };
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
@@ -41,6 +41,7 @@ import org.jdbi.v3.sqlobject.statement.BatchChunkSize;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 
 public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> {
     private final SqlBatch sqlBatch;
@@ -50,6 +51,10 @@ public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> 
 
     public SqlBatchHandler(Class<?> sqlObjectType, Method method) {
         super(sqlObjectType, method);
+
+        if (method.isAnnotationPresent(UseRowReducer.class)) {
+            throw new UnsupportedOperationException("Cannot declare @UseRowReducer on a @SqlUpdate method.");
+        }
 
         this.sqlBatch = method.getAnnotation(SqlBatch.class);
         this.batchChunkSize = determineBatchChunkSize(sqlObjectType, method);
@@ -260,7 +265,7 @@ public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> 
 
         ResultIterable<Object> iterable = ResultIterable.of(result);
 
-        return magic.result(iterable, result.getContext());
+        return magic.mappedResult(iterable, result.getContext());
     }
 
     private Iterator<Object[]> zipArgs(Method method, Object[] args) {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanMapper.java
@@ -249,7 +249,7 @@ public class TestBeanMapper
         @UseRowReducer(FolderDocReducer.class)
         List<Folder> listFolders();
 
-        class FolderDocReducer extends LinkedHashMapRowReducer<Integer, Folder> {
+        class FolderDocReducer implements LinkedHashMapRowReducer<Integer, Folder> {
             @Override
             public void accumulate(Map<Integer, Folder> map, RowView rv) {
                 Folder f = map.computeIfAbsent(rv.getColumn("f_id", Integer.class),


### PR DESCRIPTION
Fixes #996.

New API:

* `RowReducer<C, R>` interface.
* `LinkedHashMapRowReducer` abstract implementation to make the most common reducer use case simple.
* `ResultBearing.reduceRows(RowReducer<C,R>)`
* `@UseRowReducer` SQL Object annotation, supported on `@SqlQuery` methods.
* `ResultBearing.collectRows(Collector<RowView,A,R>)` for good measure.

I've also added / refactored tests to demonstrate usage.

TODO:

* [x] Still not sure about `RowReducer` method names--`createAccumulator()` in particular--blah. Edit: Settled on `container(): C`, `accumulate(C, RowView)`, and `stream(C): Stream<R>`. Renamed `A` generic parameter to `C` for "container."
* [x] Decide whether to support `@UseRowReducer` with `@SqlBatch`, `@SqlUpdate`. Edit: decided not to support until we have a concrete use case.
  * If yes, implement it. I have a plausible implementation for both but haven't committed it.
  * If no, throw an exception (the current behavior). Currently leaning toward no since I can't fathom a legitimate use case.
* [x] Document reducers in developer guide.

CC @rbkrabbe