### PR TITLE
Prevent KotlinMapper from handling enum classes

### DIFF
--- a/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinMapperFactory.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinMapperFactory.kt
@@ -23,9 +23,12 @@ import java.util.*
 class KotlinMapperFactory : RowMapperFactory {
 
     override fun build(type: Type, config: ConfigRegistry): Optional<RowMapper<*>> {
-        val erasedType = getErasedType(type);
+        val erasedType = getErasedType(type)
 
-        return if (erasedType.isKotlinClass()) {
+        //TODO: Validate if we should only handle 'data' classes with the Kotlin mapper
+        // Switching this might cause issues for users, might be better to do it for a major release
+        // See https://github.com/jdbi/jdbi/issues/1218 for more info
+        return if (erasedType.isKotlinClass() && !erasedType.isEnum) {
             Optional.of(KotlinMapper(erasedType))
         } else {
             Optional.empty()

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinMapperTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinMapperTest.kt
@@ -255,4 +255,28 @@ class KotlinMapperTest {
 
         assertThat(result.fromCtor).isEqualTo(expected)
     }
+
+    enum class KotlinTestEnum {
+        A,B,C
+    }
+
+    @Test
+    fun testKotlinMapperSkipsKotlinEnums() {
+        // https://github.com/jdbi/jdbi/issues/1218
+        val values = KotlinTestEnum.values()
+
+        values.forEachIndexed { index, kotlinTestEnum ->
+            handle.createUpdate("INSERT INTO the_things(id, first) VALUES(:id, :value)")
+                .bind("id", index)
+                .bind("value", kotlinTestEnum)
+                .execute()
+        }
+
+        val result = handle.createQuery("SELECT first FROM the_things")
+            .mapTo<KotlinTestEnum>()
+            .list()
+
+        assertThat(result.size).isEqualTo(values.size)
+        assertThat(result).containsAll(values.asList())
+    }
 }


### PR DESCRIPTION
Fixes #1218. This will make sure enums (even ones written in Kotlin)
will be mapped using built-in `EnumMapper`s.