### PR TITLE
Introduced JUnit Rule to provide embedded postgres prepared by flyway

### DIFF
--- a/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
@@ -43,6 +43,15 @@ public abstract class JdbiRule extends ExternalResource {
     }
 
     /**
+     * Create a JdbiRule with an embedded Postgres instance that will be prepared by Flyway.<br>
+     * Your project must depend on the {@code otj-pg-embedded} artifact.
+     * @param migrationLocations classpath locations to scan recursively for flyway migrations. (default: db/migration)
+     */
+    public static JdbiRule preparedEmbeddedPostgres(final String... migrationLocations) {
+        return new PreparedEmbeddedPostgresJdbiRule(migrationLocations);
+    }
+
+    /**
      * Create a JdbiRule with an in-memory H2 database instance.
      * Your project must depend on the {@code h2} database artifact.
      */

--- a/testing/src/main/java/org/jdbi/v3/testing/PreparedEmbeddedPostgresJdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/PreparedEmbeddedPostgresJdbiRule.java
@@ -1,0 +1,27 @@
+package org.jdbi.v3.testing;
+
+import com.opentable.db.postgres.embedded.FlywayPreparer;
+import com.opentable.db.postgres.junit.EmbeddedPostgresRules;
+import com.opentable.db.postgres.junit.PreparedDbRule;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+class PreparedEmbeddedPostgresJdbiRule extends JdbiRule {
+
+    private final PreparedDbRule embeddedPreparedDbRule;
+
+    PreparedEmbeddedPostgresJdbiRule(final String... migrationLocations) {
+        embeddedPreparedDbRule = EmbeddedPostgresRules.preparedDatabase(FlywayPreparer.forClasspathLocation(migrationLocations));
+    }
+
+    @Override
+    protected Jdbi createJdbi() {
+        return Jdbi.create(embeddedPreparedDbRule.getTestDatabase());
+    }
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+        return embeddedPreparedDbRule.apply(super.apply(base, description), description);
+    }
+}


### PR DESCRIPTION
Also added static factory method in abstract JdbiRule for consistency.

Unsure about the class name, but the class wraps the `PreparedDBRule` from the otj-pg-embedded lib.

This newly introduced rule provides the convenience of having an in memory postgres db, that gets set up with Flyway migrations according to the provided migrationLocations.

Example usage:
```java
public class SomeTest {
   @Rule
   public JdbiRule db = JdbiRule.preparedEmbeddedPostgres("db/migration").withPlugins();
}
```