### PR TITLE
[quick fix] pmd error in noparameters module

### DIFF
--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -30,6 +30,18 @@
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.jdbi</groupId>


### PR DESCRIPTION
This module has no sources and pmd doesn't like that. Disable plugin execution there to get rid of the dozens of stacktraces in maven builds.