### PR TITLE
Created @BindMethodsList

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -1268,6 +1268,54 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
     }
 
     /**
+     * @param key attribute name
+     * @param values list of values that will be comma-spliced into the defined attribute value
+     * @param methodNames list of methods that will be invoked on the values
+     * @return this
+     * @throws IllegalArgumentException if the list of values or properties is empty.
+     * @throws UnableToCreateStatementException if the method cannot be found
+     */
+    public final This bindMethodsList(String key, List<?> values, List<String> methodNames) throws UnableToCreateStatementException {
+        if (values.isEmpty()) {
+            throw new IllegalArgumentException(
+                getClass().getSimpleName() + ".bindMethodsList was called with no values.");
+        }
+
+        if (methodNames.isEmpty()) {
+            throw new IllegalArgumentException(
+                getClass().getSimpleName() + ".bindMethodsList was called with no values.");
+        }
+
+        StringBuilder names = new StringBuilder();
+        StatementContext ctx = getContext();
+        for (int valueIndex = 0; valueIndex < values.size(); valueIndex++) {
+            if(valueIndex > 0) {
+                names.append(',');
+            }
+
+            Object bean = values.get(valueIndex);
+            ObjectMethodArguments beanMethods = new ObjectMethodArguments(null, bean);
+
+            names.append("(");
+            for (int methodIndex = 0; methodIndex < methodNames.size(); methodIndex++) {
+                if (methodIndex > 0) {
+                    names.append(",");
+                }
+
+                String methodName = methodNames.get(methodIndex);
+                String name = key + valueIndex + "." + methodName;
+                names.append(":").append(name);
+                Argument argument = beanMethods.find(methodName, ctx)
+                    .orElseThrow(() -> new UnableToCreateStatementException("Unable to get " + methodName + " argument for " + bean, ctx));
+                bind(name, argument);
+            }
+            names.append(")");
+        }
+
+        return define(key, names.toString());
+    }
+
+    /**
      * Define an attribute as the comma-separated {@link String} from the elements of the {@code values} argument.
      * <p>
      * Examples:

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -1289,7 +1289,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
         StringBuilder names = new StringBuilder();
         StatementContext ctx = getContext();
         for (int valueIndex = 0; valueIndex < values.size(); valueIndex++) {
-            if(valueIndex > 0) {
+            if (valueIndex > 0) {
                 names.append(',');
             }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindMethodsList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindMethodsList.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.customizer;
+
+import org.jdbi.v3.sqlobject.customizer.internal.BindMethodsListFactory;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Binds each method for each value in the annotated {@link Iterable} or array/varargs argument,
+ * and defines a named attribute as a comma-separated list of each bound method name.
+ *
+ * Used to create query similar to:
+ * insert into things (id, name) values (1,'abc'),(2,'def'),(3,'ghi')
+ *
+ * <pre>
+ * &#64;SqlQuery("insert into things (id, name) values &lt;items&gt;")
+ * List&lt;Thing&gt; saveThings(@BindMethodsList(value = "items", methodNames = {"getId", "getName"}) ThingKey... thingKeys)
+ * </pre>
+ * <p>
+ * Throws IllegalArgumentException if the argument is not an array or Iterable.
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@SqlStatementCustomizingAnnotation(BindMethodsListFactory.class)
+public @interface BindMethodsList {
+    /**
+     * The attribute name to define. If omitted, the name of the annotated parameter is used. It is an error to omit
+     * the name when there is no parameter naming information in your class files.
+     *
+     * @return the attribute name
+     */
+    String value() default "";
+
+    /**
+     * The list of methods to invoke on each element in the argument
+     *
+     * @return the method names
+     */
+    String[] methodNames() default {};
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindMethodsList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindMethodsList.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  *
  * <pre>
  * &#64;SqlQuery("insert into things (id, name) values &lt;items&gt;")
