### PR TITLE
Fixed transaction support for Spring

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/ConnectionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/ConnectionHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * @author Dmitry Tsydzik
+ * @since 11/8/18
+ */
+public interface ConnectionHandler {
+    Connection getConnection() throws SQLException;
+
+    void releaseConnection(Connection connection) throws SQLException;
+}

--- a/core/src/main/java/org/jdbi/v3/core/DefaultConnectionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/DefaultConnectionHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * @author Dmitry Tsydzik
+ * @since 11/8/18
+ */
+public class DefaultConnectionHandler implements ConnectionHandler {
+
+    private final ConnectionFactory connectionFactory;
+
+    public DefaultConnectionHandler(ConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return connectionFactory.openConnection();
+    }
+
+    @Override
+    public void releaseConnection(Connection connection) throws SQLException {
+        connection.close();
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -67,6 +67,15 @@ public class Jdbi implements Configurable<Jdbi> {
     }
 
     /**
+     * @param connection db connection
+     *
+     * @return a Jdbi which works on single connection
+     */
+    public static Jdbi create(Connection connection) {
+        return create(new SingleConnectionHandler(connection));
+    }
+
+    /**
      * @param dataSource the data source.
      *
      * @return a Jdbi which uses the given data source as a connection factory.

--- a/core/src/main/java/org/jdbi/v3/core/SingleConnectionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/SingleConnectionHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.sql.Connection;
+
+/**
+ * Implementation of Connection handler, which works on single connection. close operation is ignored.
+ *
+ * @author Dmitry Tsydzik
+ * @since 11/12/18
+ */
+public class SingleConnectionHandler implements ConnectionHandler {
+
+    private final Connection connection;
+
+    public SingleConnectionHandler(Connection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public Connection getConnection() {
+        return connection;
+    }
+
+    @Override
+    public void releaseConnection(Connection connection) {}
+}

--- a/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
+++ b/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
@@ -33,6 +33,6 @@ public class HandleAccess {
         Connection fakeConnection = Mockito.mock(Connection.class);
 
         return new Handle(new ConfigRegistry(), new LocalTransactionHandler(),
-                new DefaultStatementBuilder(), fakeConnection);
+                new DefaultStatementBuilder(), fakeConnection, new DefaultConnectionHandler(() -> fakeConnection));
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.core;
 
+import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -32,6 +33,19 @@ public class TestJdbi {
         try (Handle h = db.open()) {
             assertThat(h).isNotNull();
         }
+    }
+
+    @Test
+    public void testConnectionConstructor() throws SQLException {
+        Connection connection = this.dbRule.getConnectionFactory().openConnection();
+
+        Jdbi db = Jdbi.create(connection);
+
+        try (Handle h = db.open()) {
+            assertThat(h).isNotNull();
+        }
+
+        assertThat(connection.isClosed()).isFalse();
     }
 
     @Test

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiFactoryBean.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiFactoryBean.java
@@ -25,7 +25,6 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 
 /**
  * Utility class which constructs an {@link Jdbi} instance which can conveniently
@@ -46,7 +45,7 @@ public class JdbiFactoryBean extends AbstractFactoryBean<Jdbi> {
 
     @Override
     protected Jdbi createInstance() throws Exception {
-        final Jdbi jdbi = Jdbi.create(() -> DataSourceUtils.getConnection(dataSource));
+        final Jdbi jdbi = Jdbi.create(new SpringConnectionHandler(dataSource));
 
         if (autoInstallPlugins) {
             jdbi.installPlugins();

--- a/spring4/src/main/java/org/jdbi/v3/spring4/SpringConnectionHandler.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/SpringConnectionHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.spring4;
+
+import org.jdbi.v3.core.ConnectionHandler;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * @author Dmitry Tsydzik
+ * @since 11/8/18
+ */
+public class SpringConnectionHandler implements ConnectionHandler {
+
+    private final DataSource dataSource;
+
+    public SpringConnectionHandler(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return DataSourceUtils.getConnection(dataSource);
+    }
+
+    @Override
+    public void releaseConnection(Connection connection) throws SQLException {
+        DataSourceUtils.releaseConnection(connection, dataSource);
+    }
+}


### PR DESCRIPTION
jdbi doesn't support `@Transactional` annotation out of the box. To enable  it, we need to delegate opening and releasing connections to Spring. I've introduced `ConnectionHandler` and it's implementation for Spring