### PR TITLE
Fixed for POM conflict issue

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -162,7 +162,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore />
+                                        <ignore></ignore>
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>


### PR DESCRIPTION
Every time I build and install the latest JDBI3 snapshot, the build changes `core/pom.xml` so when I go to pull the latest commits, git complains that my changes to `core/pom.xml` will be overwritten. This requires me to have to `git checkout -- core/pom.xml` before every pull.

I have been able to reproduce this on an Ubuntu 16.04.4LTS Sever:

```
Apache Maven 3.3.9
Maven home: /usr/share/maven
Java version: 1.8.0_171, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-8-openjdk-amd64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.4.0-127-generic", arch: "amd64", family: "unix"
```

As well as my Mac:

```
$ mvn --version
Apache Maven 3.5.3 (3383c37e1f9e9b3bc3df5050c29c8aff9f295297; 2018-02-24T14:49:05-05:00)
Maven home: <redacted>/apache-maven-3.5.3
Java version: 1.8.0_171, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_171.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.4", arch: "x86_64", family: "mac"
```

As such, I have simply committed the change made by the build process so this never happens again.

Thanks.