### PR TITLE
Fix ClassCastException on `Error` thrown by `LocalTransactionHandler`.

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
@@ -142,7 +142,7 @@ public class LocalTransactionHandler implements TransactionHandler {
             } catch (Throwable rollback) {
                 e.addSuppressed(rollback);
             }
-            throw (X) e;
+            throw e;
         }
 
         didTxnRollback.remove();

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
@@ -23,6 +23,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestLocalTransactionHandler {
     @Rule
@@ -61,12 +62,11 @@ public class TestLocalTransactionHandler {
         Mockito.when(c.getAutoCommit()).thenReturn(true);
         Mockito.when(h.getConnection()).thenReturn(c);
 
-        try {
+        // Verify that we don't get a ClassCastException when an Error is thrown within a transaction.
+        assertThatThrownBy(() ->
             new LocalTransactionHandler().inTransaction(h, x -> {
                 throw error;
-            });
-        } catch (Throwable throwable) {
-            assertThat(throwable).isSameAs(error);
-        }
+            }))
+            .isSameAs(error);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
@@ -62,7 +62,6 @@ public class TestLocalTransactionHandler {
         Mockito.when(c.getAutoCommit()).thenReturn(true);
         Mockito.when(h.getConnection()).thenReturn(c);
 
-        // Verify that we don't get a ClassCastException when an Error is thrown within a transaction.
         assertThatThrownBy(() ->
             new LocalTransactionHandler().inTransaction(h, x -> {
                 throw error;

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
@@ -53,4 +53,20 @@ public class TestLocalTransactionHandler {
             assertThat(e.getSuppressed()[0]).isSameAs(inner);
         }
     }
+
+    @Test
+    public void testThrowError() throws Exception {
+        Error error = new Error("Transaction throws!");
+
+        Mockito.when(c.getAutoCommit()).thenReturn(true);
+        Mockito.when(h.getConnection()).thenReturn(c);
+
+        try {
+            new LocalTransactionHandler().inTransaction(h, x -> {
+                throw error;
+            });
+        } catch (Throwable throwable) {
+            assertThat(throwable).isSameAs(error);
+        }
+    }
 }


### PR DESCRIPTION
LocalTransactionHandler would attempt to cast the caught Throwable to
Exception, which would fail for non-Exception Throwables like Error.

This bug was introduced in c87c667a6d8c64795a83845b6e79cb728aa40ef6