### PR TITLE
Add methods to get attributes from Jdbi - closes #1109

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -33,6 +34,7 @@ import org.jdbi.v3.core.extension.Extensions;
 import org.jdbi.v3.core.extension.NoSuchExtensionException;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 import org.jdbi.v3.core.statement.DefaultStatementBuilder;
+import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.core.statement.StatementBuilder;
 import org.jdbi.v3.core.statement.StatementBuilderFactory;
 import org.jdbi.v3.core.transaction.LocalTransactionHandler;
@@ -241,6 +243,25 @@ public class Jdbi implements Configurable<Jdbi> {
     @Override
     public ConfigRegistry getConfig() {
         return config;
+    }
+
+    /**
+     * Returns the attributes applied in this context.
+     *
+     * @return the defined attributes.
+     */
+    public Map<String, Object> getAttributes() {
+        return getConfig(SqlStatements.class).getAttributes();
+    }
+
+    /**
+     * Obtain the value of an attribute
+     *
+     * @param key the name of the attribute
+     * @return the value of the attribute
+     */
+    public Object getAttribute(String key) {
+        return getConfig(SqlStatements.class).getAttribute(key);
     }
 
     /**

--- a/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
@@ -66,6 +66,18 @@ public class TestJdbi {
         });
         assertThat(value).isEqualTo("Brian");
     }
+    @Test
+    public void testWithAttribute() throws Exception {
+        Jdbi db = Jdbi.create(this.dbRule.getConnectionString());
+        db.define("table_thingie", "something");
+        String value = db.withHandle(handle -> {
+            handle.execute("insert into <table_thingie> (id, name) values (1, 'Brian')");
+            return handle.createQuery("select name from <table_thingie> where id = 1").mapToBean(Something.class).findOnly().getName();
+        });
+        assertThat(value).isEqualTo("Brian");
+        assertThat(db.getAttribute("table_thingie")).isEqualTo("something");
+        assertThat(db.getAttributes()).hasSize(1);
+    }
 
     @Test
     public void testUseHandle() throws Exception {


### PR DESCRIPTION
Added a couple of convenience methods to get defined attributes directly from the Jdbi instance. Basically the same way the StatementContext does it.