### PR TITLE
[done] fix for allowNoResults with mapping

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSet.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSet.java
@@ -26,7 +26,6 @@ import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.RowId;
-import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Statement;
@@ -37,952 +36,950 @@ import java.util.Map;
 
 class EmptyResultSet implements ResultSet {
     @Override
-    public <T> T unwrap(Class<T> iface) throws SQLException {
+    public <T> T unwrap(Class<T> iface) {
         return iface.cast(this);
     }
 
     @Override
-    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    public boolean isWrapperFor(Class<?> iface) {
         return false;
     }
 
     @Override
-    public boolean next() throws SQLException {
+    public boolean next() {
         return false;
     }
 
     @Override
-    public void close() throws SQLException {}
+    public void close() {}
 
     @Override
-    public boolean wasNull() throws SQLException {
+    public boolean wasNull() {
         return false;
     }
 
     @Override
-    public String getString(int columnIndex) throws SQLException {
+    public String getString(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean getBoolean(int columnIndex) throws SQLException {
+    public boolean getBoolean(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public byte getByte(int columnIndex) throws SQLException {
+    public byte getByte(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public short getShort(int columnIndex) throws SQLException {
+    public short getShort(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int getInt(int columnIndex) throws SQLException {
+    public int getInt(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public long getLong(int columnIndex) throws SQLException {
+    public long getLong(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public float getFloat(int columnIndex) throws SQLException {
+    public float getFloat(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public double getDouble(int columnIndex) throws SQLException {
+    public double getDouble(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+    public BigDecimal getBigDecimal(int columnIndex, int scale) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public byte[] getBytes(int columnIndex) throws SQLException {
+    public byte[] getBytes(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Date getDate(int columnIndex) throws SQLException {
+    public Date getDate(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Time getTime(int columnIndex) throws SQLException {
+    public Time getTime(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex) throws SQLException {
+    public Timestamp getTimestamp(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public InputStream getAsciiStream(int columnIndex) throws SQLException {
+    public InputStream getAsciiStream(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+    public InputStream getUnicodeStream(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public InputStream getBinaryStream(int columnIndex) throws SQLException {
+    public InputStream getBinaryStream(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public String getString(String columnLabel) throws SQLException {
+    public String getString(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean getBoolean(String columnLabel) throws SQLException {
+    public boolean getBoolean(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public byte getByte(String columnLabel) throws SQLException {
+    public byte getByte(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public short getShort(String columnLabel) throws SQLException {
+    public short getShort(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int getInt(String columnLabel) throws SQLException {
+    public int getInt(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public long getLong(String columnLabel) throws SQLException {
+    public long getLong(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public float getFloat(String columnLabel) throws SQLException {
+    public float getFloat(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public double getDouble(String columnLabel) throws SQLException {
+    public double getDouble(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
+    public BigDecimal getBigDecimal(String columnLabel, int scale) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public byte[] getBytes(String columnLabel) throws SQLException {
+    public byte[] getBytes(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Date getDate(String columnLabel) throws SQLException {
+    public Date getDate(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Time getTime(String columnLabel) throws SQLException {
+    public Time getTime(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel) throws SQLException {
+    public Timestamp getTimestamp(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public InputStream getAsciiStream(String columnLabel) throws SQLException {
+    public InputStream getAsciiStream(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public InputStream getUnicodeStream(String columnLabel) throws SQLException {
+    public InputStream getUnicodeStream(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public InputStream getBinaryStream(String columnLabel) throws SQLException {
+    public InputStream getBinaryStream(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException {
+    public SQLWarning getWarnings() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void clearWarnings() throws SQLException {
+    public void clearWarnings() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public String getCursorName() throws SQLException {
+    public String getCursorName() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getMetaData() {
         return EmptyResultSetMetaData.INSTANCE;
     }
 
     @Override
-    public Object getObject(int columnIndex) throws SQLException {
+    public Object getObject(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Object getObject(String columnLabel) throws SQLException {
+    public Object getObject(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int findColumn(String columnLabel) throws SQLException {
+    public int findColumn(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Reader getCharacterStream(int columnIndex) throws SQLException {
+    public Reader getCharacterStream(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Reader getCharacterStream(String columnLabel) throws SQLException {
+    public Reader getCharacterStream(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+    public BigDecimal getBigDecimal(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+    public BigDecimal getBigDecimal(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean isBeforeFirst() throws SQLException {
+    public boolean isBeforeFirst() {
         return true;
     }
 
     @Override
-    public boolean isAfterLast() throws SQLException {
+    public boolean isAfterLast() {
         return true;
     }
 
     @Override
-    public boolean isFirst() throws SQLException {
+    public boolean isFirst() {
         return false;
     }
 
     @Override
-    public boolean isLast() throws SQLException {
+    public boolean isLast() {
         return false;
     }
 
     @Override
-    public void beforeFirst() throws SQLException {}
+    public void beforeFirst() {}
 
     @Override
-    public void afterLast() throws SQLException {}
+    public void afterLast() {}
 
     @Override
-    public boolean first() throws SQLException {
+    public boolean first() {
         return false;
     }
 
     @Override
-    public boolean last() throws SQLException {
+    public boolean last() {
         return false;
     }
 
     @Override
-    public int getRow() throws SQLException {
+    public int getRow() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean absolute(int row) throws SQLException {
+    public boolean absolute(int row) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean relative(int rows) throws SQLException {
+    public boolean relative(int rows) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean previous() throws SQLException {
+    public boolean previous() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void setFetchDirection(int direction) throws SQLException {}
+    public void setFetchDirection(int direction) {}
 
     @Override
-    public int getFetchDirection() throws SQLException {
+    public int getFetchDirection() {
         return FETCH_FORWARD;
     }
 
     @Override
-    public void setFetchSize(int rows) throws SQLException {}
+    public void setFetchSize(int rows) {}
 
     @Override
-    public int getFetchSize() throws SQLException {
+    public int getFetchSize() {
         return 0;
     }
 
     @Override
-    public int getType() throws SQLException {
+    public int getType() {
         return TYPE_FORWARD_ONLY;
     }
 
     @Override
-    public int getConcurrency() throws SQLException {
+    public int getConcurrency() {
         return CONCUR_READ_ONLY;
     }
 
     @Override
-    public boolean rowUpdated() throws SQLException {
+    public boolean rowUpdated() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean rowInserted() throws SQLException {
+    public boolean rowInserted() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean rowDeleted() throws SQLException {
+    public boolean rowDeleted() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNull(int columnIndex) throws SQLException {
+    public void updateNull(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBoolean(int columnIndex, boolean x) throws SQLException {
+    public void updateBoolean(int columnIndex, boolean x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateByte(int columnIndex, byte x) throws SQLException {
+    public void updateByte(int columnIndex, byte x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateShort(int columnIndex, short x) throws SQLException {
+    public void updateShort(int columnIndex, short x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateInt(int columnIndex, int x) throws SQLException {
+    public void updateInt(int columnIndex, int x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateLong(int columnIndex, long x) throws SQLException {
+    public void updateLong(int columnIndex, long x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateFloat(int columnIndex, float x) throws SQLException {
+    public void updateFloat(int columnIndex, float x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateDouble(int columnIndex, double x) throws SQLException {
+    public void updateDouble(int columnIndex, double x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
+    public void updateBigDecimal(int columnIndex, BigDecimal x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateString(int columnIndex, String x) throws SQLException {
+    public void updateString(int columnIndex, String x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBytes(int columnIndex, byte[] x) throws SQLException {
+    public void updateBytes(int columnIndex, byte[] x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateDate(int columnIndex, Date x) throws SQLException {
+    public void updateDate(int columnIndex, Date x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateTime(int columnIndex, Time x) throws SQLException {
+    public void updateTime(int columnIndex, Time x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
+    public void updateTimestamp(int columnIndex, Timestamp x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
+    public void updateAsciiStream(int columnIndex, InputStream x, int length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
+    public void updateBinaryStream(int columnIndex, InputStream x, int length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
+    public void updateCharacterStream(int columnIndex, Reader x, int length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
+    public void updateObject(int columnIndex, Object x, int scaleOrLength) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateObject(int columnIndex, Object x) throws SQLException {
+    public void updateObject(int columnIndex, Object x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNull(String columnLabel) throws SQLException {
+    public void updateNull(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBoolean(String columnLabel, boolean x) throws SQLException {
+    public void updateBoolean(String columnLabel, boolean x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateByte(String columnLabel, byte x) throws SQLException {
+    public void updateByte(String columnLabel, byte x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateShort(String columnLabel, short x) throws SQLException {
+    public void updateShort(String columnLabel, short x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateInt(String columnLabel, int x) throws SQLException {
+    public void updateInt(String columnLabel, int x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateLong(String columnLabel, long x) throws SQLException {
+    public void updateLong(String columnLabel, long x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateFloat(String columnLabel, float x) throws SQLException {
+    public void updateFloat(String columnLabel, float x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateDouble(String columnLabel, double x) throws SQLException {
+    public void updateDouble(String columnLabel, double x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
+    public void updateBigDecimal(String columnLabel, BigDecimal x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateString(String columnLabel, String x) throws SQLException {
+    public void updateString(String columnLabel, String x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBytes(String columnLabel, byte[] x) throws SQLException {
+    public void updateBytes(String columnLabel, byte[] x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateDate(String columnLabel, Date x) throws SQLException {
+    public void updateDate(String columnLabel, Date x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateTime(String columnLabel, Time x) throws SQLException {
+    public void updateTime(String columnLabel, Time x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
+    public void updateTimestamp(String columnLabel, Timestamp x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException {
+    public void updateAsciiStream(String columnLabel, InputStream x, int length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException {
+    public void updateBinaryStream(String columnLabel, InputStream x, int length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException {
+    public void updateCharacterStream(String columnLabel, Reader reader, int length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
+    public void updateObject(String columnLabel, Object x, int scaleOrLength) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateObject(String columnLabel, Object x) throws SQLException {
+    public void updateObject(String columnLabel, Object x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void insertRow() throws SQLException {
+    public void insertRow() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateRow() throws SQLException {
+    public void updateRow() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void deleteRow() throws SQLException {
+    public void deleteRow() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void refreshRow() throws SQLException {
+    public void refreshRow() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void cancelRowUpdates() throws SQLException {
+    public void cancelRowUpdates() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void moveToInsertRow() throws SQLException {
+    public void moveToInsertRow() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void moveToCurrentRow() throws SQLException {
+    public void moveToCurrentRow() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Statement getStatement() throws SQLException {
+    public Statement getStatement() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
+    public Object getObject(int columnIndex, Map<String, Class<?>> map) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Ref getRef(int columnIndex) throws SQLException {
+    public Ref getRef(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Blob getBlob(int columnIndex) throws SQLException {
+    public Blob getBlob(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Clob getClob(int columnIndex) throws SQLException {
+    public Clob getClob(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Array getArray(int columnIndex) throws SQLException {
+    public Array getArray(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
+    public Object getObject(String columnLabel, Map<String, Class<?>> map) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Ref getRef(String columnLabel) throws SQLException {
+    public Ref getRef(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Blob getBlob(String columnLabel) throws SQLException {
+    public Blob getBlob(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Clob getClob(String columnLabel) throws SQLException {
+    public Clob getClob(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Array getArray(String columnLabel) throws SQLException {
+    public Array getArray(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+    public Date getDate(int columnIndex, Calendar cal) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+    public Date getDate(String columnLabel, Calendar cal) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+    public Time getTime(int columnIndex, Calendar cal) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+    public Time getTime(String columnLabel, Calendar cal) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+    public Timestamp getTimestamp(int columnIndex, Calendar cal) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+    public Timestamp getTimestamp(String columnLabel, Calendar cal) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public URL getURL(int columnIndex) throws SQLException {
+    public URL getURL(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public URL getURL(String columnLabel) throws SQLException {
+    public URL getURL(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateRef(int columnIndex, Ref x) throws SQLException {
+    public void updateRef(int columnIndex, Ref x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateRef(String columnLabel, Ref x) throws SQLException {
+    public void updateRef(String columnLabel, Ref x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBlob(int columnIndex, Blob x) throws SQLException {
+    public void updateBlob(int columnIndex, Blob x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBlob(String columnLabel, Blob x) throws SQLException {
+    public void updateBlob(String columnLabel, Blob x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateClob(int columnIndex, Clob x) throws SQLException {
+    public void updateClob(int columnIndex, Clob x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateClob(String columnLabel, Clob x) throws SQLException {
+    public void updateClob(String columnLabel, Clob x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateArray(int columnIndex, Array x) throws SQLException {
+    public void updateArray(int columnIndex, Array x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateArray(String columnLabel, Array x) throws SQLException {
+    public void updateArray(String columnLabel, Array x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public RowId getRowId(int columnIndex) throws SQLException {
+    public RowId getRowId(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public RowId getRowId(String columnLabel) throws SQLException {
+    public RowId getRowId(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateRowId(int columnIndex, RowId x) throws SQLException {
+    public void updateRowId(int columnIndex, RowId x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateRowId(String columnLabel, RowId x) throws SQLException {
+    public void updateRowId(String columnLabel, RowId x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int getHoldability() throws SQLException {
+    public int getHoldability() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean isClosed() throws SQLException {
+    public boolean isClosed() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNString(int columnIndex, String nString) throws SQLException {
+    public void updateNString(int columnIndex, String nString) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNString(String columnLabel, String nString) throws SQLException {
+    public void updateNString(String columnLabel, String nString) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+    public void updateNClob(int columnIndex, NClob nClob) {
 
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+    public void updateNClob(String columnLabel, NClob nClob) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public NClob getNClob(int columnIndex) throws SQLException {
+    public NClob getNClob(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public NClob getNClob(String columnLabel) throws SQLException {
+    public NClob getNClob(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public SQLXML getSQLXML(int columnIndex) throws SQLException {
+    public SQLXML getSQLXML(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public SQLXML getSQLXML(String columnLabel) throws SQLException {
+    public SQLXML getSQLXML(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateSQLXML(int columnIndex, SQLXML xmlObject)
-            throws SQLException {
+    public void updateSQLXML(int columnIndex, SQLXML xmlObject) {
 
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
+    public void updateSQLXML(String columnLabel, SQLXML xmlObject) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public String getNString(int columnIndex) throws SQLException {
+    public String getNString(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public String getNString(String columnLabel) throws SQLException {
+    public String getNString(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Reader getNCharacterStream(int columnIndex) throws SQLException {
+    public Reader getNCharacterStream(int columnIndex) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Reader getNCharacterStream(String columnLabel) throws SQLException {
+    public Reader getNCharacterStream(String columnLabel) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNCharacterStream(int columnIndex, Reader x, long length)
-            throws SQLException {
+    public void updateNCharacterStream(int columnIndex, Reader x, long length) {
 
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+    public void updateNCharacterStream(String columnLabel, Reader reader, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
+    public void updateAsciiStream(int columnIndex, InputStream x, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
+    public void updateBinaryStream(int columnIndex, InputStream x, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+    public void updateCharacterStream(int columnIndex, Reader x, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException {
+    public void updateAsciiStream(String columnLabel, InputStream x, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException {
+    public void updateBinaryStream(String columnLabel, InputStream x, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+    public void updateCharacterStream(String columnLabel, Reader reader, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException {
+    public void updateBlob(int columnIndex, InputStream inputStream, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException {
+    public void updateBlob(String columnLabel, InputStream inputStream, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
+    public void updateClob(int columnIndex, Reader reader, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
+    public void updateClob(String columnLabel, Reader reader, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
+    public void updateNClob(int columnIndex, Reader reader, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
+    public void updateNClob(String columnLabel, Reader reader, long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
+    public void updateNCharacterStream(int columnIndex, Reader x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
+    public void updateNCharacterStream(String columnLabel, Reader reader) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
+    public void updateAsciiStream(int columnIndex, InputStream x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
+    public void updateBinaryStream(int columnIndex, InputStream x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
+    public void updateCharacterStream(int columnIndex, Reader x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
+    public void updateAsciiStream(String columnLabel, InputStream x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
+    public void updateBinaryStream(String columnLabel, InputStream x) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
+    public void updateCharacterStream(String columnLabel, Reader reader) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
+    public void updateBlob(int columnIndex, InputStream inputStream) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
+    public void updateBlob(String columnLabel, InputStream inputStream) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateClob(int columnIndex, Reader reader) throws SQLException {
+    public void updateClob(int columnIndex, Reader reader) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateClob(String columnLabel, Reader reader) throws SQLException {
+    public void updateClob(String columnLabel, Reader reader) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNClob(int columnIndex, Reader reader) throws SQLException {
+    public void updateNClob(int columnIndex, Reader reader) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void updateNClob(String columnLabel, Reader reader) throws SQLException {
+    public void updateNClob(String columnLabel, Reader reader) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+    public <T> T getObject(int columnIndex, Class<T> type) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+    public <T> T getObject(String columnLabel, Class<T> type) {
         throw new UnsupportedOperationException();
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSet.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSet.java
@@ -236,7 +236,7 @@ class EmptyResultSet implements ResultSet {
 
     @Override
     public ResultSetMetaData getMetaData() throws SQLException {
-        throw new UnsupportedOperationException();
+        return EmptyResultSetMetaData.INSTANCE;
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSetMetaData.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSetMetaData.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jdbi.v3.core.result;
 
 import java.sql.ResultSetMetaData;

--- a/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSetMetaData.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSetMetaData.java
@@ -15,8 +15,8 @@ package org.jdbi.v3.core.result;
 
 import java.sql.ResultSetMetaData;
 
-public class EmptyResultSetMetaData implements ResultSetMetaData {
-    public static final EmptyResultSetMetaData INSTANCE = new EmptyResultSetMetaData();
+class EmptyResultSetMetaData implements ResultSetMetaData {
+    static final EmptyResultSetMetaData INSTANCE = new EmptyResultSetMetaData();
 
     private EmptyResultSetMetaData() {}
 

--- a/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSetMetaData.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/EmptyResultSetMetaData.java
@@ -1,0 +1,124 @@
+package org.jdbi.v3.core.result;
+
+import java.sql.ResultSetMetaData;
+
+public class EmptyResultSetMetaData implements ResultSetMetaData {
+    public static final EmptyResultSetMetaData INSTANCE = new EmptyResultSetMetaData();
+
+    private EmptyResultSetMetaData() {}
+
+    @Override
+    public int getColumnCount() {
+        return 0;
+    }
+
+    @Override
+    public boolean isAutoIncrement(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCaseSensitive(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSearchable(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCurrency(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int isNullable(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSigned(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getColumnDisplaySize(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getColumnLabel(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getSchemaName(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getPrecision(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getScale(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTableName(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCatalogName(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getColumnType(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getColumnTypeName(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isReadOnly(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isWritable(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDefinitelyWritable(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getColumnClassName(int column) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -80,4 +80,16 @@ public class TestStatements {
         h.getConfig(ResultProducers.class).allowNoResults(true);
         assertThat(h.createQuery("commit").mapTo(Integer.class).findFirst()).isEmpty();
     }
+
+    @Test
+    public void testStatementWithOptionalBeanResults() {
+        h.getConfig(ResultProducers.class).allowNoResults(true);
+        assertThat(h.createQuery("commit").mapToBean(Object.class).findFirst()).isEmpty();
+    }
+
+    @Test
+    public void testStatementWithOptionalMapResults() {
+        h.getConfig(ResultProducers.class).allowNoResults(true);
+        assertThat(h.createQuery("commit").mapToMap().findFirst()).isEmpty();
+    }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -38,24 +38,24 @@ public class TestStatements {
     }
 
     @After
-    public void doTearDown() throws Exception {
+    public void doTearDown() {
         if (h != null) h.close();
     }
 
     @Test
-    public void testStatement() throws Exception {
+    public void testStatement() {
         int rows = h.createUpdate("insert into something (id, name) values (1, 'eric')").execute();
         assertThat(rows).isEqualTo(1);
     }
 
     @Test
-    public void testSimpleInsert() throws Exception {
+    public void testSimpleInsert() {
         int c = h.execute("insert into something (id, name) values (1, 'eric')");
         assertThat(c).isEqualTo(1);
     }
 
     @Test
-    public void testUpdate() throws Exception {
+    public void testUpdate() {
         h.execute("insert into something (id, name) values (1, 'eric')");
         h.createUpdate("update something set name = 'ERIC' where id = 1").execute();
         Something eric = h.createQuery("select * from something where id = 1").mapToBean(Something.class).list().get(0);
@@ -63,7 +63,7 @@ public class TestStatements {
     }
 
     @Test
-    public void testSimpleUpdate() throws Exception {
+    public void testSimpleUpdate() {
         h.execute("insert into something (id, name) values (1, 'eric')");
         h.execute("update something set name = 'cire' where id = 1");
         Something eric = h.createQuery("select * from something where id = 1").mapToBean(Something.class).list().get(0);
@@ -71,12 +71,12 @@ public class TestStatements {
     }
 
     @Test
-    public void testStatementWithRequiredResults() throws Exception {
+    public void testStatementWithRequiredResults() {
         assertThatThrownBy(() -> h.createQuery("commit").mapTo(Integer.class).findFirst()).isInstanceOf(NoResultsException.class);
     }
 
     @Test
-    public void testStatementWithOptionalResults() throws Exception {
+    public void testStatementWithOptionalResults() {
         h.getConfig(ResultProducers.class).allowNoResults(true);
         assertThat(h.createQuery("commit").mapTo(Integer.class).findFirst()).isEmpty();
     }


### PR DESCRIPTION
Statements a la `handle.createQuery(line).configure(ResultProducers.class, rp -> rp.allowNoResults(true)).mapToMap().list()` throw an exception because of mappers calling `EmptyResultSet.getMetaData`, which I've now patched to return EmptyResultSetMetaData, where `getColumnCount() == 0` is the magic bit. This fixes the use case (see tests) and shouldn't break anything.

There is the philosophical argument of throwing exceptions vs returning neutral values (for the other methods), if anyone wants to go into that, but I think it works fine as-is.