### PR TITLE
[poc/wip] Support generics in Map mapping

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,9 @@
+3.4.0
+  - New API
+    - GenericMapMapperFactory enables fluent and SqlObject support for mapping to `Map<String, V>` for any `V` that can be handled by a ColumnMapper.
+    - GenericTypes.findGenericParameter(Type, Class) now also takes an index, e.g. to resolve `V` in `Map<K, V>`
+    - ResultBearing.mapToGenericMap(Type) convenience method to use the GenericMapMapperFactory
+
 3.3.0
   - New API
     - SerializableTransactionRunner.setOnFailure(), setOnSuccess() methods allow callbacks to be

--- a/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
@@ -58,34 +58,47 @@ public class GenericTypes {
     }
 
     /**
+     * Same as {@link #findGenericParameter(Type, Class, int)} with n = 0
+     */
+    public static Optional<Type> findGenericParameter(Type type, Class<?> parameterizedSupertype) {
+        return findGenericParameter(type, parameterizedSupertype, 0);
+    }
+
+    /**
      * For the given type which extends parameterizedSupertype, returns the
-     * first generic parameter for parameterized supertype, if concretely
+     * nth generic parameter for the parameterized supertype, if concretely
      * expressed.
      *
      * <p>
      * Example:
      * </p>
      * <ul>
-     * <li>if <code>type</code> is <code>ArrayList&lt;String&gt;</code> and
-     * <code>parameterizedSuperType</code> is <code>List.class</code>, returns
-     * <code>Optional.of(String.class)</code>.</li>
-     * <li>if <code>type</code> is <code>ArrayList.class</code> (raw) and
-     * <code>parameterizedSuperType</code> is <code>List.class</code>, returns
-     * <code>Optional.empty()</code>.</li>
+     * <li>if <code>type</code> is <code>ArrayList&lt;String&gt;</code>,
+     * <code>parameterizedSuperType</code> is <code>List.class</code>,
+     * and <code>n</code> is <code>0</code>,
+     * returns <code>Optional.of(String.class)</code>.</li>
+     * <li>if <code>type</code> is <code>Map&lt;String, Integer&gt;</code>,
+     * <code>parameterizedSuperType</code> is <code>Map.class</code>,
+     * and <code>n</code> is <code>1</code>,
+     * returns <code>Optional.of(Integer.class)</code>.</li>
+     * <li>if <code>type</code> is <code>ArrayList.class</code> (raw),
+     * <code>parameterizedSuperType</code> is <code>List.class</code>,
+     * and <code>n</code> is <code>0</code>,
+     * returns <code>Optional.empty()</code>.</li>
      * </ul>
      *
-     * @param type
-     *            the subtype of parameterizedSupertype
-     * @param parameterizedSupertype
-     *            the parameterized supertype from which we want the generic
+     * @param type the subtype of parameterizedSupertype
+     * @param parameterizedSupertype the parameterized supertype from which we want the generic
      *            parameter
+     * @param n the index in <code>Foo&lt;X, Y, Z, ...&gt;</code>
      * @return the parameter on the supertype, if it is concretely defined.
+     * @throws ArrayIndexOutOfBoundsException if n > the number of type variables the type has
      */
