### PR TITLE
Fix doc build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,28 @@ install:
 
 matrix:
   include:
-    - script:
+    - env:
+        - TESTS=Y
+      script:
         - src/build/ci-test.sh
       jdk: oraclejdk8
-    - script:
+    - env:
+        - TESTS=Y
+      script:
         - src/build/ci-test.sh
       jdk: oraclejdk9
-    - script:
+    - env:
+        - TESTS=Y
+      script:
         - src/build/ci-test.sh
       jdk: openjdk11
-    - script:
+    - env:
+        - DOCUMENTATION=Y
+      script:
         - src/build/ci-doc.sh
       jdk: oraclejdk8
-    - script:
+    - env:
+        - CODE_STYLE=Y
+      script:
         - src/build/ci-code-style.sh
       jdk: oraclejdk8

--- a/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
@@ -92,7 +92,7 @@ public class GenericTypes {
      *            parameter
      * @param n the index in <code>Foo&lt;X, Y, Z, ...&gt;</code>
      * @return the parameter on the supertype, if it is concretely defined.
-     * @throws ArrayIndexOutOfBoundsException if n > the number of type variables the type has
+     * @throws ArrayIndexOutOfBoundsException if n &gt; the number of type variables the type has
      */
     public static Optional<Type> findGenericParameter(Type type, Class<?> parameterizedSupertype, int n) {
         Type parameterType = resolveType(parameterizedSupertype.getTypeParameters()[n], type);

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -28,7 +28,6 @@
 
     <properties>
         <basepom.check.skip-license>true</basepom.check.skip-license>
-        <basepom.javadoc.skip>false</basepom.javadoc.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -28,6 +28,7 @@
 
     <properties>
         <basepom.check.skip-license>true</basepom.check.skip-license>
+        <basepom.javadoc.skip>false</basepom.javadoc.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 

--- a/src/build/ci-code-style.sh
+++ b/src/build/ci-code-style.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -xe
 
-export CODE_STYLE=Y
-
 OPTS="-DskipTests=true -Dmaven.javadoc.skip=true -B"
 
 PROFILES="toolchains"

--- a/src/build/ci-doc.sh
+++ b/src/build/ci-doc.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -xe
 
-export DOCUMENTATION=Y
-
 OPTS="-DskipTests=true -Dbasepom.check.skip-all=true -B"
 
 PROFILES="toolchains"

--- a/src/build/ci-doc.sh
+++ b/src/build/ci-doc.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -xe
 
-OPTS="-DskipTests=true -Dbasepom.check.skip-all=true -B"
+OPTS="-Dbasepom.javadoc.skip=false -DskipTests=true -Dbasepom.check.skip-all=true -B"
 
 PROFILES="toolchains"
 

--- a/src/build/ci-test.sh
+++ b/src/build/ci-test.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -xe
 
-export TESTS=Y
 OPTS="-Dmaven.javadoc.skip=true -Dbasepom.check.skip-basic=true -Dbasepom.check.skip-findbugs=true -Dbasepom.check.skip-pmd=true -Dbasepom.check.skip-checkstyle=true -B"
 
 PROFILES="toolchains"


### PR DESCRIPTION
The upgrade from basepom 19 to 27 inadvertently disabled javadoc during normal builds. This re-enables it during doc builds.

Additionally, I suggested moving environment variables from `.travis.yml` down into individual build scripts a while back, but these were only used to distinguish the different builds in TravisCI. I've moved them back so we can tell the test, doc, and style builds apart again.