### PR TITLE
BridgeMethodHandlerFactory: use MethodHandle in preference to legacy reflection

### DIFF
--- a/4.0_TODO
+++ b/4.0_TODO
@@ -1,0 +1,1 @@
+* <X extends Exception> should probably generally be <X extends Throwable>

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,6 +1,8 @@
 3.4.0
   - New API
     - StatementException.getShortMessage
+  - Bug Fixes
+    - Bridge methods cause SqlObject exceptions to get wrapped in `InvocationTargetException`
 
 3.3.0
   - New API

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-bom</artifactId>

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>jdbi3-commons-text</artifactId>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-core</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-docs</artifactId>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-freemarker</artifactId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-guava</artifactId>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-jodatime2</artifactId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-jpa</artifactId>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-kotlin-sqlobject</artifactId>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-kotlin</artifactId>

--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-noparameters</artifactId>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-oracle12</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.jdbi</groupId>
     <artifactId>jdbi3-parent</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>jdbi3 Parent</name>
     <description>Jdbi is designed to provide convenient tabular data access in

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-postgres</artifactId>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-spring4</artifactId>

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-sqlite</artifactId>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-sqlobject</artifactId>

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandler.java
@@ -40,7 +40,7 @@ class DefaultMethodHandler implements Handler {
 
     private static final Map<Class<?>, MethodHandles.Lookup> PRIVATE_LOOKUPS = synchronizedMap(new WeakHashMap<>());
 
-    private static MethodHandles.Lookup lookupFor(Class<?> clazz) {
+    static MethodHandles.Lookup lookupFor(Class<?> clazz) {
         if (PRIVATE_LOOKUP_IN != null) {
             try {
                 return (MethodHandles.Lookup) PRIVATE_LOOKUP_IN.invoke(null, clazz, MethodHandles.lookup());

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UnableToCreateSqlObjectException.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/UnableToCreateSqlObjectException.java
@@ -24,4 +24,8 @@ public class UnableToCreateSqlObjectException extends JdbiException {
     public UnableToCreateSqlObjectException(String message) {
         super(message);
     }
+
+    public UnableToCreateSqlObjectException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBridgeException.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBridgeException.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import org.assertj.core.api.Assertions;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestBridgeException {
+
+    @Rule
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    @Before
+    public void setUp() {
+        this.dbRule.getSharedHandle().execute("CREATE TABLE uniq (id INTEGER PRIMARY KEY)");
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void testBridgeExceptionPassthru() throws Throwable {
+        final ExceptionalBridge dao = this.dbRule.getSharedHandle().attach(ExceptionallyTypedBridge.class);
+        final Object arg = 3;
+        Assertions.assertThatThrownBy(() -> {
+            for (int i = 0; i < 2; i++) {
+                dao.insert(arg);
+            }
+        })
+        .isInstanceOf(UnableToExecuteStatementException.class);
+    }
+
+    public interface ExceptionalBridge<T> extends SqlObject {
+        void insert(T value);
+    }
+
+    public interface ExceptionallyTypedBridge extends ExceptionalBridge<Integer> {
+        @Override
+        @SqlUpdate("INSERT INTO uniq (id) VALUES(:value)")
+        void insert(Integer value);
+    }
+}

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-stringtemplate4</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-testing</artifactId>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-vavr</artifactId>


### PR DESCRIPTION
This prevents any thrown exceptions from getting unexpectedly wrapped in InvocationTargetException

Fixes #1188