### PR TITLE
Additional pom fix for build time pom change

### DIFF
--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -30,18 +30,6 @@
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.jdbi</groupId>
@@ -82,4 +70,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Recent changes to JDBI have introduced another case where the build itself creates a modified pom. Rather than having to blow the file away after every build so I can keep merging master into my local fork, I have simply committed the post-build POM file.