### PR TITLE
Correct missing characters in BindList documentation

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -344,13 +344,13 @@ List<String> keys = new ArrayList<String>()
 keys.add("user_name");
 keys.add("street");
 
-handle.createQuery("SELECT value FROM items WHERE kind in (<listOfKinds>)
+handle.createQuery("SELECT value FROM items WHERE kind in (<listOfKinds>)")
       .bindList("listOfKinds", keys)
       .mapTo(String.class)
       .list();
      
 // Or, using the `vararg` definition
-handle.createQuery("SELECT value FROM items WHERE kind in (<varargListOfKinds>)
+handle.createQuery("SELECT value FROM items WHERE kind in (<varargListOfKinds>)")
       .bindList("varargListOfKinds", "user_name", "docs", "street", "library")
       .mapTo(String.class)
       .list();


### PR DESCRIPTION
Some time ago, when I made a PR to document `@BindList` and `bindList`, I seem to have forgotten to close the string and method call. This is both wrong and doesn't look right in docs. Let's fix that.