### PR TITLE
[poc + discuss] support generic Map<String, V> with MapMapper

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
@@ -82,10 +82,14 @@ public class GenericTypes {
      * @return the parameter on the supertype, if it is concretely defined.
      */
     public static Optional<Type> findGenericParameter(Type type, Class<?> parameterizedSupertype) {
-        Type parameterType = resolveType(parameterizedSupertype.getTypeParameters()[0], type);
+        return findGenericParameter(type, parameterizedSupertype, 0);
+    }
+
+    public static Optional<Type> findGenericParameter(Type type, Class<?> parameterizedSupertype, int i) {
+        Type parameterType = resolveType(parameterizedSupertype.getTypeParameters()[i], type);
         return parameterType instanceof Class || parameterType instanceof ParameterizedType
-                ? Optional.of(parameterType)
-                : Optional.empty();
+            ? Optional.of(parameterType)
+            : Optional.empty();
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
@@ -28,13 +28,16 @@ import org.jdbi.v3.core.statement.StatementContext;
  * default.
  */
 public class MapMapper implements RowMapper<Map<String, Object>> {
+    private static final ColumnMapper<?> GET_OBJECT = (r, columnNumber, ctx) -> r.getObject(columnNumber);
+
     private final boolean foldCase;
+    private final ColumnMapper<?> colMapper;
 
     /**
      * Constructs a new MapMapper, with map keys converted to lowercase.
      */
     public MapMapper() {
-        this(true);
+        this(true, GET_OBJECT);
     }
 
     /**
@@ -42,7 +45,16 @@ public class MapMapper implements RowMapper<Map<String, Object>> {
      * @param foldCase if true, column names are converted to lowercase in the mapped {@link Map}.
      */
     public MapMapper(boolean foldCase) {
+        this(foldCase, GET_OBJECT);
+    }
+
+    public MapMapper(ColumnMapper<?> colMapper) {
+        this(true, colMapper);
+    }
+
+    public MapMapper(boolean foldCase, ColumnMapper<?> colMapper) {
         this.foldCase = foldCase;
+        this.colMapper = colMapper;
     }
 
     @Override
@@ -74,7 +86,7 @@ public class MapMapper implements RowMapper<Map<String, Object>> {
             Map<String, Object> row = new LinkedHashMap<>(columnCount);
 
             for (int i = 1; i <= columnCount; i++) {
-                row.put(columnNames[i], rs.getObject(i));
+                row.put(columnNames[i], colMapper.map(r, i, ctx));
             }
 
             return row;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMapperFactory.java
@@ -1,0 +1,26 @@
+package org.jdbi.v3.core.mapper;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Optional;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.generic.GenericTypes;
+
+public class MapMapperFactory implements RowMapperFactory {
+    @Override
+    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+        if (type instanceof ParameterizedType && GenericTypes.getErasedType(type) == Map.class) {
+            Type valueType = GenericTypes.findGenericParameter(type, Map.class, 1).orElseThrow(IllegalStateException::new);
+            Optional<ColumnMapper<?>> colMapper = config.get(ColumnMappers.class).findFor(valueType);
+
+            if (colMapper.isPresent()) {
+                ColumnMapper<?> columnMapper = colMapper.get();
+
+                return Optional.of(new MapMapper(columnMapper));
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMapMapperGenerics.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMapMapperGenerics.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.generic.GenericTypes;
+import org.jdbi.v3.core.mapper.MapMapperFactory;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapperFactory;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMapMapperGenerics {
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private Jdbi jdbi;
+
+    @Before
+    public void before() {
+        jdbi = db.getJdbi();
+    }
+
+    @Test
+    public void testGenericMapReturnType() {
+        GenericTypes.findGenericParameter(new GenericType<Map<String, BigDecimal>>() {}.getType(), Map.class, 1);
+
+        jdbi.useExtension(Foo.class, foo -> {
+            List<Map<String, BigDecimal>> list = foo.getMapList();
+
+            assertThat(list).hasSize(1);
+
+            Map<String, BigDecimal> map = list.get(0);
+
+            assertThat(map)
+                .containsOnlyKeys("one", "two", "three")
+                .containsValues(new BigDecimal("1.0"), new BigDecimal("2.0"), new BigDecimal("3.0"));
+        });
+    }
+
+    @RegisterRowMapperFactory(MapMapperFactory.class)
+    public interface Foo {
+        @SqlQuery("select 1.0 as one, 2.0 as two, 3.0 as three from (values(null))")
+        List<Map<String, BigDecimal>> getMapList();
+    }
+}


### PR DESCRIPTION
I came across an annoyance in my project today. SqlObject has OOTB support for turning a resultset into a (`List` of) `Map<String, Object>` like so:

```
@SqlQuery("select 1.0 as one, 2.0 as two, 3.0 as three from (values(null))")
List<Map<String, Object>> getMapList();
// will be
// "one" -> (some jdbc driver mapped object, e.g. BigDecimal in case of hsqldb),
// "two" -> ...
```

But I wanted to get my `BigDecimal`s out of that map without having to cast them, because you know, what do we have generics for? 

```
@SqlQuery("select 1.0 as one, 2.0 as two, 3.0 as three from (values(null))")
List<Map<String, BigDecimal>> getMapList();
```

This would be ideal. I know the values will be mappable (even directly castable) to `BigDecimal`, so jdbi should be able to extract them with the registered `BigDecimalColumnMapper`. But this does not work because `MapMapper` only responds to `Map<String, Object>` specifically.

I propose we extend the functionality of `MapMapper` by moving it into a `MapMapperFactory` that resolves the `V` in `Map<String, V>` and uses a registered `ColumnMapper` on the context to neatly map the value objects, instead of returning them as `Object` in the `Map` and forcing the user to do casts.

The code I wrote for this PR is just a quick&dirty POC that needs some discussion, but it shows how very easy it is to achieve. Since `MapMapper` is already Core and what I'm suggesting would be an improvement to its support for generics, not a whole different use case, I'd like to put this into Core.

Obviously, if you agree to this idea, I'll reimplement my changes properly. This is just a rough draft.

As an aside, shouldn't the `foldCase` property on `MapMapper` come in a config class, like we have on `SerializableTransactionRunner`? The way it is now seems useful only for the fluent api.