- * List&lt;Thing&gt; saveThings(@BindMethodsList(value = "items", methodNames = {"getId", "getName"}) ThingKey... thingKeys)
+ * List&lt;Thing&gt; saveThings(@BindMethodsList(value = "items", methodNames = {"getId", "getName"}) Thing... things)
  * </pre>
  * <p>
  * Throws IllegalArgumentException if the argument is not an array or Iterable.

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindMethodsListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindMethodsListFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.customizer.internal;
+
+import org.jdbi.v3.core.internal.IterableLike;
+import org.jdbi.v3.sqlobject.customizer.BindMethodsList;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
+import org.jdbi.v3.sqlobject.internal.ParameterUtil;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+public final class BindMethodsListFactory implements SqlStatementCustomizerFactory {
+    @Override
+    public SqlStatementParameterCustomizer createForParameter(Annotation annotation,
+                                                              Class<?> sqlObjectType,
+                                                              Method method,
+                                                              Parameter param,
+                                                              int index,
+                                                              Type paramType) {
+        final BindMethodsList bindMethodsList = (BindMethodsList) annotation;
+        final String name = ParameterUtil.findParameterName(bindMethodsList.value(), param)
+            .orElseThrow(() -> new UnsupportedOperationException("A @BindMethodsList parameter was not given a name, "
+                + "and parameter name data is not present in the class file, for: "
+                + param.getDeclaringExecutable() + "::" + param));
+
+        return (stmt, arg) -> {
+            if (arg == null) {
+                throw new IllegalArgumentException("argument is null; null was explicitly forbidden on BindMethodsList");
+            }
+
+            stmt.bindMethodsList(name, IterableLike.toList(arg), Arrays.asList(bindMethodsList.methodNames()));
+        };
+    }
+}

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethodsList.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethodsList.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.mapper.reflect.FieldMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.core.statement.TestBindBeanList;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindMethodsList;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestBindMethodsList {
+    @Rule
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    @Before
+    public void setUp() {
+        Handle handle = dbRule.getSharedHandle();
+        handle.registerRowMapper(FieldMapper.factory(TestBindBeanList.Thing.class));
+        handle.execute("create table thing (id identity primary key, foo varchar(50), bar varchar(50), baz varchar(50))");
+    }
+
+    @Test
+    public void bindMethodsListWithNoValue() throws Exception {
+        assertThatThrownBy(() -> dbRule.getSharedHandle().createQuery("insert into thing (id, foo, bar, baz) VALUES <items>")
+            .bindMethodsList("items", Collections.emptyList(), Arrays.asList("getFoo", "getBar"))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void bindMethodsListWithNoMethods() throws Exception {
+        Thing thing = new Thing(1, "foo", "bar", "baz");
+        assertThatThrownBy(() -> dbRule.getSharedHandle().createQuery("insert into (id, foo, bar, baz) VALUES <items>")
+            .bindMethodsList("items", Collections.singletonList(thing), Collections.emptyList())).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void happyPath() throws Exception {
+        Thing thing1 = new Thing(1, "foo1", "bar1", "baz1");
+        Thing thing2 = new Thing(2, "foo2", "bar2", "baz2");
+
+        List<Thing> things = Arrays.asList(thing1, thing2);
+
+        final ThingDAO dao = this.dbRule.getJdbi().onDemand(ThingDAO.class);
+
+        assertThat(dao.insert(things)).isEqualTo(things.size());
+        assertThat(dao.getBazById(2)).isEqualTo("baz2");
+    }
+
+    public interface ThingDAO {
+        @SqlUpdate("insert into thing (id, foo, bar, baz) VALUES <items>")
+        int insert(@BindMethodsList(value = "items", methodNames = {"getId", "getFoo", "getBar", "getBaz"}) Collection<Thing> thing);
+
+        @SqlQuery("select baz from thing where id = :id")
+        String getBazById(@Bind("id") int id);
+    }
+
+    public static class Thing {
+        private int id;
+        private String foo_test;
+        private String bar_test;
+        private String baz_test;
+
+        public Thing(int id, String foo_test, String bar_test, String baz_test) {
+            this.id = id;
+            this.foo_test = foo_test;
+            this.bar_test = bar_test;
+            this.baz_test = baz_test;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getFoo() {
+            return foo_test;
+        }
+
+        public String getBar() {
+            return bar_test;
+        }
+
+        public String getBaz() {
+            return baz_test;
+        }
+    }
+}

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethodsList.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethodsList.java
@@ -80,15 +80,15 @@ public class TestBindMethodsList {
 
     public static class Thing {
         private int id;
-        private String foo_test;
-        private String bar_test;
-        private String baz_test;
+        private String fooTest;
+        private String barTest;
+        private String bazTest;
 
-        public Thing(int id, String foo_test, String bar_test, String baz_test) {
+        public Thing(int id, String fooTest, String barTest, String bazTest) {
             this.id = id;
-            this.foo_test = foo_test;
-            this.bar_test = bar_test;
-            this.baz_test = baz_test;
+            this.fooTest = fooTest;
+            this.barTest = barTest;
+            this.bazTest = bazTest;
         }
 
         public int getId() {
@@ -96,15 +96,15 @@ public class TestBindMethodsList {
         }
 
         public String getFoo() {
-            return foo_test;
+            return fooTest;
         }
 
         public String getBar() {
-            return bar_test;
+            return barTest;
         }
 
         public String getBaz() {
-            return baz_test;
+            return bazTest;
         }
     }
 }


### PR DESCRIPTION
So I loved the functionality of `@BindMethods` and `@BindBeanList` and wanted to combine the two. This pull request is for `@BindMethodsList`. The use case is simple: 

```java
SqlQuery("insert into things (id, name) values <items>;")
List<Thing> saveThings(@BindMethodsList(value = "items", methodNames = {"getId", "getName"}) Thing... things)
``` 

Looking for comments, questions and feedback. If this functionality already exists I apologize, I couldn't seem to find it. 