### PR TITLE
Test that statement parser can handle quoted unicode characters

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/TestHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestHandle.java
@@ -59,4 +59,10 @@ public class TestHandle
         h.close();
         assertThat(h.isClosed()).isTrue();
     }
+
+    @Test
+    public void testMrWinter() {
+        final Handle h = dbRule.getSharedHandle();
+        h.execute("CREATE TABLE \"\u2603\" (pk int primary key)");
+    }
 }

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -4884,6 +4884,9 @@ handle.createUpdate("insert into characters (id, name) values (#id, #name)")
       .execute();
 ----
 
+[NOTE]
+The default parsers do not readily recognize non-Latin characters as identifiers;
+they must be surrounded by double quotes.
 
 For you fearless adventurers who have read the
 link:https://www.amazon.com/Compilers-Principles-Techniques-Tools-2nd/dp/0321486811[Dragon book^],


### PR DESCRIPTION
I think this is a reasonable compromise.  It'd be nice to have it
recognize arbitrary characters but the SQL language itself is pretty
biased already, and that could get confusing really fast.

Fixes #350