### PR TITLE
Upgrade Guava to 24.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>21.0</version>
+                <version>24.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>io.vavr</groupId>


### PR DESCRIPTION
Upgrade the dependency to the latest version of Guava, so we can make sure that the integration works with it.