### PR TITLE
[done] #1175 allow unused Bindings + todo bug

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,9 +1,10 @@
 3.4.0
   - New API
     - StatementException.getShortMessage
-    - SqlStatements.allowUnusedBindings allows you to bind Arguments to query parts that may be left out of the final query (e.g. by a TemplateEngine that renders conditional blocks) without getting an Exception.
+    - SqlStatements.setUnusedBindingAllowed allows you to bind Arguments to query parts that may be left out of the final query (e.g. by a TemplateEngine that renders conditional blocks) without getting an Exception.
   - Bug Fixes
-    - Bridge methods cause SqlObject exceptions to get wrapped in `InvocationTargetException`
+    - Bridge methods cause SqlObject exceptions to get wrapped in `InvocationTargetException`.
+    - behavioral fixes in Argument binding where the number of provided Arguments differs from the expected number.
 
 3.3.0
   - New API

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+3.4.0
+  - New API
+    - SqlStatements.allowUnusedBindings allows you to bind Arguments to query parts that may be left out of the final query (e.g. by a TemplateEngine that renders conditional blocks) without getting an Exception.
+
 3.3.0
   - New API
     - SerializableTransactionRunner.setOnFailure(), setOnSuccess() methods allow callbacks to be

--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -50,7 +50,7 @@ class ArgumentBinder {
 
     private static void bindNamed(List<String> parameterNames, Binding binding, PreparedStatement statement, StatementContext context) {
         // TODO throw on any mismatch, not only empty/non-empty
-        if (!context.getConfig(SqlStatements.class).getAllowUnusedBindings() && parameterNames.isEmpty() && !binding.isEmpty()) {
+        if (parameterNames.isEmpty() && !binding.isEmpty() && !context.getConfig(SqlStatements.class).getAllowUnusedBindings()) {
             throw new UnableToExecuteStatementException(
                     String.format("Unable to execute. The query doesn't have named parameters, but provided binding '%s'.", binding),
                     context);

--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -43,14 +43,11 @@ class ArgumentBinder {
         for (int i = 0; i < params.getParameterCount(); i++) {
             Optional<Argument> argument = binding.findForPosition(i);
 
-            if (argument.isPresent()) {
-                try {
-                    argument.get().apply(i + 1, statement, context);
-                } catch (SQLException e) {
-                    throw new UnableToCreateStatementException("Exception while binding positional param at (0 based) position " + i, e, context);
-                }
-            } else {
-                throw new UnableToCreateStatementException("Missing positional param at (0 based) position " + i, context);
+            try {
+                int index = i;
+                argument.orElseThrow(() -> new UnableToCreateStatementException("Missing positional param at (0 based) position " + index, context)).apply(i + 1, statement, context);
+            } catch (SQLException e) {
+                throw new UnableToCreateStatementException("Exception while binding positional param at (0 based) position " + i, e, context);
             }
         }
     }
@@ -69,14 +66,10 @@ class ArgumentBinder {
 
             Optional<Argument> argument = binding.findForName(name, context);
 
-            if (argument.isPresent()) {
-                try {
-                    argument.get().apply(i + 1, statement, context);
-                } catch (SQLException e) {
-                    throw new UnableToCreateStatementException(String.format("Exception while binding named parameter '%s'", name), e, context);
-                }
-            } else {
-                throw new UnableToCreateStatementException(String.format("Missing named parameter '%s'.", name), context);
+            try {
+                argument.orElseThrow(() -> new UnableToCreateStatementException(String.format("Missing named parameter '%s'.", name), context)).apply(i + 1, statement, context);
+            } catch (SQLException e) {
+                throw new UnableToCreateStatementException(String.format("Exception while binding named parameter '%s'", name), e, context);
             }
         }
     }

--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -36,7 +36,7 @@ class ArgumentBinder {
     private static void bindPositional(ParsedParameters params, Binding binding, PreparedStatement statement, StatementContext context) {
         // best effort: just try +1 (unless we expose a method to get the full binding count)
         boolean moreArgumentsProvidedThanDeclared = binding.findForPosition(params.getParameterCount()).isPresent();
-        if (moreArgumentsProvidedThanDeclared && !context.getConfig(SqlStatements.class).getAllowUnusedBindings()) {
+        if (moreArgumentsProvidedThanDeclared && !context.getConfig(SqlStatements.class).isUnusedBindingAllowed()) {
             throw new UnableToCreateStatementException("Superfluous positional param at (0 based) position " + params.getParameterCount(), context);
         }
 
@@ -60,7 +60,7 @@ class ArgumentBinder {
 
         // best effort: compare empty to non-empty because we can't list the individual binding names (unless we expose a method to do so)
         boolean argumentsProvidedButNoneDeclared = paramNames.isEmpty() && !binding.isEmpty();
-        if (argumentsProvidedButNoneDeclared && !context.getConfig(SqlStatements.class).getAllowUnusedBindings()) {
+        if (argumentsProvidedButNoneDeclared && !context.getConfig(SqlStatements.class).isUnusedBindingAllowed()) {
             throw new UnableToCreateStatementException(String.format("Superfluous named parameters provided while the query declares none: '%s'.", binding), context);
         }
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -33,6 +33,7 @@ class ArgumentBinder {
     }
 
     private static void bindPositional(int size, Binding binding, PreparedStatement statement, StatementContext context) {
+        // TODO check matching?
         for (int i = 0; i < size; i++) {
             try {
                 Argument argument = binding.findForPosition(i).orElse(null);
@@ -48,11 +49,13 @@ class ArgumentBinder {
     }
 
     private static void bindNamed(List<String> parameterNames, Binding binding, PreparedStatement statement, StatementContext context) {
-        if (parameterNames.isEmpty() && !binding.isEmpty()) {
+        // TODO throw on any mismatch, not only empty/non-empty
+        if (!context.getConfig(SqlStatements.class).getAllowUnusedBindings() && parameterNames.isEmpty() && !binding.isEmpty()) {
             throw new UnableToExecuteStatementException(
                     String.format("Unable to execute. The query doesn't have named parameters, but provided binding '%s'.", binding),
                     context);
         }
+
         for (int i = 0; i < parameterNames.size(); i++) {
             String param = parameterNames.get(i);
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -167,7 +167,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
         return this;
     }
 
-    public boolean getAllowUnusedBindings() {
+    public boolean isUnusedBindingAllowed() {
         return allowUnusedBindings;
     }
 
@@ -176,7 +176,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      *
      * @see org.jdbi.v3.core.argument.Argument
      */
-    public SqlStatements setAllowUnusedBindings(boolean allowUnusedBindings) {
+    public SqlStatements setUnusedBindingAllowed(boolean allowUnusedBindings) {
         this.allowUnusedBindings = allowUnusedBindings;
         return this;
     }

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.meta.Beta;
 
 /**
  * Configuration holder for {@link SqlStatement}s.
@@ -28,19 +29,22 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     private TemplateEngine templateEngine;
     private SqlParser sqlParser;
     private SqlLogger sqlLogger;
+    private boolean allowUnusedBindings;
 
     public SqlStatements() {
         attributes = new ConcurrentHashMap<>();
         templateEngine = new DefinedAttributeTemplateEngine();
         sqlParser = new ColonPrefixSqlParser();
         sqlLogger = SqlLogger.NOP_SQL_LOGGER;
+        allowUnusedBindings = false;
     }
 
     private SqlStatements(SqlStatements that) {
-        this.attributes = new ConcurrentHashMap<>(that.attributes);
-        this.templateEngine = that.templateEngine;
-        this.sqlParser = that.sqlParser;
-        this.sqlLogger = that.sqlLogger;
+        attributes = new ConcurrentHashMap<>(that.attributes);
+        templateEngine = that.templateEngine;
+        sqlParser = that.sqlParser;
+        sqlLogger = that.sqlLogger;
+        allowUnusedBindings = that.allowUnusedBindings;
     }
 
     /**
@@ -162,6 +166,17 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
 
     public SqlStatements setSqlLogger(SqlLogger sqlLogger) {
         this.sqlLogger = sqlLogger == null ? SqlLogger.NOP_SQL_LOGGER : sqlLogger;
+        return this;
+    }
+
+    @Beta
+    public boolean getAllowUnusedBindings() {
+        return allowUnusedBindings;
+    }
+
+    @Beta
+    public SqlStatements setAllowUnusedBindings(boolean allowUnusedBindings) {
+        this.allowUnusedBindings = allowUnusedBindings;
         return this;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -16,9 +16,7 @@ package org.jdbi.v3.core.statement;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.jdbi.v3.core.config.JdbiConfig;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Configuration holder for {@link SqlStatement}s.
@@ -169,12 +167,15 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
         return this;
     }
 
-    @Beta
     public boolean getAllowUnusedBindings() {
         return allowUnusedBindings;
     }
 
-    @Beta
+    /**
+     * Sets whether or not an exception should be thrown when any arguments are given to a query but not actually used in it. Unused bindings tend to be bugs or oversights, but can also just be convenient. Defaults to false: unused bindings are not allowed.
+     *
+     * @see org.jdbi.v3.core.argument.Argument
+     */
     public SqlStatements setAllowUnusedBindings(boolean allowUnusedBindings) {
         this.allowUnusedBindings = allowUnusedBindings;
         return this;

--- a/core/src/test/java/org/jdbi/v3/core/statement/ArgumentBinderTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/ArgumentBinderTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import java.sql.PreparedStatement;
+import java.util.Arrays;
+import org.jdbi.v3.core.argument.Argument;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+public class ArgumentBinderTest {
+    private static final Argument NOP = (position, statement, ctx) -> {};
+
+    @Rule
+    public MethodRule mockito = MockitoJUnit.rule();
+    @Mock
+    private PreparedStatement stmt;
+    @Mock
+    private StatementContext ctx;
+
+    private SqlStatements statements = new SqlStatements();
+
+    @Before
+    public void before() {
+        when(ctx.getConfig(SqlStatements.class)).thenReturn(statements);
+    }
+
+    @Test
+    public void testPositionalEmpty() {
+        assertThatCode(() -> ArgumentBinder.bind(positionalParams(0), positionalBinding(0), stmt, ctx))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testNamedEmpty() {
+        assertThatCode(() -> ArgumentBinder.bind(namedParams(), namedBinding(), stmt, ctx))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testPositionalDeclaredButNotProvided() {
+        assertThatThrownBy(() -> ArgumentBinder.bind(positionalParams(1), positionalBinding(0), stmt, ctx))
+            .isInstanceOf(UnableToCreateStatementException.class);
+    }
+
+    @Test
+    public void testNamedDeclaredButNotProvided() {
+        assertThatThrownBy(() -> ArgumentBinder.bind(namedParams("unused"), namedBinding(), stmt, ctx))
+            .isInstanceOf(UnableToCreateStatementException.class);
+    }
+
+    @Test
+    public void testPositionalNotDeclaredButProvided() {
+        assertThatThrownBy(() -> ArgumentBinder.bind(positionalParams(0), positionalBinding(1), stmt, ctx))
+            .isInstanceOf(UnableToCreateStatementException.class);
+    }
+
+    @Test
+    public void testNamedNotDeclaredButProvided() {
+        assertThatThrownBy(() -> ArgumentBinder.bind(namedParams(), namedBinding("unused"), stmt, ctx))
+            .isInstanceOf(UnableToCreateStatementException.class);
+    }
+
+    @Test
+    public void testPositionalNotDeclaredButProvidedWithPermission() {
+        allowUnused();
+
+        assertThatCode(() -> ArgumentBinder.bind(positionalParams(0), positionalBinding(1), stmt, ctx))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testNamedNotDeclaredButProvidedWithPermission() {
+        allowUnused();
+
+        assertThatCode(() -> ArgumentBinder.bind(namedParams(), namedBinding("unused"), stmt, ctx))
+            .doesNotThrowAnyException();
+    }
+
+    private ParsedParameters positionalParams(int size) {
+        String[] names = new String[size];
+        Arrays.fill(names, "?");
+        return new ParsedParameters(true, Arrays.asList(names));
+    }
+
+    private ParsedParameters namedParams(String... names) {
+        return new ParsedParameters(false, Arrays.asList(names));
+    }
+
+    private Binding positionalBinding(int size) {
+        Binding b = new Binding();
+        for (int i = 0; i < size; i++) {
+            b.addPositional(i, NOP);
+        }
+        return b;
+    }
+
+    private Binding namedBinding(String... names) {
+        Binding b = new Binding();
+        for (String name: names) {
+            b.addNamed(name, NOP);
+        }
+        return b;
+    }
+
+    private void allowUnused() {
+        statements.setAllowUnusedBindings(true);
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/ArgumentBinderTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/ArgumentBinderTest.java
@@ -123,6 +123,6 @@ public class ArgumentBinderTest {
     }
 
     private void allowUnused() {
-        statements.setAllowUnusedBindings(true);
+        statements.setUnusedBindingAllowed(true);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPositionalParameterBinding.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPositionalParameterBinding.java
@@ -64,7 +64,7 @@ public class TestPositionalParameterBinding {
         assertThatThrownBy(() -> h.createQuery("select * from something where id = ? and name = ?")
             .bind(0, 1)
             .mapToBean(Something.class)
-            .list()).isInstanceOf(UnableToExecuteStatementException.class);
+            .list()).isInstanceOf(UnableToCreateStatementException.class);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class TestPositionalParameterBinding {
             .bind(1, 1)
             .bind(2, "Hi")
             .mapToBean(Something.class)
-            .list()).isInstanceOf(UnableToExecuteStatementException.class);
+            .list()).isInstanceOf(UnableToCreateStatementException.class);
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
@@ -145,8 +145,8 @@ public class TestQueries {
                         .bind(0, "eric")
                         .mapToBean(Something.class)
                         .list())
-                .isInstanceOf(UnableToExecuteStatementException.class)
-                .hasMessageContaining("no named parameter matches 'name'");
+                .isInstanceOf(UnableToCreateStatementException.class)
+                .hasMessageContaining("Missing named parameter 'name'");
     }
 
     @Test
@@ -160,14 +160,14 @@ public class TestQueries {
                         .bind("id", 1)
                         .mapToBean(Something.class)
                         .list())
-                .isInstanceOf(UnableToExecuteStatementException.class)
-                .hasMessageContaining("no named parameter matches 'name'");
+                .isInstanceOf(UnableToCreateStatementException.class)
+                .hasMessageContaining("Missing named parameter 'name'");
     }
 
     @Test
     public void testHelpfulErrorOnNothingSet() throws Exception {
         assertThatThrownBy(() -> h.createQuery("select * from something where name = :name").mapToMap().list())
-            .isInstanceOf(UnableToExecuteStatementException.class);
+            .isInstanceOf(UnableToCreateStatementException.class);
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -119,7 +119,7 @@ public class TestStatements {
 
     @Test
     public void testPermittedUnusedBinding() {
-       assertThatCode(() ->  h.configure(SqlStatements.class, s -> s.setAllowUnusedBindings(true))
+       assertThatCode(() -> h.configure(SqlStatements.class, s -> s.setAllowUnusedBindings(true))
            .createQuery("select * from something")
            .bind("id", 1)
            .collectRows(Collectors.counting())).doesNotThrowAnyException();

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -103,7 +103,7 @@ public class TestStatements {
         assertThatThrownBy(() -> h.createQuery("select * from something")
             .bind("id", 1)
             .collectRows(Collectors.counting())
-        ).isInstanceOf(UnableToExecuteStatementException.class);
+        ).isInstanceOf(UnableToCreateStatementException.class);
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -21,7 +21,6 @@ import org.jdbi.v3.core.result.ResultProducers;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -107,17 +106,6 @@ public class TestStatements {
     }
 
     @Test
-    @Ignore
-    // TODO fix in ArgumentBinder
-    public void testUsedAndUnusedBinding() {
-        assertThatThrownBy(() -> h.createQuery("select * from something where id = :id")
-            .bind("id", 1)
-            .bind("name", "jack")
-            .collectRows(Collectors.counting())
-        ).isInstanceOf(UnableToExecuteStatementException.class);
-    }
-
-    @Test
     public void testPermittedUnusedBinding() {
        assertThatCode(() -> h.configure(SqlStatements.class, s -> s.setUnusedBindingAllowed(true))
            .createQuery("select * from something")
@@ -132,5 +120,25 @@ public class TestStatements {
             .bind("id", 1)
             .bind("name", "jack")
             .collectRows(Collectors.counting())).doesNotThrowAnyException();
+    }
+
+    @Test
+    // TODO it would be nice if this failed in the future
+    public void testUsedAndUnusedNamed() {
+        assertThatCode(() -> h.createQuery("select * from something where id = :id")
+            .bind("id", 1)
+            .bind("name", "jack")
+            .collectRows(Collectors.counting())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    // TODO it would be nice if this failed in the future
+    public void testFarAwayPositional() {
+        assertThatCode(() -> h.createQuery("select * from something where id = ?")
+            .bind(0, 1)
+            .bind(2, "jack")
+            .collectRows(Collectors.counting())
+        ).doesNotThrowAnyException();
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -119,7 +119,7 @@ public class TestStatements {
 
     @Test
     public void testPermittedUnusedBinding() {
-       assertThatCode(() -> h.configure(SqlStatements.class, s -> s.setAllowUnusedBindings(true))
+       assertThatCode(() -> h.configure(SqlStatements.class, s -> s.setUnusedBindingAllowed(true))
            .createQuery("select * from something")
            .bind("id", 1)
            .collectRows(Collectors.counting())).doesNotThrowAnyException();
@@ -127,7 +127,7 @@ public class TestStatements {
 
     @Test
     public void testPermittedUsedAndUnusedBinding() {
-        assertThatCode(() -> h.configure(SqlStatements.class, s -> s.setAllowUnusedBindings(true))
+        assertThatCode(() -> h.configure(SqlStatements.class, s -> s.setUnusedBindingAllowed(true))
             .createQuery("select * from something where id = :id")
             .bind("id", 1)
             .bind("name", "jack")

--- a/noparameters/src/test/java/org/jdbi/v3/noparameters/TestSqlObjectNoParameterNames.java
+++ b/noparameters/src/test/java/org/jdbi/v3/noparameters/TestSqlObjectNoParameterNames.java
@@ -13,17 +13,12 @@
  */
 package org.jdbi.v3.noparameters;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assume.assumeFalse;
-
 import java.util.List;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.reflect.BeanMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
-import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
@@ -33,6 +28,10 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assume.assumeFalse;
 
 public class TestSqlObjectNoParameterNames {
     @Rule
@@ -63,15 +62,15 @@ public class TestSqlObjectNoParameterNames {
     @Test
     public void implicitBindNamed() throws Exception {
         assertThatThrownBy(() -> h.attach(BindDao.class).getByIdImplicitBindNamed(1))
-                .isInstanceOf(UnableToExecuteStatementException.class)
-                .hasMessageContaining("no named parameter matches 'id'");
+                .isInstanceOf(UnableToCreateStatementException.class)
+                .hasMessageContaining("Missing named parameter 'id'");
     }
 
     @Test
     public void explicitBindNamed() throws Exception {
         assertThatThrownBy(() -> h.attach(BindDao.class).getByIdExplicitBindNamed(1))
-                .isInstanceOf(UnableToExecuteStatementException.class)
-                .hasMessageContaining("no named parameter matches 'id'");
+                .isInstanceOf(UnableToCreateStatementException.class)
+                .hasMessageContaining("Missing named parameter 'id'");
     }
 
     public interface BindDao {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMap.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMap.java
@@ -19,7 +19,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
-import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindMap;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -101,7 +101,7 @@ public class TestBindMap {
     @Test
     public void testBindMapKeyNotInMapOrKeys() throws Exception {
         handle.execute("insert into something(id, name) values (3, 'Carol')");
-        exception.expect(UnableToExecuteStatementException.class);
+        exception.expect(UnableToCreateStatementException.class);
 
         dao.update(3, emptyMap());
     }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMistypedNamedParameter.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMistypedNamedParameter.java
@@ -15,7 +15,7 @@ package org.jdbi.v3.sqlobject;
 
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
-import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -23,8 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestMistypedNamedParameter {
 
@@ -45,10 +44,9 @@ public class TestMistypedNamedParameter {
 
     @Test
     public void testWarnAboutUnmatchedBinding() throws Exception {
-        assertThatExceptionOfType(UnableToExecuteStatementException.class)
-                .isThrownBy(() -> dao.deleteSomething(2))
-                .satisfies(e -> assertThat(e.getMessage())
-                        .startsWith("Unable to execute. The query doesn't have named parameters, but provided binding"));
+        assertThatThrownBy(() -> dao.deleteSomething(2))
+            .isInstanceOf(UnableToCreateStatementException.class)
+            .hasMessageStartingWith("Superfluous named parameters provided while the query declares none");
     }
 
     @RegisterRowMapper(SomethingMapper.class)


### PR DESCRIPTION
fixes #1175

Testing showed the current code is inconsistent and doesn't cover many cases. It throws an exception when >0 arguments are provided but the query contains 0 variables. It does not throw when too many arguments are provided as long as the query defines at least 1 variable. @rjnay could work around his problem for now by changing his query to `where :id = :id<if(bool)> and id = :id<endif>`. I think this should be fixed. Shall I make a separate PR for that too when other open things have been wrapped up?