### PR TITLE
Through experimental testing, it's clear that allowing StringTemplate to load templates concurrently is what's causing #1052

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -6,7 +6,7 @@
   - add a TemplateEngine based on java.text.MessageFormat
   - allow absence of 'value' on @MaxRows and validate its (lack of) use on SqlObjects
   - fix SqlObject getting confused about result types due to bridge methods
-  - StringTemplate no longer loads templates concurrently to prevent races
+  - StringTemplate no longer shares template groups across threads, to work around concurrency issues
 
 3.1.1
   - Improve IBM JDK compatibility with default methods

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -6,6 +6,7 @@
   - add a TemplateEngine based on java.text.MessageFormat
   - allow absence of 'value' on @MaxRows and validate its (lack of) use on SqlObjects
   - fix SqlObject getting confused about result types due to bridge methods
+  - StringTemplate no longer loads templates concurrently to prevent races
 
 3.1.1
   - Improve IBM JDK compatibility with default methods

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateSqlLocator.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateSqlLocator.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
+
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.STGroupFile;
@@ -130,7 +131,13 @@ public class StringTemplateSqlLocator {
      * @return the loaded StringTemplateGroup.
      */
     public static STGroup findStringTemplateGroup(ClassLoader classLoader, String path) {
-        return CACHE.computeIfAbsent(path, p -> readStringTemplateGroup(classLoader, path));
+        final STGroup cached = CACHE.get(path);
+        if (cached != null) {
+            return cached;
+        }
+        synchronized (StringTemplateSqlLocator.class) {
+            return CACHE.computeIfAbsent(path, p -> readStringTemplateGroup(classLoader, path));
+        }
     }
 
     private static STGroup readStringTemplateGroup(ClassLoader classLoader, String path) {


### PR DESCRIPTION
Fixes #1052