### PR TITLE
[housekeeping] pom checkup

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,6 @@
         <version>3.2.2-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.jdbi</groupId>
     <artifactId>jdbi3-bom</artifactId>
     <packaging>pom</packaging>
     <name>jdbi3 BOM</name>

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -49,11 +49,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -114,11 +114,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.antlr</groupId>
-                    <artifactId>antlr3-maven-plugin</artifactId>
-                    <version>${dep.antlr.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
@@ -148,7 +143,6 @@
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
                     <configuration>
                         <lifecycleMappingMetadata>
                             <pluginExecutions>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -303,7 +303,6 @@
                 <dependency>
                     <groupId>org.jdbi</groupId>
                     <artifactId>jdbi3-oracle12</artifactId>
-                    <version>${project.version}</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -136,11 +136,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -178,8 +178,6 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${dep.kotlin.version}</version>
-
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -199,7 +197,6 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>1.5.3</version>
                 <executions>
                     <execution>
                         <id>output-html</id>
@@ -318,7 +315,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-scm-publish-plugin</artifactId>
-                        <version>1.1</version>
                         <executions>
                             <execution>
                                 <id>publish-docs</id>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -176,6 +176,7 @@
                 <executions>
                     <execution>
                         <id>compile</id>
+                        <phase>process-sources</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.28</version>
         </dependency>
 
         <dependency>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.9.3</version>
         </dependency>
 
         <dependency>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>javax.persistence</groupId>
             <artifactId>persistence-api</artifactId>
-            <version>1.0.2</version>
         </dependency>
 
         <dependency>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -106,8 +106,6 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${dep.kotlin.version}</version>
-
                 <executions>
                     <execution>
                         <id>compile</id>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -111,8 +111,6 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${dep.kotlin.version}</version>
-
                 <executions>
                     <execution>
                         <id>compile</id>

--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -55,16 +55,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>com.oracle.jdbc</groupId>
             <artifactId>ojdbc7</artifactId>
-            <version>12.1.0.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@
                 <artifactId>jdbi3-vavr</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-oracle12</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -374,6 +379,42 @@
                 <groupId>org.xerial</groupId>
                 <artifactId>sqlite-jdbc</artifactId>
                 <version>3.8.11.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>stringtemplate</artifactId>
+                <version>4.0.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.oracle.jdbc</groupId>
+                <artifactId>ojdbc7</artifactId>
+                <version>12.1.0.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.persistence</groupId>
+                <artifactId>persistence-api</artifactId>
+                <version>1.0.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.9.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.freemarker</groupId>
+                <artifactId>freemarker</artifactId>
+                <version>2.3.28</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -506,13 +506,42 @@
                         <jdkVersion>8</jdkVersion>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.antlr</groupId>
+                    <artifactId>antlr3-maven-plugin</artifactId>
+                    <version>${dep.antlr.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-maven-plugin</artifactId>
+                    <version>${dep.kotlin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.asciidoctor</groupId>
+                    <artifactId>asciidoctor-maven-plugin</artifactId>
+                    <version>1.5.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-scm-publish-plugin</artifactId>
+                    <version>1.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.ekryd.sortpom</groupId>
+                    <artifactId>sortpom-maven-plugin</artifactId>
+                    <version>2.8.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>com.github.ekryd.sortpom</groupId>
                 <artifactId>sortpom-maven-plugin</artifactId>
-                <version>2.8.0</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <dep.kotlin.version>1.2.31</dep.kotlin.version>
         <dep.plugin.checkstyle.version>3.0.0</dep.plugin.checkstyle.version>
         <dep.plugin.pmd.version>3.9.0</dep.plugin.pmd.version>
+        <dep.plugin.sortpom.version>2.8.0</dep.plugin.sortpom.version>
         <dep.pmd.version>6.0.1</dep.pmd.version>
         <dep.slf4j.version>1.7.25</dep.slf4j.version>
         <dep.spring.version>4.2.4.RELEASE</dep.spring.version>
@@ -473,16 +474,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <inherited>true</inherited>
-                    <configuration>
-                        <configLocation>/src/build/checkstyle.xml</configLocation>
-                        <suppressionsLocation>/src/build/checkstyle-suppress.xml</suppressionsLocation>
-                        <sourceDirectories>${project.build.sourceDirectory},${project.build.testSourceDirectory}</sourceDirectories>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <source>${project.build.targetJdk}</source>
@@ -534,7 +525,36 @@
                 <plugin>
                     <groupId>com.github.ekryd.sortpom</groupId>
                     <artifactId>sortpom-maven-plugin</artifactId>
-                    <version>2.8.0</version>
+                    <version>${dep.plugin.sortpom.version}</version>
+                    <configuration>
+                        <createBackupFile>false</createBackupFile>
+                        <lineSeparator>\n</lineSeparator>
+                        <nrOfIndentSpace>4</nrOfIndentSpace>
+                        <sortProperties>true</sortProperties>
+                        <keepBlankLines>true</keepBlankLines>
+                        <sortDependencies>scope</sortDependencies>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <configuration>
+                        <linkXRef>false</linkXRef>
+                        <analysisCache>true</analysisCache>
+                        <verbose>true</verbose>
+                        <rulesets>
+                            <ruleset>${maven.multiModuleProjectDirectory}/src/build/pmd.xml</ruleset>
+                        </rulesets>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/src/build/checkstyle.xml</configLocation>
+                        <suppressionsLocation>${maven.multiModuleProjectDirectory}/src/build/checkstyle-suppress.xml</suppressionsLocation>
+                        <sourceDirectories>${project.build.sourceDirectory},${project.build.testSourceDirectory}</sourceDirectories>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -544,41 +564,36 @@
                 <artifactId>sortpom-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>verify</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>sort</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <createBackupFile>false</createBackupFile>
-                    <lineSeparator>\n</lineSeparator>
-                    <nrOfIndentSpace>4</nrOfIndentSpace>
-                    <sortProperties>true</sortProperties>
-                    <keepBlankLines>true</keepBlankLines>
-                    <sortDependencies>scope</sortDependencies>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>default-cli</id>
                         <phase>test</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <linkXRef>false</linkXRef>
-                    <analysisCache>true</analysisCache>
-                    <verbose>true</verbose>
-                    <rulesets>
-                        <ruleset>${maven.multiModuleProjectDirectory}/src/build/pmd.xml</ruleset>
-                    </rulesets>
-                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -197,11 +197,6 @@
                 <artifactId>jdbi3-vavr</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-oracle12</artifactId>
-                <version>${project.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -392,12 +387,6 @@
                 <groupId>javax.annotation</groupId>
                 <artifactId>javax.annotation-api</artifactId>
                 <version>1.3.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.oracle.jdbc</groupId>
-                <artifactId>ojdbc7</artifactId>
-                <version>12.1.0.2</version>
             </dependency>
 
             <dependency>
@@ -706,6 +695,11 @@
             </modules>
             <dependencyManagement>
                 <dependencies>
+                    <dependency>
+                        <groupId>com.oracle.jdbc</groupId>
+                        <artifactId>ojdbc7</artifactId>
+                        <version>12.1.0.2</version>
+                    </dependency>
                     <dependency>
                         <groupId>org.jdbi</groupId>
                         <artifactId>jdbi3-oracle12</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,11 @@
                     <version>1.1</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-toolchains-plugin</artifactId>
+                    <version>1.1</version>
+                </plugin>
+                <plugin>
                     <groupId>com.github.ekryd.sortpom</groupId>
                     <artifactId>sortpom-maven-plugin</artifactId>
                     <version>${dep.plugin.sortpom.version}</version>
@@ -600,7 +605,6 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-toolchains-plugin</artifactId>
-                            <version>1.1</version>
                             <configuration>
                                 <toolchains>
                                     <jdk>
@@ -625,7 +629,6 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-toolchains-plugin</artifactId>
-                            <version>1.1</version>
                             <configuration>
                                 <toolchains>
                                     <jdk>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -98,7 +98,6 @@
                 <dependency>
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.1</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -58,12 +58,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>stringtemplate</artifactId>
-            <version>4.0.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I'm no maven expert, but I believe it's universally bad form to specify inline versions anywhere but the dependencyManagement section of the parent pom, or the properties section for child poms to refer to for plugin versions.

Also moved the checkstyle plugin to what I think is a more correct location and bound it explicitly, along with pmd and sortpom, to a proper lifecycle.

Like I said though, not a maven pro. Have worked with the thing for over 6 years but some of it still confuses me.