### PR TITLE
Fixed plugin issues with CI build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
         <dep.antlr.version>3.4</dep.antlr.version>
         <dep.checkstyle.version>8.10</dep.checkstyle.version>
-        <dep.dokka.version>0.9.16</dep.dokka.version>
+        <dep.dokka.version>0.9.17</dep.dokka.version>
         <dep.jetbrainsAnnotations.version>13.0</dep.jetbrainsAnnotations.version>
         <dep.kotlin.version>1.2.31</dep.kotlin.version>
         <dep.plugin.checkstyle.version>3.0.0</dep.plugin.checkstyle.version>
@@ -496,6 +496,11 @@
                     <configuration>
                         <jdkVersion>8</jdkVersion>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <!-- Fixes missing plugin during CI builds -->
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
                 </plugin>
                 <plugin>
                     <groupId>org.antlr</groupId>


### PR DESCRIPTION
Please see: #1183

If this is approved and merged into master, I will merge master into the branch for #1183 and these changes will disappear from that PR. This PR fixes the issues that have been plaguing a number of PRs and HEAD of master with respect to CI failures.

There are two fixes:

* 0.9.17 of dokka (known issue with 0.9.16, fixed in 0.9.17)
* Including maven jar plugin in managed plugins; CI was unable to find this plugin (which is supposed to be there be default, a quick search showed that when this issue is seen, including the plugin in your managed plugins fixes the error, so this what I have done)