### PR TITLE
fix sortpom nuisance

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -162,7 +162,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore></ignore>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -482,11 +482,12 @@
                 </executions>
                 <configuration>
                     <createBackupFile>false</createBackupFile>
+                    <expandEmptyElements>false</expandEmptyElements>
+                    <keepBlankLines>true</keepBlankLines>
                     <lineSeparator>\n</lineSeparator>
                     <nrOfIndentSpace>4</nrOfIndentSpace>
-                    <sortProperties>true</sortProperties>
-                    <keepBlankLines>true</keepBlankLines>
                     <sortDependencies>scope</sortDependencies>
+                    <sortProperties>true</sortProperties>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Proper fix for the symptom-fighting mentioned in https://github.com/jdbi/jdbi/pull/1162#discussion_r192883403

Does the jdbi team agree that empty tags in xml should be written self-closed or do we instead go with expanded empty tags (and reject this PR)? Either works for me. It just seems to me the current situation goes against general xml convention. I wonder why sortpom does that by default...

I know this seems a bit silly but this is just something that should've been decided from the start, but was overlooked/swept under the rug :)