### PR TITLE
Release notes for @JdbiConstructor on static factory methods

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -2,6 +2,7 @@
   - New API
     - ConnectionFactory now also may customize connection closing
     - GenericTypes.findGenericParameter(Type, Class) now also takes an index, e.g. to resolve `V` in `Map<K, V>`
+    - @JdbiConstructor can now be placed on a static factory method
   - New beta API
     - Type qualifiers for binding and mapping. Use annotations to distinguish between different SQL
       data types that map to the same Java type. e.g. VARCHAR, NVARCHAR, and Postgres MACADDR all


### PR DESCRIPTION
Release notes for https://github.com/jdbi/jdbi/pull/1316. I missed the RELEASE_NOTES file.

I leave this totally up to you to decide whether this should be mentioned or not.