### PR TITLE
Improve JdbiFactoryBean

### DIFF
--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiFactoryBean.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiFactoryBean.java
@@ -19,20 +19,19 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
-import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 
 /**
- * Utility class which constructs an {@link Jdbi} instance which can conveniently participate
- * in Spring's transaction management system.
+ * Utility class which constructs an {@link Jdbi} instance which can conveniently
+ * participate in Spring's transaction management system.
  */
-public class JdbiFactoryBean implements FactoryBean<Jdbi> {
+public class JdbiFactoryBean extends AbstractFactoryBean<Jdbi> {
     private DataSource dataSource;
     private final Map<String, Object> globalDefines = new HashMap<>();
 
@@ -45,11 +44,8 @@ public class JdbiFactoryBean implements FactoryBean<Jdbi> {
         this.dataSource = dataSource;
     }
 
-    /**
-     * See {@link org.springframework.beans.factory.FactoryBean#getObject}
-     */
     @Override
-    public Jdbi getObject() throws Exception {
+    protected Jdbi createInstance() throws Exception {
         final Jdbi jdbi = Jdbi.create(() -> DataSourceUtils.getConnection(dataSource));
 
         if (autoInstallPlugins) {
@@ -69,16 +65,6 @@ public class JdbiFactoryBean implements FactoryBean<Jdbi> {
     @Override
     public Class<Jdbi> getObjectType() {
         return Jdbi.class;
-    }
-
-    /**
-     * See {@link org.springframework.beans.factory.FactoryBean#isSingleton}
-     *
-     * @return false
-     */
-    @Override
-    public boolean isSingleton() {
-        return true;
     }
 
     /**
@@ -125,11 +111,11 @@ public class JdbiFactoryBean implements FactoryBean<Jdbi> {
     /**
      * Verifies that a dataSource has been set
      */
-    @PostConstruct
     @SuppressWarnings("unused")
-    private void afterPropertiesSet() {
+    public void afterPropertiesSet() throws Exception {
         if (dataSource == null) {
             throw new IllegalStateException("'dataSource' property must be set");
         }
+        super.afterPropertiesSet();
     }
 }


### PR DESCRIPTION
This commit improves the JdbiFactoryBean. The getObject() method
re-created the Jdbi instances each time getObject() was called.
It is better to create it once and cache it afterwards. This
could also potentially break the contract as Jdbi should be
a singleton (according to the isSingleton method).

To further improve it build upon the AbstractFactoryBean from
Spring itself which allows to specify if it should be a singleton
or not and act accordingly.