### PR TITLE
boot out jexl test dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,18 +244,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-jexl</artifactId>
-                <version>2.1.1</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>commons-logging</artifactId>
-                        <groupId>commons-logging</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-test</artifactId>
                 <version>${dep.spring.version}</version>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -76,12 +76,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-jexl</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindExpression.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindExpression.java
@@ -13,7 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import com.google.common.collect.ImmutableMap;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -21,9 +20,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Optional;
-import org.apache.commons.jexl2.Expression;
-import org.apache.commons.jexl2.JexlEngine;
-import org.apache.commons.jexl2.MapContext;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -43,71 +39,54 @@ public class TestBindExpression {
     @Rule
     public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
 
+    @Test
+    public void testExpression() {
+        DB db = dbRule.getSharedHandle().attach(DB.class);
+        db.insert(new Something(1, "syrup"), new Something(2, "whipped cream"));
+
+        Something selected = db.findBySpecifier(new SyrupSpecifying());
+
+        assertThat(selected).isEqualTo(new Something(1, "syrup"));
+    }
+
     @RegisterRowMapper(SomethingMapper.class)
     public interface DB {
         @SqlBatch("insert into something (id, name) values(:id, :name)")
         void insert(@BindBean Something... things);
 
         @SqlQuery("select id, name from something where name = :breakfast.waffle.topping limit 1")
-        Something findByBreakfast(@BindRoot("breakfast") Breakfast b);
+        Something findBySpecifier(@BindNameSpecifying("breakfast") SyrupSpecifying b);
     }
 
-    @Test
-    public void testExpression() {
-        DB db = dbRule.getSharedHandle().attach(DB.class);
-        db.insert(new Something(1, "syrup"), new Something(2, "whipped cream"));
-        Something withSyrup = db.findByBreakfast(new Breakfast());
-        assertThat(withSyrup).isEqualTo(new Something(1, "syrup"));
+    private static class SyrupSpecifying {
+        private String getNameValue() {
+            return "syrup";
+        }
     }
 
     @Retention(RetentionPolicy.RUNTIME)
-    @SqlStatementCustomizingAnnotation(BindRoot.BindExpressionCustomizerFactory.class)
-    public @interface BindRoot {
+    @SqlStatementCustomizingAnnotation(NameSpecifyingCustomizerFactory.class)
+    private @interface BindNameSpecifying {
         String value();
+    }
 
-        class BindExpressionCustomizerFactory implements SqlStatementCustomizerFactory {
-            @Override
-            public SqlStatementParameterCustomizer createForParameter(Annotation annotation,
-                                                                      Class<?> sqlObjectType,
-                                                                      Method method,
-                                                                      Parameter param,
-                                                                      int index,
-                                                                      Type type) {
-                final String rootName = ((BindRoot) annotation).value();
-                final JexlEngine engine = new JexlEngine();
-                return (q, root) -> q.bindNamedArgumentFinder((name, context) -> {
-                    Expression e = engine.createExpression(name);
-                    final Object it = e.evaluate(new MapContext(ImmutableMap.of(rootName, root)));
-                    return it == null
-                            ? Optional.empty()
-                            : Optional.of((position, statement, ctx) -> statement.setObject(position, it));
-                });
-            }
+    public static class NameSpecifyingCustomizerFactory implements SqlStatementCustomizerFactory {
+        @Override
+        public SqlStatementParameterCustomizer createForParameter(Annotation annotation,
+                                                                  Class<?> sqlObjectType,
+                                                                  Method method,
+                                                                  Parameter param,
+                                                                  int index,
+                                                                  Type type) {
+            String bindingName = ((BindNameSpecifying) annotation).value();
+            assertThat(bindingName).isEqualTo("breakfast");
+
+            return (stmt, specifier) -> stmt.bindNamedArgumentFinder((paramName, context) -> {
+                assertThat(paramName).isEqualTo("breakfast.waffle.topping");
+
+                SyrupSpecifying syrupSpecifier = (SyrupSpecifying) specifier;
+                return Optional.of((position, statement, ctx) -> statement.setObject(position, syrupSpecifier.getNameValue()));
+            });
         }
     }
-
-    public static class Breakfast {
-        private final Waffle waffle = new Waffle();
-
-        public Waffle getWaffle() {
-            return waffle;
-        }
-    }
-
-    public static class Waffle {
-        private final String topping = "syrup";
-
-        public String getTopping() {
-            return topping;
-        }
-    }
-
-    @Test
-    public void testJexl() {
-        JexlEngine engine = new JexlEngine();
-        Object topping = engine.createExpression("breakfast.waffle.topping")
-                               .evaluate(new MapContext(ImmutableMap.<String, Object>of("breakfast", new Breakfast())));
-        assertThat(topping).isEqualTo("syrup");
-    }
-
 }


### PR DESCRIPTION
jexl was added as a test dep to jdbi just to write a test that appears to verify it's possible to implement a statementcustomizer...

This change ditches the jexl dep (:tada:) and brings what I believe is a more informative test.