### PR TITLE
StringSubstitutor TemplateEngine

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,6 +83,11 @@
 
         <dependency>
             <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
             <artifactId>commons-jexl</artifactId>
             <scope>test</scope>
         </dependency>

--- a/core/src/main/java/org/jdbi/v3/core/statement/StringSubstitutorTemplateEngine.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StringSubstitutorTemplateEngine.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import org.apache.commons.text.StringSubstitutor;
+
+public class StringSubstitutorTemplateEngine implements TemplateEngine {
+	private final String prefix, suffix;
+	private final Character escape;
+
+	public StringSubstitutorTemplateEngine() {
+	    this(null, null, null);
+    }
+
+	public StringSubstitutorTemplateEngine(String prefix, String suffix, Character escape) {
+		this.prefix = prefix;
+		this.suffix = suffix;
+		this.escape = escape;
+	}
+
+	@Override
+	public String render(String template, StatementContext ctx) {
+		StringSubstitutor substitutor = new StringSubstitutor(ctx.getAttributes());
+
+		if (prefix != null) {
+			substitutor.setVariablePrefix(prefix);
+		}
+		if (suffix != null) {
+			substitutor.setVariableSuffix(suffix);
+		}
+		if (escape != null) {
+			substitutor.setEscapeChar(escape);
+		}
+
+		return substitutor.replace(template);
+	}
+
+	public static class Builder {
+		private String prefix = "${", suffix = "}";
+		private Character escape = '$';
+
+		public Builder withPrefix(String prefix) {
+			this.prefix = prefix;
+			return this;
+		}
+
+		public Builder withSuffix(String suffix) {
+			this.suffix = suffix;
+			return this;
+		}
+
+		public Builder withEscape(Character escape) {
+			this.escape = escape;
+			return this;
+		}
+
+		public StringSubstitutorTemplateEngine build() {
+			return new StringSubstitutorTemplateEngine(prefix, suffix, escape);
+		}
+	}
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStringSubstitutorTemplateEngine.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStringSubstitutorTemplateEngine.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.rule.DatabaseRule;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestStringSubstitutorTemplateEngine {
+    @Rule
+    public DatabaseRule db = new H2DatabaseRule();
+
+    private Jdbi jdbi;
+
+    @Before
+    public void before() {
+        jdbi = db.getJdbi();
+
+        jdbi.getConfig(SqlStatements.class).setTemplateEngine(new StringSubstitutorTemplateEngine());
+    }
+
+    @Test
+    public void foo() {
+        String out = jdbi.withHandle(h -> h.createQuery("select * from (values(${foo}))")
+            .define("foo", "'bar'")
+            .mapTo(String.class)
+            .findOnly());
+
+        assertThat(out).isEqualTo("bar");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -402,6 +402,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.3</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-test</artifactId>
                 <version>${dep.spring.version}</version>


### PR DESCRIPTION
Thought this could be simple and general enough to be worth including. Feel free to call it too niche to be worth bothering with though.

StringSubstitutor could be used to implement the default \<foo\> TemplateEngine too, btw. I mean, this class is basically the generified version of it, with \< and \> set instead of ${ and }.

![image](https://cdn.iwastesomuchtime.com/November-30-2011-11-10-09-ScreenShot20111130at8.jpg)
