### PR TITLE
Fix misworded comment in Vavr Option example

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -4143,7 +4143,7 @@ Here are some usage examples of the features listed above:
 String query = "select * from users where :name is null or name = :name";
 Option<String> param = Option.of("eric");
 
-// will fetch first user with given name or first user without name (Option.none)
+// will fetch first user with given name or first user with any name (Option.none)
 return handle.createQuery(query)
         .bind("name", param)
         .mapToBean(User.class)


### PR DESCRIPTION
When name is bound to Option.none() in the query `select * from users
where :name is null or name = :name`, the first clause of the `WHERE`
evaluates to `null is null` which is true, so it matches _any_ row, not
necessarily a row where the name `IS NULL`.

Not sure if this is what you were going for, though. If the intent was
to illustrate an example with the original comment's meaning, the query
should probably be changed to something like `select * from users where
name IS NOT DISTINCT FROM :name`