### PR TITLE
Use FreeMarker's built-in classpath template loading instead of rolli…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
     <artifactId>jdbi3-commons-text</artifactId>
 

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
     <artifactId>jdbi3-commons-text</artifactId>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-core</artifactId>
@@ -168,7 +168,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore></ignore>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -168,7 +168,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore />
+                                        <ignore></ignore>
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-core</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -111,6 +111,11 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
@@ -128,11 +133,6 @@
             <artifactId>jdbi3-postgres</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
 
         <dependency>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-docs</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-docs</artifactId>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-freemarker</artifactId>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -53,10 +53,6 @@
         </dependency>
 
         <dependency>
-            <groupId>net.jodah</groupId>
-            <artifactId>expiringmap</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
             <classifier>tests</classifier>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-freemarker</artifactId>

--- a/freemarker/src/main/java/org/jdbi/v3/freemarker/FreemarkerSqlLocator.java
+++ b/freemarker/src/main/java/org/jdbi/v3/freemarker/FreemarkerSqlLocator.java
@@ -13,10 +13,6 @@
  */
 package org.jdbi.v3.freemarker;
 
-import java.io.File;
-import java.io.FileReader;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -39,39 +35,21 @@ public class FreemarkerSqlLocator {
 
     private FreemarkerSqlLocator() {}
 
-    private static File findTemplateDirectory(Class<?> type) {
-        try {
-            String classFolder = getPath(type);
-            URL resource = type.getClassLoader().getResource(classFolder);
-            if (resource != null) {
-                return new File(resource.toURI());
-            }
-        } catch (URISyntaxException ignored) { }
-        return null;
-    }
-
     public static Template findTemplate(Class<?> type, String templateName) {
-        File templateDirectory = findTemplateDirectory(type);
-        if (templateDirectory == null) {
-            throw new IllegalStateException("No template directory found for class " + type);
-        }
-        File templateFile = new File(templateDirectory, templateName + ".sql.ftl");
-        return CACHE.computeIfAbsent(templateFile.getPath(), (p) -> {
-            Exception ex;
+        String path = getPath(type);
+
+        return CACHE.computeIfAbsent(path + "#" + templateName, k -> {
             try {
-                if (templateFile.exists()) {
-                    Configuration configuration = new Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
-                    ClassTemplateLoader ctl1 = new ClassTemplateLoader(type, "/");
-                    ClassTemplateLoader ctl2 = new ClassTemplateLoader(type, "/" + getPath(type));
-                    MultiTemplateLoader mtl = new MultiTemplateLoader(new TemplateLoader[] {ctl1, ctl2});
-                    configuration.setTemplateLoader(mtl);
-                    return new Template(templateName, new FileReader(templateFile), configuration);
-                }
-                ex = new IllegalArgumentException("Template file " + templateFile.getPath() + " does not exist");
-            } catch (Exception templateLoadingException) {
-                ex = templateLoadingException;
+                Configuration configuration = new Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+                ClassTemplateLoader ctl1 = new ClassTemplateLoader(type, "/");
+                ClassTemplateLoader ctl2 = new ClassTemplateLoader(type, "/" + path);
+                MultiTemplateLoader mtl = new MultiTemplateLoader(new TemplateLoader[] {ctl1, ctl2});
+                configuration.setTemplateLoader(mtl);
+                return configuration.getTemplate(templateName + ".sql.ftl");
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to load Freemarker template " + templateName + " in " + path, e);
             }
-            throw new IllegalStateException("Failed to load Freemarker template " + templateName + " in " + templateDirectory.getAbsolutePath(), ex);
+
         });
     }
 

--- a/freemarker/src/test/resources/org/jdbi/v3/freemarker/FreemarkerSqlLocatorTest$Wombat/findNamesForSomethings.sql.ftl
+++ b/freemarker/src/test/resources/org/jdbi/v3/freemarker/FreemarkerSqlLocatorTest$Wombat/findNamesForSomethings.sql.ftl
@@ -13,6 +13,6 @@
     limitations under the License.
 
 -->
-<#include "org/jdbi/v3/freemarker/util.ftl">
+<#include "/org/jdbi/v3/freemarker/util.ftl">
 <#include "util2.ftl">
 select name from something where id in (<#list somethings as something>${something.id}<#sep>, </#list>) <@groupBy field="name" /> <@orderBy field="name" />

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-guava</artifactId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-guava</artifactId>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-jodatime2</artifactId>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-jodatime2</artifactId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-jpa</artifactId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-jpa</artifactId>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-kotlin-sqlobject</artifactId>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-kotlin-sqlobject</artifactId>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-kotlin</artifactId>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-kotlin</artifactId>

--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-noparameters</artifactId>

--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-noparameters</artifactId>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-oracle12</artifactId>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-oracle12</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.jdbi</groupId>
     <artifactId>jdbi3-parent</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>jdbi3 Parent</name>
     <description>Jdbi is designed to provide convenient tabular data access in
@@ -65,7 +65,7 @@
     <scm>
         <connection>scm:git:git://github.com/jdbi/jdbi.git</connection>
         <developerConnection>scm:git:git@github.com:jdbi/jdbi.git</developerConnection>
-        <tag>v3.2.1</tag>
+        <tag>HEAD</tag>
         <url>https://github.com/jdbi/jdbi/</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.jdbi</groupId>
     <artifactId>jdbi3-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.1</version>
     <packaging>pom</packaging>
     <name>jdbi3 Parent</name>
     <description>Jdbi is designed to provide convenient tabular data access in
@@ -65,7 +65,7 @@
     <scm>
         <connection>scm:git:git://github.com/jdbi/jdbi.git</connection>
         <developerConnection>scm:git:git@github.com:jdbi/jdbi.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v3.2.1</tag>
         <url>https://github.com/jdbi/jdbi/</url>
     </scm>
 

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-postgres</artifactId>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-postgres</artifactId>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-spring4</artifactId>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-spring4</artifactId>

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-sqlite</artifactId>

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-sqlite</artifactId>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-sqlobject</artifactId>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-sqlobject</artifactId>

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-stringtemplate4</artifactId>

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-stringtemplate4</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-testing</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-testing</artifactId>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.2.1</version>
     </parent>
 
     <artifactId>jdbi3-vavr</artifactId>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-vavr</artifactId>


### PR DESCRIPTION
…ng it ourselves.

Confirmed this change fixes an error seen while trying to use FreeMarker SQL locator:

```
! java.lang.IllegalArgumentException: URI is not hierarchical
! at java.io.File.<init>(File.java:418)
! at org.jdbi.v3.freemarker.FreemarkerSqlLocator.findTemplateDirectory(FreemarkerSqlLocator.java:47)
! at org.jdbi.v3.freemarker.FreemarkerSqlLocator.findTemplate(FreemarkerSqlLocator.java:54)
! at org.jdbi.v3.freemarker.internal.UseFreemarkerSqlLocatorImpl.lambda$configureForType$1(UseFreemarkerSqlLocatorImpl.java:39)
! at org.jdbi.v3.sqlobject.statement.internal.CustomizingStatementHandler.locateSql(CustomizingStatementHandler.java:172)
```

We were calling URL, URI, File APIs to load files on the classpath, but FreeMarker already provides facilities to load templates in a much easier way.