### PR TITLE
Dependency Convergence Fix for ANTLR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@ Jdbi places serious emphasis on not breaking compatibility. Remember these simpl
 
 If you must make some internal code `public` to access it from other packages, put the class in a package named `internal`. Packages named so are not considered API.
 
+### Forward compatibility
+
+Completely new API should, in most cases, be marked with `@Beta`. This lets users know not to rely too much on your changes yet, as the public release might reveal that more work needs to be done.
+
 ## Technical design
 
 We favor constructors — especially the default one — over factory methods where possible. Adding factory methods is not discouraged, but restricting the visibility of useful constructors without technical reason is.

--- a/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
@@ -50,7 +50,7 @@ public class OutParameters {
     }
 
     /**
-     * Type-casting convenience method which obtains an object from the the results positionally
+     * Type-casting convenience method which obtains an object from the results positionally
      * object obtained should have been created with {@link CallableStatementMapper}
      *
      * @param position The out parameter name

--- a/docs/src/main/resources/jdbi2/page8/index.html
+++ b/docs/src/main/resources/jdbi2/page8/index.html
@@ -90,7 +90,7 @@
 <span class='n'>h</span><span class='o'>.</span><span class='na'>close</span><span class='o'>();</span>
 </code></pre>
 </div>
-<p>The values which will be bound for each binding into the the prepared batch are therefore</p>
+<p>The values which will be bound for each binding into the prepared batch are therefore</p>
 <pre>
 id | first | last
 ------------------------

--- a/docs/src/main/resources/jdbi2/sql_object_api_batching/index.html
+++ b/docs/src/main/resources/jdbi2/sql_object_api_batching/index.html
@@ -89,7 +89,7 @@
 <span class='n'>h</span><span class='o'>.</span><span class='na'>close</span><span class='o'>();</span>
 </code></pre>
 </div>
-<p>The values which will be bound for each binding into the the prepared batch are therefore</p>
+<p>The values which will be bound for each binding into the prepared batch are therefore</p>
 <pre>
 id | first | last
 ------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
         <dep.antlr.version>3.4</dep.antlr.version>
         <dep.checkstyle.version>8.10</dep.checkstyle.version>
-        <dep.dokka.version>0.9.16</dep.dokka.version>
+        <dep.dokka.version>0.9.17</dep.dokka.version>
         <dep.jetbrainsAnnotations.version>13.0</dep.jetbrainsAnnotations.version>
         <dep.kotlin.version>1.2.31</dep.kotlin.version>
         <dep.plugin.checkstyle.version>3.0.0</dep.plugin.checkstyle.version>
@@ -496,6 +496,11 @@
                     <configuration>
                         <jdkVersion>8</jdkVersion>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <!-- Fixes missing plugin during CI builds -->
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
                 </plugin>
                 <plugin>
                     <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,19 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>default-jar</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.jetbrains.dokka</groupId>
                     <artifactId>dokka-maven-plugin</artifactId>
                     <version>${dep.dokka.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -606,6 +606,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-jdbi</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- Ensure consistency -->
+                                <dependencyConvergence />
+                                <requireJavaVersion>
+                                    <!-- Java 8 min -->
+                                    <version>[1.8,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,12 @@
                 <groupId>org.antlr</groupId>
                 <artifactId>stringtemplate</artifactId>
                 <version>4.0.2</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>antlr-runtime</artifactId>
+                        <groupId>org.antlr</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -496,17 +496,9 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <!-- Fixes missing plugin during CI builds -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>default-jar</id>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.jetbrains.dokka</groupId>


### PR DESCRIPTION
This PR does two things:

**Enable Maven Enforcement**

I have enabled two built in rules, the first is for Java version (I've set a minimum of Java 8 as the code base does utilize lambda) and the second for dependency convergence checks.

**Exclude antlr-runtime for stringtemplate in Maven managed dependencies**

This seems to fix the issue where a circular dependency is introduced by requiring 3.4 of ANTLR while requiring 4.0.2 for string template.

Please see my notes here: #1182 