### PR TITLE
Add collector factory for EnumSet

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/collector/EnumSetBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/EnumSetBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.collector;
+
+import java.util.EnumSet;
+
+class EnumSetBuilder {
+
+    private final EnumSet set;
+
+    @SuppressWarnings("unchecked")
+    EnumSetBuilder(Class<? extends Enum> componentType) {
+        this.set = EnumSet.noneOf(componentType);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void add(Object element) {
+        // EnumSet.add() checks against componentType and throws ClassCastException in case of mismatch
+        set.add(element);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static EnumSetBuilder combine(EnumSetBuilder a, EnumSetBuilder b) {
+        if (b.set.size() < a.set.size()) {
+            a.set.addAll(b.set);
+            return a;
+        } else {
+            b.set.addAll(a.set);
+            return b;
+        }
+    }
+
+    public EnumSet build() {
+        return set;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/collector/EnumSetCollectorFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/EnumSetCollectorFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.collector;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.stream.Collector;
+
+import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
+
+class EnumSetCollectorFactory implements CollectorFactory {
+
+    @Override
+    public boolean accepts(Type containerType) {
+        // elements of EnumSet must always be enums, no need to check
+        return EnumSet.class.isAssignableFrom(getErasedType(containerType))
+            && containerType instanceof ParameterizedType;
+    }
+
+    @Override
+    public Optional<Type> elementType(Type containerType) {
+        return findGenericParameter(containerType, getErasedType(containerType));
+    }
+
+    @Override
+    public Collector<?, ?, ?> build(Type containerType) {
+        Class<? extends Enum> componentType = getComponentClass(containerType);
+        return Collector.of(
+                () -> new EnumSetBuilder(componentType),
+                EnumSetBuilder::add,
+                EnumSetBuilder::combine,
+                EnumSetBuilder::build);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends Enum> getComponentClass(Type containerType) {
+        return findGenericParameter(containerType, getErasedType(containerType))
+            .map(type -> {
+                Class<? extends Enum> componentClass = null;
+                if (type instanceof Class) {
+                    componentClass = (Class<? extends Enum>) type;
+                } else if (type instanceof ParameterizedType) {
+                    componentClass = (Class<? extends Enum>) ((ParameterizedType) type).getRawType();
+                }
+
+                return componentClass;
+            })
+            .orElseThrow(() ->
+                new IllegalArgumentException("cannot determine class of type " + containerType.getTypeName()
+                    + " represented by " + containerType.getClass().getSimpleName()));
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/collector/JdbiCollectors.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/JdbiCollectors.java
@@ -32,6 +32,7 @@ public class JdbiCollectors implements JdbiConfig<JdbiCollectors> {
         register(new BuiltInCollectorFactory());
         register(new OptionalPrimitiveCollectorFactory());
         register(new ArrayCollectorFactory());
+        register(new EnumSetCollectorFactory());
     }
 
     private JdbiCollectors(JdbiCollectors that) {

--- a/core/src/test/java/org/jdbi/v3/core/collector/EnumSetCollectorFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/collector/EnumSetCollectorFactoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.collector;
+
+import org.jdbi.v3.core.generic.GenericType;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
+
+public class EnumSetCollectorFactoryTest {
+
+    private EnumSetCollectorFactory factory = new EnumSetCollectorFactory();
+
+    @Test
+    public void enumSet() {
+        GenericType genericType = new GenericType<EnumSet<Color>>() {};
+        Type containerType = genericType.getType();
+        Class<?> erasedType = getErasedType(containerType);
+        assertThat(factory.accepts(containerType)).isTrue();
+        assertThat(factory.accepts(erasedType)).isFalse();
+        assertThat(factory.elementType(containerType)).contains(Color.class);
+
+        Collector<Color, ?, EnumSet<Color>> collector = (Collector<Color, ?, EnumSet<Color>>) factory.build(containerType);
+        assertThat(Stream.of(Color.RED, Color.BLUE).collect(collector))
+            .isInstanceOf(erasedType)
+            .containsExactly(Color.RED, Color.BLUE);
+    }
+
+    /**
+     * For EnumSet test only.
+     */
+    private enum Color {
+        RED,
+        GREEN,
+        BLUE
+    }
+}


### PR DESCRIPTION
 * Similar use case as https://github.com/jdbi/jdbi/pull/523
 * Relies on default enum mapping facilities
 * Includes unit test

The PR mentioned above and the old branch "enum_sets" were not merged because of direct ties with PostgreSQL "varbit" SQL type.

This PR avoids these pitfalls.