### PR TITLE
fix #1377: BindList conditionals with null and StringTemplate

### DIFF
--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListNullPostgresTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListNullPostgresTest.java
@@ -85,6 +85,6 @@ public class BindListNullPostgresTest {
     @RegisterRowMapper(SomethingMapper.class)
     public interface SomethingByIterableHandleNull {
         @SqlQuery("select id, name from something where name in (${names})")
-        List<Something> get(@BindList(value = "names", onEmpty = BindList.EmptyHandling.NULL) Iterable<Object> ids);
+        List<Something> get(@BindList(value = "names", onEmpty = BindList.EmptyHandling.NULL_STRING) Iterable<Object> ids);
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -57,24 +57,24 @@ public @interface BindList {
         /**
          * <p>Output "" (without quotes, i.e. nothing).</p>
          *
-         * <code>select * from things where x in ()</code>
+         * {@code select * from things where x in ()}
          */
         VOID,
         /**
          * <p>Output "null" (without quotes, as keyword), useful e.g. in postgresql where "in ()" is invalid syntax.</p>
          *
-         * <code>select * from things where x in (null)</code>
+         * {@code select * from things where x in (null)}
          */
         NULL,
-        /**
-         * Throw IllegalArgumentException.
-         */
-        THROW,
         /**
          * <p>Define an empty list, leaving the resulting query text up to the {@link org.jdbi.v3.core.statement.TemplateEngine} to decide.</p>
          *
          * This value was specifically added to <a href="https://github.com/jdbi/jdbi/issues/1377">make conditionals work better with <code>StringTemplate</code></a>.
          */
-        EMPTY_LIST
+        EMPTY_LIST,
+        /**
+         * Throw IllegalArgumentException.
+         */
+        THROW
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -67,11 +67,11 @@ public @interface BindList {
          */
         NULL,
         /**
-         * <p>Define an empty list, leaving the resulting query text up to the {@link org.jdbi.v3.core.statement.TemplateEngine} to decide.</p>
+         * <p>Define a {@code null} value, leaving the resulting query text up to the {@link org.jdbi.v3.core.statement.TemplateEngine} to decide.</p>
          *
          * This value was specifically added to <a href="https://github.com/jdbi/jdbi/issues/1377">make conditionals work better with <code>StringTemplate</code></a>.
          */
-        EMPTY_LIST,
+        JAVA_NULL,
         /**
          * Throw IllegalArgumentException.
          */

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -71,7 +71,7 @@ public @interface BindList {
          *
          * This value was specifically added to <a href="https://github.com/jdbi/jdbi/issues/1377">make conditionals work better with <code>StringTemplate</code></a>.
          */
-        JAVA_NULL,
+        NULL_VALUE,
         /**
          * Throw IllegalArgumentException.
          */

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -55,25 +55,25 @@ public @interface BindList {
      */
     enum EmptyHandling {
         /**
-         * output "" (without quotes, i.e. nothing)
-         * <p>
-         * select * from things where x in ()
+         * <p>Output "" (without quotes, i.e. nothing).</p>
+         *
+         * <code>select * from things where x in ()</code>
          */
         VOID,
         /**
-         * output "null" (without quotes, as keyword), useful e.g. in postgresql where "in ()" is invalid syntax
-         * <p>
-         * select * from things where x in (null)
+         * <p>Output "null" (without quotes, as keyword), useful e.g. in postgresql where "in ()" is invalid syntax.</p>
+         *
+         * <code>select * from things where x in (null)</code>
          */
         NULL,
         /**
-         * throw IllegalArgumentException
+         * Throw IllegalArgumentException.
          */
         THROW,
         /**
-         * <p>define an empty list, leaving the resulting query text up to the {@link org.jdbi.v3.core.statement.TemplateEngine} to decide.</p>
+         * <p>Define an empty list, leaving the resulting query text up to the {@link org.jdbi.v3.core.statement.TemplateEngine} to decide.</p>
          *
-         * @apiNote this value was specifically added to <a href="https://github.com/jdbi/jdbi/issues/1377">make conditionals work better with <code>StringTemplate</code></a>
+         * This value was specifically added to <a href="https://github.com/jdbi/jdbi/issues/1377">make conditionals work better with <code>StringTemplate</code></a>.
          */
         EMPTY_LIST
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -69,6 +69,12 @@ public @interface BindList {
         /**
          * throw IllegalArgumentException
          */
-        THROW;
+        THROW,
+        /**
+         * <p>define an empty list, leaving the resulting query text up to the {@link org.jdbi.v3.core.statement.TemplateEngine} to decide.</p>
+         *
+         * @apiNote this value was specifically added to <a href="https://github.com/jdbi/jdbi/issues/1377">make conditionals work better with <code>StringTemplate</code></a>
+         */
+        EMPTY_LIST
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -18,6 +18,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import java.util.function.BiConsumer;
+import org.jdbi.v3.core.statement.SqlStatement;
 import org.jdbi.v3.sqlobject.customizer.internal.BindListFactory;
 
 /**
@@ -59,7 +61,7 @@ public @interface BindList {
          *
          * {@code select * from things where x in ()}
          */
-        VOID,
+        VOID((stmt, name) -> stmt.define(name, "")),
         /**
          * <p>Output "null" (without quotes, as keyword), useful e.g. in postgresql where "in ()" is invalid syntax.</p>
          *
@@ -68,22 +70,34 @@ public @interface BindList {
          * @deprecated vaguely named in light of new additions, use {@link EmptyHandling#NULL_STRING} instead
          */
         @Deprecated
-        NULL,
+        NULL((stmt, name) -> stmt.define(name, "null")),
         /**
          * <p>Output "null" (without quotes, as keyword), useful e.g. in postgresql where "in ()" is invalid syntax.</p>
          *
          * {@code select * from things where x in (null)}
          */
-        NULL_STRING,
+        NULL_STRING((stmt, name) -> stmt.define(name, "null")),
         /**
          * <p>Define a {@code null} value, leaving the resulting query text up to the {@link org.jdbi.v3.core.statement.TemplateEngine} to decide.</p>
          *
          * This value was specifically added to <a href="https://github.com/jdbi/jdbi/issues/1377">make conditionals work better with <code>StringTemplate</code></a>.
          */
-        NULL_VALUE,
+        NULL_VALUE((stmt, name) -> stmt.define(name, null)),
         /**
          * Throw IllegalArgumentException.
          */
-        THROW
+        THROW((stmt, name) -> {
+            throw new IllegalArgumentException("argument is null or empty; this was explicitly forbidden on this instance of BindList");
+        });
+
+        private final BiConsumer<SqlStatement, String> rendering;
+
+        EmptyHandling(BiConsumer<SqlStatement, String> rendering) {
+            this.rendering = rendering;
+        }
+
+        public void define(SqlStatement stmt, String name) {
+            rendering.accept(stmt, name);
+        }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -64,8 +64,17 @@ public @interface BindList {
          * <p>Output "null" (without quotes, as keyword), useful e.g. in postgresql where "in ()" is invalid syntax.</p>
          *
          * {@code select * from things where x in (null)}
+         *
+         * @deprecated vaguely named in light of new additions, use {@link EmptyHandling#NULL_STRING} instead
          */
+        @Deprecated
         NULL,
+        /**
+         * <p>Output "null" (without quotes, as keyword), useful e.g. in postgresql where "in ()" is invalid syntax.</p>
+         *
+         * {@code select * from things where x in (null)}
+         */
+        NULL_STRING,
         /**
          * <p>Define a {@code null} value, leaving the resulting query text up to the {@link org.jdbi.v3.core.statement.TemplateEngine} to decide.</p>
          *

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 
+import java.util.Collections;
 import org.jdbi.v3.core.internal.IterableLike;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
@@ -53,6 +54,9 @@ public final class BindListFactory implements SqlStatementCustomizerFactory {
                     throw new IllegalArgumentException(arg == null
                     ? "argument is null; null was explicitly forbidden on this instance of BindList"
                             : "argument is empty; emptiness was explicitly forbidden on this instance of BindList");
+                case EMPTY_LIST:
+                    stmt.define(name, Collections.emptyList());
+                    return;
                 default:
                     throw new IllegalStateException(VALUE_NOT_HANDLED_MESSAGE);
                 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -50,13 +50,14 @@ public final class BindListFactory implements SqlStatementCustomizerFactory {
                 case NULL:
                     stmt.define(name, "null");
                     return;
-                case THROW:
-                    throw new IllegalArgumentException(arg == null
-                    ? "argument is null; null was explicitly forbidden on this instance of BindList"
-                            : "argument is empty; emptiness was explicitly forbidden on this instance of BindList");
                 case EMPTY_LIST:
                     stmt.define(name, Collections.emptyList());
                     return;
+                case THROW:
+                    String msg = arg == null
+                        ? "argument is null; null was explicitly forbidden on this instance of BindList"
+                        : "argument is empty; emptiness was explicitly forbidden on this instance of BindList";
+                    throw new IllegalArgumentException(msg);
                 default:
                     throw new IllegalStateException(VALUE_NOT_HANDLED_MESSAGE);
                 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -24,8 +24,6 @@ import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
 import org.jdbi.v3.sqlobject.internal.ParameterUtil;
 
 public final class BindListFactory implements SqlStatementCustomizerFactory {
-    private static final String VALUE_NOT_HANDLED_MESSAGE = "EmptyHandling type on BindList not handled. Please report this to the jdbi developers.";
-
     @Override
     public SqlStatementParameterCustomizer createForParameter(Annotation annotation,
                                                               Class<?> sqlObjectType,

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -48,7 +48,7 @@ public final class BindListFactory implements SqlStatementCustomizerFactory {
                 case NULL:
                     stmt.define(name, "null");
                     return;
-                case JAVA_NULL:
+                case NULL_VALUE:
                     stmt.define(name, null);
                     return;
                 case THROW:

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -17,8 +17,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
-
-import java.util.Collections;
 import org.jdbi.v3.core.internal.IterableLike;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
@@ -50,8 +48,8 @@ public final class BindListFactory implements SqlStatementCustomizerFactory {
                 case NULL:
                     stmt.define(name, "null");
                     return;
-                case EMPTY_LIST:
-                    stmt.define(name, Collections.emptyList());
+                case JAVA_NULL:
+                    stmt.define(name, null);
                     return;
                 case THROW:
                     String msg = arg == null

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -41,28 +41,10 @@ public final class BindListFactory implements SqlStatementCustomizerFactory {
 
         return (stmt, arg) -> {
             if (arg == null || IterableLike.isEmpty(arg)) {
-                switch (bindList.onEmpty()) {
-                case VOID:
-                    stmt.define(name, "");
-                    return;
-                case NULL:
-                case NULL_STRING:
-                    stmt.define(name, "null");
-                    return;
-                case NULL_VALUE:
-                    stmt.define(name, null);
-                    return;
-                case THROW:
-                    String msg = arg == null
-                        ? "argument is null; null was explicitly forbidden on this instance of BindList"
-                        : "argument is empty; emptiness was explicitly forbidden on this instance of BindList";
-                    throw new IllegalArgumentException(msg);
-                default:
-                    throw new IllegalStateException(VALUE_NOT_HANDLED_MESSAGE);
-                }
+                bindList.onEmpty().define(stmt, name);
+            } else {
+                stmt.bindList(name, IterableLike.toList(arg));
             }
-
-            stmt.bindList(name, IterableLike.toList(arg));
         };
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -46,6 +46,7 @@ public final class BindListFactory implements SqlStatementCustomizerFactory {
                     stmt.define(name, "");
                     return;
                 case NULL:
+                case NULL_STRING:
                     stmt.define(name, "null");
                     return;
                 case NULL_VALUE:

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullPostgresTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullPostgresTest.java
@@ -76,6 +76,6 @@ public class BindListNullPostgresTest {
     @RegisterRowMapper(SomethingMapper.class)
     public interface SomethingByIterableHandleNull {
         @SqlQuery("select id, name from something where name in (<names>)")
-        List<Something> get(@BindList(value = "names", onEmpty = BindList.EmptyHandling.NULL) Iterable<Object> ids);
+        List<Something> get(@BindList(value = "names", onEmpty = BindList.EmptyHandling.NULL_STRING) Iterable<Object> ids);
     }
 }

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullTest.java
@@ -32,7 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL;
+import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL_STRING;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.VOID;
 
 public class BindListNullTest {
@@ -83,7 +83,7 @@ public class BindListNullTest {
 
     public interface SomethingByIterableHandleNull {
         @SqlQuery("select id, name from something where name in (<names>)")
-        List<Something> get(@BindList(onEmpty = NULL) Iterable<Object> names);
+        List<Something> get(@BindList(onEmpty = NULL_STRING) Iterable<Object> names);
     }
 
     //

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -17,38 +17,36 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.THROW;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.VOID;
 
 public class BindListTest {
-    private Handle handle;
-
-    private List<Something> expectedSomethings;
-
     @Rule
-    public final H2DatabaseRule dbRule = new H2DatabaseRule();
+    public final H2DatabaseRule h2 = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private Handle handle;
+    private List<Something> expectedSomethings;
 
     @Before
     public void before() {
-        final Jdbi db = dbRule.getJdbi();
-        db.installPlugin(new SqlObjectPlugin());
-        db.registerRowMapper(new SomethingMapper());
-        handle = db.open();
+        handle = h2.getJdbi()
+            .registerRowMapper(new SomethingMapper())
+            .open();
 
         handle.execute("insert into something(id, name) values(1, '1')");
         handle.execute("insert into something(id, name) values(2, '2')");
@@ -57,11 +55,6 @@ public class BindListTest {
         handle.execute("insert into something(id, name) values(3, '3')");
 
         expectedSomethings = Arrays.asList(new Something(1, "1"), new Something(2, "2"));
-    }
-
-    @After
-    public void after() {
-        handle.close();
     }
 
     //

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -233,10 +233,10 @@ public class BindListTest {
             .hasSize(4);
     }
 
-    @UseStringTemplateEngine
     private interface ConditionalDao {
         // `in (null)` doesn't work on h2
         @SqlQuery("select name from something <if(name)> where name is <name> <endif>")
+        @UseStringTemplateEngine
         List<String> get(@Nullable @BindList(value = "name", onEmpty = EMPTY_LIST) List<String> name);
     }
 }

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.JAVA_NULL;
+import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL_VALUE;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.THROW;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.VOID;
 
@@ -237,6 +237,6 @@ public class BindListTest {
         // `in (null)` doesn't work on h2
         @SqlQuery("select name from something <if(name)> where name is <name> <endif>")
         @UseStringTemplateEngine
-        List<String> get(@Nullable @BindList(value = "name", onEmpty = JAVA_NULL) List<String> name);
+        List<String> get(@Nullable @BindList(value = "name", onEmpty = NULL_VALUE) List<String> name);
     }
 }

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.EMPTY_LIST;
+import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.JAVA_NULL;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.THROW;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.VOID;
 
@@ -237,6 +237,6 @@ public class BindListTest {
         // `in (null)` doesn't work on h2
         @SqlQuery("select name from something <if(name)> where name is <name> <endif>")
         @UseStringTemplateEngine
-        List<String> get(@Nullable @BindList(value = "name", onEmpty = EMPTY_LIST) List<String> name);
+        List<String> get(@Nullable @BindList(value = "name", onEmpty = JAVA_NULL) List<String> name);
     }
 }

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL;
+import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.EMPTY_LIST;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.THROW;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.VOID;
 
@@ -237,6 +237,6 @@ public class BindListTest {
     private interface ConditionalDao {
         // `in (null)` doesn't work on h2
         @SqlQuery("select name from something <if(name)> where name is <name> <endif>")
-        List<String> get(@Nullable @BindList(value = "name", onEmpty = NULL) List<String> name);
+        List<String> get(@Nullable @BindList(value = "name", onEmpty = EMPTY_LIST) List<String> name);
     }
 }


### PR DESCRIPTION
fixes #1377 

I haven't really considered this change from a conservative or nitpicky point of view yet, but all this really is, is making a constant for `if (list == null) list = emptyList()`, so it can't really be a problem? The only "risk" to this is that you leave the text representation of an empty list in the query up to the TemplateEngine, but that's what allows it to treat it as a falsy conditional in the first place.

@shelocks