### PR TITLE
[API niceness] MessageFormatTemplateEngine not an enum

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/MessageFormatTemplateEngine.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/MessageFormatTemplateEngine.java
@@ -38,8 +38,10 @@ import java.util.Set;
  *         .invoke());
  * }</pre>
  */
-public enum MessageFormatTemplateEngine implements TemplateEngine {
-    INSTANCE;
+public class MessageFormatTemplateEngine implements TemplateEngine {
+    public static final TemplateEngine INSTANCE = new MessageFormatTemplateEngine();
+
+    private MessageFormatTemplateEngine() {}
 
     @Override
     public String render(String template, StatementContext ctx) {


### PR DESCRIPTION
With this class using `enum` as a singleton mechanism, IDEs tend to suggest silly things like `MessageFormatTemplateEngine.valueOf(string)` and other `Enum` methods. This is really just confusing for users.

A plain static instance and private constructor will suffice. This change is non-breaking.