### PR TITLE
api: resolve any generic param index, not just 0

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
@@ -58,34 +58,47 @@ public class GenericTypes {
     }
 
     /**
+     * Same as {@link #findGenericParameter(Type, Class, int)} with n = 0
+     */
+    public static Optional<Type> findGenericParameter(Type type, Class<?> parameterizedSupertype) {
+        return findGenericParameter(type, parameterizedSupertype, 0);
+    }
+
+    /**
      * For the given type which extends parameterizedSupertype, returns the
-     * first generic parameter for parameterized supertype, if concretely
+     * nth generic parameter for the parameterized supertype, if concretely
      * expressed.
      *
      * <p>
      * Example:
      * </p>
      * <ul>
-     * <li>if <code>type</code> is <code>ArrayList&lt;String&gt;</code> and
-     * <code>parameterizedSuperType</code> is <code>List.class</code>, returns
-     * <code>Optional.of(String.class)</code>.</li>
-     * <li>if <code>type</code> is <code>ArrayList.class</code> (raw) and
-     * <code>parameterizedSuperType</code> is <code>List.class</code>, returns
-     * <code>Optional.empty()</code>.</li>
+     * <li>if <code>type</code> is <code>ArrayList&lt;String&gt;</code>,
+     * <code>parameterizedSuperType</code> is <code>List.class</code>,
+     * and <code>n</code> is <code>0</code>,
+     * returns <code>Optional.of(String.class)</code>.</li>
+     * <li>if <code>type</code> is <code>Map&lt;String, Integer&gt;</code>,
+     * <code>parameterizedSuperType</code> is <code>Map.class</code>,
+     * and <code>n</code> is <code>1</code>,
+     * returns <code>Optional.of(Integer.class)</code>.</li>
+     * <li>if <code>type</code> is <code>ArrayList.class</code> (raw),
+     * <code>parameterizedSuperType</code> is <code>List.class</code>,
+     * and <code>n</code> is <code>0</code>,
+     * returns <code>Optional.empty()</code>.</li>
      * </ul>
      *
-     * @param type
-     *            the subtype of parameterizedSupertype
-     * @param parameterizedSupertype
-     *            the parameterized supertype from which we want the generic
+     * @param type the subtype of parameterizedSupertype
+     * @param parameterizedSupertype the parameterized supertype from which we want the generic
      *            parameter
+     * @param n the index in <code>Foo&lt;X, Y, Z, ...&gt;</code>
      * @return the parameter on the supertype, if it is concretely defined.
+     * @throws ArrayIndexOutOfBoundsException if n > the number of type variables the type has
      */
