### PR TITLE
@UseTemplateEngine more expandable + fixes

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -4,6 +4,7 @@
       registered to observe transaction success and failure.
     - JdbiRule.migrateWithFlyway() chaining method to run Flyway migrations on the test database
       prior to running tests.
+    - added @UseStringSubstitutorTemplateEngine for custom configuration. @UseTemplateEngine(StringSubstitutorTemplateEngine.class) is also supported.
   - Improvements
     - MessageFormatTemplateEngine is not an enum anymore but a regular singleton
     - added some extra javadoc to SqlLogger
@@ -11,10 +12,14 @@
     - SqlStatement.bindMethods() (and @BindMethods) now selects the correct method when the
       method return type is generic.
     - mapToMap() no longer throws an exception on empty resultsets when ResultProducers.allowNoResults is true
+    - @UseTemplateEngine works with MessageFormatTemplateEngine and StringSubstitutorTemplateEngine now
   - Breaking changes
     - Removed JdbiRule.createJdbi() in favor of createDataSource(). This was necessary to
       facilitate the migrateWithFlyway() feature above, and pave the way for future additions.
     - Removed SqlLogger.wrap() added in 3.2.0 from public API.
+  - Deprecations
+    - deprecated MessageFormatTemplateEngine.INSTANCE in favor of a default constructor
+    - deprecated StringSubstitutorTemplateEngine.INSTANCE, -.defaults, and -.withCustomizer in favor of public constructors
 
 3.2.1
   - Fix IllegalArgumentException "URI is not hierarchical" in FreemarkerSqlLocator.

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -35,23 +35,23 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-core</artifactId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-sqlobject</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -42,10 +42,21 @@
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/StringSubstitutorTemplateEngine.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/StringSubstitutorTemplateEngine.java
@@ -22,6 +22,8 @@ import org.jdbi.v3.core.statement.TemplateEngine;
  * Register an instance of this class ({@link org.jdbi.v3.core.statement.SqlStatements#setTemplateEngine}) to use an Apache Commons Text {@link StringSubstitutor} as a {@link TemplateEngine}. This lets you use any pair of strings as variable delimiters, enabling the use of syntax like <pre>select * from ${foo}</pre>, <pre>select * from &lt;foo&gt;</pre>, <pre>select * from %foo%</pre>, etc.
  */
 public class StringSubstitutorTemplateEngine implements TemplateEngine {
+    public static final TemplateEngine INSTANCE = defaults();
+
     private final Consumer<StringSubstitutor> customizer;
 
     private StringSubstitutorTemplateEngine(Consumer<StringSubstitutor> customizer) {

--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/StringSubstitutorTemplateEngine.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/StringSubstitutorTemplateEngine.java
@@ -22,6 +22,10 @@ import org.jdbi.v3.core.statement.TemplateEngine;
  * Register an instance of this class ({@link org.jdbi.v3.core.statement.SqlStatements#setTemplateEngine}) to use an Apache Commons Text {@link StringSubstitutor} as a {@link TemplateEngine}. This lets you use any pair of strings as variable delimiters, enabling the use of syntax like <pre>select * from ${foo}</pre>, <pre>select * from &lt;foo&gt;</pre>, <pre>select * from %foo%</pre>, etc.
  */
 public class StringSubstitutorTemplateEngine implements TemplateEngine {
+    static final String DEFAULT_PREFIX = "${";
+    static final String DEFAULT_SUFFIX = "}";
+    static final char DEFAULT_ESCAPE = '\\';
+
     private final Consumer<StringSubstitutor> customizer;
 
     /**
@@ -29,9 +33,9 @@ public class StringSubstitutorTemplateEngine implements TemplateEngine {
      */
     public StringSubstitutorTemplateEngine() {
         this(substitutor -> {
-            substitutor.setVariablePrefix("${");
-            substitutor.setVariableSuffix("}");
-            substitutor.setEscapeChar('\\');
+            substitutor.setVariablePrefix(DEFAULT_PREFIX);
+            substitutor.setVariableSuffix(DEFAULT_SUFFIX);
+            substitutor.setEscapeChar(DEFAULT_ESCAPE);
         });
     }
 

--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/StringSubstitutorTemplateEngine.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/StringSubstitutorTemplateEngine.java
@@ -22,11 +22,23 @@ import org.jdbi.v3.core.statement.TemplateEngine;
  * Register an instance of this class ({@link org.jdbi.v3.core.statement.SqlStatements#setTemplateEngine}) to use an Apache Commons Text {@link StringSubstitutor} as a {@link TemplateEngine}. This lets you use any pair of strings as variable delimiters, enabling the use of syntax like <pre>select * from ${foo}</pre>, <pre>select * from &lt;foo&gt;</pre>, <pre>select * from %foo%</pre>, etc.
  */
 public class StringSubstitutorTemplateEngine implements TemplateEngine {
-    public static final TemplateEngine INSTANCE = defaults();
-
     private final Consumer<StringSubstitutor> customizer;
 
-    private StringSubstitutorTemplateEngine(Consumer<StringSubstitutor> customizer) {
+    /**
+     * Default is <pre>${foo}</pre> syntax.
+     */
+    public StringSubstitutorTemplateEngine() {
+        this(substitutor -> {
+            substitutor.setVariablePrefix("${");
+            substitutor.setVariableSuffix("}");
+            substitutor.setEscapeChar('\\');
+        });
+    }
+
+    /**
+     * Customize the given {@link StringSubstitutor} instance to set your preferred prefix, suffix, escape character, and perhaps other configuration. The instance is created by Jdbi, and is not shared nor re-used. Your customizer function however will be re-used for all instances.
+     */
+    public StringSubstitutorTemplateEngine(Consumer<StringSubstitutor> customizer) {
         this.customizer = customizer;
     }
 
@@ -38,15 +50,17 @@ public class StringSubstitutorTemplateEngine implements TemplateEngine {
     }
 
     /**
-     * At the time of writing, defaults means <pre>${foo}</pre> syntax.
+     * @deprecated use the default constructor instead
      */
+    @Deprecated
     public static StringSubstitutorTemplateEngine defaults() {
-        return new StringSubstitutorTemplateEngine(substitutor -> {});
+        return new StringSubstitutorTemplateEngine();
     }
 
     /**
-     * Customize the given {@link StringSubstitutor} instance to set your preferred prefix, suffix, escape character, and perhaps other configuration. The instance is created by Jdbi, and is not shared nor re-used. Your customizer function however will be re-used for all instances.
+     * @deprecated use the constructor instead
      */
+    @Deprecated
     public static StringSubstitutorTemplateEngine withCustomizer(Consumer<StringSubstitutor> customizer) {
         return new StringSubstitutorTemplateEngine(customizer);
     }

--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/UseStringSubstitutorTemplateEngine.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/UseStringSubstitutorTemplateEngine.java
@@ -24,7 +24,7 @@ import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation;
 @ConfiguringAnnotation(UseStringSubstitutorTemplateEngineImpl.class)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface UseStringSubstitutorTemplateEngine {
-    String prefix() default "${";
-    String suffix() default "}";
-    char escape() default '\\';
+    String prefix() default StringSubstitutorTemplateEngine.DEFAULT_PREFIX;
+    String suffix() default StringSubstitutorTemplateEngine.DEFAULT_SUFFIX;
+    char escape() default StringSubstitutorTemplateEngine.DEFAULT_ESCAPE;
 }

--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/UseStringSubstitutorTemplateEngine.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/UseStringSubstitutorTemplateEngine.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.commonstext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.jdbi.v3.commonstext.internal.UseStringSubstitutorTemplateEngineImpl;
+import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation;
+
+@Retention(RetentionPolicy.RUNTIME)
+@ConfiguringAnnotation(UseStringSubstitutorTemplateEngineImpl.class)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface UseStringSubstitutorTemplateEngine {
+    String prefix() default "${";
+    String suffix() default "}";
+    char escape() default '\\';
+}

--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/internal/UseStringSubstitutorTemplateEngineImpl.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/internal/UseStringSubstitutorTemplateEngineImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.commonstext.internal;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import org.jdbi.v3.commonstext.StringSubstitutorTemplateEngine;
+import org.jdbi.v3.commonstext.UseStringSubstitutorTemplateEngine;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.core.statement.TemplateEngine;
+import org.jdbi.v3.sqlobject.config.Configurer;
+
+public class UseStringSubstitutorTemplateEngineImpl implements Configurer {
+    @Override
+    public void configureForType(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType) {
+        UseStringSubstitutorTemplateEngine anno = (UseStringSubstitutorTemplateEngine) annotation;
+        TemplateEngine engine = StringSubstitutorTemplateEngine.between(anno.prefix(), anno.suffix(), anno.escape());
+        registry.get(SqlStatements.class).setTemplateEngine(engine);
+    }
+
+    @Override
+    public void configureForMethod(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType, Method method) {
+        configureForType(registry, annotation, sqlObjectType);
+    }
+}

--- a/commons-text/src/test/java/org/jdbi/v3/commonstext/TestStringSubstitutorTemplateEngine.java
+++ b/commons-text/src/test/java/org/jdbi/v3/commonstext/TestStringSubstitutorTemplateEngine.java
@@ -45,7 +45,7 @@ public class TestStringSubstitutorTemplateEngine {
     public void testDefaults() {
         attributes.put("name", "foo");
 
-        assertThat(StringSubstitutorTemplateEngine.defaults().render("create table ${name};", ctx))
+        assertThat(new StringSubstitutorTemplateEngine().render("create table ${name};", ctx))
             .isEqualTo("create table foo;");
     }
 

--- a/commons-text/src/test/java/org/jdbi/v3/commonstext/TestUseStringSubstitutorTemplateEngine.java
+++ b/commons-text/src/test/java/org/jdbi/v3/commonstext/TestUseStringSubstitutorTemplateEngine.java
@@ -39,14 +39,27 @@ public class TestUseStringSubstitutorTemplateEngine {
 
     @Test
     public void testUseTemplateEngine() {
-        String selected = jdbi.withExtension(Queries.class, q -> q.select("foo"));
+        String selected = jdbi.withExtension(Queries1.class, q -> q.select("foo"));
 
         assertThat(selected).isEqualTo("foo");
     }
 
-    public interface Queries {
+    @Test
+    public void testCustomAnnotation() {
+        String selected = jdbi.withExtension(Queries2.class, q -> q.select("foo"));
+
+        assertThat(selected).isEqualTo("foo");
+    }
+
+    public interface Queries1 {
         @UseTemplateEngine(StringSubstitutorTemplateEngine.class)
         @SqlQuery("select * from (values('${v}'))")
+        String select(@Define("v") String value);
+    }
+
+    public interface Queries2 {
+        @UseStringSubstitutorTemplateEngine(prefix = "_", suffix = "_")
+        @SqlQuery("select * from (values('_v_'))")
         String select(@Define("v") String value);
     }
 }

--- a/commons-text/src/test/java/org/jdbi/v3/commonstext/TestUseStringSubstitutorTemplateEngine.java
+++ b/commons-text/src/test/java/org/jdbi/v3/commonstext/TestUseStringSubstitutorTemplateEngine.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.commonstext;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.rule.DatabaseRule;
+import org.jdbi.v3.core.rule.SqliteDatabaseRule;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.config.UseTemplateEngine;
+import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestUseStringSubstitutorTemplateEngine {
+    @Rule
+    public DatabaseRule db = new SqliteDatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private Jdbi jdbi;
+
+    @Before
+    public void before() {
+        jdbi = db.getJdbi();
+    }
+
+    @Test
+    public void testUseTemplateEngine() {
+        String selected = jdbi.withExtension(Queries.class, q -> q.select("foo"));
+
+        assertThat(selected).isEqualTo("foo");
+    }
+
+    public interface Queries {
+        @UseTemplateEngine(StringSubstitutorTemplateEngine.class)
+        @SqlQuery("select * from (values('${v}'))")
+        String select(@Define("v") String value);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/statement/MessageFormatTemplateEngine.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/MessageFormatTemplateEngine.java
@@ -39,9 +39,13 @@ import java.util.Set;
  * }</pre>
  */
 public class MessageFormatTemplateEngine implements TemplateEngine {
+    /**
+     * @deprecated use the default constructor instead
+     */
+    @Deprecated
     public static final TemplateEngine INSTANCE = new MessageFormatTemplateEngine();
 
-    private MessageFormatTemplateEngine() {}
+    public MessageFormatTemplateEngine() {}
 
     @Override
     public String render(String template, StatementContext ctx) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/TemplateEngine.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/TemplateEngine.java
@@ -16,9 +16,9 @@ package org.jdbi.v3.core.statement;
 /**
  * Renders an SQL statement from a template.
  *
- * @see DefinedAttributeTemplateEngine
+ * Note for implementors: define a suitable public constructor for SqlObject's {@code UseTemplateEngine} annotation, and/or create your own custom annotation in case your {@link TemplateEngine} has configuration parameters! Suitable constructors are the no-arg constructor, one that takes a {@link java.lang.Class}, and one that takes both a {@link java.lang.Class} and a {@link java.lang.reflect.Method}.
  *
- * Note for implementors: define a public default constructor, or one that takes a {@link java.lang.Class} and/or {@link java.lang.reflect.Method}, for SqlObject's {@code UseTemplateEngine} annotation, and/or create your own custom annotation in case your {@link TemplateEngine} has configuration parameters!
+ * @see DefinedAttributeTemplateEngine
  */
 @FunctionalInterface
 public interface TemplateEngine {

--- a/core/src/main/java/org/jdbi/v3/core/statement/TemplateEngine.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/TemplateEngine.java
@@ -17,6 +17,8 @@ package org.jdbi.v3.core.statement;
  * Renders an SQL statement from a template.
  *
  * @see DefinedAttributeTemplateEngine
+ *
+ * Note for implementors: define a public default constructor, or one that takes a {@link java.lang.Class} and/or {@link java.lang.reflect.Method}, for SqlObject's {@code UseTemplateEngine} annotation, and/or create your own custom annotation in case your {@link TemplateEngine} has configuration parameters!
  */
 @FunctionalInterface
 public interface TemplateEngine {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestMessageFormatTemplateEngine.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestMessageFormatTemplateEngine.java
@@ -30,7 +30,7 @@ public class TestMessageFormatTemplateEngine {
 
     @Before
     public void setUp() {
-        templateEngine = MessageFormatTemplateEngine.INSTANCE;
+        templateEngine = new MessageFormatTemplateEngine();
         attributes = new HashMap<>();
         ctx = mock(StatementContext.class);
         when(ctx.getAttributes()).thenReturn(attributes);

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -110,6 +110,12 @@
             <artifactId>assertj-guava</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseTemplateEngineImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseTemplateEngineImpl.java
@@ -14,56 +14,52 @@
 package org.jdbi.v3.sqlobject.config.internal;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.statement.TemplateEngine;
 import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.core.statement.TemplateEngine;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.UseTemplateEngine;
 
 public class UseTemplateEngineImpl implements Configurer {
     @Override
-    public void configureForMethod(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType, Method method) {
+    public void configureForMethod(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType, @Nullable Method method) {
         UseTemplateEngine anno = (UseTemplateEngine) annotation;
-        try {
-            final TemplateEngine templateEngine = instantiate(anno.value(), sqlObjectType, method);
-            registry.get(SqlStatements.class).setTemplateEngine(templateEngine);
-        } catch (Exception e) {
-            throw new IllegalStateException(e);
-        }
+        TemplateEngine templateEngine = instantiate(anno.value(), sqlObjectType, method);
+        registry.get(SqlStatements.class).setTemplateEngine(templateEngine);
     }
 
     @Override
     public void configureForType(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType) {
-        UseTemplateEngine anno = (UseTemplateEngine) annotation;
-        try {
-            final TemplateEngine templateEngine = instantiate(anno.value(), sqlObjectType, null);
-            registry.get(SqlStatements.class).setTemplateEngine(templateEngine);
-        } catch (Exception e) {
-            throw new IllegalStateException(e);
-        }
+        configureForMethod(registry, annotation, sqlObjectType, null);
     }
 
-    private TemplateEngine instantiate(Class<? extends TemplateEngine> value,
-                                       Class<?> sqlObjectType,
-                                       Method m) throws Exception {
-        try {
-            Constructor<? extends TemplateEngine> noArg = value.getConstructor();
-            return noArg.newInstance();
-        } catch (NoSuchMethodException e) {
+    private static TemplateEngine instantiate(Class<? extends TemplateEngine> engineClass, Class<?> sqlObjectType, @Nullable Method method) {
+        return Stream.of(tryConstructor(engineClass), tryConstructor(engineClass, sqlObjectType), tryConstructor(engineClass, sqlObjectType, method))
+            .map(Supplier::get)
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Unable to instantiate, no viable constructor for " + engineClass.getName()));
+    }
+
+    private static <T extends TemplateEngine> Supplier<T> tryConstructor(Class<T> c, Object... args) {
+        Object[] nonNullArgs = Arrays.stream(args).filter(Objects::nonNull).toArray(Object[]::new);
+
+        return () -> {
             try {
-                Constructor<? extends TemplateEngine> classArg = value.getConstructor(Class.class);
-                return classArg.newInstance(sqlObjectType);
-            } catch (NoSuchMethodException e1) {
-                if (m != null) {
-                    Constructor<? extends TemplateEngine> constructor = value.getConstructor(Class.class,
-                                                                                            Method.class);
-                    return constructor.newInstance(sqlObjectType, m);
-                }
-                throw new IllegalStateException("Unable to instantiate, no viable constructor " + value.getName());
+                Class[] classes = Arrays.stream(nonNullArgs).map(Object::getClass).toArray(Class[]::new);
+                return c.getConstructor(classes).newInstance(nonNullArgs);
+            } catch (NoSuchMethodException ignored) {
+                return null;
+            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+                throw new RuntimeException(e);
             }
-        }
+        };
     }
 }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseTemplateEngine.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseTemplateEngine.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.rule.DatabaseRule;
+import org.jdbi.v3.core.rule.SqliteDatabaseRule;
+import org.jdbi.v3.core.statement.DefinedAttributeTemplateEngine;
+import org.jdbi.v3.core.statement.MessageFormatTemplateEngine;
+import org.jdbi.v3.sqlobject.config.UseTemplateEngine;
+import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestUseTemplateEngine {
+    @Rule
+    public DatabaseRule db = new SqliteDatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private Jdbi jdbi;
+
+    @Before
+    public void before() {
+        jdbi = db.getJdbi();
+    }
+
+    @Test
+    public void testUseMessageFormat() {
+        String selected = jdbi.withExtension(QueriesForMessageFormatTE.class, q -> q.select("foo"));
+
+        assertThat(selected).isEqualTo("foo");
+    }
+
+    @Test
+    public void testUseDefinedAttributes() {
+        String selected = jdbi.withExtension(QueriesForDefinedAttributeTE.class, q -> q.select("foo"));
+
+        assertThat(selected).isEqualTo("foo");
+    }
+
+    public interface QueriesForMessageFormatTE {
+        @UseTemplateEngine(MessageFormatTemplateEngine.class)
+        @SqlQuery("select * from (values(''{0}''))")
+        String select(@Define("0") String value);
+    }
+
+    public interface QueriesForDefinedAttributeTE {
+        @UseTemplateEngine(DefinedAttributeTemplateEngine.class)
+        @SqlQuery("select * from (values(\\'<v>\\'))")
+        String select(@Define("v") String value);
+    }
+}


### PR DESCRIPTION
I'm working on a MustacheTemplateEngine module. During testing, I realized using `@UseTemplateEngine` was failing for it, as well as for StringSubTE. I revised the impl class behind it to do 2 things:
- use a stream-based lookup sequence to avoid pyramid exception blocks
- try to find a const `INSTANCE` in addition to constructors so TemplateEngines don't necessarily need to allow pointless instantiation and to reserve the constructor for internal use. The same idea could apply to factory methods named e.g. `of` if desired.