-    public static Optional<Type> findGenericParameter(Type type, Class<?> parameterizedSupertype) {
-        Type parameterType = resolveType(parameterizedSupertype.getTypeParameters()[0], type);
+    public static Optional<Type> findGenericParameter(Type type, Class<?> parameterizedSupertype, int n) {
+        Type parameterType = resolveType(parameterizedSupertype.getTypeParameters()[n], type);
         return parameterType instanceof Class || parameterType instanceof ParameterizedType
-                ? Optional.of(parameterType)
-                : Optional.empty();
+            ? Optional.of(parameterType)
+            : Optional.empty();
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/GenericMapMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/GenericMapMapperFactory.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.generic.GenericTypes;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.meta.Beta;
+
+@Beta
+public class GenericMapMapperFactory implements RowMapperFactory {
+    @Override
+    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+        // it's a non-raw Map...
+        if (!(type instanceof ParameterizedType) || GenericTypes.getErasedType(type) != Map.class) {
+            return Optional.empty();
+        }
+        Optional<Type> maybeKeyType = GenericTypes.findGenericParameter(type, Map.class, 0);
+
+        // ... with a concrete K type...
+        if (!maybeKeyType.isPresent()) {
+            return Optional.empty();
+        }
+        Type keyType = maybeKeyType.get();
+
+        // ... which is a String...
+        if (keyType != String.class) {
+            return Optional.empty();
+        }
+        Optional<Type> maybeValueType = GenericTypes.findGenericParameter(type, Map.class, 1);
+
+        // ... and a concrete V type...
+        if (!maybeValueType.isPresent()) {
+            return Optional.empty();
+        }
+        Type valueType = maybeValueType.get();
+
+        // ... that is not Object...
+        if (valueType == Object.class) {
+            return Optional.empty();
+        }
+        Optional<ColumnMapper<?>> maybeColumnMapper = config.get(ColumnMappers.class).findFor(valueType);
+
+        // ... for which there is a ColumnMapper
+        return maybeColumnMapper.map(t -> forType(valueType));
+
+    }
+
+    @Beta
+    public static <X> RowMapper<Map<String, X>> forType(Type type) {
+        return new GenericMapMapper<>(type);
+    }
+
+    private static class GenericMapMapper<X> implements RowMapper<Map<String, X>> {
+        private final Type type;
+
+        private GenericMapMapper(Type type) {
+            this.type = type;
+        }
+
+        @Override
+        public Map<String, X> map(ResultSet rs, StatementContext ctx) throws SQLException {
+            return specialize(rs, ctx).map(rs, ctx);
+        }
+
+        @Override
+        public RowMapper<Map<String, X>> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
+            Optional<ColumnMapper<?>> maybeColumnMapper = ctx.getConfig(ColumnMappers.class).findFor(type);
+
+            if (maybeColumnMapper.isPresent()) {
+                ColumnMapper<?> columnMapper = maybeColumnMapper.get();
+                List<String> columnNames = getColumnNames(rs.getMetaData(), ctx.getConfig(Config.class).getToLowerCase());
+
+                return (r, c) -> {
+                    Map<String, X> row = new HashMap<>();
+
+                    for (int i = 0; i < columnNames.size(); i++) {
+                        row.put(columnNames.get(i), (X) columnMapper.map(r, i + 1, ctx));
+                    }
+
+                    return row;
+                };
+            } else {
+                throw new RuntimeException("no such mapper present");
+            }
+        }
+
+        private static List<String> getColumnNames(ResultSetMetaData meta, boolean toLowerCase) throws SQLException {
+            // important: ordered and unique
+            Set<String> names = new LinkedHashSet<>();
+            int columnCount = meta.getColumnCount();
+
+            for (int i = 0; i < columnCount; i++) {
+                String columnName = meta.getColumnName(i + 1);
+                String columnLabel = meta.getColumnLabel(i + 1);
+
+                String name = columnLabel == null ? columnName : columnLabel;
+                if (toLowerCase) {
+                    name = name.toLowerCase(Locale.ROOT);
+                }
+
+                boolean added = names.add(name);
+                if (!added) {
+                    throw new RuntimeException("column " + name + " appears twice in this resultset!");
+                }
+            }
+
+            return new ArrayList<>(names);
+        }
+    }
+
+    @Beta
+    public static class Config implements JdbiConfig<Config> {
+        private boolean toLowerCase;
+
+        public Config() {
+            toLowerCase = false;
+        }
+
+        private Config(Config that) {
+            toLowerCase = that.toLowerCase;
+        }
+
+        @Beta
+        public boolean getToLowerCase() {
+            return toLowerCase;
+        }
+
+        @Beta
+        public void setToLowerCase(boolean toLowerCase) {
+            this.toLowerCase = toLowerCase;
+        }
+
+        @Override
+        public Config createCopy() {
+            return new Config(this);
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/mapper/GenericMapMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/GenericMapMapperFactory.java
@@ -33,6 +33,7 @@ import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.meta.Beta;
 
 @Beta
+// TODO jdbi4: consolidate with MapMapper
 public class GenericMapMapperFactory implements RowMapperFactory {
     @Override
     public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
@@ -26,6 +26,8 @@ import org.jdbi.v3.core.statement.StatementContext;
  * Yo dawg, I heard you like maps, so I made you a mapper that maps rows into {@code Map<String,Object>}. Map
  * keys are column names, while map values are the values in those columns. Map keys are converted to lowercase by
  * default.
+ *
+ * @see GenericMapMapperFactory for generics support (i.e. to get {@code Map<String, X>})
  */
 public class MapMapper implements RowMapper<Map<String, Object>> {
     private final boolean foldCase;

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
@@ -13,18 +13,6 @@
  */
 package org.jdbi.v3.core.result;
 
-import org.jdbi.v3.core.collector.ElementTypeNotFoundException;
-import org.jdbi.v3.core.collector.NoSuchCollectorException;
-import org.jdbi.v3.core.config.Configurable;
-import org.jdbi.v3.core.generic.GenericType;
-import org.jdbi.v3.core.mapper.ColumnMapper;
-import org.jdbi.v3.core.mapper.MapMapper;
-import org.jdbi.v3.core.mapper.NoSuchMapperException;
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.mapper.SingleColumnMapper;
-import org.jdbi.v3.core.mapper.reflect.BeanMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
 import java.lang.reflect.Type;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -34,6 +22,19 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+import org.jdbi.v3.core.collector.ElementTypeNotFoundException;
+import org.jdbi.v3.core.collector.NoSuchCollectorException;
+import org.jdbi.v3.core.config.Configurable;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.GenericMapMapperFactory;
+import org.jdbi.v3.core.mapper.MapMapper;
+import org.jdbi.v3.core.mapper.NoSuchMapperException;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.mapper.SingleColumnMapper;
+import org.jdbi.v3.core.mapper.reflect.BeanMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.meta.Beta;
 
 /**
  * Provides access to the contents of a {@link ResultSet} by mapping to Java types.
@@ -115,6 +116,11 @@ public interface ResultBearing {
                     .orElseThrow(() -> new NoSuchMapperException("No mapper registered for type " + type));
             return ResultIterable.of(supplier, mapper, ctx);
         });
+    }
+
+    @Beta
+    default <T> ResultIterable<Map<String, T>> mapToGenericMap(Class<T> type) {
+        return map(GenericMapMapperFactory.forType(type));
     }
 
     /**

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMapMapperGenerics.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMapMapperGenerics.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.mapper.GenericMapMapperFactory;
+import org.jdbi.v3.core.rule.SqliteDatabaseRule;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMapMapperGenerics {
+    private static final String QUERY = "select 1.0 as one, 2.0 as two, 3.0 as three from (values(null))";
+
+    @Rule
+    public SqliteDatabaseRule db = new SqliteDatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private Jdbi jdbi;
+
+    @Before
+    public void before() {
+        jdbi = db.getJdbi().registerRowMapper(new GenericMapMapperFactory());
+    }
+
+    @Test
+    public void testGenericMapFluent() {
+        jdbi.useHandle(h -> {
+            Map<String, BigDecimal> map = h.createQuery(QUERY)
+                .mapTo(new GenericType<Map<String, BigDecimal>>() {})
+                .findOnly();
+
+            assertThat(map)
+                .containsOnlyKeys("one", "two", "three")
+                .containsValues(new BigDecimal("1.0"), new BigDecimal("2.0"), new BigDecimal("3.0"));
+        });
+    }
+
+    @Test
+    public void testGenericMapFluentConvenient() {
+        jdbi.useHandle(h -> {
+            Map<String, BigDecimal> map = h.createQuery(QUERY)
+                .mapToGenericMap(BigDecimal.class)
+                .findOnly();
+
+            assertThat(map)
+                .containsOnlyKeys("one", "two", "three")
+                .containsValues(new BigDecimal("1.0"), new BigDecimal("2.0"), new BigDecimal("3.0"));
+        });
+    }
+
+    @Test
+    public void testGenericMapReturnType() {
+        jdbi.useExtension(Foo.class, foo -> {
+            List<Map<String, BigDecimal>> list = foo.getMapList();
+
+            assertThat(list).hasSize(1);
+
+            Map<String, BigDecimal> map = list.get(0);
+
+            assertThat(map)
+                .containsOnlyKeys("one", "two", "three")
+                .containsValues(new BigDecimal("1.0"), new BigDecimal("2.0"), new BigDecimal("3.0"));
+        });
+    }
+
+    public interface Foo {
+        @SqlQuery(QUERY)
+        List<Map<String, BigDecimal>> getMapList();
+    }
+}


### PR DESCRIPTION
Right now Jdbi can only map to `Map<String, Object>` in both the fluent api (`mapToMap()`) and SqlObjects (`@SqlQuery Map<String, Object> getMap();`). This saddles the user up with having to do annoying manual type converions: getting `ColumnMapper`s from the context, or doing plain casts.

With this additional factory, which is basically a refactor and slight expansion of `MapMapper`, users will be able to map to a `Map<String, V>` with full generics support. The factory will get an appropriate `ColumnMapper` for V off the context during mapping.

Fluent api: `.mapTo(new GenericType<Map<String, BigDecimal>>() {})` or `.mapToGenericMap(BigDecimal.class)`
SqlObject: just return a `Map<String, BigDecimal>`

Since mapping to `Map` is a core feature already but just lacks proper generics support, I feel this belongs in Core and not in private code.