### PR TITLE
EnumMapper: allow case insensitive mapping

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,6 @@
+3.0.2
+  - EnumMapper now tries a case insensitive match if there's no exact match
+
 3.0.1
   - Kotlin mapper support for @Nested annotation
   - ReflectionMapperUtil utility class made public.

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
@@ -18,8 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -94,5 +94,12 @@ public class TestEnums
         h.createQuery("select * from something order by id")
                 .mapToBean(SomethingElse.class)
                 .findFirst();
+    }
+
+    @Test
+    public void testEnumCaseInsensitive() throws Exception
+    {
+        assertThat(dbRule.getSharedHandle().createQuery("select 'BrIaN'").mapTo(SomethingElse.Name.class).findOnly())
+            .isEqualTo(SomethingElse.Name.brian);
     }
 }


### PR DESCRIPTION
Nobody is crazy enough to care about case sensitive enum matching, right?