### PR TITLE
[done] MapMapper JdbiConfig

### DIFF
--- a/4.0_TODO
+++ b/4.0_TODO
@@ -1,1 +1,3 @@
 * <X extends Exception> should probably generally be <X extends Throwable>
+* move SerializableTransactionRunner.Config to top-level class to comply with convention
+* MapMappers.MapMappers(): law of least surprise, change default to nop (update javadoc too)

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,9 @@
+3.4.0
+  - New API
+    - Added a JdbiConfig class to MapMapper to configure column name case changes, with a setting to entirely ignore the old preference (necessary for SqlObject usage).
+  - Deprecations
+    - Deprecated the boolean property `foldCase` on MapMapper in favor of the JdbiConfig mechanism.
+
 3.3.0
   - New API
     - SerializableTransactionRunner.setOnFailure(), setOnSuccess() methods allow callbacks to be

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,8 +1,6 @@
 3.4.0
   - New API
-    - Added a JdbiConfig class to MapMapper to configure column name case changes, with a setting to entirely ignore the old preference (necessary for SqlObject usage).
-  - Deprecations
-    - Deprecated the boolean property `foldCase` on MapMapper in favor of the JdbiConfig mechanism.
+    - Added the MapMappers JdbiConfig class to configure column name case changes in favor of the old boolean toggle.
 
 3.3.0
   - New API

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,7 +1,7 @@
 3.4.0
   - New API
     - StatementException.getShortMessage
