### PR TITLE
Fix memory leak in StringTemplateEngine

### DIFF
--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.stringtemplate4;
 import org.jdbi.v3.core.statement.TemplateEngine;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.STGroup;
 
 /**
  * Rewrites a StringTemplate template, using the attributes on the {@link StatementContext} as template parameters.
@@ -23,7 +24,7 @@ import org.stringtemplate.v4.ST;
 public class StringTemplateEngine implements TemplateEngine {
     @Override
     public String render(String sql, StatementContext ctx) {
-        ST template = new ST(sql);
+        ST template = new ST(new STGroup(), sql);
 
         ctx.getAttributes().forEach(template::add);
 


### PR DESCRIPTION
When an instance of `ST` is created without an explicit group, it adds
the parsed template to `STGroup.defaultGroup`. This leads to a leak
everytime a query is parsed, as it is a singleton.

This change passes a new instance of `STGroup` everytime a new instance
of `ST` is created and thus allows GC to reclaim the templates.