### PR TITLE
ColonStatementLexer: ignore postgres array slice e.g. `[3:5]`

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -22,6 +22,8 @@
     - Support for Postgres MACADDR columns, using the @MacAddr qualifying annotation
     - Support for HSTORE columns, using the @HStore annotation
     - @Json type qualifier with Jackson 2 and Gson 2 bindings
+  - Improvements
+    - ColonStatementLexer: don't trip up over postgres array slice `array[3:4]` syntax
   - Oracle DB support changes
     - Due to ongoing stability problems with Oracle's Maven servers, we have split the
       jdbi3-oracle12 artifact out of the main project, to a new home at

--- a/core/src/main/antlr3/org/jdbi/v3/core/internal/lexer/ColonStatementLexer.g
+++ b/core/src/main/antlr3/org/jdbi/v3/core/internal/lexer/ColonStatementLexer.g
@@ -19,7 +19,9 @@ fragment COLON: {input.LA(2) != ':'}?=> ':';
 fragment DOUBLE_COLON: {input.LA(2) == ':'}?=> '::';
 fragment QUESTION: {input.LA(2) != '?'}?=> '?';
 fragment DOUBLE_QUESTION: {input.LA(2) == '?'}?=> '??';
-fragment NAME: 'a'..'z' | 'A'..'Z' | '0'..'9' | '_' | '.' | '?.' | '#';
+fragment DIGIT: '0'..'9';
+fragment NAME: 'a'..'z' | 'A'..'Z' | DIGIT | '_' | '.' | '?.' | '#';
+fragment BRACKET_OR_SLICE: '[' (' '* DIGIT* ' '* ':' ' '* DIGIT* ' '* ']')?;
 
 COMMENT: '/*' .* '*/';
 QUOTED_TEXT: QUOTE (ESCAPE_QUOTE | ~QUOTE)* QUOTE;
@@ -29,5 +31,5 @@ ESCAPED_TEXT : ESCAPE . ;
 NAMED_PARAM: COLON (NAME)+;
 POSITIONAL_PARAM: QUESTION;
 
-LITERAL: (NAME | ' ' | '\t' | '\n' | '\r' | ',' | '@' | '!' | '=' | DOUBLE_COLON | ';' | '(' | ')' | '[' | ']'
+LITERAL: (NAME | ' ' | '\t' | '\n' | '\r' | ',' | '@' | '!' | '=' | DOUBLE_COLON | ';' | '(' | ')' | BRACKET_OR_SLICE | ']'
          | '+' | '-' | '<' | '>' | '%' | '&' | '^' | '|' | '$' | '~' | '{' | '}' | '`' | COLON '=' | DOUBLE_QUESTION)+ | '*' | '/';

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestArraySliceParsing.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestArraySliceParsing.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.postgres;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jdbi.v3.testing.JdbiRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestArraySliceParsing {
+    @Rule
+    public JdbiRule db = JdbiRule.embeddedPostgres();
+
+    @Test
+    public void testArraySliceFull() {
+        assertThat(db.getHandle().createQuery(
+                    "select col[2:2] from (values ('{1,2,3}'::int[])) as tbl(col)")
+                .mapTo(int[].class)
+                .findOnly())
+            .isEqualTo(new int[] {2});
+    }
+
+    @Test
+    public void testArraySliceLower() {
+        assertThat(db.getHandle().createQuery(
+                    "select col[2:] from (values ('{1,2,3}'::int[])) as tbl(col)")
+                .mapTo(int[].class)
+                .findOnly())
+            .isEqualTo(new int[] {2, 3});
+    }
+
+    @Test
+    public void testArraySliceUpper() {
+        assertThat(db.getHandle().createQuery(
+                    "select col[:2] from (values ('{1,2,3}'::int[])) as tbl(col)")
+                .mapTo(int[].class)
+                .findOnly())
+            .isEqualTo(new int[] {1, 2});
+    }
+
+    @Test
+    public void testNumeralName() {
+        assertThat(db.getHandle().createQuery("values(:2)")
+                    .bind("2", 42)
+                    .mapTo(int.class)
+                    .findOnly())
+            .isEqualTo(42);
+    }
+}


### PR DESCRIPTION
Fixes #1387 

Note that this change attempts to be conservative -- we only change lexing rules that happen *after* we already see a leading `[`, and simply ignore anything that looks like a slice.  I've verified that it is not valid syntax (parse error) to try to bind a parameter into an array slice, so there isn't any ambiguity as to whether `[:2]` is a open ended slice or a named parameter slice, as the latter is a Postgres syntax error.