### PR TITLE
Properly rollback transaction on failures in LocalTransactionHandler

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
@@ -139,7 +139,7 @@ public class LocalTransactionHandler implements TransactionHandler {
         } catch (Throwable e) {
             try {
                 handle.rollback();
-            } catch (Exception rollback) {
+            } catch (Throwable rollback) {
                 e.addSuppressed(rollback);
             }
             throw (X) e;

--- a/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
@@ -136,7 +136,7 @@ public class LocalTransactionHandler implements TransactionHandler {
             if (!didTxnRollback.get()) {
                 handle.commit();
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             try {
                 handle.rollback();
             } catch (Exception rollback) {


### PR DESCRIPTION
In `LocalTransactionHandler.inTransaction()`, if the callback throws `Throwable` that does not extends `Exception`, `rollback()` will not be called and the connection can be closed with an active transaction. The behavior on open transaction when closing connection depends on JDBC driver implementation details ([doc](https://docs.oracle.com/javase/10/docs/api/java/sql/Connection.html#close())). It's better that we catch it and rollback properly in JDBI. 

Additionally, during rollback, it would also be helpful if we catch `Throwable` so that we won't lose the original exception when non `Exception` is thrown during rollback.

cc @electrum 