### PR TITLE
Optional nested mapping

### DIFF
--- a/4.0_TODO
+++ b/4.0_TODO
@@ -1,1 +1,2 @@
 * <X extends Exception> should probably generally be <X extends Throwable>
+* Make ColumnNameMatcher.columnNameBeginsWith abstract (non-default)

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-bom</artifactId>

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
     <artifactId>jdbi3-commons-text</artifactId>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-core</artifactId>

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/BeanMapper.java
@@ -36,6 +36,7 @@ import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.SingleColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
+import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.anyColumnsStartWithPrefix;
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.findColumnIndex;
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNames;
 
@@ -49,6 +50,26 @@ import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnName
  * The mapped class must have a default constructor.
  */
 public class BeanMapper<T> implements RowMapper<T> {
+    private static final String DEFAULT_PREFIX = "";
+
+    private static final String NO_MATCHING_COLUMNS =
+        "Mapping bean type %s didn't find any matching columns in result set";
+
+    private static final String UNMATCHED_COLUMNS_STRICT =
+        "Mapping bean type %s could not match properties for columns: %s";
+
+    private static final String TYPE_NOT_INSTANTIABLE =
+        "A bean, %s, was mapped which was not instantiable";
+
+    private static final String MISSING_SETTER =
+        "No appropriate method to write property %s";
+
+    private static final String SETTER_NOT_ACCESSIBLE =
+        "Unable to access setter for property, %s";
+
+    private static final String INVOCATION_TARGET_EXCEPTION =
+        "Invocation target exception trying to invoker setter for the %s property";
+
     /**
      * Returns a mapper factory that maps to the given bean class
      *
@@ -93,8 +114,6 @@ public class BeanMapper<T> implements RowMapper<T> {
         return new BeanMapper<>(type, prefix);
     }
 
-    static final String DEFAULT_PREFIX = "";
-
     private final Class<T> type;
     private final String prefix;
     private final BeanInfo info;
@@ -122,25 +141,23 @@ public class BeanMapper<T> implements RowMapper<T> {
                 ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
         final List<String> unmatchedColumns = new ArrayList<>(columnNames);
 
-        RowMapper<T> result = specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns);
+        RowMapper<T> result = specialize0(ctx, columnNames, columnNameMatchers, unmatchedColumns)
+            .orElseThrow(() -> new IllegalArgumentException(String.format(NO_MATCHING_COLUMNS, type)));
 
         if (ctx.getConfig(ReflectionMappers.class).isStrictMatching()
-            && unmatchedColumns.stream().anyMatch(col -> col.startsWith(prefix))) {
+            && anyColumnsStartWithPrefix(unmatchedColumns, prefix, columnNameMatchers)) {
 
-            throw new IllegalArgumentException(String.format(
-                "Mapping bean type %s could not match properties for columns: %s",
-                type.getSimpleName(),
-                unmatchedColumns));
+            throw new IllegalArgumentException(
+                String.format(UNMATCHED_COLUMNS_STRICT, type.getSimpleName(), unmatchedColumns));
         }
 
         return result;
     }
 
-    private RowMapper<T> specialize0(ResultSet rs,
-                                     StatementContext ctx,
-                                     List<String> columnNames,
-                                     List<ColumnNameMatcher> columnNameMatchers,
-                                     List<String> unmatchedColumns) throws SQLException {
+    private Optional<RowMapper<T>> specialize0(StatementContext ctx,
+                                               List<String> columnNames,
+                                               List<ColumnNameMatcher> columnNameMatchers,
+                                               List<String> unmatchedColumns) {
         final List<RowMapper<?>> mappers = new ArrayList<>();
         final List<PropertyDescriptor> properties = new ArrayList<>();
 
@@ -168,22 +185,23 @@ public class BeanMapper<T> implements RowMapper<T> {
                     });
             } else {
                 String nestedPrefix = prefix + anno.value();
-
-                RowMapper<?> nestedMapper = nestedMappers
-                    .computeIfAbsent(descriptor, d -> new BeanMapper<>(d.getPropertyType(), nestedPrefix))
-                    .specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns);
-
-                mappers.add(nestedMapper);
-                properties.add(descriptor);
+                if (anyColumnsStartWithPrefix(columnNames, nestedPrefix, columnNameMatchers)) {
+                    nestedMappers
+                        .computeIfAbsent(descriptor, d -> new BeanMapper<>(d.getPropertyType(), nestedPrefix))
+                        .specialize0(ctx, columnNames, columnNameMatchers, unmatchedColumns)
+                        .ifPresent(nestedMapper -> {
+                            mappers.add(nestedMapper);
+                            properties.add(descriptor);
+                        });
+                }
             }
         }
 
         if (mappers.isEmpty() && !columnNames.isEmpty()) {
-            throw new IllegalArgumentException(String.format("Mapping bean type %s "
-                + "didn't find any matching columns in result set", type));
+            return Optional.empty();
         }
 
-        return (r, c) -> {
+        return Optional.of((r, c) -> {
             T bean = construct();
 
             for (int i = 0; i < mappers.size(); i++) {
@@ -196,7 +214,7 @@ public class BeanMapper<T> implements RowMapper<T> {
             }
 
             return bean;
-        };
+        });
     }
 
     private static String paramName(PropertyDescriptor descriptor) {
@@ -222,8 +240,7 @@ public class BeanMapper<T> implements RowMapper<T> {
         try {
             return type.newInstance();
         } catch (Exception e) {
-            throw new IllegalArgumentException(String.format("A bean, %s, was mapped "
-                + "which was not instantiable", type.getName()), e);
+            throw new IllegalArgumentException(String.format(TYPE_NOT_INSTANTIABLE, type.getName()), e);
         }
     }
 
@@ -231,15 +248,13 @@ public class BeanMapper<T> implements RowMapper<T> {
         try {
             Method writeMethod = property.getWriteMethod();
             if (writeMethod == null) {
-                throw new IllegalArgumentException(String.format("No appropriate method to write property %s", property.getName()));
+                throw new IllegalArgumentException(String.format(MISSING_SETTER, property.getName()));
             }
             writeMethod.invoke(bean, value);
         } catch (IllegalAccessException e) {
-            throw new IllegalArgumentException(String.format("Unable to access setter for "
-                + "property, %s", property.getName()), e);
+            throw new IllegalArgumentException(String.format(SETTER_NOT_ACCESSIBLE, property.getName()), e);
         } catch (InvocationTargetException e) {
-            throw new IllegalArgumentException(String.format("Invocation target exception trying to "
-                + "invoker setter for the %s property", property.getName()), e);
+            throw new IllegalArgumentException(String.format(INVOCATION_TARGET_EXCEPTION, property.getName()), e);
         }
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/CaseInsensitiveColumnNameMatcher.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/CaseInsensitiveColumnNameMatcher.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
+import java.util.Locale;
+
 /**
  * Matches column names with identical java names, ignoring case.
  * <p>
@@ -21,7 +23,16 @@ package org.jdbi.v3.core.mapper.reflect;
 public class CaseInsensitiveColumnNameMatcher implements ColumnNameMatcher {
     @Override
     public boolean columnNameMatches(String columnName, String javaName) {
-        return columnName.equalsIgnoreCase(javaName);
+        return normalize(columnName).equals(normalize(javaName));
+    }
+
+    @Override
+    public boolean columnNameStartsWith(String columnName, String prefix) {
+        return normalize(columnName).startsWith(normalize(prefix));
+    }
+
+    private String normalize(String string) {
+        return string.toLowerCase(Locale.ROOT);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ColumnNameMatcher.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ColumnNameMatcher.java
@@ -25,4 +25,21 @@ public interface ColumnNameMatcher {
      * @return whether the given names are logically equivalent
      */
     boolean columnNameMatches(String columnName, String javaName);
+
+    /**
+     * Return whether the column name starts with the given prefix, according to the matching strategy of this
+     * {@code ColumnNameMatcher}. This method is used by reflective mappers to short-circuit nested mapping when no
+     * column begin with the prefix.
+     *
+     * By default, this method returns {@code columnName.startWith(prefix)}. Third party implementations should override
+     * this method to match prefixes by the same criteria as {@link #columnNameMatches(String, String)}.
+     *
+     * @param columnName the column name to test
+     * @param prefix the prefix to test for
+     * @return whether the column name begins with the prefix.
+     * @since 3.5.0
+     */
+    default boolean columnNameStartsWith(String columnName, String prefix) {
+        return columnName.startsWith(prefix);
+    }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -29,6 +29,7 @@ import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.SingleColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
+import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.anyColumnsStartWithPrefix;
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.findColumnIndex;
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNames;
 
@@ -40,6 +41,18 @@ import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnName
  * The mapped class must have a default constructor.
  */
 public class FieldMapper<T> implements RowMapper<T> {
+    private static final String DEFAULT_PREFIX = "";
+
+    private static final String NO_MATCHING_COLUMNS =
+        "Mapping fields for type %s didn't find any matching columns in result set";
+
+    private static final String UNMATCHED_COLUMNS_STRICT =
+        "Mapping type %s could not match fields for columns: %s";
+
+    private static final String TYPE_NOT_INSTANTIABLE =
+        "A type, %s, was mapped which was not instantiable";
+    public static final String CANNOT_ACCESS_PROPERTY = "Unable to access property, %s";
+
     /**
      * Returns a mapper factory that maps to the given bean class
      *
@@ -84,8 +97,6 @@ public class FieldMapper<T> implements RowMapper<T> {
         return new FieldMapper<>(type, prefix);
     }
 
-    static final String DEFAULT_PREFIX = "";
-
     private final Class<T> type;
     private final String prefix;
     private final Map<Field, FieldMapper<?>> nestedMappers = new ConcurrentHashMap<>();
@@ -107,24 +118,22 @@ public class FieldMapper<T> implements RowMapper<T> {
                 ctx.getConfig(ReflectionMappers.class).getColumnNameMatchers();
         final List<String> unmatchedColumns = new ArrayList<>(columnNames);
 
-        RowMapper<T> mapper = specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns);
+        RowMapper<T> mapper = specialize0(ctx, columnNames, columnNameMatchers, unmatchedColumns)
+            .orElseThrow(() -> new IllegalArgumentException(String.format(NO_MATCHING_COLUMNS, type)));
 
         if (ctx.getConfig(ReflectionMappers.class).isStrictMatching()
-            && unmatchedColumns.stream().anyMatch(col -> col.startsWith(prefix))) {
-            throw new IllegalArgumentException(String.format(
-                "Mapping type %s could not match fields for columns: %s",
-                type.getSimpleName(),
-                unmatchedColumns));
+            && anyColumnsStartWithPrefix(unmatchedColumns, prefix, columnNameMatchers)) {
+            throw new IllegalArgumentException(
+                String.format(UNMATCHED_COLUMNS_STRICT, type.getSimpleName(), unmatchedColumns));
         }
 
         return mapper;
     }
 
-    private RowMapper<T> specialize0(ResultSet rs,
-                                     StatementContext ctx,
-                                     List<String> columnNames,
-                                     List<ColumnNameMatcher> columnNameMatchers,
-                                     List<String> unmatchedColumns) throws SQLException {
+    private Optional<RowMapper<T>> specialize0(StatementContext ctx,
+                                               List<String> columnNames,
+                                               List<ColumnNameMatcher> columnNameMatchers,
+                                               List<String> unmatchedColumns) {
         final List<RowMapper<?>> mappers = new ArrayList<>();
         final List<Field> fields = new ArrayList<>();
 
@@ -138,8 +147,8 @@ public class FieldMapper<T> implements RowMapper<T> {
                         .ifPresent(index -> {
                             Type type = field.getGenericType();
                             ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
-                                .orElse((r, n, c) -> rs.getObject(n));
-                            mappers.add(new SingleColumnMapper(mapper, index + 1));
+                                .orElse((r, n, c) -> r.getObject(n));
+                            mappers.add(new SingleColumnMapper<>(mapper, index + 1));
                             fields.add(field);
 
                             unmatchedColumns.remove(columnNames.get(index));
@@ -147,34 +156,36 @@ public class FieldMapper<T> implements RowMapper<T> {
                 } else {
                     String nestedPrefix = prefix + anno.value().toLowerCase();
 
-                    RowMapper<?> mapper = nestedMappers
-                        .computeIfAbsent(field, f -> new FieldMapper<>(field.getType(), nestedPrefix))
-                        .specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns);
-
-                    mappers.add(mapper);
-                    fields.add(field);
+                    if (anyColumnsStartWithPrefix(columnNames, nestedPrefix, columnNameMatchers)) {
+                        nestedMappers
+                            .computeIfAbsent(field, f -> new FieldMapper<>(field.getType(), nestedPrefix))
+                            .specialize0(ctx, columnNames, columnNameMatchers, unmatchedColumns)
+                            .ifPresent(mapper -> {
+                                mappers.add(mapper);
+                                fields.add(field);
+                            });
+                    }
                 }
             }
         }
 
         if (mappers.isEmpty() && !columnNames.isEmpty()) {
-            throw new IllegalArgumentException(String.format("Mapping fields for type %s "
-                + "didn't find any matching columns in result set", type));
+            return Optional.empty();
         }
 
-        return (r, c) -> {
+        return Optional.of((r, c) -> {
             T obj = construct();
 
             for (int i = 0; i < mappers.size(); i++) {
                 RowMapper<?> mapper = mappers.get(i);
                 Field field = fields.get(i);
 
-                Object value = mapper.map(rs, ctx);
+                Object value = mapper.map(r, ctx);
                 writeField(obj, field, value);
             }
 
             return obj;
-        };
+        });
     }
 
     private static String paramName(Field field) {
@@ -191,10 +202,7 @@ public class FieldMapper<T> implements RowMapper<T> {
         try {
             return type.newInstance();
         } catch (Exception e) {
-            String message = String.format(
-                "A type, %s, was mapped which was not instantiable",
-                type.getName());
-            throw new IllegalArgumentException(message, e);
+            throw new IllegalArgumentException(String.format(TYPE_NOT_INSTANTIABLE, type.getName()), e);
         }
     }
 
@@ -203,8 +211,7 @@ public class FieldMapper<T> implements RowMapper<T> {
             field.setAccessible(true);
             field.set(obj, value);
         } catch (IllegalAccessException e) {
-            throw new IllegalArgumentException(String.format("Unable to access "
-                + "property, %s", field.getName()), e);
+            throw new IllegalArgumentException(String.format(CANNOT_ACCESS_PROPERTY, field.getName()), e);
         }
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
@@ -17,6 +17,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.function.Supplier;
@@ -81,5 +82,20 @@ public class ReflectionMapperUtil {
         }
 
         return result;
+    }
+
+    /**
+     * Returns whether any of the given column names begin with the given prefix, according to the list of column name
+     * matchers.
+     *
+     * @param columnNames the column names to search
+     * @param prefix the prefix to search for
+     * @param columnNameMatchers list of column name matchers
+     * @return
+     */
+    public static boolean anyColumnsStartWithPrefix(Collection<String> columnNames, String prefix, List<ColumnNameMatcher> columnNameMatchers) {
+        return columnNames.stream().anyMatch(
+            columnName -> columnNameMatchers.stream().anyMatch(
+                matcher -> matcher.columnNameStartsWith(columnName, prefix)));
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/SnakeCaseColumnNameMatcher.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/SnakeCaseColumnNameMatcher.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
+import java.util.Locale;
+
 /**
  * Matches snake case column names to java camel case names, ignoring case.
  * <p>
@@ -21,7 +23,16 @@ package org.jdbi.v3.core.mapper.reflect;
 public class SnakeCaseColumnNameMatcher implements ColumnNameMatcher {
     @Override
     public boolean columnNameMatches(String columnName, String javaName) {
-        return columnName.replace("_", "").equalsIgnoreCase(javaName.replace("_", ""));
+        return normalize(columnName).equals(normalize(javaName));
+    }
+
+    @Override
+    public boolean columnNameStartsWith(String columnName, String prefix) {
+        return normalize(columnName).startsWith(normalize(prefix));
+    }
+
+    private String normalize(String string) {
+        return string.replace("_", "").toLowerCase(Locale.ROOT);
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
@@ -340,8 +340,29 @@ public class BeanMapperTest {
             .hasMessageContaining("could not match properties for columns: [other]");
     }
 
+    @Test
+    public void testNestedNotReturned() {
+        Handle handle = dbRule.getSharedHandle();
+        handle.registerRowMapper(BeanMapper.factory(NestedBean.class));
+        assertThat(handle
+            .createQuery("select 42 as testValue")
+            .mapTo(NestedBean.class)
+            .findOnly())
+            .extracting("testValue", "nested")
+            .containsExactly(42, null);
+    }
+
     static class NestedBean {
+        private Integer testValue;
         private Something nested;
+
+        public Integer getTestValue() {
+            return testValue;
+        }
+
+        public void setTestValue(Integer testValue) {
+            this.testValue = testValue;
+        }
 
         @Nested
         public Something getNested() {
@@ -396,6 +417,18 @@ public class BeanMapperTest {
             .findOnly())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("could not match properties for columns: [nested_other]");
+    }
+
+    @Test
+    public void testNestedPrefixNotReturned() {
+        Handle handle = dbRule.getSharedHandle();
+        handle.registerRowMapper(BeanMapper.factory(NestedPrefixBean.class));
+        assertThat(handle
+            .createQuery("select 42 as integerValue")
+            .mapTo(NestedPrefixBean.class)
+            .findOnly())
+            .extracting("integerValue", "nested")
+            .containsExactly(42, null);
     }
 
     static class NestedPrefixBean {

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-docs</artifactId>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-freemarker</artifactId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-guava</artifactId>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-jodatime2</artifactId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-jpa</artifactId>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-kotlin-sqlobject</artifactId>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-kotlin</artifactId>

--- a/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinMapper.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinMapper.kt
@@ -19,10 +19,13 @@ import org.jdbi.v3.core.mapper.RowMapper
 import org.jdbi.v3.core.mapper.SingleColumnMapper
 import org.jdbi.v3.core.mapper.reflect.ColumnName
 import org.jdbi.v3.core.mapper.reflect.ColumnNameMatcher
-import org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.*
+import org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.anyColumnsStartWithPrefix
+import org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.findColumnIndex
+import org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNames
 import org.jdbi.v3.core.mapper.reflect.ReflectionMappers
 import org.jdbi.v3.core.statement.StatementContext
 import java.sql.ResultSet
+import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
@@ -36,15 +39,17 @@ import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.jvmErasure
 
-private val nullValueRowMapper = RowMapper<Any?> { rs, ctx -> null }
+private val nullValueRowMapper = RowMapper<Any?> { _, _ -> null }
 
 class KotlinMapper(clazz: Class<*>, private val prefix: String = "") : RowMapper<Any> {
     private val kClass: KClass<*> = clazz.kotlin
     private val constructor = findConstructor(kClass)
     private val constructorParameters = constructor.parameters
-    private val memberProperties = kClass.memberProperties.mapNotNull { it as? KMutableProperty1<*, *>}.filter { property ->
-        !constructorParameters.any { parameter -> parameter.paramName() == property.propName() }
-    }
+    private val memberProperties = kClass.memberProperties
+        .mapNotNull { it as? KMutableProperty1<*, *> }
+        .filter { property ->
+            !constructorParameters.any { parameter -> parameter.paramName() == property.propName() }
+        }
 
     private val nestedMappers = ConcurrentHashMap<KParameter, KotlinMapper>()
     private val nestedPropertyMappers = ConcurrentHashMap<KMutableProperty1<*, *>, KotlinMapper>()
@@ -58,43 +63,77 @@ class KotlinMapper(clazz: Class<*>, private val prefix: String = "") : RowMapper
         val columnNameMatchers = ctx.getConfig(ReflectionMappers::class.java).columnNameMatchers
         val unmatchedColumns = columnNames.toMutableSet()
 
-        val mapper = specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns)
+        val mapper = specialize0(ctx, columnNames, columnNameMatchers, unmatchedColumns)
+            .orElseThrow {
+                IllegalArgumentException(
+                    "Mapping Kotlin type ${kClass.simpleName} didn't find any columns matching required, " +
+                        "non-default constructor parameters in result set")
+            }
 
         if (ctx.getConfig(ReflectionMappers::class.java).isStrictMatching &&
-                unmatchedColumns.any { col -> col.startsWith(prefix) }) {
+            unmatchedColumns.any { col -> col.startsWith(prefix) }) {
 
-            throw IllegalArgumentException(String.format(
-                    "Mapping constructor-injected type %s could not match parameters for columns: %s",
-                    kClass.simpleName,
-                    unmatchedColumns))
+            throw IllegalArgumentException(
+                "Mapping constructor-injected type ${kClass.simpleName} could not match parameters " +
+                    "for columns: $unmatchedColumns")
         }
 
         return mapper
     }
 
-    private fun specialize0(rs: ResultSet,
-                            ctx: StatementContext,
+    private fun specialize0(ctx: StatementContext,
                             columnNames: List<String>,
                             columnNameMatchers: List<ColumnNameMatcher>,
                             unmatchedColumns: MutableSet<String>
-    ): RowMapper<Any> {
-        val constructorParameterMappers = constructorParameters.associate { parameter ->
-            parameter to getConstructorParameterProvider(rs, ctx, parameter, columnNames, columnNameMatchers, unmatchedColumns)
+    ): Optional<RowMapper<Any>> {
+        val resolvedConstructorParameters = constructorParameters
+            .associate { parameter ->
+                parameter to resolveConstructorParameterMapper(
+                    ctx, parameter, columnNames, columnNameMatchers, unmatchedColumns)
+            }
+
+        val explicitlyMappedConstructorParameters = resolvedConstructorParameters
+            .filter { it.value.first == ParamResolution.MAPPED }
+            .keys
+        val unmappedConstructorParameters = resolvedConstructorParameters
+            .filter { it.value.first == ParamResolution.UNMAPPED }
+            .keys
+        if (unmappedConstructorParameters.isNotEmpty()) {
+            if (explicitlyMappedConstructorParameters.isEmpty()) {
+                // at least one constructor parameter is unmapped, and the rest are defaulted or nullable
+                return Optional.empty()
+            }
+            // some constructor parameters explicitly mapped, and some unmapped
+            throw IllegalArgumentException(
+                "Mapping constructor-injected type ${kClass.simpleName} matched columns " +
+                    "for constructor parameters ${explicitlyMappedConstructorParameters}, " +
+                    "but not for ${unmappedConstructorParameters}"
+            )
         }
 
-        val memberPropertyMappers = memberProperties.associate { property ->
-            property to getMemberPropertyProvider(rs, ctx, property, columnNames, columnNameMatchers, unmatchedColumns)
+        val memberPropertyMappers = memberProperties
+            .associate { property ->
+                property to resolveMemberPropertyMapper(
+                    ctx, property, columnNames, columnNameMatchers, unmatchedColumns)
+            }
+            .filterValues { it != null }
+
+        if (explicitlyMappedConstructorParameters.isEmpty() && memberPropertyMappers.isEmpty()) {
+            // no constructor parameters or properties are mapped. nothing for us to do
+            return Optional.empty()
         }
 
-        return RowMapper { r, c ->
+        val constructorParameterMappers = resolvedConstructorParameters
+            .mapValues { (_, value) -> value.second }
             // We filter 'null' mappers to remove parameters with no mappers but a default value
-            val constructorParametersWithValues = constructorParameterMappers.filterValues { it != null }.mapValues { (_, mapper) ->
-                mapper?.map(r, c)
-            }
+            .filterValues { it != null }
 
-            val memberPropertiesWithValues = memberPropertyMappers.mapValues { (_, mapper) ->
-                mapper.map(r, c)
-            }
+        return Optional.of(RowMapper { r, c ->
+            val constructorParametersWithValues = constructorParameterMappers
+                .mapValues { it.value?.map(r, c) }
+
+            val memberPropertiesWithValues = memberPropertyMappers
+                .mapValues { it.value?.map(r, c) }
 
             constructor.isAccessible = true
             constructor.callBy(constructorParametersWithValues).also { instance ->
@@ -103,94 +142,105 @@ class KotlinMapper(clazz: Class<*>, private val prefix: String = "") : RowMapper
                     prop.setter.call(instance, value)
                 }
             }
-        }
+        })
     }
 
-    private fun getConstructorParameterProvider(rs: ResultSet,
-                                                ctx: StatementContext,
-                                                parameter: KParameter,
-                                                columnNames: List<String>,
-                                                columnNameMatchers: List<ColumnNameMatcher>,
-                                                unmatchedColumns: MutableSet<String>
-    ): RowMapper<*>? {
+    private enum class ParamResolution {
+        MAPPED,
+        USE_DEFAULT,
+        USE_NULL,
+        UNMAPPED
+    }
+
+    private fun resolveConstructorParameterMapper(ctx: StatementContext,
+                                                  parameter: KParameter,
+                                                  columnNames: List<String>,
+                                                  columnNameMatchers: List<ColumnNameMatcher>,
+                                                  unmatchedColumns: MutableSet<String>
+    ): Pair<ParamResolution, RowMapper<*>?> {
         val parameterName = parameter.paramName()
 
         val nested = parameter.findAnnotation<Nested>()
+        if (nested == null) {
+            val columnIndex = findColumnIndex(parameterName, columnNames, columnNameMatchers) { parameter.name }
+            if (columnIndex.isPresent) {
+                val type = parameter.type.javaType
 
-        return if (nested == null) {
-            val columnIndex = findColumnIndex(parameterName, columnNames, columnNameMatchers, { parameter.name })
-            when {
-                columnIndex.isPresent -> {
-                    val type = parameter.type.javaType
-
-                    ctx.findColumnMapperFor(type)
-                            .map { mapper -> SingleColumnMapper(mapper, columnIndex.asInt + 1) }
-                            .orElseThrow {
-                                IllegalArgumentException(
-                                        "Could not find column mapper for type '$type' of parameter " +
-                                                "'$parameter' for constructor '$constructor'")
-                            }.also {
+                return ctx.findColumnMapperFor(type)
+                    .map { mapper ->
+                        Pair(ParamResolution.MAPPED, SingleColumnMapper(mapper, columnIndex.asInt + 1))
+                    }
+                    .orElseThrow {
+                        IllegalArgumentException(
+                            "Could not find column mapper for type '$type' of parameter " +
+                                "'$parameter' for constructor '$constructor'")
+                    }.also {
                         unmatchedColumns.remove(columnNames[columnIndex.asInt])
                     }
-                }
-                parameter.isOptional -> {
-                    // Parameter has no matching column but has a default value, use the default value
-                    null
-                }
-                parameter.type.isMarkedNullable -> nullValueRowMapper
-                else -> throw IllegalArgumentException(
-                        "Constructor '${constructor.name}' parameter '$parameterName' has no column in the result set" +
-                                " and is not nullable. " +
-                                "Verify that your result set has the columns expected, or annotate the " +
-                                "parameter names explicitly with @ColumnName"
-                )
             }
         } else {
             val nestedPrefix = prefix + nested.value
 
-            nestedMappers
-                    .computeIfAbsent(parameter, { p -> KotlinMapper(p.type.jvmErasure.java, nestedPrefix) })
-                    .specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns)
+            if (anyColumnsStartWithPrefix(columnNames, nestedPrefix, columnNameMatchers)) {
+                val nestedMapper = nestedMappers
+                    .computeIfAbsent(parameter) { p ->
+                        KotlinMapper(p.type.jvmErasure.java, nestedPrefix)
+                    }
+                    .specialize0(ctx, columnNames, columnNameMatchers, unmatchedColumns)
+                if (nestedMapper.isPresent) {
+                    return Pair(ParamResolution.MAPPED, nestedMapper.get())
+                }
+            }
         }
+
+        if (parameter.isOptional) {
+            // Parameter has no matching columns but has a default value, use the default value
+            return Pair(ParamResolution.USE_DEFAULT, null)
+        }
+
+        if (parameter.type.isMarkedNullable) {
+            return Pair(ParamResolution.USE_NULL, nullValueRowMapper)
+        }
+
+        return Pair(ParamResolution.UNMAPPED, null)
     }
 
-    private fun getMemberPropertyProvider(rs: ResultSet,
-                                          ctx: StatementContext,
-                                          property: KMutableProperty1<*, *>,
-                                          columnNames: List<String>,
-                                          columnNameMatchers: List<ColumnNameMatcher>,
-                                          unmatchedColumns: MutableSet<String>
-    ): RowMapper<*> {
+    private fun resolveMemberPropertyMapper(ctx: StatementContext,
+                                            property: KMutableProperty1<*, *>,
+                                            columnNames: List<String>,
+                                            columnNameMatchers: List<ColumnNameMatcher>,
+                                            unmatchedColumns: MutableSet<String>
+    ): RowMapper<*>? {
         val propertyName = property.propName()
         val nested = property.javaField?.getAnnotation(Nested::class.java)
 
-        return if (nested == null) {
-            val columnIndex = findColumnIndex(propertyName, columnNames, columnNameMatchers, { property.name }).orElseThrow {
-                IllegalArgumentException(
-                        "Member '${property.name}' of class '${kClass.simpleName} has no column in the result set. " +
-                                "Verify that your result set has the columns expected, or annotate the " +
-                                "property explicitly with @ColumnName"
-                )
-            }
-
-            val type = property.returnType.javaType
-            ctx.findColumnMapperFor(type)
-                    .map { mapper -> SingleColumnMapper(mapper, columnIndex + 1) }
+        if (nested == null) {
+            val columnIndex = findColumnIndex(propertyName, columnNames, columnNameMatchers) { property.name }
+            if (columnIndex.isPresent) {
+                val type = property.returnType.javaType
+                return ctx.findColumnMapperFor(type)
+                    .map { mapper -> SingleColumnMapper(mapper, columnIndex.asInt + 1) }
                     .orElseThrow {
                         IllegalArgumentException(
-                                "Could not find column mapper for type '$type' of property " +
-                                        "'${property.name}' for constructor '${kClass.simpleName}'")
+                            "Could not find column mapper for type '$type' of property " +
+                                "'${property.name}' for constructor '${kClass.simpleName}'")
                     }
                     .also {
-                        unmatchedColumns.remove(columnNames[columnIndex])
+                        unmatchedColumns.remove(columnNames[columnIndex.asInt])
                     }
+            }
         } else {
             val nestedPrefix = prefix + nested.value
 
-            nestedPropertyMappers
-                    .computeIfAbsent(property, { p -> KotlinMapper(p.returnType.jvmErasure.java, nestedPrefix) })
-                    .specialize0(rs, ctx, columnNames, columnNameMatchers, unmatchedColumns)
+            if (anyColumnsStartWithPrefix(columnNames, nestedPrefix, columnNameMatchers)) {
+                return nestedPropertyMappers
+                    .computeIfAbsent(property) { p -> KotlinMapper(p.returnType.jvmErasure.java, nestedPrefix) }
+                    .specialize0(ctx, columnNames, columnNameMatchers, unmatchedColumns)
+                    .orElse(null)
+            }
         }
+
+        return null
     }
 
     private fun KParameter.paramName(): String? {

--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-noparameters</artifactId>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-oracle12</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.jdbi</groupId>
     <artifactId>jdbi3-parent</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>jdbi3 Parent</name>
     <description>Jdbi is designed to provide convenient tabular data access in
@@ -325,7 +325,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.11.0</version>
+                <version>3.11.1</version>
             </dependency>
 
             <dependency>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-postgres</artifactId>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-spring4</artifactId>

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-sqlite</artifactId>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-sqlobject</artifactId>

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-stringtemplate4</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-testing</artifactId>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jdbi3-parent</artifactId>
         <groupId>org.jdbi</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-vavr</artifactId>


### PR DESCRIPTION
Fixes #1212 
Alternative to #1213 
Possibly fixes #1226 (@strmer15 please confirm), assuming one is using `@Nested` with prefixes.

Changes:
- New interface default method `ColumnNameMatcher.columnNameStartsWith(String columnName, String prefix):boolean`. Default implementation returns `columnName.startWith(prefix)` (to match existing strict checking code in reflection mappers)
- `ReflectionMapperUtil.anyColumnsStartWithPrefix(columnNames, prefix, matchers):boolean`
- `BeanMapper`, `FieldMapper`, and `KotlinMapper` ignore `@Nested` members if no columns match that nested element.
- ConstructorMapper allows constructor parameters annotated `@Nullable` (from any package) to be absent from the result set, including nested objects, and/or individual properties of nested objects. 
- All mappers short-circuit nested mapping attempts if no columns begin with the nested prefix. (This is what I hope will fix #1226. 

To do:
* [ ] Document the stuff above in javadoc and in the developer guide.
* [ ] Add tests for optional nested mapping in Kotlin mapper. The combination of normal, default, and optional parameters in the Kotlin constructors makes for a wide test surface.

/cc @strmer15