### PR TITLE
[done?] SerializableTransactionRunner onFailure/onSuccess callback

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+3.2.1
+  - New API
+    - added informative callbacks to SerializableTransactionRunner
+
 3.2.0
   - New modules:
     - jdbi3-testing - JdbiRule test rule for JUnit tests

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,4 @@
-3.2.1
+3.3.0
   - New API
     - added informative callbacks to SerializableTransactionRunner
 

--- a/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
@@ -67,9 +67,7 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
                 // no more attempts left? Throw ALL the exceptions! \o/
                 if (--attempts <= 0) {
                     X toThrow = stack.removeFirst();
-                    while (!stack.isEmpty()) {
-                        toThrow.addSuppressed(stack.removeFirst());
-                    }
+                    stack.forEach(toThrow::addSuppressed);
                     throw toThrow;
                 }
             }

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestSerializableTransactionRunner.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestSerializableTransactionRunner.java
@@ -14,37 +14,49 @@
 package org.jdbi.v3.core.transaction;
 
 import java.sql.SQLException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class TestSerializableTransactionRunner {
     private static final int RETRIES = 5;
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public MockitoRule mockito = MockitoJUnit.rule();
+    @Mock
+    private Consumer<List<Exception>> onFailure;
 
-    private Jdbi db;
+    @Rule
+    public H2DatabaseRule dbRule = new H2DatabaseRule();
 
     @Before
     public void setUp() throws Exception {
-        db = Jdbi.create(dbRule.getConnectionFactory());
-        db.setTransactionHandler(new SerializableTransactionRunner());
-        db.getConfig(SerializableTransactionRunner.Configuration.class).setMaxRetries(RETRIES);
+        dbRule.getJdbi().setTransactionHandler(new SerializableTransactionRunner());
+        dbRule.getJdbi().getConfig(SerializableTransactionRunner.Configuration.class)
+            .setMaxRetries(RETRIES)
+            .setOnFailure(onFailure);
     }
 
     @Test
     public void testEventuallyFails() {
         final AtomicInteger attempts = new AtomicInteger(0);
-        Handle handle = db.open();
+        Handle handle = dbRule.getJdbi().open();
 
         assertThatExceptionOfType(SQLException.class)
                 .isThrownBy(() -> handle.inTransaction(TransactionIsolationLevel.SERIALIZABLE,
@@ -60,7 +72,7 @@ public class TestSerializableTransactionRunner {
     @Test
     public void testEventuallySucceeds() throws Exception {
         final AtomicInteger remaining = new AtomicInteger(RETRIES / 2);
-        Handle handle = db.open();
+        Handle handle = dbRule.getJdbi().open();
 
         handle.inTransaction(TransactionIsolationLevel.SERIALIZABLE, conn -> {
             if (remaining.decrementAndGet() == 0) {
@@ -74,8 +86,31 @@ public class TestSerializableTransactionRunner {
 
     @Test
     public void testNonsenseRetryCount() {
-        assertThatThrownBy(() -> db.configure(SerializableTransactionRunner.Configuration.class, config -> config.setMaxRetries(-1)))
+        assertThatThrownBy(() -> dbRule.getJdbi().configure(SerializableTransactionRunner.Configuration.class, config -> config.setMaxRetries(-1)))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Set a number >= 0");
+    }
+
+    @Test
+    public void testOnFailureCallback() throws SQLException {
+        AtomicInteger remaining = new AtomicInteger(4);
+        AtomicInteger expectedExceptions = new AtomicInteger(1);
+
+        doAnswer(invocation -> {
+            assertThat((List<Exception>) invocation.getArgument(0))
+                .describedAs("should be called with " + expectedExceptions.get() + " exceptions")
+                .hasSize(expectedExceptions.getAndIncrement());
+            return null;
+        }).when(onFailure).accept(anyList());
+
+        dbRule.getJdbi().open().inTransaction(TransactionIsolationLevel.SERIALIZABLE, conn -> {
+            if (remaining.decrementAndGet() == 0) {
+                return null;
+            }
+            throw new SQLException("serialization", "40001");
+        });
+
+        verify(onFailure, times(3)).accept(anyList());
+        assertThat(expectedExceptions.get()).isEqualTo(4);
     }
 }


### PR DESCRIPTION
Inspired by something I wanted to do in my private project: log some info when SerializableTransactionRunner encounters a serialization failure, and a final time upon success.

> transaction failed 1 time! retrying...
> transaction failed 2 times! retrying...
> transaction succeeded after 2 retries!