### PR TITLE
Fix write-only property in BeanMapper

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import org.jdbi.v3.core.mapper.ColumnMapper;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
@@ -156,7 +156,7 @@ public class BeanMapper<T> implements RowMapper<T> {
 
                 findColumnIndex(paramName, columnNames, columnNameMatchers, () -> debugName(descriptor))
                     .ifPresent(index -> {
-                        Type type = descriptor.getReadMethod().getGenericReturnType();
+                        Type type = propertyType(descriptor);
                         ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
                             .orElse((r, n, c) -> r.getObject(n));
 
@@ -206,6 +206,11 @@ public class BeanMapper<T> implements RowMapper<T> {
                 .map(ColumnName::value)
                 .findFirst()
                 .orElseGet(descriptor::getName);
+    }
+
+    private static Type propertyType(PropertyDescriptor descriptor) {
+        return Optional.ofNullable(descriptor.getReadMethod()).map(Method::getGenericReturnType)
+                .orElseGet(() -> descriptor.getWriteMethod().getGenericParameterTypes()[0]);
     }
 
     private String debugName(PropertyDescriptor descriptor) {


### PR DESCRIPTION
If there is only a setter method the BeanMapper can still be useful as a RowMapper for output.
In this case, the `descriptor.getReadMethod()` being `null` will cause NPE when determining the type to be mapped.
This is not necessary, as the type can then determined by parameter of the `descriptor.getWriteMethod()`.