### PR TITLE
Disable toolchain profile for ci to see if we can actually use our build matrix

### DIFF
--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/locator/TestSqlLocator.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/locator/TestSqlLocator.java
@@ -32,7 +32,7 @@ public class TestSqlLocator {
     public PgDatabaseRule dbRule = new PgDatabaseRule().withPlugin(new SqlObjectPlugin());
 
     @Test
-    public void testLocateConfigDriven() {
+    public void testLocateConfigDriven() throws Exception {
         Jdbi jdbi = dbRule.getJdbi();
         jdbi.useHandle(h -> {
             h.execute("create table something (id int, name text)");

--- a/src/build/ci-install.sh
+++ b/src/build/ci-install.sh
@@ -2,6 +2,4 @@
 
 OPTS="-DskipTests=true -Dbasepom.check.skip-all=true -Dmaven.javadoc.skip=true -B"
 
-PROFILES="toolchains"
-
-exec mvn ${OPTS} -P${PROFILES} verify
+exec mvn ${OPTS} verify

--- a/src/build/ci-install.sh
+++ b/src/build/ci-install.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
+set -xe
 
 OPTS="-DskipTests=true -Dbasepom.check.skip-all=true -Dmaven.javadoc.skip=true -B"
 

--- a/src/build/ci-pre-install.sh
+++ b/src/build/ci-pre-install.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
+set -xe
 
 cp src/build/travis-toolchains.xml ~/.m2/toolchains.xml
 

--- a/src/build/ci-test.sh
+++ b/src/build/ci-test.sh
@@ -3,6 +3,4 @@ set -xe
 
 OPTS="-Dmaven.javadoc.skip=true -Dbasepom.check.skip-basic=true -Dbasepom.check.skip-findbugs=true -Dbasepom.check.skip-pmd=true -Dbasepom.check.skip-checkstyle=true -B"
 
-PROFILES="toolchains"
-
-exec mvn ${OPTS} -P${PROFILES} verify
+exec mvn ${OPTS} verify


### PR DESCRIPTION
I'm sure there was some reason it's this way in the first place, but doesn't enabling the `toolchains` profile for ci ensure we run our Travis build repeatedly using the exact same JDK?