### PR TITLE
Update SQL parsers to treat `??` as a literal instead of positional parameters

### DIFF
--- a/core/src/main/antlr3/org/jdbi/v3/core/internal/lexer/ColonStatementLexer.g
+++ b/core/src/main/antlr3/org/jdbi/v3/core/internal/lexer/ColonStatementLexer.g
@@ -17,6 +17,8 @@ fragment ESCAPE_QUOTE: ESCAPE QUOTE;
 fragment DOUBLE_QUOTE: '"';
 fragment COLON: {input.LA(2) != ':'}?=> ':';
 fragment DOUBLE_COLON: {input.LA(2) == ':'}?=> '::';
+fragment QUESTION: {input.LA(2) != '?'}?=> '?';
+fragment DOUBLE_QUESTION: {input.LA(2) == '?'}?=> '??';
 fragment NAME: 'a'..'z' | 'A'..'Z' | '0'..'9' | '_' | '.' | '#';
 
 COMMENT: '/*' .* '*/';
@@ -25,7 +27,7 @@ DOUBLE_QUOTED_TEXT: DOUBLE_QUOTE (~DOUBLE_QUOTE)+ DOUBLE_QUOTE;
 ESCAPED_TEXT : ESCAPE . ;
 
 NAMED_PARAM: COLON (NAME)+;
-POSITIONAL_PARAM: '?';
+POSITIONAL_PARAM: QUESTION;
 
 LITERAL: (NAME | ' ' | '\t' | '\n' | '\r' | ',' | '@' | '!' | '=' | DOUBLE_COLON | ';' | '(' | ')' | '[' | ']'
-         | '+' | '-' | '<' | '>' | '%' | '&' | '^' | '|' | '$' | '~' | '{' | '}' | '`' | COLON '=')+ | '*' | '/';
+         | '+' | '-' | '<' | '>' | '%' | '&' | '^' | '|' | '$' | '~' | '{' | '}' | '`' | COLON '=' | DOUBLE_QUESTION)+ | '*' | '/';

--- a/core/src/main/antlr3/org/jdbi/v3/core/internal/lexer/HashStatementLexer.g
+++ b/core/src/main/antlr3/org/jdbi/v3/core/internal/lexer/HashStatementLexer.g
@@ -16,6 +16,8 @@ fragment ESCAPE: '\\';
 fragment ESCAPE_QUOTE: ESCAPE QUOTE;
 fragment DOUBLE_QUOTE: '"';
 fragment HASH: '#';
+fragment QUESTION: {input.LA(2) != '?'}?=> '?';
+fragment DOUBLE_QUESTION: {input.LA(2) == '?'}?=> '??';
 fragment NAME: 'a'..'z' | 'A'..'Z' | '0'..'9' | '_' | '.' | ':';
 
 COMMENT: '/*' .* '*/';
@@ -24,7 +26,7 @@ DOUBLE_QUOTED_TEXT: DOUBLE_QUOTE (~DOUBLE_QUOTE)+ DOUBLE_QUOTE;
 ESCAPED_TEXT : ESCAPE . ;
 
 NAMED_PARAM: HASH (NAME)+;
