### PR TITLE
Avoid formatting string when not needed

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/generic/internal/Preconditions.java
+++ b/core/src/main/java/org/jdbi/v3/core/generic/internal/Preconditions.java
@@ -14,8 +14,7 @@
 
 package org.jdbi.v3.core.generic.internal;
 
-import java.util.Objects;
-
+@SuppressWarnings("PMD.AvoidThrowingNullPointerException")
 public final class Preconditions {
     private Preconditions() {
         throw new UnsupportedOperationException("utility class");
@@ -28,7 +27,11 @@ public final class Preconditions {
     }
 
     public static <T> T checkNotNull(T reference, String errorMessageTemplate, Object... errorMessageArgs) {
-        return Objects.requireNonNull(reference, String.format(errorMessageTemplate, errorMessageArgs));
+        if (reference == null) {
+            throw new NullPointerException(String.format(errorMessageTemplate, errorMessageArgs));
+        }
+
+        return reference;
     }
 
     public static void checkState(boolean expression, String errorMessageTemplate, Object... errorMessageArgs) {


### PR DESCRIPTION
When profiling a project using JDBI 3.4.0, I noticed that up to 25% of the samples would happen in `Preconditions#checkNotNull`.

This was due to the error message being formatted even if the reference was not null (as it is in the great majority of the calls).

Running this patch, the profiler doesn't even pick up calls to the method anymore.

The more recent versions of Guava (where I assume this file was pulled from) use this way of checking for nullability.