-    - Added the MapMappers JdbiConfig class to configure column name case changes in favor of the old boolean toggle.
+    - Added the MapMappers JdbiConfig class to configure column name case changes, preferred over the old boolean toggle.
     - SqlStatements.setQueryTimeout(int) to configure the JDBC Statement queryTimeout.
   - Bug Fixes
     - Bridge methods cause SqlObject exceptions to get wrapped in `InvocationTargetException`

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
@@ -63,7 +63,7 @@ public class MapMapper implements RowMapper<Map<String, Object>> {
     public RowMapper<Map<String, Object>> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         UnaryOperator<String> caseChange = toLowerCase == null
             ? ctx.getConfig(MapMappers.class).getCaseChange()
-            : (toLowerCase ? MapMappers.LOCALE_LOWER : MapMappers.NOP);
+            : toLowerCase ? MapMappers.LOCALE_LOWER : MapMappers.NOP;
 
         List<String> columnNames = getColumnNames(rs, caseChange);
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
-import javax.annotation.Nullable;
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**
@@ -39,18 +38,18 @@ public class MapMapper implements RowMapper<Map<String, Object>> {
     private final Boolean toLowerCase;
 
     /**
-     * Constructs a new MapMapper, with map keys converted to lowercase.
+     * Constructs a new MapMapper and delegates case control to MapMappers.
      */
     public MapMapper() {
-        this(null);
+        toLowerCase = null;
     }
 
     /**
      * Constructs a new MapMapper
-     * @param toLowerCase if true, column names are converted to lowercase in the mapped {@link Map}. If null, the new MapNappers config will be used.
+     * @param toLowerCase if true, column names are converted to lowercase in the mapped {@link Map}. If false, nothing is done. Use the other constructor to delegate case control to MapMappers instead.
      */
     // TODO deprecate when MapMappers.caseChange is out of beta
-    public MapMapper(@Nullable Boolean toLowerCase) {
+    public MapMapper(boolean toLowerCase) {
         this.toLowerCase = toLowerCase;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
@@ -32,7 +32,7 @@ import org.jdbi.v3.core.statement.StatementContext;
  */
 public class MapMapper implements RowMapper<Map<String, Object>> {
     /**
-     * @deprecated TODO remove in jdbi4
+     * @deprecated remove
      */
     @Deprecated
     private final Boolean toLowerCase;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jdbi.v3.core.mapper;
 
 import java.util.Locale;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
@@ -28,17 +28,14 @@ public class MapMappers implements JdbiConfig<MapMappers> {
     public static final UnaryOperator<String> LOCALE_UPPER = s -> s.toUpperCase(Locale.ROOT);
 
     private UnaryOperator<String> caseChange;
-    private boolean forceNewApi;
 
     public MapMappers() {
-        // TODO law of least surprise: change to nop in jdbi4
+        // TODO jdbi4 law of least surprise: change to nop
         caseChange = LOCALE_LOWER;
-        forceNewApi = false;
     }
 
     private MapMappers(MapMappers that) {
         caseChange = that.caseChange;
-        forceNewApi = that.forceNewApi;
     }
 
     @Beta

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
@@ -1,0 +1,46 @@
+package org.jdbi.v3.core.mapper;
+
+import java.util.Locale;
+import java.util.function.UnaryOperator;
+import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.meta.Beta;
+
+@Beta
+public class MapMappers implements JdbiConfig<MapMappers> {
+    @Beta
+    public static final UnaryOperator<String> NOP = UnaryOperator.identity();
+    @Beta
+    public static final UnaryOperator<String> LOCALE_LOWER = s -> s.toLowerCase(Locale.ROOT);
+    @Beta
+    public static final UnaryOperator<String> LOCALE_UPPER = s -> s.toUpperCase(Locale.ROOT);
+
+    private UnaryOperator<String> caseChange;
+    private boolean forceNewApi;
+
+    public MapMappers() {
+        // TODO law of least surprise: change to nop in jdbi4
+        caseChange = LOCALE_LOWER;
+        forceNewApi = false;
+    }
+
+    private MapMappers(MapMappers that) {
+        caseChange = that.caseChange;
+        forceNewApi = that.forceNewApi;
+    }
+
+    @Beta
+    public UnaryOperator<String> getCaseChange() {
+        return caseChange;
+    }
+
+    @Beta
+    public MapMappers setCaseChange(UnaryOperator<String> caseChange) {
+        this.caseChange = caseChange;
+        return this;
+    }
+
+    @Override
+    public MapMappers createCopy() {
+        return new MapMappers(this);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
@@ -30,7 +30,6 @@ public class MapMappers implements JdbiConfig<MapMappers> {
     private UnaryOperator<String> caseChange;
 
     public MapMappers() {
-        // TODO jdbi4 law of least surprise: change to nop (update javadoc too)
         caseChange = LOCALE_LOWER;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
@@ -30,7 +30,7 @@ public class MapMappers implements JdbiConfig<MapMappers> {
     private UnaryOperator<String> caseChange;
 
     public MapMappers() {
-        // TODO jdbi4 law of least surprise: change to nop
+        // TODO jdbi4 law of least surprise: change to nop (update javadoc too)
         caseChange = LOCALE_LOWER;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
@@ -113,6 +113,7 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
     /**
      * Configuration for serializable transaction runner
      */
+    // TODO jdbi4 move to top-level class to comply with convention
     public static class Configuration implements JdbiConfig<Configuration> {
         private static final int DEFAULT_MAX_RETRIES = 5;
         private static final Consumer<List<Exception>> NOP = list -> {};

--- a/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
@@ -115,7 +115,6 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
     /**
      * Configuration for serializable transaction runner
      */
-    // TODO jdbi4 move to top-level class to comply with convention
     public static class Configuration implements JdbiConfig<Configuration> {
         private static final int DEFAULT_MAX_RETRIES = 5;
         private static final Consumer<List<Exception>> NOP = list -> {};

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestMapMapper.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestMapMapper.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import java.util.Map;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.rule.SqliteDatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMapMapper {
+    @Rule
+    // h2 makes column names uppercase
+    public SqliteDatabaseRule db = new SqliteDatabaseRule();
+
+    private Handle h;
+
+    @Before
+    public void before() {
+        h = db.getSharedHandle();
+        h.getConfig(MapMapper.Config.class).setForceNewApi(true);
+
+        h.execute("create table Foo (Id int primary key, FirstName varchar)");
+        h.execute("insert into Foo(Id, FirstName) values(1, 'No one')");
+    }
+
+    @Test
+    public void testCaseDefaultNop() {
+        Map<String, Object> noOne = h.createQuery("select * from Foo").mapToMap().findOnly();
+
+        assertThat(noOne).containsOnlyKeys("Id", "FirstName");
+    }
+
+    @Test
+    public void testCaseLower() {
+        h.getConfig(MapMapper.Config.class).setCaseChange(MapMapper.Config.CaseChange.LOWER);
+
+        Map<String, Object> noOne = h.createQuery("select * from Foo").mapToMap().findOnly();
+
+        assertThat(noOne).containsOnlyKeys("id", "firstname");
+    }
+
+    @Test
+    public void testCaseUpper() {
+        h.getConfig(MapMapper.Config.class).setCaseChange(MapMapper.Config.CaseChange.UPPER);
+
+        Map<String, Object> noOne = h.createQuery("select * from Foo").mapToMap().findOnly();
+
+        assertThat(noOne).containsOnlyKeys("ID", "FIRSTNAME");
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestMapMapper.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestMapMapper.java
@@ -32,7 +32,6 @@ public class TestMapMapper {
     @Before
     public void before() {
         h = db.getSharedHandle();
-        h.getConfig(MapMapper.Config.class).setForceNewApi(true);
 
         h.execute("create table Foo (Id int primary key, FirstName varchar)");
         h.execute("insert into Foo(Id, FirstName) values(1, 'No one')");
@@ -40,6 +39,8 @@ public class TestMapMapper {
 
     @Test
     public void testCaseDefaultNop() {
+        h.getConfig(MapMappers.class).setCaseChange(MapMappers.NOP);
+
         Map<String, Object> noOne = h.createQuery("select * from Foo").mapToMap().findOnly();
 
         assertThat(noOne).containsOnlyKeys("Id", "FirstName");
@@ -47,7 +48,7 @@ public class TestMapMapper {
 
     @Test
     public void testCaseLower() {
-        h.getConfig(MapMapper.Config.class).setCaseChange(MapMapper.Config.CaseChange.LOWER);
+        h.getConfig(MapMappers.class).setCaseChange(MapMappers.LOCALE_LOWER);
 
         Map<String, Object> noOne = h.createQuery("select * from Foo").mapToMap().findOnly();
 
@@ -56,7 +57,7 @@ public class TestMapMapper {
 
     @Test
     public void testCaseUpper() {
-        h.getConfig(MapMapper.Config.class).setCaseChange(MapMapper.Config.CaseChange.UPPER);
+        h.getConfig(MapMappers.class).setCaseChange(MapMappers.LOCALE_UPPER);
 
         Map<String, Object> noOne = h.createQuery("select * from Foo").mapToMap().findOnly();
 


### PR DESCRIPTION
This PR enables MapMapper configuration the proper way so that it works with SqlObject and follows project convention, and adds an uppercase option.

100% backward compatible: if foldCase is true, LOWER is used, otherwise the new option value is used, which defaults to NOP. Users who prefer the new API would have a problem using this option in SqlObject for the time being, since they wouldn't be able to turn off foldCase. I've added an override setting for them. Tests show this.

`@Beta` added where necessary, as well as `@Deprecated` so that a cleanup can be done for jdbi4.