### PR TITLE
Default number format for Freemarker configuration

### DIFF
--- a/freemarker/src/main/java/org/jdbi/v3/freemarker/FreemarkerSqlLocator.java
+++ b/freemarker/src/main/java/org/jdbi/v3/freemarker/FreemarkerSqlLocator.java
@@ -30,6 +30,7 @@ public class FreemarkerSqlLocator {
     static {
         Configuration c = new Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
         c.setTemplateLoader(new ClassTemplateLoader(selectClassLoader(), "/"));
+        c.setNumberFormat("computer");
         CONFIGURATION = c;
     }
 

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerSqlLocatorTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerSqlLocatorTest.java
@@ -80,10 +80,10 @@ public class FreemarkerSqlLocatorTest {
 
     @Test
     public void testDefinedBeanList() throws Exception {
-        handle.execute("insert into something (id, name) values (6, 'Martin')");
+        handle.execute("insert into something (id, name) values (6666666, 'Martin')");
         handle.execute("insert into something (id, name) values (7, 'Peter')");
 
-        List<String> s = handle.attach(Wombat.class).findNamesForSomethings(Arrays.asList(new Something(6, "Martin"), new Something(7, "Peter")));
+        List<String> s = handle.attach(Wombat.class).findNamesForSomethings(Arrays.asList(new Something(6666666, "Martin"), new Something(7, "Peter")));
         assertThat(s.size()).isEqualTo(2);
         assertThat(s).containsExactly("Martin", "Peter");
     }


### PR DESCRIPTION
I need to have Freemarker use computer as default number format. It doesnt make sense to use thousand separators for numbers in sql. At least not implicitly. Its too much work having to always use ?c on all numbers to be used in queries.