### PR TITLE
[experiment] more categorized arguments/mappers for easier composition and more safety

### DIFF
--- a/core/src/main/java/org/jdbi/v3/wip/BlockAllDataTypesPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/BlockAllDataTypesPlugin.java
@@ -1,0 +1,16 @@
+package org.jdbi.v3.wip;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+public class BlockAllDataTypesPlugin implements JdbiPlugin {
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		jdbi.registerArgument((type, value, config) -> {
+			throw new UnsupportedOperationException("install an appropriate argument factory for " + type + "!");
+		});
+		jdbi.registerColumnMapper((type, config) -> {
+			throw new UnsupportedOperationException("install an appropriate column mapper for " + type + "!");
+		});
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/EnumPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/EnumPlugin.java
@@ -1,0 +1,30 @@
+package org.jdbi.v3.wip;
+
+import java.sql.Types;
+import java.util.Optional;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+public class EnumPlugin implements JdbiPlugin {
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		jdbi.registerArgument((type, value, config) -> {
+            if (type instanceof Class && Enum.class.isAssignableFrom((Class) type)) {
+                if (value == null) {
+                    return Optional.of((position, statement, ctx) -> statement.setNull(position, Types.VARCHAR));
+                }
+            }
+            return Optional.empty();
+        });
+
+		jdbi.registerColumnMapper((type, config) -> {
+            if (type instanceof Class && Enum.class.isAssignableFrom((Class) type)) {
+                return Optional.of((r, columnNumber, ctx) -> r.getObject(columnNumber) == null
+                    ? null
+                    : Enum.valueOf((Class) type, r.getString(columnNumber)));
+            } else {
+                return Optional.empty();
+            }
+        });
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/GetSetObjectPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/GetSetObjectPlugin.java
@@ -1,0 +1,51 @@
+package org.jdbi.v3.wip;
+
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+public class GetSetObjectPlugin implements JdbiPlugin {
+	public static final Optional<Argument> NULL = Optional.of((position, statement, ctx) -> statement.setNull(position, Types.NULL));
+
+	private final Map<Class<?>, Optional<ColumnMapper<?>>> mapperCache = new ConcurrentHashMap<>();
+
+	private final Set<Class<?>> supported;
+
+	public GetSetObjectPlugin(Class<?> c, Class<?>... cs) {
+		supported = new HashSet<>(1 + cs.length);
+		supported.add(c);
+		supported.addAll(Arrays.asList(cs));
+	}
+
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		jdbi.registerArgument((type, value, config) -> {
+			if (type instanceof Class<?> && supported.contains(type)) {
+				if (value == null) {
+					return NULL;
+				} else {
+					return Optional.of(new LoggableArgument(value, (position, statement, ctx) -> statement.setObject(position, value)));
+				}
+			} else {
+				return Optional.empty();
+			}
+		});
+
+		jdbi.registerColumnMapper((type, config) -> {
+			if (type instanceof Class<?> && supported.contains(type)) {
+				Class<?> c = (Class<?>) type;
+				return mapperCache.computeIfAbsent(c, c2 -> Optional.of((r, columnNumber, ctx) -> r.getObject(columnNumber, c2)));
+			} else {
+				return Optional.empty();
+			}
+		});
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/LoggableArgument.java
+++ b/core/src/main/java/org/jdbi/v3/wip/LoggableArgument.java
@@ -1,0 +1,27 @@
+package org.jdbi.v3.wip;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Objects;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class LoggableArgument implements Argument {
+	private final Object value;
+	private final Argument argument;
+
+	public LoggableArgument(Object value, Argument argument) {
+		this.value = value;
+		this.argument = argument;
+	}
+
+	@Override
+	public void apply(int position, PreparedStatement statement, StatementContext context) throws SQLException {
+		argument.apply(position, statement, context);
+	}
+
+	@Override
+	public String toString() {
+		return Objects.toString(value);
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/OptionalPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/OptionalPlugin.java
@@ -1,0 +1,34 @@
+package org.jdbi.v3.wip;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.argument.Arguments;
+import org.jdbi.v3.core.generic.GenericTypes;
+import org.jdbi.v3.core.mapper.ColumnMappers;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+public class OptionalPlugin implements JdbiPlugin {
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		jdbi.registerArgument((type, value, config) -> {
+			if (Optional.class.equals(GenericTypes.getErasedType(type))) {
+				Optional<Type> t = GenericTypes.findGenericParameter(type, Optional.class);
+				if (t.isPresent()) {
+					return config.get(Arguments.class).findFor(t.get(), value);
+				}
+			}
+			return Optional.empty();
+		});
+
+		jdbi.registerColumnMapper((type, config) -> {
+			if (Optional.class.equals(GenericTypes.getErasedType(type))) {
+				Optional<Type> t = GenericTypes.findGenericParameter(type, Optional.class);
+				if (t.isPresent()) {
+					return config.get(ColumnMappers.class).findFor(t.get());
+				}
+			}
+			return Optional.empty();
+		});
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/categories/JdbcBasicsPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/categories/JdbcBasicsPlugin.java
@@ -1,0 +1,33 @@
+package org.jdbi.v3.wip.categories;
+
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+import static org.jdbi.v3.wip.categories.PluginUtils.registerClassArgument;
+import static org.jdbi.v3.wip.categories.PluginUtils.registerClassMapper;
+
+public class JdbcBasicsPlugin implements JdbiPlugin {
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		registerClassArgument(jdbi, BigDecimal.class, Types.NUMERIC, PreparedStatement::setBigDecimal);
+		registerClassArgument(jdbi, String.class, Types.VARCHAR, PreparedStatement::setString);
+		registerClassArgument(jdbi, URL.class, Types.DATALINK, PreparedStatement::setURL);
+		registerClassArgument(jdbi, byte[].class, Types.VARBINARY, PreparedStatement::setBytes);
+		registerClassArgument(jdbi, Blob.class, Types.BLOB, PreparedStatement::setBlob);
+		registerClassArgument(jdbi, Clob.class, Types.CLOB, PreparedStatement::setClob);
+
+		registerClassMapper(jdbi, BigDecimal.class, ResultSet::getBigDecimal);
+		registerClassMapper(jdbi, String.class, ResultSet::getString);
+		registerClassMapper(jdbi, URL.class, ResultSet::getURL);
+		registerClassMapper(jdbi, byte[].class, ResultSet::getBytes);
+		registerClassMapper(jdbi, Blob.class, ResultSet::getBlob);
+		registerClassMapper(jdbi, Clob.class, ResultSet::getClob);
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/categories/LegacyTimePlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/categories/LegacyTimePlugin.java
@@ -1,0 +1,27 @@
+package org.jdbi.v3.wip.categories;
+
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+import static org.jdbi.v3.wip.categories.PluginUtils.registerClassArgument;
+import static org.jdbi.v3.wip.categories.PluginUtils.registerClassMapper;
+
+@Deprecated
+public class LegacyTimePlugin implements JdbiPlugin {
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		registerClassArgument(jdbi, Date.class, Types.DATE, PreparedStatement::setDate);
+		registerClassArgument(jdbi, Time.class, Types.TIME, PreparedStatement::setTime);
+		registerClassArgument(jdbi, Timestamp.class, Types.TIMESTAMP, PreparedStatement::setTimestamp);
+
+		registerClassMapper(jdbi, Date.class, ResultSet::getDate);
+		registerClassMapper(jdbi, Time.class, ResultSet::getTime);
+		registerClassMapper(jdbi, Timestamp.class, ResultSet::getTimestamp);
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/categories/OptionalPrimitivesPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/categories/OptionalPrimitivesPlugin.java
@@ -1,0 +1,80 @@
+package org.jdbi.v3.wip.categories;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+import static org.jdbi.v3.wip.categories.PluginUtils.registerClassArgument;
+import static org.jdbi.v3.wip.categories.PluginUtils.registerClassMapper;
+import static org.jdbi.v3.wip.categories.PluginUtils.registerGenericTypeArgument;
+import static org.jdbi.v3.wip.categories.PluginUtils.registerGenericTypeMapper;
+
+public class OptionalPrimitivesPlugin implements JdbiPlugin {
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		registerOptionalArgument(jdbi, new GenericType<Optional<Boolean>>() {}, Types.BOOLEAN, PreparedStatement::setBoolean);
+		registerOptionalArgument(jdbi, new GenericType<Optional<Byte>>() {}, Types.TINYINT, PreparedStatement::setByte);
+		registerOptionalArgument(jdbi, new GenericType<Optional<Character>>() {}, Types.TINYINT, (p, i, v) -> p.setByte(i, (byte) (char) v));
+		registerOptionalArgument(jdbi, new GenericType<Optional<Short>>() {}, Types.SMALLINT, PreparedStatement::setShort);
+		registerOptionalArgument(jdbi, new GenericType<Optional<Integer>>() {}, Types.INTEGER, PreparedStatement::setInt);
+		registerOptionalArgument(jdbi, new GenericType<Optional<Long>>() {}, Types.BIGINT, PreparedStatement::setLong);
+		registerOptionalArgument(jdbi, new GenericType<Optional<Float>>() {}, Types.FLOAT, PreparedStatement::setFloat);
+		registerOptionalArgument(jdbi, new GenericType<Optional<Double>>() {}, Types.DOUBLE, PreparedStatement::setDouble);
+
+		registerClassArgument(jdbi, OptionalInt.class, Types.INTEGER, (p, i, v) -> {
+			if (v.isPresent()) {
+				p.setInt(i, v.getAsInt());
+			} else {
+				p.setNull(i, Types.INTEGER);
+			}
+		});
+		registerClassArgument(jdbi, OptionalLong.class, Types.BIGINT, (p, i, v) -> {
+			if (v.isPresent()) {
+				p.setLong(i, v.getAsLong());
+			} else {
+				p.setNull(i, Types.BIGINT);
+			}
+		});
+		registerClassArgument(jdbi, OptionalDouble.class, Types.DOUBLE, (p, i, v) -> {
+			if (v.isPresent()) {
+				p.setDouble(i, v.getAsDouble());
+			} else {
+				p.setNull(i, Types.DOUBLE);
+			}
+		});
+
+		registerOptionalMapper(jdbi, new GenericType<Optional<Boolean>>() {}, ResultSet::getBoolean);
+		registerOptionalMapper(jdbi, new GenericType<Optional<Byte>>() {}, ResultSet::getByte);
+		registerOptionalMapper(jdbi, new GenericType<Optional<Character>>() {}, (r, i) -> (char) r.getByte(i));
+		registerOptionalMapper(jdbi, new GenericType<Optional<Short>>() {}, ResultSet::getShort);
+		registerOptionalMapper(jdbi, new GenericType<Optional<Integer>>() {}, ResultSet::getInt);
+		registerOptionalMapper(jdbi, new GenericType<Optional<Long>>() {}, ResultSet::getLong);
+		registerOptionalMapper(jdbi, new GenericType<Optional<Float>>() {}, ResultSet::getFloat);
+		registerOptionalMapper(jdbi, new GenericType<Optional<Double>>() {}, ResultSet::getDouble);
+
+		registerClassMapper(jdbi, OptionalInt.class, (r, i) -> r.getObject(i) == null ? OptionalInt.empty() : OptionalInt.of(r.getInt(i)));
+		registerClassMapper(jdbi, OptionalLong.class, (r, i) -> r.getObject(i) == null ? OptionalLong.empty() : OptionalLong.of(r.getLong(i)));
+		registerClassMapper(jdbi, OptionalDouble.class, (r, i) -> r.getObject(i) == null ? OptionalDouble.empty() : OptionalDouble.of(r.getDouble(i)));
+	}
+
+	private static <T> void registerOptionalArgument(Jdbi jdbi, GenericType<Optional<T>> genericType, int sqlType, PluginUtils.Binder<T> binder) {
+		registerGenericTypeArgument(jdbi, genericType, sqlType, (p, i, v) -> {
+			if (v.isPresent()) {
+				binder.bind(p, i, v.get());
+			} else {
+				p.setNull(i, sqlType);
+			}
+		});
+	}
+
+	private static <T> void registerOptionalMapper(Jdbi jdbi, GenericType<Optional<T>> genericType, PluginUtils.ResultGetter<T> getter) {
+		registerGenericTypeMapper(jdbi, genericType, (r, i) -> r.getObject(i) == null ? Optional.empty() : Optional.of(getter.get(r, i)));
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/categories/PluginUtils.java
+++ b/core/src/main/java/org/jdbi/v3/wip/categories/PluginUtils.java
@@ -1,0 +1,56 @@
+package org.jdbi.v3.wip.categories;
+
+import java.lang.reflect.Type;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.wip.LoggableArgument;
+
+class PluginUtils {
+	static <T> void registerGenericTypeArgument(Jdbi jdbi, GenericType<T> genericType, int sqlType, Binder<T> binder) {
+		registerTypeArgument(jdbi, genericType.getType(), sqlType, binder);
+	}
+
+	static <T> void registerClassArgument(Jdbi jdbi, Class<T> clazz, int sqlType, Binder<T> binder) {
+		registerTypeArgument(jdbi, clazz, sqlType, binder);
+	}
+
+	static <T> void registerTypeArgument(Jdbi jdbi, Type t, int sqlType, Binder<T> binder) {
+		jdbi.registerArgument((type, value, config) -> {
+			if (t.equals(type)) {
+				if (value == null) {
+					return Optional.of(new LoggableArgument(null, (position, statement, ctx) -> statement.setNull(position, sqlType)));
+				} else {
+					return Optional.of(new LoggableArgument(value, (position, statement, ctx) -> binder.bind(statement, position, (T) value)));
+				}
+			} else {
+				return Optional.empty();
+			}
+		});
+	}
+
+	static <T> void registerGenericTypeMapper(Jdbi jdbi, GenericType<T> genericType, ResultGetter<T> getter) {
+		registerTypeMapper(jdbi, genericType.getType(), getter);
+	}
+
+	static <T> void registerClassMapper(Jdbi jdbi, Class<T> clazz, ResultGetter<T> getter) {
+		registerTypeMapper(jdbi, clazz, getter);
+	}
+
+	static <T> void registerTypeMapper(Jdbi jdbi, Type t, ResultGetter<T> getter) {
+		jdbi.registerColumnMapper(t, (r, columnNumber, ctx) -> getter.get(r, columnNumber));
+	}
+
+	@FunctionalInterface
+	interface Binder<T> {
+		void bind(PreparedStatement p, int index, T value) throws SQLException;
+	}
+
+	@FunctionalInterface
+	interface ResultGetter<T> {
+		T get(ResultSet r, int i) throws SQLException;
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/categories/PrimitivesPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/categories/PrimitivesPlugin.java
@@ -1,0 +1,86 @@
+package org.jdbi.v3.wip.categories;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.Optional;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jdbi.v3.wip.LoggableArgument;
+
+import static org.jdbi.v3.wip.categories.PluginUtils.registerClassArgument;
+
+public class PrimitivesPlugin implements JdbiPlugin {
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		registerPrimitiveArgument(jdbi, boolean.class, PreparedStatement::setBoolean);
+		registerPrimitiveArgument(jdbi, byte.class, PreparedStatement::setByte);
+		registerPrimitiveArgument(jdbi, char.class, (p, i, v) -> p.setByte(i, (byte) (char) v));
+		registerPrimitiveArgument(jdbi, short.class, PreparedStatement::setShort);
+		registerPrimitiveArgument(jdbi, int.class, PreparedStatement::setInt);
+		registerPrimitiveArgument(jdbi, long.class, PreparedStatement::setLong);
+		registerPrimitiveArgument(jdbi, float.class, PreparedStatement::setFloat);
+		registerPrimitiveArgument(jdbi, double.class, PreparedStatement::setDouble);
+
+		registerClassArgument(jdbi, Boolean.class, Types.BOOLEAN, PreparedStatement::setBoolean);
+		registerClassArgument(jdbi, Byte.class, Types.TINYINT, PreparedStatement::setByte);
+		registerClassArgument(jdbi, Character.class, Types.TINYINT, (p, i, v) -> p.setByte(i, (byte) (char) v));
+		registerClassArgument(jdbi, Short.class, Types.SMALLINT, PreparedStatement::setShort);
+		registerClassArgument(jdbi, Integer.class, Types.INTEGER, PreparedStatement::setInt);
+		registerClassArgument(jdbi, Long.class, Types.BIGINT, PreparedStatement::setLong);
+		registerClassArgument(jdbi, Float.class, Types.FLOAT, PreparedStatement::setFloat);
+		registerClassArgument(jdbi, Double.class, Types.DOUBLE, PreparedStatement::setDouble);
+
+		registerPrimitiveMapper(jdbi, boolean.class, ResultSet::getBoolean);
+		registerPrimitiveMapper(jdbi, byte.class, ResultSet::getByte);
+		registerPrimitiveMapper(jdbi, char.class, (r, i) -> (char) r.getByte(i));
+		registerPrimitiveMapper(jdbi, short.class, ResultSet::getShort);
+		registerPrimitiveMapper(jdbi, int.class, ResultSet::getInt);
+		registerPrimitiveMapper(jdbi, long.class, ResultSet::getLong);
+		registerPrimitiveMapper(jdbi, float.class, ResultSet::getFloat);
+		registerPrimitiveMapper(jdbi, double.class, ResultSet::getDouble);
+
+		registerBoxedMapper(jdbi, Boolean.class, ResultSet::getBoolean);
+		registerBoxedMapper(jdbi, Byte.class, ResultSet::getByte);
+		registerBoxedMapper(jdbi, Character.class, (r, i) -> (char) r.getByte(i));
+		registerBoxedMapper(jdbi, Short.class, ResultSet::getShort);
+		registerBoxedMapper(jdbi, Integer.class, ResultSet::getInt);
+		registerBoxedMapper(jdbi, Long.class, ResultSet::getLong);
+		registerBoxedMapper(jdbi, Float.class, ResultSet::getFloat);
+		registerBoxedMapper(jdbi, Double.class, ResultSet::getDouble);
+	}
+
+	private static <T> void registerPrimitiveArgument(Jdbi jdbi, Class<T> clazz, PluginUtils.Binder<T> binder) {
+		jdbi.registerArgument((type, value, config) -> {
+			if (clazz.equals(type)) {
+				if (value == null) {
+					throw new IllegalArgumentException("nulls should not be bound as primitives");
+				} else {
+					return Optional.of(new LoggableArgument(value, (position, statement, ctx) -> binder.bind(statement, position, (T) value)));
+				}
+			} else {
+				return Optional.empty();
+			}
+		});
+	}
+
+	private static <T> void registerPrimitiveMapper(Jdbi jdbi, Class<T> clazz, PluginUtils.ResultGetter<T> getter) {
+		PluginUtils.registerClassMapper(jdbi, clazz, (r, i) -> {
+			if (r.getObject(i) == null) {
+				throw new IllegalArgumentException("nulls cannot be mapped to primitives");
+			} else {
+				return getter.get(r, i);
+			}
+		});
+	}
+
+	private static <T> void registerBoxedMapper(Jdbi jdbi, Class<T> clazz, PluginUtils.ResultGetter<T> getter) {
+		PluginUtils.registerClassMapper(jdbi, clazz, (r, i) -> {
+			if (r.getObject(i) == null) {
+				return null;
+			} else {
+				return getter.get(r, i);
+			}
+		});
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/categories/UnreliableJavaTimePlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/categories/UnreliableJavaTimePlugin.java
@@ -1,0 +1,42 @@
+package org.jdbi.v3.wip.categories;
+
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+import static org.jdbi.v3.wip.categories.PluginUtils.registerClassArgument;
+import static org.jdbi.v3.wip.categories.PluginUtils.registerClassMapper;
+
+@Deprecated
+public class UnreliableJavaTimePlugin implements JdbiPlugin {
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		registerClassArgument(jdbi, LocalDate.class, Types.DATE, (p, i, v) -> p.setDate(i, java.sql.Date.valueOf(v)));
+		registerClassArgument(jdbi, LocalTime.class, Types.TIME, (p, i, v) -> p.setTime(i, Time.valueOf(v)));
+		registerClassArgument(jdbi, LocalDateTime.class, Types.TIMESTAMP, (p, i, v) -> p.setTimestamp(i, Timestamp.valueOf(v)));
+
+		registerClassArgument(jdbi, Instant.class, Types.TIMESTAMP, (p, i, v) -> p.setTimestamp(i, Timestamp.from(v)));
+		registerClassArgument(jdbi, OffsetDateTime.class, Types.TIMESTAMP, (p, i, v) -> p.setTimestamp(i, Timestamp.from(v.toInstant())));
+		registerClassArgument(jdbi, ZonedDateTime.class, Types.TIMESTAMP, (p, i, v) -> p.setTimestamp(i, Timestamp.from(v.toInstant())));
+		registerClassArgument(jdbi, Year.class, Types.INTEGER, (p, i, v) -> p.setInt(i, v.getValue()));
+
+		registerClassMapper(jdbi, LocalDate.class, (r, i) -> r.getDate(i).toLocalDate());
+		registerClassMapper(jdbi, LocalTime.class, (r, i) -> r.getTime(i).toLocalTime());
+		registerClassMapper(jdbi, LocalDateTime.class, (r, i) -> r.getTimestamp(i).toLocalDateTime());
+
+		registerClassMapper(jdbi, Instant.class, (r, i) -> r.getTimestamp(i).toInstant());
+		registerClassMapper(jdbi, OffsetDateTime.class, (r, i) -> OffsetDateTime.ofInstant(r.getTimestamp(i).toInstant(), ZoneId.systemDefault()));
+		registerClassMapper(jdbi, ZonedDateTime.class, (r, i) -> r.getTimestamp(i).toInstant().atZone(ZoneId.systemDefault()));
+		registerClassMapper(jdbi, Year.class, (r, i) -> Year.of(r.getInt(i)));
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/meta/EssentialsPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/meta/EssentialsPlugin.java
@@ -1,0 +1,38 @@
+package org.jdbi.v3.wip.meta;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jdbi.v3.wip.BlockAllDataTypesPlugin;
+import org.jdbi.v3.wip.EnumPlugin;
+import org.jdbi.v3.wip.OptionalPlugin;
+import org.jdbi.v3.wip.categories.JdbcBasicsPlugin;
+import org.jdbi.v3.wip.categories.LegacyTimePlugin;
+import org.jdbi.v3.wip.categories.OptionalPrimitivesPlugin;
+import org.jdbi.v3.wip.categories.PrimitivesPlugin;
+import org.jdbi.v3.wip.categories.UnreliableJavaTimePlugin;
+
+public class EssentialsPlugin implements JdbiPlugin {
+	public static final JdbiPlugin CORE = new EssentialsPlugin(false);
+	public static final JdbiPlugin CONTROVERSIAL = new EssentialsPlugin(true);
+
+	private final boolean controversial;
+
+	private EssentialsPlugin(boolean controversial) {
+		this.controversial = controversial;
+	}
+
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		jdbi.installPlugin(new BlockAllDataTypesPlugin());
+		jdbi.installPlugin(new EnumPlugin());
+		jdbi.installPlugin(new OptionalPlugin());
+		jdbi.installPlugin(new PrimitivesPlugin());
+		jdbi.installPlugin(new OptionalPrimitivesPlugin());
+		jdbi.installPlugin(new JdbcBasicsPlugin());
+
+		if (controversial) {
+			jdbi.installPlugin(new LegacyTimePlugin());
+			jdbi.installPlugin(new UnreliableJavaTimePlugin());
+		}
+	}
+}

--- a/core/src/main/java/org/jdbi/v3/wip/meta/HsqldbPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/wip/meta/HsqldbPlugin.java
@@ -1,0 +1,26 @@
+package org.jdbi.v3.wip.meta;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.util.UUID;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jdbi.v3.wip.GetSetObjectPlugin;
+
+public class HsqldbPlugin implements JdbiPlugin {
+	@Override
+	public void customizeJdbi(Jdbi jdbi) {
+		jdbi.installPlugin(EssentialsPlugin.CORE);
+		jdbi.installPlugin(new GetSetObjectPlugin(
+			UUID.class,
+			LocalDate.class,
+			LocalTime.class,
+			LocalDateTime.class,
+			OffsetTime.class,
+			OffsetDateTime.class
+		));
+	}
+}


### PR DESCRIPTION
So this is a POC I wanted to make, based on what I've done in my private project. It ties in to a discussion we previously had about avoiding presumptions about data type support in databases and saddling users up with undesired conversion behavior they'd need to weed out, as well as the `NaiveJavaTimePlugin` I was going to/asked to make, and the db-specific preconfiguration plugins that were brought up once as a desirable Jdbi feature.

At its core are the `PrimitivesPlugin`, `OptionalPrimitivesPlugin`, and `JdbcbasicsPlugin` (built on pure non-primitive jdbc-provided get/set methods, like for `String` and `java.sql` classes). This represents the very core java/sql conversions.

Beside those are the `LegacyTimePlugin` (`java.util.Date` et al), and the `UnreliableJavaTimePlugin` aka `NaiveJavaTimePlugin`.

Where it gets interesting is the `meta` package. This contains the `EssentialsPlugin` with a `controversial` option, to install the core converters and optionally the unsafe ones that are de facto standards but not always desirable. All other data types are blocked out for safety.

Beside that is the convenient `HsqldbPlugin`, which registers the core plugin and a special plugin that uses `getObject`/`setObject` without any types for a set of classes. Hsqldb has explicit support for doing this for some classes such as `UUID` and `java.time` instances, removing the need for any special mapping logic or fickle byte array messing. Installing this plugin tailors Jdbi to support 1:1 the same data types hsqldb supports, no more or less.
This is something I'm personally very fond of, and I think Jdbi would benefit from too. Other databases could get similar plugins, from people who are properly familiar with them and their conversion support. As you can see from the code, a structure like this makes it very easy to tailor a plugin to a database's specific type support.

It's just a POC so no tests, javadoc, or dependency version restrictions atm... I'll write tests later if this idea takes off, but I already know 99% of it will work because my private project basically contains what the HsqldbPlugin does (in less concentrated form), *with* a ton of integration tests to verify nullity and integrity.

I'm a little unsure how Optional support works in jdbi atm so I just included a quick plugin for it... And for enums too while I'm at it ¯\\\_(ツ)\_/¯ I'm not saying the code is perfect or anything yet though...