### PR TITLE
[experiment] regex sqlparser

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/RegexSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/RegexSqlParser.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexSqlParser implements SqlParser {
+    private final Pattern pattern;
+    private final String prefix, suffix;
+
+    /**
+     * @param prefix the <b>literal</b> prefix to match, e.g. <code>"${"</code>
+     * @param suffix the <b>literal</b> suffix to match, e.g. <code>"}"</code>
+     */
+    public RegexSqlParser(String prefix, String suffix) {
+        this.pattern = Pattern.compile(Pattern.quote(prefix) + "([a-z0-9_]+)" + Pattern.quote(suffix));
+        this.prefix = prefix;
+        this.suffix = suffix;
+    }
+
+    @Override
+    public ParsedSql parse(String sql, StatementContext ctx) {
+        ParsedSql.Builder builder = ParsedSql.builder();
+        Matcher matcher = pattern.matcher(sql);
+
+        int lastIndex = 0;
+        while (matcher.find()) {
+            MatchResult r = matcher.toMatchResult();
+            builder.append(sql.substring(lastIndex, r.start()));
+            builder.appendNamedParameter(r.group(1));
+            lastIndex = r.end();
+        }
+        builder.append(sql.substring(lastIndex));
+
+        return builder.build();
+    }
+
+    @Override
+    public String nameParameter(String rawName, StatementContext ctx) {
+        return prefix + rawName + suffix;
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestRegexSqlParser.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestRegexSqlParser.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class TestRegexSqlParser {
+    private SqlParser parser;
+    private StatementContext ctx;
+
+    @Before
+    public void setUp() throws Exception {
+        parser = new RegexSqlParser("${", "}");
+        ctx = mock(StatementContext.class);
+    }
+
+    @Test
+    public void typicalUse() {
+        ParsedSql parsed = parser.parse("hello ${where}, general ${who}!", ctx);
+
+        assertThat(parsed.getSql()).isEqualTo("hello ?, general ?!");
+        assertThat(parsed.getParameters().getParameterNames()).containsExactly("where", "who");
+    }
+}


### PR DESCRIPTION
Quick implementation of a regex-based non-lexing SqlParser.

Has obvious risks but works great if the user watches his step accordingly. Has the advantage of being configurable, unlike the antlr SqlParsers. You gain some you lose some.

Needs some more tests, javadoc, and maybe some more implementation (I don't know yet what to do about positionals for example).

Is this appealing to be fleshed out and merged or nah?