### PR TITLE
Readme change regarding java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Jdbi with it.
 
 Jdbi 3 requires Java 8.
 
-We've done some light testing with Java 9, and would appreciate reports of any problems!
+We've done some light testing with Java 9 and 11, and would appreciate reports of any problems!
 
 ## Builds
 


### PR DESCRIPTION
You should consider updating the readme to include informations about using Jdbi with Java 11 since you now also use Java 11 for your runners