### PR TITLE
[wip refactor] reusable high-level classpath builder

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/locator/ClasspathSqlLocator.java
+++ b/core/src/main/java/org/jdbi/v3/core/locator/ClasspathSqlLocator.java
@@ -61,7 +61,12 @@ public final class ClasspathSqlLocator {
      * @return the located SQL.
      */
     public static String findSqlOnClasspath(Class<?> type, String methodName) {
-        String path = new ClasspathBuilder().appendFullyQualifiedClassName(type).appendVerbatim(methodName).setExtension(SQL_EXTENSION).build();
+        String path = new ClasspathBuilder()
+            .appendFullyQualifiedClassName(type)
+            .appendVerbatim(methodName)
+            .setExtension(SQL_EXTENSION)
+            .build();
+
         return getResourceOnClasspath(type.getClassLoader(), path);
     }
 
@@ -73,7 +78,10 @@ public final class ClasspathSqlLocator {
      * @return the located SQL.
      */
     public static String findSqlOnClasspath(String name) {
-        ClasspathBuilder builder = new ClasspathBuilder().appendDotPath(name).setExtension(SQL_EXTENSION);
+        ClasspathBuilder builder = new ClasspathBuilder()
+            .appendDotPath(name)
+            .setExtension(SQL_EXTENSION);
+
         return getResourceOnClasspath(selectClassLoader(), builder.build());
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/locator/ClasspathSqlLocator.java
+++ b/core/src/main/java/org/jdbi/v3/core/locator/ClasspathSqlLocator.java
@@ -61,7 +61,7 @@ public final class ClasspathSqlLocator {
      * @return the located SQL.
      */
     public static String findSqlOnClasspath(Class<?> type, String methodName) {
-        String path = new ClasspathBuilder().appendFullyQualifiedClassName(type).append(methodName).setExtension(SQL_EXTENSION).build();
+        String path = new ClasspathBuilder().appendFullyQualifiedClassName(type).appendVerbatim(methodName).setExtension(SQL_EXTENSION).build();
         return getResourceOnClasspath(type.getClassLoader(), path);
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
@@ -1,0 +1,100 @@
+package org.jdbi.v3.core.locator.internal;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class ClasspathBuilder {
+    private static final String DOT = ".";
+    private static final String SLASH = "/";
+
+    private final List<String> parts = new ArrayList<>();
+    private String extension = null;
+
+    public ClasspathBuilder append(@Nonnull String s) {
+        sanitize(s).ifPresent(this::add);
+        return this;
+    }
+
+    public ClasspathBuilder appendPackage(@Nonnull Package p) {
+        return add(p.getName().replace(DOT, SLASH));
+    }
+
+    public ClasspathBuilder appendSimpleClassName(@Nonnull Class c) {
+        return add(c.getSimpleName());
+    }
+
+    public ClasspathBuilder appendMethodName(@Nonnull Method m) {
+        return add(m.getName());
+    }
+
+    public ClasspathBuilder appendFullyQualifiedClassName(@Nonnull Class c) {
+        return appendPackage(c.getPackage()).appendSimpleClassName(c);
+    }
+
+    public ClasspathBuilder appendSimpleClassAndMethodName(@Nonnull Method m) {
+        return appendSimpleClassName(m.getDeclaringClass()).appendMethodName(m);
+    }
+
+    public ClasspathBuilder appendFullyQualifiedMethodName(@Nonnull Method m) {
+        return appendFullyQualifiedClassName(m.getDeclaringClass()).appendMethodName(m);
+    }
+
+    public ClasspathBuilder appendDotPath(@Nonnull String p) {
+        return add(p.replace(DOT, SLASH));
+    }
+
+    public ClasspathBuilder setExtension(@Nullable String extension) {
+        if (extension != null) {
+            String trimmed = extension.trim();
+            if (!trimmed.isEmpty()) {
+                this.extension = trimmed;
+            }
+        }
+        return this;
+    }
+
+    /**
+     * @return the current path string
+     */
+    public String build() {
+        if (parts.isEmpty()) {
+            throw new IllegalStateException("specify path parts before building the path");
+        }
+
+        String ext = extension == null ? "" : DOT + extension;
+        return String.join(SLASH, parts) + ext;
+    }
+
+    /**
+     * @return a readable representation of this builder — NOT the path string!
+     */
+    @Override
+    public String toString() {
+        return extension == null ? parts.toString() : (parts.toString() + " + ." + extension);
+    }
+
+    private ClasspathBuilder add(String s) {
+        parts.add(s);
+        return this;
+    }
+
+    private static Optional<String> sanitize(String path) {
+        if (path == null || path.isEmpty() || SLASH.equals(path)) {
+            return Optional.empty();
+        }
+
+        String sanitized = Arrays.stream(path.split(SLASH))
+            .map(part -> part.isEmpty() ? null : part)
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining(SLASH));
+
+        return Optional.of(sanitized);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
@@ -57,7 +57,7 @@ public class ClasspathBuilder {
     }
 
     public ClasspathBuilder appendFullyQualifiedClassName(@Nonnull Class clazz) {
-        return appendPackage(clazz.getPackage()).appendSimpleClassName(clazz);
+        return appendDotPath(clazz.getName());
     }
 
     // shame we can't get the name out of a MethodHandle
@@ -116,7 +116,9 @@ public class ClasspathBuilder {
      */
     @Override
     public String toString() {
-        return extension == null ? parts.toString() : (parts.toString() + " + ." + extension);
+        return extension == null
+            ? parts.toString()
+            : parts.toString() + " + ." + extension;
     }
 
     private ClasspathBuilder add(String s) {

--- a/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
@@ -13,18 +13,16 @@
  */
 package org.jdbi.v3.core.locator;
 
-import static org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.statement.StatementException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestClasspathSqlLocator {
     @Rule
@@ -34,30 +32,30 @@ public class TestClasspathSqlLocator {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void testLocateNamed() throws Exception {
+    public void testLocateNamed() {
         Handle h = dbRule.openHandle();
-        h.execute(findSqlOnClasspath("insert-keith"));
+        h.execute(ClasspathSqlLocator.findSqlOnClasspath("insert-keith"));
         assertThat(h.select("select name from something").mapTo(String.class).list()).hasSize(1);
     }
 
     @Test
-    public void testCommentsInExternalSql() throws Exception {
+    public void testCommentsInExternalSql() {
         Handle h = dbRule.openHandle();
-        h.execute(findSqlOnClasspath("insert-eric-with-comments"));
+        h.execute(ClasspathSqlLocator.findSqlOnClasspath("insert-eric-with-comments"));
         assertThat(h.select("select name from something").mapTo(String.class).list()).hasSize(1);
     }
 
     @Test
-    public void testPositionalParamsInPrepared() throws Exception {
+    public void testPositionalParamsInPrepared() {
         Handle h = dbRule.openHandle();
-        h.execute(findSqlOnClasspath("insert-id-name-positional"), 3, "Tip");
+        h.execute(ClasspathSqlLocator.findSqlOnClasspath("insert-id-name-positional"), 3, "Tip");
         assertThat(h.select("select name from something").mapTo(String.class).list()).hasSize(1);
     }
 
     @Test
-    public void testNamedParamsInExternal() throws Exception {
+    public void testNamedParamsInExternal() {
         Handle h = dbRule.openHandle();
-        h.createUpdate(findSqlOnClasspath("insert-id-name"))
+        h.createUpdate(ClasspathSqlLocator.findSqlOnClasspath("insert-id-name"))
                 .bind("id", 1)
                 .bind("name", "Tip")
                 .execute();
@@ -65,25 +63,25 @@ public class TestClasspathSqlLocator {
     }
 
     @Test
-    public void testUsefulExceptionForBackTracing() throws Exception {
+    public void testUsefulExceptionForBackTracing() {
         Handle h = dbRule.openHandle();
 
         exception.expect(StatementException.class);
         exception.expectMessage("insert into something(id, name) values (:id, :name)");
         exception.expectMessage("insert into something(id, name) values (?, ?)");
-        h.createUpdate(findSqlOnClasspath("insert-id-name"))
+        h.createUpdate(ClasspathSqlLocator.findSqlOnClasspath("insert-id-name"))
                 .bind("id", 1)
                 .execute();
     }
 
     @Test
-    public void testNonExistentResource() throws Exception {
+    public void testNonExistentResource() {
         exception.expect(IllegalArgumentException.class);
-        findSqlOnClasspath("this-does-not-exist");
+        ClasspathSqlLocator.findSqlOnClasspath("this-does-not-exist");
     }
 
     @Test
-    public void testCachesResultAfterFirstLookup() throws Exception {
+    public void testCachesResultAfterFirstLookup() {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final AtomicInteger loadCount = new AtomicInteger(0);
 
@@ -95,31 +93,31 @@ public class TestClasspathSqlLocator {
             }
         });
 
-        findSqlOnClasspath("caches-result-after-first-lookup");
+        ClasspathSqlLocator.findSqlOnClasspath("caches-result-after-first-lookup");
         assertThat(loadCount.get()).isEqualTo(1);
 
-        findSqlOnClasspath("caches-result-after-first-lookup");
+        ClasspathSqlLocator.findSqlOnClasspath("caches-result-after-first-lookup");
         assertThat(loadCount.get()).isEqualTo(1); // has not increased since previous
 
         Thread.currentThread().setContextClassLoader(classLoader);
     }
 
     @Test
-    public void testLocateByMethodName() throws Exception {
-        assertThat(findSqlOnClasspath(getClass(), "testLocateByMethodName"))
+    public void testLocateByMethodName() {
+        assertThat(ClasspathSqlLocator.findSqlOnClasspath(getClass(), "testLocateByMethodName"))
                 .contains("select 1");
     }
 
     @Test
-    public void testSelectByExtensionMethodName() throws Exception {
-        assertThat(findSqlOnClasspath(getClass(), "test-locate-by-custom-name"))
+    public void testSelectByExtensionMethodName() {
+        assertThat(ClasspathSqlLocator.findSqlOnClasspath(getClass(), "test-locate-by-custom-name"))
                 .contains("select 1");
     }
 
     @Test
-    public void testColonInComment() throws Exception {
+    public void testColonInComment() {
         // Used to throw exception in SQL statement lexer
         // see https://github.com/jdbi/jdbi/issues/748
-        findSqlOnClasspath(getClass(), "test-colon-in-comment");
+        ClasspathSqlLocator.findSqlOnClasspath(getClass(), "test-colon-in-comment");
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/locator/internal/TestClasspathBuilder.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/internal/TestClasspathBuilder.java
@@ -13,10 +13,6 @@
  */
 package org.jdbi.v3.core.locator.internal;
 
-import java.lang.reflect.Method;
-import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +29,7 @@ public class TestClasspathBuilder {
 
     @Test
     public void testWhitespace() {
-        assertThat(builder.appendVerbatim(" abc // / xyz ").build())
+        assertThat(builder.appendVerbatim("// abc // / xyz / /").build())
             .isEqualTo("abc/xyz");
     }
 
@@ -53,83 +49,6 @@ public class TestClasspathBuilder {
     public void testDotPath() {
         assertThat(builder.appendDotPath("foo.bar.baz").build())
             .isEqualTo("foo/bar/baz");
-    }
-
-    @Test
-    public void testUnixPath() {
-        Path path = Paths.get("/home/johndoe/docs");
-        assertThat(builder.appendRelativePath(path).build())
-            .isEqualTo("home/johndoe/docs");
-    }
-
-    @Test
-    // cross-platform behavior, especially of absolute instead of relative paths, is unpredictable
-    // but since you don't tend to run into windows paths on a unix system, it shouldn't matter
-    public void testAbsoluteWindowsPath() {
-        Path path = Paths.get("C:\\Program Files\\My Program");
-        assertThat(builder.appendRelativePath(path).build())
-            // windows vs linux interpretation
-            .isIn("Program Files/My Program", "C:\\Program Files\\My Program");
-    }
-
-    @Test
-    // cross-platform behavior, especially of absolute instead of relative paths, is unpredictable
-    // but since you don't tend to run into windows paths on a unix system, it shouldn't matter
-    public void testRelativeWindowsPath() {
-        Path path = Paths.get("Program Files\\My Program");
-        assertThat(builder.appendRelativePath(path).build())
-            // windows vs linux interpretation
-            .isIn("Program Files/My Program", "Program Files\\My Program");
-    }
-
-    @Test
-    public void testDomain() {
-        assertThat(builder.appendHostname(URI.create("https://john:doe@google.com:8080/foo")).build())
-            .isEqualTo("com/google");
-    }
-
-    @Test
-    public void testPackage() {
-        assertThat(builder.appendPackage(String.class.getPackage()).build())
-            .isEqualTo("java/lang");
-    }
-
-    @Test
-    public void testSimpleClassWithExtension() {
-        assertThat(builder.appendSimpleClassName(String.class).setExtension("java").build())
-            .isEqualTo("String.java");
-    }
-
-    @Test
-    public void testMethod() throws NoSuchMethodException {
-        Method method = String.class.getMethod("join", CharSequence.class, CharSequence[].class);
-
-        assertThat(builder.appendVerbatim("luke").appendMethodName(method).appendDotPath("the.dark.side").build())
-            .isEqualTo("luke/join/the/dark/side");
-    }
-
-    @Test
-    public void testSimpleClassAndMethod() throws NoSuchMethodException {
-        Method method = String.class.getMethod("join", CharSequence.class, CharSequence[].class);
-
-        assertThat(builder.appendSimpleClassAndMethodName(method).build())
-            .isEqualTo("String/join");
-    }
-
-    @Test
-    public void testFqClassAndMethod() throws NoSuchMethodException {
-        Method method = String.class.getMethod("join", CharSequence.class, CharSequence[].class);
-
-        assertThat(builder.appendFullyQualifiedMethodName(method).build())
-            .isEqualTo("java/lang/String/join");
-    }
-
-    @Test
-    public void testFqNestedClassAndMethod() throws NoSuchMethodException {
-        Method method = Foo.class.getMethod("bar");
-
-        assertThat(builder.appendFullyQualifiedMethodName(method).build())
-            .isEqualTo("org/jdbi/v3/core/locator/internal/TestClasspathBuilder$Foo/bar");
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/locator/internal/TestClasspathBuilder.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/internal/TestClasspathBuilder.java
@@ -125,8 +125,26 @@ public class TestClasspathBuilder {
     }
 
     @Test
+    public void testFqNestedClassAndMethod() throws NoSuchMethodException {
+        Method method = Foo.class.getMethod("bar");
+
+        assertThat(builder.appendFullyQualifiedMethodName(method).build())
+            .isEqualTo("org/jdbi/v3/core/locator/internal/TestClasspathBuilder$Foo/bar");
+    }
+
+    @Test
     public void testFqClass() {
         assertThat(builder.appendFullyQualifiedClassName(String.class).build())
             .isEqualTo("java/lang/String");
+    }
+
+    @Test
+    public void testFqNestedClass() {
+        assertThat(builder.appendFullyQualifiedClassName(Foo.class).build())
+            .isEqualTo("org/jdbi/v3/core/locator/internal/TestClasspathBuilder$Foo");
+    }
+
+    public static class Foo {
+        public void bar() {}
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/locator/internal/TestClasspathBuilder.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/internal/TestClasspathBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.locator.internal;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestClasspathBuilder {
+    private final ClasspathBuilder builder = new ClasspathBuilder();
+
+    @Test
+    public void testEmpty() {
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testWhitespace() {
+        assertThat(builder.appendVerbatim(" abc // / xyz ").build())
+            .isEqualTo("abc/xyz");
+    }
+
+    @Test
+    public void testSimpleVerbatimWithExtension() {
+        assertThat(builder.appendVerbatim("foo").appendVerbatim("bar").setExtension("baz").build())
+            .isEqualTo("foo/bar.baz");
+    }
+
+    @Test
+    public void testWeirdVerbatim() {
+        assertThat(builder.appendVerbatim("foo.bar@x-y-z").build())
+            .isEqualTo("foo.bar@x-y-z");
+    }
+
+    @Test
+    public void testDotPath() {
+        assertThat(builder.appendDotPath("foo.bar.baz").build())
+            .isEqualTo("foo/bar/baz");
+    }
+
+    @Test
+    public void testUnixPath() {
+        Path path = Paths.get("/home/johndoe/docs");
+        assertThat(builder.appendRelativePath(path).build())
+            .isEqualTo("home/johndoe/docs");
+    }
+
+    @Test
+    // cross-platform behavior, especially of absolute instead of relative paths, is unpredictable
+    // but since you don't tend to run into windows paths on a unix system, it shouldn't matter
+    public void testAbsoluteWindowsPath() {
+        Path path = Paths.get("C:\\Program Files\\My Program");
+        assertThat(builder.appendRelativePath(path).build())
+            // windows vs linux interpretation
+            .isIn("Program Files/My Program", "C:\\Program Files\\My Program");
+    }
+
+    @Test
+    // cross-platform behavior, especially of absolute instead of relative paths, is unpredictable
+    // but since you don't tend to run into windows paths on a unix system, it shouldn't matter
+    public void testRelativeWindowsPath() {
+        Path path = Paths.get("Program Files\\My Program");
+        assertThat(builder.appendRelativePath(path).build())
+            // windows vs linux interpretation
+            .isIn("Program Files/My Program", "Program Files\\My Program");
+    }
+
+    @Test
+    public void testDomain() {
+        assertThat(builder.appendHostname(URI.create("https://john:doe@google.com:8080/foo")).build())
+            .isEqualTo("com/google");
+    }
+
+    @Test
+    public void testPackage() {
+        assertThat(builder.appendPackage(String.class.getPackage()).build())
+            .isEqualTo("java/lang");
+    }
+
+    @Test
+    public void testSimpleClassWithExtension() {
+        assertThat(builder.appendSimpleClassName(String.class).setExtension("java").build())
+            .isEqualTo("String.java");
+    }
+
+    @Test
+    public void testMethod() throws NoSuchMethodException {
+        Method method = String.class.getMethod("join", CharSequence.class, CharSequence[].class);
+
+        assertThat(builder.appendVerbatim("luke").appendMethodName(method).appendDotPath("the.dark.side").build())
+            .isEqualTo("luke/join/the/dark/side");
+    }
+
+    @Test
+    public void testSimpleClassAndMethod() throws NoSuchMethodException {
+        Method method = String.class.getMethod("join", CharSequence.class, CharSequence[].class);
+
+        assertThat(builder.appendSimpleClassAndMethodName(method).build())
+            .isEqualTo("String/join");
+    }
+
+    @Test
+    public void testFqClassAndMethod() throws NoSuchMethodException {
+        Method method = String.class.getMethod("join", CharSequence.class, CharSequence[].class);
+
+        assertThat(builder.appendFullyQualifiedMethodName(method).build())
+            .isEqualTo("java/lang/String/join");
+    }
+
+    @Test
+    public void testFqClass() {
+        assertThat(builder.appendFullyQualifiedClassName(String.class).build())
+            .isEqualTo("java/lang/String");
+    }
+}

--- a/freemarker/src/main/java/org/jdbi/v3/freemarker/FreemarkerSqlLocator.java
+++ b/freemarker/src/main/java/org/jdbi/v3/freemarker/FreemarkerSqlLocator.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
+import org.jdbi.v3.core.locator.internal.ClasspathBuilder;
 
 /**
  * Locates SQL in {@code .sql.ftl} Freemarker files on the classpath.
@@ -40,7 +41,11 @@ public class FreemarkerSqlLocator {
     }
 
     public static Template findTemplate(Class<?> type, String templateName) {
-        String path = type.getName().replace(".", "/") + "/" + templateName + ".sql.ftl";
+        String path = new ClasspathBuilder()
+            .appendFullyQualifiedClassName(type)
+            .appendVerbatim(templateName)
+            .setExtension("sql.ftl")
+            .build();
 
         try {
             return CONFIGURATION.getTemplate(path);


### PR DESCRIPTION
This is a little thing I've had sitting on a branch for a while now. I remember getting annoyed that there are bits and pieces of classpath traversing code everywhere for stuff like loading sql files, and the logic to build the path is reinvented every time. This utility should fit most current and future needs and is holding up well so far in unit tests.

Does it seem an interesting thing to you guys and should I migrate as much as possible ad-hoc pathing to this utility, or nah? I feel it could add some consistency, clarity, and ease to parts of the code, and replace a lot of downcasting-meaningful-objects-to-strings, like in `UseClasspathSqlLocatorImpl` where a nice reflection Method object is turned into a string for manipulation.

I included a touch of portability in the parts involving Paths so that stuff like windows' special path separator won't be a problem. It's basically platform-agnostic, both in its public and private workings.