### PR TITLE
Fix for dropwizard-jdbi3 build issues (dependency convergence)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,12 @@
                 <groupId>org.antlr</groupId>
                 <artifactId>stringtemplate</artifactId>
                 <version>4.0.2</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>antlr-runtime</artifactId>
+                        <groupId>org.antlr</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -603,6 +609,28 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-jdbi</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- Ensure consistency -->
+                                <dependencyConvergence />
+                                <requireJavaVersion>
+                                    <!-- Java 8 min -->
+                                    <version>[1.8,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
**NOTE** This is a recreation of #1183 so that the commit history and diffs are simple and clean; this branch is created off of HEAD of master at the time of this writing so features several other fixes that were complicating a merge/rebase of the original PR.

DropWizard JDBI3 library relies on the enforcer plugin to ensure that
all dependencies use the same version (dependency convergence).
Unfortunately, due to the versions of antlr-runtime and springtemplate
used by JDBI3, this check fails.

In order to fix this issue, this commit features two changes to the
parent pom.xml:

1) Excluding the antlr-runtime library from the dependency declaration
for antlr's stringtemplete; the newer version of stringtemplate brings
in an older version of the runtime.

2) Enabling the enforcer plugin so that should such an issue happen
again, the JDBI build will fail before such an issue is released (and
thus breaking projects that depend on JDBI).