-    public static Optional<Type> findGenericParameter(Type type, Class<?> parameterizedSupertype) {
-        Type parameterType = resolveType(parameterizedSupertype.getTypeParameters()[0], type);
+    public static Optional<Type> findGenericParameter(Type type, Class<?> parameterizedSupertype, int n) {
+        Type parameterType = resolveType(parameterizedSupertype.getTypeParameters()[n], type);
         return parameterType instanceof Class || parameterType instanceof ParameterizedType
-                ? Optional.of(parameterType)
-                : Optional.empty();
+            ? Optional.of(parameterType)
+            : Optional.empty();
     }
 
     /**

--- a/core/src/test/java/org/jdbi/v3/core/generic/GenericTypesTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/generic/GenericTypesTest.java
@@ -21,80 +21,48 @@ import static java.util.Optional.empty;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GenericTypesTest {
-
-    class Foo<T> {}
-
-    @SuppressWarnings("rawtypes")
-    Foo raw() {
-        return null;
+    @Test
+    public void getErasedTypeOfRaw() throws NoSuchMethodException {
+        assertThat(GenericTypes.getErasedType(methodReturnType(Foo.class, "raw"))).isEqualTo(Foo.class);
     }
 
     @Test
-    public void getErasedTypeOfRaw() throws Exception {
-        assertThat(GenericTypes.getErasedType(methodReturnType("raw"))).isEqualTo(Foo.class);
+    public void findGenericParameterOfRaw() throws NoSuchMethodException {
+        assertThat(GenericTypes.findGenericParameter(methodReturnType(Foo.class, "raw"), Foo.class)).isEqualTo(empty());
     }
 
     @Test
-    public void findGenericParameterOfRaw() throws Exception {
-        assertThat(GenericTypes.findGenericParameter(methodReturnType("raw"), Foo.class)).isEqualTo(empty());
-    }
-
-    Foo<String> generic() {
-        return null;
+    public void getErasedTypeOfGeneric() throws NoSuchMethodException {
+        assertThat(GenericTypes.getErasedType(methodReturnType(Foo.class, "generic"))).isEqualTo(Foo.class);
     }
 
     @Test
-    public void getErasedTypeOfGeneric() throws Exception {
-        assertThat(GenericTypes.getErasedType(methodReturnType("generic"))).isEqualTo(Foo.class);
-    }
-
-    @Test
-    public void findGenericParameterOfGeneric() throws Exception {
-        assertThat(GenericTypes.findGenericParameter(methodReturnType("generic"), Foo.class))
+    public void findGenericParameterOfGeneric() throws NoSuchMethodException {
+        assertThat(GenericTypes.findGenericParameter(methodReturnType(Foo.class, "generic"), Foo.class))
                 .contains(String.class);
     }
 
-    Foo<Foo<String>> nestedGeneric() {
-        return null;
+    @Test
+    public void getErasedTypeOfNestedGeneric() throws NoSuchMethodException {
+        assertThat(GenericTypes.getErasedType(methodReturnType(Foo.class, "nestedGeneric"))).isEqualTo(Foo.class);
     }
 
     @Test
-    public void getErasedTypeOfNestedGeneric() throws Exception {
-        assertThat(GenericTypes.getErasedType(methodReturnType("nestedGeneric"))).isEqualTo(Foo.class);
+    public void findGenericParameterOfNestedGeneric() throws NoSuchMethodException {
+        assertThat(GenericTypes.findGenericParameter(methodReturnType(Foo.class, "nestedGeneric"), Foo.class))
+                .contains(methodReturnType(Foo.class, "generic"));
     }
 
     @Test
-    public void findGenericParameterOfNestedGeneric() throws Exception {
-        assertThat(GenericTypes.findGenericParameter(methodReturnType("nestedGeneric"), Foo.class))
-                .contains(methodReturnType("generic"));
-    }
-
-    class Bar<T> extends Foo<T> {}
-
-    Bar<Integer> subTypeGeneric() {
-        return null;
-    }
-
-    @Test
-    public void findGenericParameterOfSuperClass() throws Exception {
-        assertThat(GenericTypes.findGenericParameter(methodReturnType("subTypeGeneric"), Foo.class))
+    public void findGenericParameterOfSuperClass() throws NoSuchMethodException {
+        assertThat(GenericTypes.findGenericParameter(methodReturnType(Bar.class, "subTypeGeneric"), Foo.class))
                 .isEqualTo(Optional.of(Integer.class));
     }
 
-    class Baz<T> extends Bar<T> {}
-
-    Baz<String> descendentTypeGeneric() {
-        return null;
-    }
-
     @Test
-    public void findGenericParameterOfAncestorClass() throws Exception {
-        assertThat(GenericTypes.findGenericParameter(methodReturnType("descendentTypeGeneric"), Foo.class))
+    public void findGenericParameterOfAncestorClass() throws NoSuchMethodException {
+        assertThat(GenericTypes.findGenericParameter(methodReturnType(Baz.class, "descendentTypeGeneric"), Foo.class))
                 .contains(String.class);
-    }
-
-    private Type methodReturnType(String methodName) throws NoSuchMethodException {
-        return getClass().getDeclaredMethod(methodName).getGenericReturnType();
     }
 
     @Test
@@ -102,6 +70,7 @@ public class GenericTypesTest {
         abstract class A<T> {
             abstract T a();
         }
+
         abstract class B extends A<String> {}
 
         assertThat(GenericTypes.resolveType(A.class.getDeclaredMethod("a").getGenericReturnType(), B.class))
@@ -109,7 +78,7 @@ public class GenericTypesTest {
     }
 
     @Test
-    public void resolveTypeUnrelatedContext() throws Exception {
+    public void resolveTypeUnrelatedContext() throws NoSuchMethodException {
         abstract class A1<T> {
             abstract T a();
         }
@@ -120,5 +89,35 @@ public class GenericTypesTest {
 
         Type t = A1.class.getDeclaredMethod("a").getGenericReturnType();
         assertThat(GenericTypes.resolveType(t, B.class)).isEqualTo(t);
+    }
+
+    private static Type methodReturnType(Class<?> clazz, String methodName) throws NoSuchMethodException {
+        return clazz.getDeclaredMethod(methodName).getGenericReturnType();
+    }
+
+    private static class Foo<T> {
+        private static Foo raw() {
+            return null;
+        }
+
+        private static Foo<String> generic() {
+            return null;
+        }
+
+        private static Foo<Foo<String>> nestedGeneric() {
+            return null;
+        }
+    }
+
+    private static class Bar<T> extends Foo<T> {
+        private static Bar<Integer> subTypeGeneric() {
+            return null;
+        }
+    }
+
+    private static class Baz<T> extends Bar<T> {
+        private static Baz<String> descendentTypeGeneric() {
+            return null;
+        }
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/generic/GenericTypesTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/generic/GenericTypesTest.java
@@ -66,7 +66,17 @@ public class GenericTypesTest {
     }
 
     @Test
-    public void resolveType() throws Exception {
+    public void findMultipleGenericParameters() throws NoSuchMethodException {
+        assertThat(GenericTypes.findGenericParameter(methodReturnType(Xyz.class, "sample"), Xyz.class, 0))
+            .contains(String.class);
+        assertThat(GenericTypes.findGenericParameter(methodReturnType(Xyz.class, "sample"), Xyz.class, 1))
+            .contains(Integer.class);
+        assertThat(GenericTypes.findGenericParameter(methodReturnType(Xyz.class, "sample"), Xyz.class, 2))
+            .contains(Void.class);
+    }
+
+    @Test
+    public void resolveType() throws NoSuchMethodException {
         abstract class A<T> {
             abstract T a();
         }
@@ -117,6 +127,12 @@ public class GenericTypesTest {
 
     private static class Baz<T> extends Bar<T> {
         private static Baz<String> descendentTypeGeneric() {
+            return null;
+        }
+    }
+
+    private static class Xyz<X, Y, Z> {
+        private static Xyz<String, Integer, Void> sample() {
             return null;
         }
     }


### PR DESCRIPTION
Side-effect from an old piece of work I intend to finish sometime. We offer the ability to resolve X in <X, Y> but it's a trivial change to let the caller specify which index they want, to be able to resolve Y, Z, etc too, which is useful when working with Maps and other multi-variable types.