### PR TITLE
Add a test to show jsonb query '?' can be escaped as '??' and work

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -3678,6 +3678,10 @@ It also configures SQL array type support for `int`, `long`, `float`, `double`,
 See the link:{jdbidocs}/postgres/package-summary.html[javadoc^] for an
 exhaustive list.
 
+TIP: Some Postgres operators, for example the `?` query operator, collide
+with `jdbi` or `JDBC` special characters.  In such cases, you may need to
+escape operators to e.g. `??` or `\:`.
+
 [reftext="PostgreSQL-hstore"]
 ==== hstore
 

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestJsonOperator.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestJsonOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jdbi.v3.testing.JdbiRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestJsonOperator {
+    @Rule
+    public JdbiRule db = PostgresDbRule.rule();
+
+    @Test
+    public void testJsonQuery() throws Exception {
+        assertThat(db.getHandle()
+                .createQuery("SELECT '{\"a\":1, \"b\":2}'::jsonb ?? 'b'")
+                .mapTo(boolean.class)
+                .findOnly())
+            .isEqualTo(true);
+    }
+}


### PR DESCRIPTION
Fixes #1069