### PR TITLE
Support named parameters with OracleReturning

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
@@ -98,6 +98,17 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This>
         return typedThis;
     }
 
+    final void beforeBinding(final PreparedStatement stmt) {
+        for (StatementCustomizer customizer : customizers) {
+            try {
+                customizer.beforeBinding(stmt, ctx);
+            }
+            catch (SQLException e) {
+                throw new UnableToExecuteStatementException("Exception thrown in statement customization", e, ctx);
+            }
+        }
+    }
+
     final void beforeExecution(final PreparedStatement stmt)
     {
         for (StatementCustomizer customizer : customizers) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/Binding.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Binding.java
@@ -33,8 +33,30 @@ public class Binding
     private final Map<String, Argument> named = new HashMap<>();
     private final List<NamedArgumentFinder> namedArgumentFinder = new ArrayList<>();
 
-    void addPositional(int position, Argument parameter) {
-        positionals.put(position, parameter);
+    /**
+     * Bind a positional parameter at the given index (0-based)
+     * @param position binding position
+     * @param argument the argument to bind
+     */
+    public void addPositional(int position, Argument argument) {
+        positionals.put(position, argument);
+    }
+
+    /**
+     * Bind a named parameter for the given name
+     * @param name bound argument name
+     * @param argument the argument to bind
+     */
+    public void addNamed(String name, Argument argument) {
+        this.named.put(name, argument);
+    }
+
+    /**
+     * Bind a named argument finder
+     * @param args the argument finder to bind
+     */
+    public void addNamedArgumentFinder(NamedArgumentFinder args) {
+        namedArgumentFinder.add(args);
     }
 
     /**
@@ -64,14 +86,6 @@ public class Binding
      */
     public Optional<Argument> findForPosition(int position) {
         return Optional.ofNullable(positionals.get(position));
-    }
-
-    void addNamed(String name, Argument argument) {
-        this.named.put(name, argument);
-    }
-
-    void addNamedArgumentFinder(NamedArgumentFinder args) {
-        namedArgumentFinder.add(args);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -166,6 +166,7 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
                 throw new UnableToCreateStatementException(e, getContext());
             }
 
+            beforeBinding(stmt);
 
             try {
                 for (Binding binding : bindings) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -1440,6 +1440,8 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
 
         getContext().setStatement(stmt);
 
+        beforeBinding(stmt);
+
         ArgumentBinder.bind(parsedParameters, getBinding(), stmt, getContext());
 
         beforeExecution(stmt);

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementCustomizer.java
@@ -22,6 +22,15 @@ import java.sql.SQLException;
 public interface StatementCustomizer
 {
     /**
+     * Invoked prior to applying bound parameters to the {@link PreparedStatement}.
+     *
+     * @param stmt Prepared statement being customized
+     * @param ctx Statement context associated with the statement being customized
+     * @throws SQLException go ahead and percolate it for Jdbi to handle
+     */
+    default void beforeBinding(PreparedStatement stmt, StatementContext ctx) throws SQLException { }
+
+    /**
      * Make the changes you need to inside this method. It will be invoked prior to execution of
      * the prepared statement
      *


### PR DESCRIPTION
Fixes #1022 

* Added method `OracleReturning.ReturnParameters.register(String name, int oracleType)`
* Made `Binding` methods `addPositional`, `addNamed`, and `addNamedArgumentFinder` public. `OracleReturning` does not have access to the `SqlStatement` to bind in the usual way, however we are able to add the binding via `StatementContext.getBinding().addXyz()`.
* Added new lifecycle hook `StatementCustomizer.beforeBinding()` to allow customizers to bind extra parameters before they are applied to the statement.
