### PR TITLE
Support SQL Object default methods in JDK9+

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandler.java
@@ -18,6 +18,7 @@ import static java.util.Collections.synchronizedMap;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -25,22 +26,47 @@ import java.util.WeakHashMap;
 import org.jdbi.v3.core.extension.HandleSupplier;
 
 class DefaultMethodHandler implements Handler {
+    // MethodHandles.privateLookupIn(Class, Lookup) was added in JDK 9.
+    // JDK 9 allows us to unreflectSpecial() on an interface default method, where JDK 8 did not.
+    private static final Method PRIVATE_LOOKUP_IN = privateLookupIn();
+
+    private static Method privateLookupIn() {
+        try {
+            return MethodHandles.class.getMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
+        } catch (NoSuchMethodException e) {
+            // Method was added in JDK 9
+            return null;
+        }
+    }
+
     private static final Map<Class<?>, MethodHandles.Lookup> privateLookups = synchronizedMap(new WeakHashMap<>());
 
     private static MethodHandles.Lookup lookupFor(Class<?> clazz) {
+        if (PRIVATE_LOOKUP_IN != null) {
+            try {
+                return (MethodHandles.Lookup) PRIVATE_LOOKUP_IN.invoke(null, clazz, MethodHandles.lookup());
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                String message = String.format(
+                        "Error invoking MethodHandles.privateLookupIn(%s.class, MethodHandles.lookup()) in JDK 9+ runtime",
+                        clazz);
+                throw new RuntimeException(message, e);
+            }
+        }
+
+        // TERRIBLE, HORRIBLE, NO GOOD, VERY BAD HACK
+        // Courtesy of:
+        // https://rmannibucau.wordpress.com/2014/03/27/java-8-default-interface-methods-and-jdk-dynamic-proxies/
+
+        // We can use MethodHandles to look up and invoke the super method, but since this class is not an
+        // implementation of method.getDeclaringClass(), MethodHandles.Lookup will throw an exception since
+        // this class doesn't have access to the super method, according to Java's access rules. This horrible,
+        // awful workaround allows us to directly invoke MethodHandles.Lookup's private constructor, bypassing
+        // the usual access checks.
+
+        // This workaround is only used in JDK 8.x runtimes. JDK 9+ runtimes use MethodHandles.privateLookupIn()
+        // above.
         return privateLookups.computeIfAbsent(clazz, type -> {
             try {
-                // TERRIBLE, HORRIBLE, NO GOOD, VERY BAD HACK
-                // Courtesy of:
-                // https://rmannibucau.wordpress.com/2014/03/27/java-8-default-interface-methods-and-jdk-dynamic-proxies/
-
-                // We can use MethodHandles to look up and invoke the super method, but since this class is not an
-                // implementation of method.getDeclaringClass(), MethodHandles.Lookup will throw an exception since
-                // this class doesn't have access to the super method, according to Java's access rules. This horrible,
-                // awful workaround allows us to directly invoke MethodHandles.Lookup's private constructor, bypassing
-                // the usual access checks.
-
-                // We should get rid of this workaround as soon as a viable alternative exists.
 
                 final Constructor<MethodHandles.Lookup> constructor =
                         MethodHandles.Lookup.class.getDeclaredConstructor(Class.class, int.class);


### PR DESCRIPTION
Fixes #497.

@keithbranton can you please confirm this fixes SQL Object default methods in JDK 9?