-POSITIONAL_PARAM: '?';
+POSITIONAL_PARAM: QUESTION;
 
 LITERAL: (NAME | ' ' | '\t' | '\n' | '\r' | ',' | '@' | '!' | '=' | ';' | '(' | ')' | '[' | ']'
-         | '+' | '-' | '>' | '<' | '%' | '&' | '^' | '|' | '$' | '~' | '{' | '}' | '`')+ | '*' | '/';
+         | '+' | '-' | '>' | '<' | '%' | '&' | '^' | '|' | '$' | '~' | '{' | '}' | '`' | DOUBLE_QUESTION)+ | '*' | '/';

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestColonPrefixSqlParser.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestColonPrefixSqlParser.java
@@ -25,26 +25,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-public class TestColonPrefixTemplateEngine {
-    private TemplateEngine templateEngine;
+public class TestColonPrefixSqlParser {
     private SqlParser parser;
     private StatementContext ctx;
 
     @Before
     public void setUp() throws Exception {
-        templateEngine = new DefinedAttributeTemplateEngine();
         parser = new ColonPrefixSqlParser();
         ctx = mock(StatementContext.class);
-    }
-
-    private String render(String sql) {
-        return render(sql, Collections.emptyMap());
-    }
-
-    private String render(String sql, Map<String, Object> attributes) {
-        attributes.forEach((key, value) -> when(ctx.getAttribute(key)).thenReturn(value));
-
-        return templateEngine.render(sql, ctx);
     }
 
     @Test
@@ -92,36 +80,15 @@ public class TestColonPrefixTemplateEngine {
 
     @Test
     public void testBailsOutOnInvalidInput() throws Exception {
-        assertThatThrownBy(() -> render(parser.parse("select * from something\n where id = :\u0087\u008e\u0092\u0097\u009c", ctx).getSql()))
+        assertThatThrownBy(() -> parser.parse("select * from something\n where id = :\u0087\u008e\u0092\u0097\u009c", ctx).getSql())
             .isInstanceOf(UnableToCreateStatementException.class);
     }
 
     @Test
     public void testSubstitutesDefinedAttributes() throws Exception {
-        Map<String, Object> attributes = ImmutableMap.of(
-                "column", "foo",
-                "table", "bar");
-        String rendered = render("select <column> from <table> where <column> = :someValue", attributes);
-        ParsedSql parsed = parser.parse(rendered, ctx);
+        String sql = "select foo from bar where foo = :someValue";
+        ParsedSql parsed = parser.parse(sql, ctx);
         assertThat(parsed.getSql()).isEqualTo("select foo from bar where foo = ?");
-    }
-
-    @Test
-    public void testUndefinedAttribute() throws Exception {
-        assertThatThrownBy(() -> render("select * from <table>", Collections.emptyMap()))
-            .isInstanceOf(UnableToCreateStatementException.class);
-    }
-
-    @Test
-    public void testLeaveEnquotedTokensIntact() throws Exception {
-        String sql = "select '<foo>' foo, \"<bar>\" bar from something";
-        assertThat(render(sql, ImmutableMap.of("foo", "no", "bar", "stahp"))).isEqualTo(sql);
-    }
-
-    @Test
-    public void testIgnoreAngleBracketsNotPartOfToken() throws Exception {
-        String sql = "select * from foo where end_date < ? and start_date > ?";
-        assertThat(render(sql)).isEqualTo(sql);
     }
 
     @Test
@@ -134,14 +101,13 @@ public class TestColonPrefixTemplateEngine {
     }
 
     @Test
-    public void testCommentQuote() throws Exception {
-        String sql = "select 1 /* ' \" <foo> */";
-        assertThat(render(sql)).isEqualTo(sql);
-    }
+    public void testEscapedQuestionMark() throws Exception {
+        String sql = "SELECT '{\"a\":1, \"b\":2}'::jsonb ?? :key";
+        ParsedSql parsed = parser.parse(sql, ctx);
 
-    @Test
-    public void testColonInComment() throws Exception {
-        String sql = "/* comment with : colons :: inside it */ select 1";
-        assertThat(render(sql)).isEqualTo(sql);
+        assertThat(parsed).isEqualTo(ParsedSql.builder()
+            .append("SELECT '{\"a\":1, \"b\":2}'::jsonb ?? ")
+            .appendNamedParameter("key")
+            .build());
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestDefinedAttributeTemplateEngine.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestDefinedAttributeTemplateEngine.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestDefinedAttributeTemplateEngine {
+    private TemplateEngine templateEngine;
+    private StatementContext ctx;
+
+    @Before
+    public void setUp() throws Exception {
+        templateEngine = new DefinedAttributeTemplateEngine();
+        ctx = mock(StatementContext.class);
+    }
+
+    private String render(String sql) {
+        return render(sql, Collections.emptyMap());
+    }
+
+    private String render(String sql, Map<String, Object> attributes) {
+        attributes.forEach((key, value) -> when(ctx.getAttribute(key)).thenReturn(value));
+
+        return templateEngine.render(sql, ctx);
+    }
+
+    @Test
+    public void testSubstitutesDefinedAttributes() throws Exception {
+        Map<String, Object> attributes = ImmutableMap.of(
+                "column", "foo",
+                "table", "bar");
+        String rendered = render("select <column> from <table> where <column> = :someValue", attributes);
+        assertThat(rendered).isEqualTo("select foo from bar where foo = :someValue");
+    }
+
+    @Test
+    public void testUndefinedAttribute() throws Exception {
+        assertThatThrownBy(() -> render("select * from <table>", Collections.emptyMap()))
+            .isInstanceOf(UnableToCreateStatementException.class);
+    }
+
+    @Test
+    public void testLeaveEnquotedTokensIntact() throws Exception {
+        String sql = "select '<foo>' foo, \"<bar>\" bar from something";
+        assertThat(render(sql, ImmutableMap.of("foo", "no", "bar", "stahp"))).isEqualTo(sql);
+    }
+
+    @Test
+    public void testIgnoreAngleBracketsNotPartOfToken() throws Exception {
+        String sql = "select * from foo where end_date < ? and start_date > ?";
+        assertThat(render(sql)).isEqualTo(sql);
+    }
+
+    @Test
+    public void testCommentQuote() throws Exception {
+        String sql = "select 1 /* ' \" <foo> */";
+        assertThat(render(sql)).isEqualTo(sql);
+    }
+
+    @Test
+    public void testColonInComment() throws Exception {
+        String sql = "/* comment with : colons :: inside it */ select 1";
+        assertThat(render(sql)).isEqualTo(sql);
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestHashPrefixSqlParser.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestHashPrefixSqlParser.java
@@ -24,26 +24,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 public class TestHashPrefixSqlParser {
-    private TemplateEngine templateEngine;
     private SqlParser parser;
     private StatementContext ctx;
 
     @Before
     public void setUp() throws Exception {
-        this.templateEngine = new DefinedAttributeTemplateEngine();
         this.parser = new HashPrefixSqlParser();
         ctx = mock(StatementContext.class);
-    }
-
-    private String render(String sql) {
-        return render(sql, Collections.emptyMap());
-    }
-
-    private String render(String sql, Map<String, Object> attributes) {
-        StatementContext ctx = StatementContextAccess.createContext();
-        attributes.forEach(ctx::define);
-
-        return templateEngine.render(sql, ctx);
     }
 
     @Test
@@ -90,35 +77,25 @@ public class TestHashPrefixSqlParser {
 
     @Test
     public void testSubstitutesDefinedAttributes() throws Exception {
-        Map<String, Object> attributes = ImmutableMap.of(
-                "column", "foo",
-                "table", "bar");
-        String rendered = render("select <column> from <table> where <column> = #someValue", attributes);
-        ParsedSql parsed = parser.parse(rendered, ctx);
+        String sql = "select foo from bar where foo = #someValue";
+        ParsedSql parsed = parser.parse(sql, ctx);
         assertThat(parsed.getSql()).isEqualTo("select foo from bar where foo = ?");
-    }
-
-    @Test
-    public void testUndefinedAttribute() throws Exception {
-        assertThatThrownBy(() -> render("select * from <table>", Collections.emptyMap()))
-            .isInstanceOf(UnableToCreateStatementException.class);
-    }
-
-    @Test
-    public void testLeaveEnquotedTokensIntact() throws Exception {
-        String sql = "select '<foo>' foo, \"<bar>\" bar from something";
-        assertThat(render(sql, ImmutableMap.of("foo", "no", "bar", "stahp"))).isEqualTo(sql);
-    }
-
-    @Test
-    public void testIgnoreAngleBracketsNotPartOfToken() throws Exception {
-        String sql = "select * from foo where end_date < ? and start_date > ?";
-        assertThat(render(sql)).isEqualTo(sql);
     }
 
     @Test
     public void testCommentQuote() throws Exception {
         String sql = "select 1 /* ' \" <foo> */";
         assertThat(parser.parse(sql, ctx).getSql()).isEqualTo(sql);
+    }
+
+    @Test
+    public void testEscapedQuestionMark() throws Exception {
+        String sql = "SELECT '{\"a\":1, \"b\":2}'::jsonb ?? #key";
+        ParsedSql parsed = parser.parse(sql, ctx);
+
+        assertThat(parsed).isEqualTo(ParsedSql.builder()
+            .append("SELECT '{\"a\":1, \"b\":2}'::jsonb ?? ")
+            .appendNamedParameter("key")
+            .build());
     }
 }

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestJsonOperator.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestJsonOperator.java
@@ -31,4 +31,14 @@ public class TestJsonOperator {
                 .findOnly())
             .isEqualTo(true);
     }
+
+    @Test
+    public void testJsonQueryWithBindedInput() throws Exception {
+        assertThat(db.getHandle()
+            .createQuery("SELECT '{\"a\":1, \"b\":2}'::jsonb ?? :key")
+            .bind("key", "a")
+            .mapTo(boolean.class)
+            .findOnly())
+            .isEqualTo(true);
+    }
 }

--- a/postgres/src/test/java/org/jdbi/v3/sqlobject/TestJsonOperator.java
+++ b/postgres/src/test/java/org/jdbi/v3/sqlobject/TestJsonOperator.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import com.google.common.collect.ImmutableSet;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.rule.PgDatabaseRule;
+import org.jdbi.v3.postgres.PostgresDbRule;
+import org.jdbi.v3.postgres.PostgresPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.testing.JdbiRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJsonOperator {
+    @Rule
+    public JdbiRule db = PostgresDbRule.rule();
+
+    @Rule
+    public PgDatabaseRule dbRule = new PgDatabaseRule()
+        .withPlugin(new SqlObjectPlugin())
+        .withPlugin(new PostgresPlugin());
+    private Handle handle;
+    private KeyValueStore kvs;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        handle = dbRule.openHandle();
+        handle.execute("create table something (id serial primary key, value jsonb)");
+        kvs = handle.attach(KeyValueStore.class);
+    }
+
+    @Test
+    public void testHasProperty() throws Exception
+    {
+        kvs.insert(1, "{\"a\":1, \"b\":2}");
+        assertThat(kvs.hasProperty("a")).isEqualTo(ImmutableSet.of(1));
+        assertThat(kvs.hasProperty("b")).isEqualTo(ImmutableSet.of(1));
+        assertThat(kvs.hasProperty("c")).isEqualTo(Collections.emptySet());
+    }
+
+    public interface KeyValueStore
+    {
+        @SqlUpdate("insert into something (id, value) values (:id, cast(:value as jsonb))")
+        void insert(@Bind("id") int id, @Bind("value") String value);
+
+        @SqlQuery("select id from something where value ?? :property")
+        Set<Integer> hasProperty(@Bind("property") String property);
+    }
+}


### PR DESCRIPTION
Fixes #1069.

Includes the tests from #1094.

/cc @alwins0n @EthanLozano 

Edit: also refactored the tests around SQL parsers and defined attribute template engine--they were all jumbled together, so I split them into separate test classes.