### PR TITLE
Allow @Nested objects to be optionally included in result sets

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
@@ -340,8 +340,30 @@ public class BeanMapperTest {
             .hasMessageContaining("could not match properties for columns: [other]");
     }
 
+    @Test
+    public void testNestedNotReturned() {
+        Handle handle = dbRule.getSharedHandle();
+        handle.registerRowMapper(BeanMapper.factory(NestedBean.class));
+
+        assertThat(handle
+            .createQuery("select 42 as testValue")
+            .mapTo(NestedBean.class)
+            .findOnly())
+            .extracting("testValue", "nested")
+            .containsExactly(42, null);
+    }
+
     static class NestedBean {
+        private Integer testValue;
         private Something nested;
+
+        public Integer getTestValue() {
+            return testValue;
+        }
+
+        public void setTestValue(Integer testValue) {
+            this.testValue = testValue;
+        }
 
         @Nested
         public Something getNested() {
@@ -396,6 +418,19 @@ public class BeanMapperTest {
             .findOnly())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("could not match properties for columns: [nested_other]");
+    }
+
+    @Test
+    public void testNestedPrefixNotReturned() {
+        Handle handle = dbRule.getSharedHandle();
+        handle.registerRowMapper(BeanMapper.factory(NestedPrefixBean.class));
+
+        assertThat(handle
+            .createQuery("select 42 as integerValue")
+            .mapTo(NestedPrefixBean.class)
+            .findOnly())
+            .extracting("integerValue", "nested")
+            .containsExactly(42, null);
     }
 
     static class NestedPrefixBean {

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
@@ -271,7 +271,22 @@ public class FieldMapperTest {
             .hasMessageContaining("could not match fields for columns: [other]");
     }
 
+    @Test
+    public void testNestedNotReturned() {
+        Handle handle = dbRule.getSharedHandle();
+
+        assertThat(handle
+            .registerRowMapper(FieldMapper.factory(NestedThing.class))
+            .select("SELECT 42 as testValue")
+            .mapTo(NestedThing.class)
+            .findOnly())
+            .extracting("testValue", "nested")
+            .containsExactly(42, null);
+    }
+
     static class NestedThing {
+        Integer testValue;
+
         @Nested
         ColumnNameThing nested;
     }
@@ -318,6 +333,19 @@ public class FieldMapperTest {
             .findOnly())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("could not match fields for columns: [nested_other]");
+    }
+
+    @Test
+    public void testNestedPrefixNotReturned() {
+        Handle handle = dbRule.getSharedHandle();
+
+        assertThat(handle
+            .registerRowMapper(FieldMapper.factory(NestedPrefixThing.class))
+            .select("SELECT 42 as integerValue")
+            .mapTo(NestedPrefixThing.class)
+            .findOnly())
+            .extracting("integerValue", "nested")
+            .containsExactly(42, null);
     }
 
     static class NestedPrefixThing {

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.10.0</version>
+                <version>3.11.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixes #1212 

The ConstructorMapper, FieldMapper, and BeanMapper now all provide extra context during the specialize0() method to know whether or not a nested call is being made, and if so, to not throw an exception if no columns were mapped but rather create a row mapper that returns null, as per @qualidafial 's suggestion.

The ConstructorMapper was tricky because it throws an exception immediately upon finding an unmatched parameter; I moved the exception handling to after all the parameter mapping so that it could be ignored by nested calls if all the parameters of the nested object were unmapped.  That way, it would catch when a nested object is partially retrieved, as well as when a nested object has other nested objects.

I've also added in test cases to the the mapper tests that hopefully illustrate and cover the fix.