### PR TITLE
Add support for binding primitive optionals

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/BuiltInArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/BuiltInArgumentFactory.java
@@ -37,6 +37,9 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.UUID;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.SqlStatement;
@@ -111,6 +114,28 @@ public class BuiltInArgumentFactory implements ArgumentFactory {
         register(map, OffsetDateTime.class, Types.TIMESTAMP, (p, i, v) -> p.setTimestamp(i, Timestamp.from(v.toInstant())));
         register(map, ZonedDateTime.class, Types.TIMESTAMP, (p, i, v) -> p.setTimestamp(i, Timestamp.from(v.toInstant())));
         register(map, LocalTime.class, Types.TIME, (p, i, v) -> p.setTime(i, Time.valueOf(v)));
+
+        register(map, OptionalInt.class, Types.INTEGER, (p, i, v) -> {
+            if (v.isPresent()) {
+                p.setInt(i, v.getAsInt());
+            } else {
+                p.setNull(i, Types.INTEGER);
+            }
+        });
+        register(map, OptionalLong.class, Types.BIGINT, (p, i, v) -> {
+            if (v.isPresent()) {
+                p.setLong(i, v.getAsLong());
+            } else {
+                p.setNull(i, Types.BIGINT);
+            }
+        });
+        register(map, OptionalDouble.class, Types.DOUBLE, (p, i, v) -> {
+            if (v.isPresent()) {
+                p.setDouble(i, v.getAsDouble());
+            } else {
+                p.setNull(i, Types.DOUBLE);
+            }
+        });
 
         return Collections.unmodifiableMap(map);
     }

--- a/core/src/test/java/org/jdbi/v3/core/TestOptional.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestOptional.java
@@ -213,6 +213,48 @@ public class TestOptional {
                 .list();
     }
 
+    @Test
+    public void testBindOptionalInt()
+    {
+        assertThat(handle.createQuery("SELECT :value")
+                .bind("value", OptionalInt.empty())
+                .collectInto(OptionalInt.class))
+                .isEmpty();
+
+        assertThat(handle.createQuery("SELECT :value")
+                .bind("value", OptionalInt.of(123))
+                .collectInto(OptionalInt.class))
+                .hasValue(123);
+    }
+
+    @Test
+    public void testBindOptionalLong()
+    {
+        assertThat(handle.createQuery("SELECT :value")
+                .bind("value", OptionalLong.empty())
+                .collectInto(OptionalLong.class))
+                .isEmpty();
+
+        assertThat(handle.createQuery("SELECT :value")
+                .bind("value", OptionalLong.of(123))
+                .collectInto(OptionalLong.class))
+                .hasValue(123);
+    }
+
+    @Test
+    public void testBindOptionalDouble()
+    {
+        assertThat(handle.createQuery("SELECT :value")
+                .bind("value", OptionalDouble.empty())
+                .collectInto(OptionalDouble.class))
+                .isEmpty();
+
+        assertThat(handle.createQuery("SELECT :value")
+                .bind("value", OptionalDouble.of(123.45))
+                .collectInto(OptionalDouble.class))
+                .hasValue(123.45);
+    }
+
     class Name {
         final String value;
 


### PR DESCRIPTION
This adds a built-in argument factory for
OptionalInt, OptionalLong and OptionalDouble.