### PR TITLE
[alternative] DollarSqlParser

### DIFF
--- a/core/src/main/antlr3/org/jdbi/v3/core/internal/lexer/DollarStatementLexer.g
+++ b/core/src/main/antlr3/org/jdbi/v3/core/internal/lexer/DollarStatementLexer.g
@@ -1,0 +1,32 @@
+lexer grammar DollarStatementLexer;
+
+@header {
+    package org.jdbi.v3.core.internal.lexer;
+}
+
+@lexer::members {
+  @Override
+  public void reportError(RecognitionException e) {
+    throw new IllegalArgumentException(e);
+  }
+}
+
+fragment QUOTE: '\'';
+fragment ESCAPE: '\\';
+fragment ESCAPE_QUOTE: ESCAPE QUOTE;
+fragment DOUBLE_QUOTE: '"';
+fragment DOLLAR: '$';
+fragment QUESTION: {input.LA(2) != '?'}?=> '?';
+fragment DOUBLE_QUESTION: {input.LA(2) == '?'}?=> '??';
+fragment NAME: 'a'..'z' | 'A'..'Z' | '0'..'9' | '_' | '.' | ':';
+
+COMMENT: '/*' .* '*/';
+QUOTED_TEXT: QUOTE (ESCAPE_QUOTE | ~QUOTE)* QUOTE;
+DOUBLE_QUOTED_TEXT: DOUBLE_QUOTE (~DOUBLE_QUOTE)+ DOUBLE_QUOTE;
+ESCAPED_TEXT : ESCAPE . ;
+
+NAMED_PARAM: DOLLAR (NAME)+;
+POSITIONAL_PARAM: QUESTION;
+
+LITERAL: (NAME | ' ' | '\t' | '\n' | '\r' | ',' | '@' | '!' | '=' | ';' | '(' | ')' | '[' | ']'
+         | '+' | '-' | '>' | '<' | '%' | '&' | '^' | '|' | '#' | '~' | '{' | '}' | '`' | DOUBLE_QUESTION)+ | '*' | '/';

