### PR TITLE
finally document how to enable single module mvn builds, patch up guide a bit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,9 @@ Here's a few pointers to help you get set up:
 
 # Policies
 
-## Backward compatibility
+## Compatibility
+
+### Backward
 
 Jdbi places serious emphasis on not breaking compatibility. Remember these simple rules and think twice before making any classes or class members `public`!
 
@@ -17,9 +19,13 @@ Jdbi places serious emphasis on not breaking compatibility. Remember these simpl
 
 If you must make some internal code `public` to access it from other packages, put the class in a package named `internal`. Packages named so are not considered API.
 
-### Forward compatibility
+### Forward
 
 Completely new API should, in most cases, be marked with `@Beta`. This lets users know not to rely too much on your changes yet, as the public release might reveal that more work needs to be done.
+
+## Functionality
+
+Jdbi should be useful for as many projects as possible with as little work as possible, within reason. It should be useful out of the box with sane defaults, but always configurable to the extent users are likely to need.
 
 ## Technical design
 
@@ -27,15 +33,11 @@ We like both constructors and factory methods/builders, but require that they be
 
 Remember to implement thread safety wherever objects are likely to be shared between threads, but don't implement it where it definitely isn't needed. Making objects stateless or immutable is strongly encouraged!
 
-### Testing
+## Testing
 
 Unit tests are nice for atomic components, but since jdbi is a complex ecosystem of components, we prefer to use tests that spin up real jdbi instances and make it work against an in-memory database. This ensures all code is covered by many different test cases and almost no flaw will go unnoticed.
 
 Since our tests essentially describe and verify jdbi's behavior, changing their specifics where it isn't inherently necessary is considered a red flag.
-
-## Functionality
-
-Jdbi should be useful for as many projects as possible with as little work as possible, within reason. It should be useful out of the box with sane defaults, but always configurable to the extent users are likely to need.
 
 ## Pull requests
 
@@ -43,21 +45,55 @@ Expect your pull request to be scrutinized in even the tiniest details (down to 
 
 Due to the volume of feedback in a typical PR, we may push changes directly to your PR branch if we are able to, in order to save time and frustration for everyone.
 
-# Enable `-parameters` compiler flag in your IDE:
+# Setup
+
+## Enable `-parameters` compiler flag
 
 Most of our SQL Object tests rely on SQL method parameter names. However by default, `javac` does not compile these
 parameter names into `.class` files. Thus, in order for unit tests to pass, the compiler must be configured to output
 parameter names.
 
-## IntelliJ
+### IntelliJ
 
-* File -> Settings
-* Build, Execution, Deployment -> Compiler -> Java Compiler
+* File &rarr; Settings
+* Build, Execution, Deployment &rarr; Compiler &rarr; Java Compiler
 * Additional command-line parameters: `-parameters`
 * Click Apply, then OK.
-* Build -> Rebuild Project
+* Build &rarr; Rebuild Project
 
-# Setting up your machine to build `jdbi3-oracle12`
+## Maven
+
+### Building individual modules
+
+Maven multi-module projects with cross-module dependencies such as plugin configurations with relative file paths are nowadays still a pain to get right.
+When building jdbi from the parent module, everything will normally work fine, as that's how it is built on our CI.
+When trying to e.g. `mvn clean package` any individual module, you may encounter an error such as this:
+
+> java -Dmaven.multiModuleProjectDirectory=D:/Projects/Java/jdbi/core
+> -Dfoo=bar maven.jar clean package  
+> ...  
+> ...  
+> [INFO] BUILD FAILURE  
+> [INFO] ------------------------------------------------------------------------  
+> [INFO] Total time: 16.767 s  
+> [INFO] Finished at: 2018-12-07T20:55:19+01:00  
+> [INFO] ------------------------------------------------------------------------  
+> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.9.0:pmd (pmd) on project jdbi3-core:
+> Execution pmd of goal org.apache.maven.plugins:maven-pmd-plugin:3.9.0:pmd failed:
+> org.apache.maven.reporting.MavenReportException:
+> **Could not find resource 'D:/Projects/Java/jdbi/core/src/build/pmd.xml'**. -> [Help 1]
+
+This typically happens when your IDE incorrectly sets the `maven.multiModuleProjectDirectory` property for maven, as in the example above.
+This property _should_ point to the _project root_, where the global files for PMD, CheckStyle, and others are housed.
+In the example, you can see it actually points to the root of _the module that was built_ — `core` in this case — which causes a global file to not be found.
+
+#### Intellij
+
+* File &rarr; Settings
+* Build Tools &rarr; Maven &rarr; Runner
+* VM Options: <code>-Dmaven.multiModuleProjectDirectory=D:/Projects/Java<b>/jdbi</b></code>
+
+## Set up your machine to build `jdbi3-oracle12`
 
 If you don't use Oracle, you can skip this section.
 
@@ -65,15 +101,15 @@ Oracle keeps their JDBC drivers on a password-gated Maven repository, so we excl
 
 To build `jdbi3-oracle12` on your machine, you'll need to do the following:
 
-## Set up an Oracle Single Sign-On account
+### Set up an Oracle Single Sign-On account
 
 Create an Oracle Single Sign-On account if you do not already have one: [Oracle Single Sign-On](https://login.oracle.com/mysso/signon.jsp)
 
-## Accept the terms of the Oracle Maven Repository license agreement
+### Accept the terms of the Oracle Maven Repository license agreement
 
 Navigate here and accept the terms of the agreement: [Oracle Technology Network License Agreement - Oracle Maven Repository](https://www.oracle.com/webapps/maven/register/license.html)
 
-## Set up `settings-security.xml`
+### Set up `settings-security.xml`
 
 Note: You can skip this step if you've already created a `settings-security.xml` file with a master password.
 
@@ -103,7 +139,7 @@ Copy and paste the encrypted password into `~/.m2/settings-security.xml`, so it 
 </settingsSecurity> 
 ```
 
-## Set up `settings.xml` to access the Oracle repository
+### Set up `settings.xml` to access the Oracle repository
 
 Create a file `~/.m2/settings.xml` if it doesn't already exist.
 
@@ -155,7 +191,7 @@ If you already had a `settings.xml` file, make sure to leave the existing settin
 
 Be sure to replace `address@domain.com` with the email address you used to create your Oracle Single Sign-On account, and the `<password>...</password>` with the encrypted password generated in the previous step.
 
-## Run Jdbi Maven builds with the `oracle` profile enabled
+### Run Jdbi Maven builds with the `oracle` profile enabled
 
 ```bash
 cd /path/to/jdbi/project
@@ -167,7 +203,7 @@ The `oracle` profile adds the `jdbi3-oracle12` artifact into the build process.
 You can enable this profile on a checkout with `jdbi3/$ touch .build-oracle`
 All release managers must do this to ensure the Oracle jars actually get released.
 
-# Running Oracle unit tests
+### Running Oracle unit tests
 
 The previous setup will allow the `jdbi3-oracle12` artifact to build, but without an Oracle database running, all Oracle unit tests will simply be ignored.
 


### PR DESCRIPTION
- replaced ascii arrows with unicode arrows
- restructured the headings a bit to make more sense IMO
- added a section on how to fix that dang build failure