### PR TITLE
Add generics to SqlStatementParameterCustomizer

### DIFF
--- a/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/KotlinSqlStatementCustomizerFactory.kt
+++ b/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/KotlinSqlStatementCustomizerFactory.kt
@@ -27,7 +27,7 @@ class KotlinSqlStatementCustomizerFactory : ParameterCustomizerFactory {
                                     method: Method,
                                     parameter: Parameter,
                                     paramIdx: Int,
-                                    type: Type): SqlStatementParameterCustomizer {
+                                    type: Type): SqlStatementParameterCustomizer<Any> {
 
         val bindName = if (parameter.isNamePresent) {
             parameter.name

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementParameterCustomizer.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementParameterCustomizer.java
@@ -20,12 +20,12 @@ import org.jdbi.v3.core.statement.SqlStatement;
 /**
  * Customize a {@link SqlStatement} according to the value of an annotated parameter.
  */
-public interface SqlStatementParameterCustomizer {
+public interface SqlStatementParameterCustomizer<T> {
     /**
      * Applies the customization to the SQL statement using the argument passed to the method.
      * @param stmt the statement being customized
      * @param arg the argument passed to the method
      * @throws SQLException will abort statement creation
      */
-    void apply(SqlStatement<?> stmt, Object arg) throws SQLException;
+    void apply(SqlStatement<?> stmt, T arg) throws SQLException;
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/MapToFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/MapToFactory.java
@@ -25,7 +25,7 @@ import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
 
 public class MapToFactory implements SqlStatementCustomizerFactory {
     @Override
-    public SqlStatementParameterCustomizer createForParameter(Annotation annotation,
+    public SqlStatementParameterCustomizer<Object> createForParameter(Annotation annotation,
                                                               Class<?> sqlObjectType,
                                                               Method method,
                                                               Parameter param,

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/BindSomethingElse.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/BindSomethingElse.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+import java.lang.reflect.Type;
+import org.jdbi.v3.core.Something;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizingAnnotation;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@SqlStatementCustomizingAnnotation(BindSomethingElse.Factory.class)
+public @interface BindSomethingElse {
+    String value();
+
+    class Factory implements SqlStatementCustomizerFactory {
+        @Override
+        public SqlStatementParameterCustomizer<Something> createForParameter(Annotation annotation,
+                                                                             Class<?> sqlObjectType,
+                                                                             Method method,
+                                                                             Parameter param,
+                                                                             int index,
+                                                                             Type type) {
+            BindSomethingElse bind = (BindSomethingElse) annotation;
+            return (stmt, arg) -> {
+                stmt.bind(bind.value() + ".id", arg.getId());
+                stmt.bind(bind.value() + ".name", arg.getName());
+            };
+        }
+    }
+}

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/BindSomethingOther.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/BindSomethingOther.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+import java.lang.reflect.Type;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizingAnnotation;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@SqlStatementCustomizingAnnotation(BindSomethingOther.Factory.class)
+public @interface BindSomethingOther {
+    String value();
+
+    class Factory implements SqlStatementCustomizerFactory {
+        @Override
+        public SqlStatementParameterCustomizer<Integer> createForParameter(Annotation annotation,
+                                                                             Class<?> sqlObjectType,
+                                                                             Method method,
+                                                                             Parameter param,
+                                                                             int index,
+                                                                             Type type) {
+            BindSomethingOther bind = (BindSomethingOther) annotation;
+            return (stmt, arg) -> {
+                stmt.bind(bind.value() + ".id", arg);
+                stmt.bind(bind.value() + ".name", arg.toString());
+            };
+        }
+    }
+}


### PR DESCRIPTION
Previously you would have to perform a cast in your
SqlStatementParameterCustomizer.apply method to get the object you knew
you were passing in. This change really only removes the need to do the
casting.

MapToFactory needs to be explicitly told to use Object. Leaving the
generics blank caused compiler errors. Seeing how it was using Object
before no change has actually been made. It's more explicit, but that's
about it.

I asked for this here: https://github.com/jdbi/jdbi/issues/1301#issuecomment-436562644
Thought the discussion, if there should be any, could be here instead of in a issue that has nothing to do with it really.