--- a/core/src/main/java/org/jdbi/v3/core/statement/DollarPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/DollarPrefixSqlParser.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import org.antlr.runtime.ANTLRStringStream;
+import org.antlr.runtime.Token;
+import org.jdbi.v3.core.internal.lexer.DollarStatementLexer;
+
+import static org.jdbi.v3.core.internal.lexer.DollarStatementLexer.COMMENT;
+import static org.jdbi.v3.core.internal.lexer.DollarStatementLexer.DOUBLE_QUOTED_TEXT;
+import static org.jdbi.v3.core.internal.lexer.DollarStatementLexer.EOF;
+import static org.jdbi.v3.core.internal.lexer.DollarStatementLexer.ESCAPED_TEXT;
+import static org.jdbi.v3.core.internal.lexer.DollarStatementLexer.LITERAL;
+import static org.jdbi.v3.core.internal.lexer.DollarStatementLexer.NAMED_PARAM;
+import static org.jdbi.v3.core.internal.lexer.DollarStatementLexer.POSITIONAL_PARAM;
+import static org.jdbi.v3.core.internal.lexer.DollarStatementLexer.QUOTED_TEXT;
+
+/**
+ * SQL parser which recognizes named parameter tokens of the form {@code $tokenName}
+ */
+public class DollarPrefixSqlParser implements SqlParser {
+    private final Map<String, ParsedSql> cache = Collections.synchronizedMap(new WeakHashMap<>());
+
+    @Override
+    public ParsedSql parse(String sql, StatementContext ctx) {
+        try {
+            return cache.computeIfAbsent(sql, this::internalParse);
+        } catch (IllegalArgumentException e) {
+            throw new UnableToCreateStatementException("Exception parsing for named parameter replacement", e, ctx);
+        }
+    }
+
+    @Override
+    public String nameParameter(String rawName, StatementContext ctx) {
+        return "$" + rawName;
+    }
+
+    private ParsedSql internalParse(String sql) {
+        ParsedSql.Builder parsedSql = ParsedSql.builder();
+        DollarStatementLexer lexer = new DollarStatementLexer(new ANTLRStringStream(sql));
+        Token t = lexer.nextToken();
+        while (t.getType() != EOF) {
+            switch (t.getType()) {
+                case COMMENT:
+                case LITERAL:
+                case QUOTED_TEXT:
+                case DOUBLE_QUOTED_TEXT:
+                    parsedSql.append(t.getText());
+                    break;
+                case NAMED_PARAM:
+                    parsedSql.appendNamedParameter(t.getText().substring(1));
+                    break;
+                case POSITIONAL_PARAM:
+                    parsedSql.appendPositionalParameter();
+                    break;
+                case ESCAPED_TEXT:
+                    parsedSql.append(t.getText().substring(1));
+                    break;
+                default:
+                    break;
+            }
+            t = lexer.nextToken();
+        }
+        return parsedSql.build();
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestColonPrefixSqlParser.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestColonPrefixSqlParser.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.core.statement;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 public class TestColonPrefixSqlParser {
     private SqlParser parser;
@@ -33,6 +29,13 @@ public class TestColonPrefixSqlParser {
     public void setUp() throws Exception {
         parser = new ColonPrefixSqlParser();
         ctx = mock(StatementContext.class);
+    }
+
+    @Test
+    public void testSubstitutesDefinedAttributes() throws Exception {
+        String sql = "select foo from bar where foo = :someValue";
+        ParsedSql parsed = parser.parse(sql, ctx);
+        assertThat(parsed.getSql()).isEqualTo("select foo from bar where foo = ?");
     }
 
     @Test
@@ -82,13 +85,6 @@ public class TestColonPrefixSqlParser {
     public void testBailsOutOnInvalidInput() throws Exception {
         assertThatThrownBy(() -> parser.parse("select * from something\n where id = :\u0087\u008e\u0092\u0097\u009c", ctx).getSql())
             .isInstanceOf(UnableToCreateStatementException.class);
-    }
-
-    @Test
-    public void testSubstitutesDefinedAttributes() throws Exception {
-        String sql = "select foo from bar where foo = :someValue";
-        ParsedSql parsed = parser.parse(sql, ctx);
-        assertThat(parsed.getSql()).isEqualTo("select foo from bar where foo = ?");
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestDollarPrefixSqlParser.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestDollarPrefixSqlParser.java
@@ -20,75 +20,75 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-public class TestHashPrefixSqlParser {
+public class TestDollarPrefixSqlParser {
     private SqlParser parser;
     private StatementContext ctx;
 
     @Before
     public void setUp() throws Exception {
-        this.parser = new HashPrefixSqlParser();
+        this.parser = new DollarPrefixSqlParser();
         ctx = mock(StatementContext.class);
     }
 
     @Test
-    public void testSubstitutesDefinedAttributes() throws Exception {
-        String sql = "select foo from bar where foo = #someValue";
+    public void testSubstitutesDefinedAttributes() {
+        String sql = "select foo from bar where foo = $someValue";
         ParsedSql parsed = parser.parse(sql, ctx);
         assertThat(parsed.getSql()).isEqualTo("select foo from bar where foo = ?");
     }
 
     @Test
-    public void testNewlinesOkay() throws Exception {
-        ParsedSql parsed = parser.parse("select * from something\n where id = #id", ctx);
+    public void testNewlinesOkay() {
+        ParsedSql parsed = parser.parse("select * from something\n where id = $id", ctx);
         assertThat(parsed.getSql()).isEqualTo("select * from something\n where id = ?");
     }
 
     @Test
-    public void testOddCharacters() throws Exception {
-        ParsedSql parsed = parser.parse("~* #boo '#nope' _%&^& *@ #id", ctx);
+    public void testOddCharacters() {
+        ParsedSql parsed = parser.parse("~* $boo '#nope' _%&^& *@ $id", ctx);
         assertThat(parsed.getSql()).isEqualTo("~* ? '#nope' _%&^& *@ ?");
     }
 
     @Test
-    public void testNumbers() throws Exception {
-        ParsedSql parsed = parser.parse("#bo0 '#nope' _%&^& *@ #id", ctx);
+    public void testNumbers() {
+        ParsedSql parsed = parser.parse("$bo0 '#nope' _%&^& *@ $0id", ctx);
         assertThat(parsed.getSql()).isEqualTo("? '#nope' _%&^& *@ ?");
+        assertThat(parsed.getParameters().getParameterNames()).containsExactly("bo0", "0id");
     }
 
     @Test
-    public void testDollarSignOkay() throws Exception {
-        ParsedSql parsed = parser.parse("select * from v$session", ctx);
-        assertThat(parsed.getSql()).isEqualTo("select * from v$session");
+    public void testPoundIsLiteral() {
+        ParsedSql parsed = parser.parse("select * from v#session", ctx);
+        assertThat(parsed.getSql()).isEqualTo("select * from v#session");
     }
 
     @Test
-    public void testColonIsLiteral() throws Exception {
+    public void testColonIsLiteral() {
         ParsedSql parsed = parser.parse("select * from foo where id = :id", ctx);
         assertThat(parsed.getSql()).isEqualTo("select * from foo where id = :id");
     }
 
     @Test
-    public void testBacktickOkay() throws Exception {
-        ParsedSql parsed = parser.parse("select * from `v$session", ctx);
-        assertThat(parsed.getSql()).isEqualTo("select * from `v$session");
+    public void testBacktickIsLiteral() {
+        ParsedSql parsed = parser.parse("select * from `v#session", ctx);
+        assertThat(parsed.getSql()).isEqualTo("select * from `v#session");
     }
 
     @Test
-    public void testBailsOutOnInvalidInput() throws Exception {
-        assertThatThrownBy(() -> parser.parse("select * from something\n where id = #\u0087\u008e\u0092\u0097\u009c", ctx))
+    public void testBailsOutOnInvalidInput() {
+        assertThatThrownBy(() -> parser.parse("select * from something\n where id = $\u0087\u008e\u0092\u0097\u009c", ctx))
             .isInstanceOf(UnableToCreateStatementException.class);
     }
 
     @Test
-    // TODO what does this test?
-    public void testCommentQuote() throws Exception {
-        String sql = "select 1 /* ' \" <foo> */";
+    public void testCommentAndQuote() {
+        String sql = "select 1 /* $foo */ from '$foo'";
         assertThat(parser.parse(sql, ctx).getSql()).isEqualTo(sql);
     }
 
     @Test
-    public void testEscapedQuestionMark() throws Exception {
-        String sql = "SELECT '{\"a\":1, \"b\":2}'::jsonb ?? #key";
+    public void testEscapedQuestionMark() {
+        String sql = "SELECT '{\"a\":1, \"b\":2}'::jsonb ?? $key";
         ParsedSql parsed = parser.parse(sql, ctx);
 
         assertThat(parsed).isEqualTo(ParsedSql.builder()

--- a/src/build/checkstyle-suppress.xml
+++ b/src/build/checkstyle-suppress.xml
@@ -20,6 +20,7 @@
     <suppress checks=".*" files="SqlScriptLexer\.java$"/>
     <suppress checks=".*" files="DefineStatementLexer\.java$"/>
     <suppress checks=".*" files="ColonStatementLexer\.java$"/>
+    <suppress checks=".*" files="DollarStatementLexer\.java$"/>
     <suppress checks=".*" files="FormatterStatementLexer\.java$"/>
     <suppress checks=".*" files="HashStatementLexer\.java$"/>
 </suppressions>


### PR DESCRIPTION
SqlParser for `$foo` placeholders. Not familiar with antlr beyond editing the existing scripts and figuring out how it works that way, so I'm not entirely sure the lexer makes perfect sense as-is (it's an edit of the Hash lexer).

Found a suspicious test case `TestHashPrefixSqlParser.testCommentQuote`. Doesn't really seem to test anything of value. I suspect it needs to look more like my `TestDollarPrefixSqlParser.testCommentAndQuote` to be meaningful.