### PR TITLE
Allow instantiation of ParsedSql and ParsedParameters

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/ParsedParameters.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ParsedParameters.java
@@ -13,11 +13,12 @@
  */
 package org.jdbi.v3.core.statement;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
-import static java.util.Collections.unmodifiableList;
 
 /**
  * The parsed parameters from an SQL statement.
@@ -77,5 +78,37 @@ public class ParsedParameters {
             + "positional=" + positional
             + ", parameterNames=" + parameterNames
             + '}';
+    }
+
+    /**
+     * A static factory of named {@link ParsedParameters} instances.
+     * List given in argument must contain parameter names from the
+     * related statement. They must be bare names, free of SQL
+     * variable processing syntax such as a prefixed colon or other
+     * delimiters.
+     *
+     * @param names the parameter names from SQL statement
+     * @return New {@link ParsedParameters} instance
+     * @throws IllegalArgumentException if names list contains positional parameter
+     */
+    public static ParsedParameters named(List<String> names) {
+        if (names.contains(ParsedSql.POSITIONAL_PARAM)) {
+            throw new IllegalArgumentException("Named parameters "
+                + "list must not contain positional parameter "
+                + "\"" + ParsedSql.POSITIONAL_PARAM + "\"");
+        }
+        return new ParsedParameters(false, names);
+    }
+
+    /**
+     * A static factory of positional {@link ParsedParameters} instances.
+     * The count given in the argument must indicate how many positional
+     * parameters are available in the statement.
+     *
+     * @param count the number of positional parameters in statement
+     * @return New {@link ParsedParameters} instance
+     */
+    public static ParsedParameters positional(int count) {
+        return new ParsedParameters(true, Collections.nCopies(count, "?"));
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/ParsedSql.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ParsedSql.java
@@ -21,7 +21,7 @@ import java.util.Objects;
  * The SQL and parameters parsed from an SQL statement.
  */
 public class ParsedSql {
-    private static final String POSITIONAL_PARAM = "?";
+    static final String POSITIONAL_PARAM = "?";
 
     private final String sql;
     private final ParsedParameters parameters;
@@ -73,6 +73,26 @@ public class ParsedSql {
     }
 
     /**
+     * A static factory of {@link ParsedSql} instances. The statement
+     * may contain only positional parameters
+     * (the {@value #POSITIONAL_PARAM} character). If your SQL
+     * code contains named parameters (for example variables preceded
+     * by a colon) then you have to replace them with positional
+     * parameters and specify the mapping in the
+     * {@link ParsedParameters}. You cannot mix named and positional
+     * parameters in one SQL statement.
+     *
+     * @param sql the SQL code containing only positional parameters
+     * @param parameters the ordered list of named parameters, or positional parameters
+     * @return New {@link ParsedSql} instance
+     * @see ParsedParameters#positional(int)
+     * @see ParsedParameters#named(List)
+     */
+    public static ParsedSql of(String sql, ParsedParameters parameters) {
+        return new ParsedSql(sql, parameters);
+    }
+
+    /**
      * @return a new ParsedSql builder.
      */
     public static Builder builder() {
@@ -110,7 +130,7 @@ public class ParsedSql {
         public Builder appendPositionalParameter() {
             positional = true;
             parameterNames.add(POSITIONAL_PARAM);
-            return append("?");
+            return append(POSITIONAL_PARAM);
         }
 
         /**
@@ -123,7 +143,7 @@ public class ParsedSql {
         public Builder appendNamedParameter(String name) {
             named = true;
             parameterNames.add(name);
-            return append("?");
+            return append(POSITIONAL_PARAM);
         }
 
         /**

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestParsedParameters.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestParsedParameters.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class TestParsedParameters {
+
+    @Test
+    public void testFactoryNamedParameters() {
+
+        final List<String> names = Arrays.asList("a", "b", "c");
+        final ParsedParameters parameters = ParsedParameters.named(names);
+
+        assertThat(parameters).isNotNull();
+        assertThat(parameters.isPositional()).isFalse();
+        assertThat(parameters.getParameterCount()).isEqualTo(3);
+        assertThat(parameters.getParameterNames()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    public void testFactoryNamedAndPositionalParametersMix() {
+        assertThatThrownBy(() -> ParsedParameters.named(Arrays.asList("a", "b", "?")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Named parameters list must not contain positional parameter \"?\"");
+    }
+
+    @Test
+    public void testFactoryPositionalParameters() {
+
+        final ParsedParameters parameters = ParsedParameters.positional(3);
+
+        assertThat(parameters).isNotNull();
+        assertThat(parameters.isPositional()).isTrue();
+        assertThat(parameters.getParameterCount()).isEqualTo(3);
+        assertThat(parameters.getParameterNames()).containsOnly("?");
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestParsedSql.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestParsedSql.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class TestParsedSql {
+
+    @Test
+    public void testFactoryNamedParameters() {
+
+        final List<String> names = Arrays.asList("a", "b", "c");
+
+        final String sql = "insert into test (a, b, c) values (?, ?, ?)";
+        final ParsedParameters parameters = ParsedParameters.named(names);
+        final ParsedSql parsedSql = ParsedSql.of(sql, parameters);
+
+        assertThat(parsedSql).isNotNull();
+        assertThat(parsedSql.getSql()).isEqualTo(sql);
+        assertThat(parsedSql.getParameters().isPositional()).isFalse();
+        assertThat(parsedSql.getParameters().getParameterNames()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    public void testFactoryPositionalParameters() {
+
+        final String sql = "insert into test (a, b, c) values (?, ?, ?)";
+        final ParsedParameters parameters = ParsedParameters.positional(3);
+        final ParsedSql parsedSql = ParsedSql.of(sql, parameters);
+
+        assertThat(parsedSql).isNotNull();
+        assertThat(parsedSql.getSql()).isEqualTo(sql);
+        assertThat(parsedSql.getParameters().isPositional()).isTrue();
+        assertThat(parsedSql.getParameters().getParameterNames()).containsOnly("?");
+    }
+
+    @Test
+    public void testBuilderWithNamedParameters() {
+
+        final List<String> names = Arrays.asList("a", "b", "c");
+
+        final ParsedSql parsedSql = ParsedSql.builder()
+            .append("insert into test (a, b, c) values (")
+            .appendNamedParameter(names.get(0))
+            .append(", ")
+            .appendNamedParameter(names.get(1))
+            .append(", ")
+            .appendNamedParameter(names.get(2))
+            .append(")")
+            .build();
+
+        assertThat(parsedSql).isNotNull();
+        assertThat(parsedSql.getSql()).isEqualTo("insert into test (a, b, c) values (?, ?, ?)");
+        assertThat(parsedSql.getParameters().isPositional()).isFalse();
+        assertThat(parsedSql.getParameters().getParameterNames()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    public void testBuilderWithPositionalParameters() {
+
+        final ParsedSql parsedSql = ParsedSql.builder()
+            .append("insert into test (a, b, c) values (")
+            .appendPositionalParameter()
+            .append(", ")
+            .appendPositionalParameter()
+            .append(", ")
+            .appendPositionalParameter()
+            .append(")")
+            .build();
+
+        assertThat(parsedSql).isNotNull();
+        assertThat(parsedSql.getSql()).isEqualTo("insert into test (a, b, c) values (?, ?, ?)");
+        assertThat(parsedSql.getParameters().isPositional()).isTrue();
+        assertThat(parsedSql.getParameters().getParameterNames()).containsOnly("?");
+    }
+}


### PR DESCRIPTION
Hello @jdbi Team :)

This change changes `ParsedSql` constructor visibility from private to protected.

Why did I change this? Let me briefly describe.

We recently migrated from JDBI v2 to v3 and we are really astonished of the number of enhancements, but while migrating the code I encountered small blocker.

In our solution I use [`SqlParser`](http://jdbi.org/#_sqlparser) to process SQL queries from annotated [SQL objects](http://jdbi.org/#_sql_objects). This processing consist of some cheap operations (e.g. prepend DAO name at the query beginning) and some pretty expensive operations (i.e. parse whole SQL and rewrite schemas found in query). Due to expensive nature of SQL parsing resultant SQL should be cached.

What I would like to do is to cache intermediate SQL together with named parameters, e.g. have cache like this one:

```
intermediateSql = "select a, b, c from {SCHEMA}.test where a > :a", parameters = [ a ]
intermediateSql = "insert into {SCHEMA}.test (a) values (:a)", parameters = [ a ]
```

And have custom implementation of ParsedSql which can be created by:

```java
public class MyParser implements SqlParser {
  public ParsedSql parse(String sql, StatementContext ctx) {
    Item item = cache.computeIfAbsent(sql, s -> doExpensiveSqlParsing(s, ctx));
    String intermediateSql = item.intermediateSql;
    ParsedParameters parameters = item.parameters;
    String finalSql = replaceAll("{SCHEMA}", schema);
    return new ParsedSql(finalSql, parameters);
  }
```

Since constructor is private and because `ParsedSql` can be created only via `ParsedSql.Builder` which takes SQL in parts, the `ParsedSql` instance cannot be instantiated from fully rendered SQL and known parameters. I have to split it into parts and merge using parameters one-by-one. This is problematic because it makes `?` a magic string which cannot be used in queries (because it's used to split it).

With current solution I can only accept `?` being magic or cache `ParsedSql` objects per schema which cause the number of items in cache to raise because there is no limit for a number of applications (and thus the number of schemas located on DB server, due to multitenant environment where application databases are isolated from each other). This will cause cache to grow bigger together with a number of applications, e.g.:

```
select a, b, c from app0001.test where a > :a; names = [ a ]
select a, b, c from app0002.test where a > :a; names = [ a ]
select a, b, c from app0003.test where a > :a; names = [ a ]
select a, b, c from app0004.test where a > :a; names = [ a ]
insert into app0001.test (a, b, c) values (:a, :b, :c); names = [a, b, c]
insert into app0002.test (a, b, c) values (:a, :b, :c); names = [a, b, c]
insert into app0003.test (a, b, c) values (:a, :b, :c); names = [a, b, c]
insert into app0004.test (a, b, c) values (:a, :b, :c); names = [a, b, c]
etc...
```

Please let me know if this change (private to protected) is acceptable. The other option for me would be to have `Builder` more fluent so I can set both SQL and parameters at once, not in parts, e.g.:

```java
ParsedSql sql = ParsedSql.builder()
  .setSql(finalSql)
  .setParameters(parameterNames)
  .build();
```