### PR TITLE
checkstyle: Import order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,21 @@ Most of our SQL Object tests rely on SQL method parameter names. However by defa
 parameter names into `.class` files. Thus, in order for unit tests to pass, the compiler must be configured to output
 parameter names.
 
+## Configure import ordering
+
+Configure import grouping for:
+
+```
+import java.*;
+import javax.*;
+import *;
+import static java.*;
+import static javax.*;
+import static *;
+```
+
+One line between each group.  Sort each group alphabetically.
+
 ### IntelliJ
 
 * File &rarr; Settings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,18 +55,19 @@ parameter names.
 
 ## Configure import ordering
 
-Configure import grouping for:
+We enforce this order of imports:
 
 ```
-import java.*;
-import javax.*;
-import *;
-import static java.*;
-import static javax.*;
-import static *;
+java.*
+javax.*
+*
+static java.*
+static javax.*
+static *
 ```
 
-One line between each group.  Sort each group alphabetically.
+A blank line is required between each group. The imports in a group must be ordered
+alphabetically. Wildcard imports (e.g. `import org.apache.*;`) are not allowed.
 
 ### IntelliJ
 

--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/StringSubstitutorTemplateEngine.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/StringSubstitutorTemplateEngine.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.commonstext;
 
 import java.util.function.Consumer;
+
 import org.apache.commons.text.StringSubstitutor;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.TemplateEngine;

--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/UseStringSubstitutorTemplateEngine.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/UseStringSubstitutorTemplateEngine.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.commonstext.internal.UseStringSubstitutorTemplateEngineImpl;
 import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation;
 

--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/internal/UseStringSubstitutorTemplateEngineImpl.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/internal/UseStringSubstitutorTemplateEngineImpl.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.commonstext.internal;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+
 import org.jdbi.v3.commonstext.StringSubstitutorTemplateEngine;
 import org.jdbi.v3.commonstext.UseStringSubstitutorTemplateEngine;
 import org.jdbi.v3.core.config.ConfigRegistry;

--- a/commons-text/src/test/java/org/jdbi/v3/commonstext/TestStringSubstitutorTemplateEngine.java
+++ b/commons-text/src/test/java/org/jdbi/v3/commonstext/TestStringSubstitutorTemplateEngine.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.commonstext;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.TemplateEngine;
 import org.junit.Before;

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -13,10 +13,6 @@
  */
 package org.jdbi.v3.core;
 
-import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-
 import java.io.Closeable;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -39,6 +35,10 @@ import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.jdbi.v3.core.transaction.UnableToManipulateTransactionIsolationLevelException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * This represents a connection to the database system. It is a wrapper around

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core;
 import java.io.Closeable;
 import java.sql.Connection;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.Configurable;
 import org.jdbi.v3.core.extension.ExtensionMethod;

--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.core;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -43,6 +40,9 @@ import org.jdbi.v3.core.transaction.TransactionHandler;
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * Main entry point; configurable wrapper around a JDBC {@link DataSource}.

--- a/core/src/main/java/org/jdbi/v3/core/OnDemandExtensions.java
+++ b/core/src/main/java/org/jdbi/v3/core/OnDemandExtensions.java
@@ -18,6 +18,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+
 import org.jdbi.v3.core.internal.JdbiThreadLocals;
 import org.jdbi.v3.core.internal.UtilityClassException;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;

--- a/core/src/main/java/org/jdbi/v3/core/argument/AbstractArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/AbstractArgumentFactory.java
@@ -13,10 +13,10 @@
  */
 package org.jdbi.v3.core.argument;
 
-import org.jdbi.v3.core.config.ConfigRegistry;
-
 import java.lang.reflect.Type;
 import java.util.Optional;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
 
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/main/java/org/jdbi/v3/core/argument/DelegatingArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/DelegatingArgumentFactory.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.v3.core.argument.internal.strategies.LoggableBinderArgument;
 import org.jdbi.v3.core.argument.internal.StatementBinder;
+import org.jdbi.v3.core.argument.internal.strategies.LoggableBinderArgument;
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/main/java/org/jdbi/v3/core/argument/EnumArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/EnumArgumentFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.argument;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.argument.internal.strategies.LoggableToStringOrNPEArgument;
 import org.jdbi.v3.core.config.ConfigRegistry;
 

--- a/core/src/main/java/org/jdbi/v3/core/argument/JavaTimeZoneIdArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/JavaTimeZoneIdArgumentFactory.java
@@ -13,11 +13,11 @@
  */
 package org.jdbi.v3.core.argument;
 
-import org.jdbi.v3.core.argument.internal.strategies.LoggableToStringOrNPEArgument;
-import org.jdbi.v3.core.config.ConfigRegistry;
-
 import java.sql.Types;
 import java.time.ZoneId;
+
+import org.jdbi.v3.core.argument.internal.strategies.LoggableToStringOrNPEArgument;
+import org.jdbi.v3.core.config.ConfigRegistry;
 
 public class JavaTimeZoneIdArgumentFactory extends AbstractArgumentFactory<ZoneId> {
     public JavaTimeZoneIdArgumentFactory() {

--- a/core/src/main/java/org/jdbi/v3/core/argument/NVarcharArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/NVarcharArgumentFactory.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.argument;
 
 import java.sql.Types;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.qualifier.NVarchar;
 

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
@@ -29,6 +29,7 @@ import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 
 import static java.util.stream.Collectors.toMap;
+
 import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/argument/OptionalArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/OptionalArgumentFactory.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;

--- a/core/src/main/java/org/jdbi/v3/core/argument/QualifiedArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/QualifiedArgumentFactory.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.core.argument;
 
-import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
-
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 import java.util.Set;
@@ -22,6 +20,8 @@ import java.util.Set;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.meta.Beta;
+
+import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
 
 @FunctionalInterface
 @Beta

--- a/core/src/main/java/org/jdbi/v3/core/argument/ToStringBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ToStringBinder.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.argument;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.argument.internal.StatementBinder;
 
 class ToStringBinder<T> implements StatementBinder<T> {

--- a/core/src/main/java/org/jdbi/v3/core/argument/UntypedNullArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/UntypedNullArgumentFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.argument;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 class UntypedNullArgumentFactory implements ArgumentFactory {

--- a/core/src/main/java/org/jdbi/v3/core/argument/internal/MethodReturnValueNamedArgumentFinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/internal/MethodReturnValueNamedArgumentFinder.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.core.argument.internal;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.jdbi.v3.core.argument.NamedArgumentFinder;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 /**
  * Base {@link NamedArgumentFinder} implementation that can be used for bindings that use the return value

--- a/core/src/main/java/org/jdbi/v3/core/argument/internal/strategies/LoggableBinderArgument.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/internal/strategies/LoggableBinderArgument.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.argument.internal.strategies;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.argument.internal.StatementBinder;
 import org.jdbi.v3.core.statement.StatementContext;
 

--- a/core/src/main/java/org/jdbi/v3/core/argument/internal/strategies/LoggableSetObjectArgument.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/internal/strategies/LoggableSetObjectArgument.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.argument.internal.strategies;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.statement.StatementContext;
 
 // TODO unify with ObjectArgument?

--- a/core/src/main/java/org/jdbi/v3/core/argument/internal/strategies/LoggableToStringOrNPEArgument.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/internal/strategies/LoggableToStringOrNPEArgument.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.argument.internal.strategies;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.function.Function;
+
 import org.jdbi.v3.core.statement.StatementContext;
 
 // TODO remove all uses of this

--- a/core/src/main/java/org/jdbi/v3/core/array/ArrayColumnMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/ArrayColumnMapper.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
 
 class ArrayColumnMapper implements ColumnMapper<Object> {
     private static final CopyOnWriteArraySet<Integer> UNSUPPORTED_TYPES = new CopyOnWriteArraySet<>();

--- a/core/src/main/java/org/jdbi/v3/core/array/InferredSqlArrayTypeFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/InferredSqlArrayTypeFactory.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.core.array;
 
-import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
-
 import java.lang.reflect.Type;
 import java.util.Optional;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
+
+import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 
 /**
  * A generic {@link SqlArrayTypeFactory} that reflectively inspects an {@link SqlArrayType SqlArrayType<T>} and maps

--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgument.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgument.java
@@ -17,6 +17,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.internal.IterableLike;
 import org.jdbi.v3.core.statement.StatementContext;

--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgumentFactory.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Type;
 import java.sql.Types;
 import java.util.Collection;
 import java.util.Optional;
+
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.NullArgument;

--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayTypes.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.core.internal.JdbiOptionals;

--- a/core/src/main/java/org/jdbi/v3/core/collector/EnumSetCollectorFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/EnumSetCollectorFactory.java
@@ -13,14 +13,14 @@
  */
 package org.jdbi.v3.core.collector;
 
-import org.jdbi.v3.core.generic.GenericTypes;
-
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collector;
+
+import org.jdbi.v3.core.generic.GenericTypes;
 
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/main/java/org/jdbi/v3/core/collector/ListCollectorFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/ListCollectorFactory.java
@@ -27,6 +27,7 @@ import java.util.stream.Collector;
 
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
+
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 

--- a/core/src/main/java/org/jdbi/v3/core/collector/MapCollectorFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/MapCollectorFactory.java
@@ -26,6 +26,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collector;
+
 import org.jdbi.v3.core.generic.GenericTypes;
 
 import static org.jdbi.v3.core.collector.MapCollectors.toMap;

--- a/core/src/main/java/org/jdbi/v3/core/collector/MapCollectors.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/MapCollectors.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.collector;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 public class MapCollectors {

--- a/core/src/main/java/org/jdbi/v3/core/collector/OptionalCollectors.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/OptionalCollectors.java
@@ -20,6 +20,7 @@ import java.util.OptionalLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/collector/SetCollectorFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/SetCollectorFactory.java
@@ -27,6 +27,7 @@ import java.util.stream.Collector;
 
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
+
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMethod.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMethod.java
@@ -13,9 +13,9 @@
  */
 package org.jdbi.v3.core.extension;
 
-import static java.util.Objects.requireNonNull;
-
 import java.lang.reflect.Method;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Holder for a {@link Class} and a {@link Method} that together

--- a/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Sneaky.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Sneaky.java
@@ -18,8 +18,10 @@ package org.jdbi.v3.core.internal.exceptions;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
+
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 public class Sneaky {

--- a/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Unchecked.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Unchecked.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 public class Unchecked {

--- a/core/src/main/java/org/jdbi/v3/core/locator/ClasspathSqlLocator.java
+++ b/core/src/main/java/org/jdbi/v3/core/locator/ClasspathSqlLocator.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
 import org.antlr.runtime.ANTLRInputStream;

--- a/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/BoxedMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/BoxedMapperFactory.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/EnumByNameMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/EnumByNameMapperFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/EnumByOrdinalMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/EnumByOrdinalMapperFactory.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.core.mapper;
 
-import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
-
 import java.lang.reflect.Type;
 import java.util.Optional;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
+
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 
 /**
  * Produces enum column mappers, which map enums from numeric columns according to ordinal value.

--- a/core/src/main/java/org/jdbi/v3/core/mapper/EnumMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/EnumMapperFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/EssentialsMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/EssentialsMapperFactory.java
@@ -21,6 +21,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/GenericMapMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/GenericMapMapperFactory.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.UnaryOperator;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.generic.GenericTypes;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/GetterMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/GetterMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.statement.StatementContext;
 
 class GetterMapper<T> implements ColumnMapper<T> {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/InferredColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/InferredColumnMapperFactory.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.mapper;
 
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/InferredRowMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/InferredRowMapperFactory.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.core.mapper;
 
-import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
-
 import java.lang.reflect.Type;
 import java.util.Optional;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
+
+import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 
 /**
  * A generic RowMapperFactory that reflectively inspects a

--- a/core/src/main/java/org/jdbi/v3/core/mapper/InternetMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/InternetMapperFactory.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/JavaTimeMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/JavaTimeMapperFactory.java
@@ -28,6 +28,7 @@ import java.time.ZonedDateTime;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMapper.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.core.mapper;
 
-import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
-import static org.jdbi.v3.core.generic.GenericTypes.resolveType;
-
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -27,6 +24,9 @@ import java.util.Optional;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
+
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
+import static org.jdbi.v3.core.generic.GenericTypes.resolveType;
 
 /**
  * Maps rows to {@link Map.Entry Map.Entry&lt;K, V&gt;}, provided there are mappers registered for types K and V. This mapper is registered out of the box.

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMapper.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/Nested.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/Nested.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.core.mapper;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
 
 /**
  * Signals that the annotated element is a nested mapped type.

--- a/core/src/main/java/org/jdbi/v3/core/mapper/OptionalMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/OptionalMapperFactory.java
@@ -23,6 +23,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/PrimitiveMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/PrimitiveMapperFactory.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/QualifiedColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/QualifiedColumnMapperFactory.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.mapper;
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 import java.util.Set;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/SqlTimeMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/SqlTimeMapperFactory.java
@@ -19,6 +19,7 @@ import java.sql.Timestamp;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ColumnName.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ColumnName.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
 
 /**
  * Specify the mapping name for a property or parameter explicitly.

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorInstanceFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorInstanceFactory.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.mapper.reflect;
 
 import java.lang.reflect.Constructor;
+
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 
 import static java.util.Objects.requireNonNull;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.mapper.RowMapper;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/InstanceFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/InstanceFactory.java
@@ -13,10 +13,11 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
-import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
+
+import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/JdbiConstructor.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/JdbiConstructor.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
 
 /**
  * Indicate to {@link ConstructorMapper} and other reflective mappers

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/JdbiConstructors.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/JdbiConstructors.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ReflectionMapperUtil.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.function.Supplier;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/StaticMethodInstanceFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/StaticMethodInstanceFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper.reflect;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 
 import static java.lang.String.format;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapperFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper.reflect.internal;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.mapper.RowMapper;

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.core.qualifier;
 
-import static java.util.stream.Collectors.toSet;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.util.Arrays;
@@ -22,6 +20,8 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.jdbi.v3.meta.Beta;
+
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Utility class for type qualifiers supported by Jdbi core.

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultIterable.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultIterable.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.core.result;
 
-import static java.util.Spliterators.spliteratorUnknownSize;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
@@ -29,6 +27,8 @@ import java.util.stream.StreamSupport;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+
+import static java.util.Spliterators.spliteratorUnknownSize;
 
 /**
  * An {@link Iterable} of values, usually mapped from a {@link java.sql.ResultSet}. Generally, ResultIterables may only

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultSetResultIterator.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultSetResultIterator.java
@@ -13,14 +13,14 @@
  */
 package org.jdbi.v3.core.result;
 
-import static java.util.Objects.requireNonNull;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.NoSuchElementException;
 
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+
+import static java.util.Objects.requireNonNull;
 
 class ResultSetResultIterator<T> implements ResultIterator<T> {
     private final ResultSet results;

--- a/core/src/main/java/org/jdbi/v3/core/result/RowView.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/RowView.java
@@ -19,11 +19,11 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;
 import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.statement;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 class ArgumentBinder {

--- a/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.statement;
 import java.io.Closeable;
 import java.sql.SQLException;
 import java.util.Collection;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.Configurable;

--- a/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.statement;
 import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
+
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.Token;
 import org.jdbi.v3.core.internal.lexer.ColonStatementLexer;

--- a/core/src/main/java/org/jdbi/v3/core/statement/DefineNamedBindingsStatementCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/DefineNamedBindingsStatementCustomizer.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.statement;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Set;
+
 import org.jdbi.v3.core.argument.NullArgument;
 
 class DefineNamedBindingsStatementCustomizer implements StatementCustomizer {

--- a/core/src/main/java/org/jdbi/v3/core/statement/DefinedAttributeTemplateEngine.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/DefinedAttributeTemplateEngine.java
@@ -13,6 +13,10 @@
  */
 package org.jdbi.v3.core.statement;
 
+import org.antlr.runtime.ANTLRStringStream;
+import org.antlr.runtime.Token;
+import org.jdbi.v3.core.internal.lexer.DefineStatementLexer;
+
 import static org.jdbi.v3.core.internal.lexer.DefineStatementLexer.COMMENT;
 import static org.jdbi.v3.core.internal.lexer.DefineStatementLexer.DEFINE;
 import static org.jdbi.v3.core.internal.lexer.DefineStatementLexer.DOUBLE_QUOTED_TEXT;
@@ -20,10 +24,6 @@ import static org.jdbi.v3.core.internal.lexer.DefineStatementLexer.EOF;
 import static org.jdbi.v3.core.internal.lexer.DefineStatementLexer.ESCAPED_TEXT;
 import static org.jdbi.v3.core.internal.lexer.DefineStatementLexer.LITERAL;
 import static org.jdbi.v3.core.internal.lexer.DefineStatementLexer.QUOTED_TEXT;
-
-import org.antlr.runtime.ANTLRStringStream;
-import org.antlr.runtime.Token;
-import org.jdbi.v3.core.internal.lexer.DefineStatementLexer;
 
 /**
  * Template engine which replaces angle-bracketed tokens like

--- a/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
@@ -13,6 +13,14 @@
  */
 package org.jdbi.v3.core.statement;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.antlr.runtime.ANTLRStringStream;
+import org.antlr.runtime.Token;
+import org.jdbi.v3.core.internal.lexer.HashStatementLexer;
+
 import static org.jdbi.v3.core.internal.lexer.HashStatementLexer.COMMENT;
 import static org.jdbi.v3.core.internal.lexer.HashStatementLexer.DOUBLE_QUOTED_TEXT;
 import static org.jdbi.v3.core.internal.lexer.HashStatementLexer.EOF;
@@ -21,14 +29,6 @@ import static org.jdbi.v3.core.internal.lexer.HashStatementLexer.LITERAL;
 import static org.jdbi.v3.core.internal.lexer.HashStatementLexer.NAMED_PARAM;
 import static org.jdbi.v3.core.internal.lexer.HashStatementLexer.POSITIONAL_PARAM;
 import static org.jdbi.v3.core.internal.lexer.HashStatementLexer.QUOTED_TEXT;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
-
-import org.antlr.runtime.ANTLRStringStream;
-import org.antlr.runtime.Token;
-import org.jdbi.v3.core.internal.lexer.HashStatementLexer;
 
 /**
  * SQL parser which recognizes named parameter tokens of the form

--- a/core/src/main/java/org/jdbi/v3/core/statement/ParsedParameters.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ParsedParameters.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.core.statement;
 
-import static java.util.Collections.unmodifiableList;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+
+import static java.util.Collections.unmodifiableList;
 
 /**
  * The parsed parameters from an SQL statement.

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.result.ResultBearing;
 import org.jdbi.v3.core.result.ResultIterator;

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlLoggerUtil.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlLoggerUtil.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.statement;
 
 import java.sql.SQLException;
 import java.time.Instant;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 class SqlLoggerUtil {

--- a/core/src/main/java/org/jdbi/v3/core/statement/Update.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Update.java
@@ -13,16 +13,16 @@
  */
 package org.jdbi.v3.core.statement;
 
-import static org.jdbi.v3.core.result.ResultProducers.returningGeneratedKeys;
-import static org.jdbi.v3.core.result.ResultProducers.returningUpdateCount;
-
 import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.result.ResultProducer;
 import org.jdbi.v3.core.result.ResultBearing;
+import org.jdbi.v3.core.result.ResultProducer;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
+
+import static org.jdbi.v3.core.result.ResultProducers.returningGeneratedKeys;
+import static org.jdbi.v3.core.result.ResultProducers.returningUpdateCount;
 
 /**
  * Used for INSERT, UPDATE, and DELETE statements

--- a/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.function.Consumer;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleCallback;
 import org.jdbi.v3.core.config.JdbiConfig;

--- a/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/Reflection.java
+++ b/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/Reflection.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 import static org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.Preconditions.checkArgument;

--- a/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/TypeParameter.java
+++ b/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/TypeParameter.java
@@ -14,10 +14,12 @@
 
 package org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+
 import javax.annotation.Nullable;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.Preconditions.checkArgument;
 

--- a/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/TypeResolver.java
+++ b/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/TypeResolver.java
@@ -27,10 +27,12 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import javax.annotation.Nullable;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
+
 import static org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.Preconditions.checkArgument;
 import static org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.Preconditions.checkNotNull;
 import static org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.Preconditions.checkState;

--- a/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/TypeToken.java
+++ b/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/TypeToken.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static java.util.Collections.singletonMap;
+
 import static org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.Preconditions.checkNotNull;
 import static org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.Preconditions.checkState;
 

--- a/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/TypeVisitor.java
+++ b/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/TypeVisitor.java
@@ -14,7 +14,6 @@
 
 package org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -22,6 +21,8 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.annotation.concurrent.NotThreadSafe;
 
 @NotThreadSafe
 @SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")

--- a/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/Types.java
+++ b/core/src/main/java/org/jdbi/v3/lib/internal/com_google_guava/guava/v21_0/Types.java
@@ -14,7 +14,6 @@
 
 package org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Array;
@@ -40,11 +39,15 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
+
 import javax.annotation.Nullable;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+
 import static org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.Preconditions.checkArgument;
 import static org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.Preconditions.checkNotNull;
 

--- a/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
+++ b/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core;
 
 import java.sql.Connection;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.DefaultStatementBuilder;
 import org.jdbi.v3.core.transaction.LocalTransactionHandler;

--- a/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +24,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestClosingHandle {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/TestJsr310.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestJsr310.java
@@ -21,6 +21,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;

--- a/core/src/test/java/org/jdbi/v3/core/TestOnDemandMethodBehavior.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestOnDemandMethodBehavior.java
@@ -13,15 +13,6 @@
  */
 package org.jdbi.v3.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -34,6 +25,15 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestOnDemandMethodBehavior {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/TestOptional.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestOptional.java
@@ -13,7 +13,14 @@
  */
 package org.jdbi.v3.core;
 
+import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -23,13 +30,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import java.lang.reflect.Type;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/core/src/test/java/org/jdbi/v3/core/TestPlugins.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestPlugins.java
@@ -13,15 +13,15 @@
  */
 package org.jdbi.v3.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
 import java.sql.Connection;
 
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class TestPlugins {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/TestUri.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestUri.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.net.URI;
 
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUri {
     private static final URI TEST_URI = URI.create("http://example.invalid/wat.jpg");

--- a/core/src/test/java/org/jdbi/v3/core/TestUuid.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestUuid.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.UUID;
 
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -22,6 +20,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUuid {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/argument/LikeClauseTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/LikeClauseTest.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.argument;
 
 import java.util.List;
+
 import org.jdbi.v3.core.rule.SqliteDatabaseRule;
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.core.statement.SqlStatements;

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestAbstractArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestAbstractArgumentFactory.java
@@ -13,6 +13,11 @@
  */
 package org.jdbi.v3.core.argument;
 
+import java.lang.reflect.Type;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -21,11 +26,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.lang.reflect.Type;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentFactory.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.argument;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Optional;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentsRegistry.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentsRegistry.java
@@ -13,17 +13,13 @@
  */
 package org.jdbi.v3.core.argument;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
-import static org.mockito.Mockito.verify;
-
 import java.lang.reflect.Type;
 import java.sql.PreparedStatement;
 import java.util.Optional;
 
-import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleAccess;
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.StatementContextAccess;
 import org.junit.Rule;
@@ -31,6 +27,10 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
+import static org.mockito.Mockito.verify;
 
 public class TestArgumentsRegistry {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestBeanArguments.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestBeanArguments.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.core.argument;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
-
 import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.Types;
@@ -28,6 +25,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 
 public class TestBeanArguments {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestCollectionArguments.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestCollectionArguments.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.argument;
 
 import java.util.Collections;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.junit.Rule;

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestInetAddressH2.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestInetAddressH2.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.core.argument;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.net.InetAddress;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,6 +21,8 @@ import org.jdbi.v3.core.rule.DatabaseRule;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInetAddressH2 {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestMapArguments.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestMapArguments.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.core.argument;
 
-import static org.mockito.Mockito.verify;
-
 import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.Types;
@@ -28,6 +26,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import static org.mockito.Mockito.verify;
 
 public class TestMapArguments {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestNamedParams.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestNamedParams.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.argument;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestOptionalArgumentH2.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestOptionalArgumentH2.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.core.argument;
 
+import java.util.Optional;
+
 import org.jdbi.v3.core.rule.DatabaseRule;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/core/src/test/java/org/jdbi/v3/core/array/ByteArrayTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/array/ByteArrayTest.java
@@ -17,6 +17,7 @@ import java.sql.Array;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
+
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.rule.DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/array/TestCustomArrayType.java
+++ b/core/src/test/java/org/jdbi/v3/core/array/TestCustomArrayType.java
@@ -13,17 +13,17 @@
  */
 package org.jdbi.v3.core.array;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.junit.Test;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/core/src/test/java/org/jdbi/v3/core/array/TestVendorArrays.java
+++ b/core/src/test/java/org/jdbi/v3/core/array/TestVendorArrays.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.array;
 
 import java.util.UUID;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.Test;

--- a/core/src/test/java/org/jdbi/v3/core/collector/EnumSetCollectorFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/collector/EnumSetCollectorFactoryTest.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.core.collector;
 
-import org.jdbi.v3.core.generic.GenericType;
-import org.junit.Test;
-
 import java.lang.reflect.Type;
 import java.util.EnumSet;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+
+import org.jdbi.v3.core.generic.GenericType;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/core/src/test/java/org/jdbi/v3/core/collector/ListCollectorFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/collector/ListCollectorFactoryTest.java
@@ -20,6 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.generic.GenericType;
 import org.junit.Test;
 

--- a/core/src/test/java/org/jdbi/v3/core/collector/MapCollectorFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/collector/MapCollectorFactoryTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.generic.GenericType;
 import org.junit.Test;
 

--- a/core/src/test/java/org/jdbi/v3/core/collector/OptionalCollectorFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/collector/OptionalCollectorFactoryTest.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.generic.GenericType;
 import org.junit.Test;
 

--- a/core/src/test/java/org/jdbi/v3/core/collector/OptionalCollectorsTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/collector/OptionalCollectorsTest.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.core.collector;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -24,6 +21,9 @@ import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class OptionalCollectorsTest {
   @Test

--- a/core/src/test/java/org/jdbi/v3/core/collector/SetCollectorFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/collector/SetCollectorFactoryTest.java
@@ -21,6 +21,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.generic.GenericType;
 import org.junit.Test;
 

--- a/core/src/test/java/org/jdbi/v3/core/generic/GenericTypesTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/generic/GenericTypesTest.java
@@ -15,9 +15,11 @@ package org.jdbi.v3.core.generic;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.junit.Test;
 
 import static java.util.Optional.empty;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GenericTypesTest {

--- a/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
+++ b/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/internal/AnnotationFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/AnnotationFactoryTest.java
@@ -13,13 +13,14 @@
  */
 package org.jdbi.v3.core.internal;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+
 import org.jdbi.v3.core.qualifier.Qualifier;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AnnotationFactoryTest {
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/org/jdbi/v3/core/internal/exceptions/SneakyTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/exceptions/SneakyTest.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.internal.exceptions;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
+
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/core/src/test/java/org/jdbi/v3/core/internal/exceptions/UncheckedTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/exceptions/UncheckedTest.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.internal.exceptions;
 
 import java.sql.SQLException;
 import java.util.function.Supplier;
+
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/org/jdbi/v3/core/internal/lexer/GrammarTestCase.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/lexer/GrammarTestCase.java
@@ -13,10 +13,10 @@
  */
 package org.jdbi.v3.core.internal.lexer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.antlr.runtime.Lexer;
 import org.antlr.runtime.Token;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class GrammarTestCase {
     public void expect(String s, int... tokens) {

--- a/core/src/test/java/org/jdbi/v3/core/internal/lexer/TestDefineIdentifierPrefix.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/lexer/TestDefineIdentifierPrefix.java
@@ -13,11 +13,11 @@
  */
 package org.jdbi.v3.core.internal.lexer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDefineIdentifierPrefix {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.locator;
 
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.statement.StatementException;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/JoinRowMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/JoinRowMapperTest.java
@@ -13,10 +13,11 @@
  */
 package org.jdbi.v3.core.mapper;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 import java.util.Objects;
 import java.util.stream.IntStream;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/MapEntryMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/MapEntryMapperTest.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper;
 
 import java.util.Map;
 import java.util.Objects;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/MapOptionalTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/MapOptionalTest.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.mapper;
 
 import java.util.Optional;
 import java.util.OptionalInt;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.mapper;
 
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Rule;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestMapMapper.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestMapMapper.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.mapper;
 
 import java.util.Map;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.SqliteDatabaseRule;
 import org.junit.Before;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestRegisteredMappers.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestRegisteredMappers.java
@@ -13,17 +13,18 @@
  */
 package org.jdbi.v3.core.mapper;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
 import java.util.Calendar;
-import org.jdbi.v3.core.generic.GenericType;
-import org.jdbi.v3.core.rule.H2DatabaseRule;
+
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class TestRegisteredMappers {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/mapper/ValueTypeMapper.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/ValueTypeMapper.java
@@ -14,8 +14,6 @@
 
 package org.jdbi.v3.core.mapper;
 
-import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
-
 import java.lang.reflect.Type;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -24,6 +22,8 @@ import java.util.Optional;
 import org.jdbi.v3.core.ValueType;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
+
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 
 public class ValueTypeMapper implements ColumnMapper<ValueType> {
     public ValueTypeMapper() {}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleAccess;
 import org.jdbi.v3.core.SampleBean;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
@@ -15,6 +15,8 @@ package org.jdbi.v3.core.mapper.reflect;
 
 import java.beans.ConstructorProperties;
 
+import javax.annotation.Nullable;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -24,8 +26,6 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import javax.annotation.Nullable;
 
 public class ConstructorMapperTest {
 

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
@@ -17,6 +17,9 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+
+import javax.annotation.Nullable;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleAccess;
 import org.jdbi.v3.core.SampleBean;
@@ -37,8 +40,6 @@ import org.mockito.junit.MockitoRule;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
-
-import javax.annotation.Nullable;
 
 public class FieldMapperTest {
 

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringArgumentFactory.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.qualifier;
 
 import java.sql.Types;
+
 import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.config.ConfigRegistry;

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringMapper.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.qualifier;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringMapperFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringMapperFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.qualifier;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestCustomQualifier.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestCustomQualifier.java
@@ -13,14 +13,12 @@
  */
 package org.jdbi.v3.core.qualifier;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.jdbi.v3.core.qualifier.Reverser.reverse;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+
 import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.Arguments;
@@ -35,6 +33,9 @@ import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.qualifier.Reverser.reverse;
 
 public class TestCustomQualifier {
 

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestNVarchar.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestNVarchar.java
@@ -13,15 +13,10 @@
  */
 package org.jdbi.v3.core.qualifier;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.List;
+
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.ColumnMappers;
@@ -32,6 +27,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestNVarchar {
     private static final QualifiedType<String> NVARCHAR_STRING = QualifiedType.of(String.class).with(NVarchar.class);

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
@@ -13,14 +13,14 @@
  */
 package org.jdbi.v3.core.qualifier;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.jdbi.v3.core.qualifier.SampleQualifiers.bar;
-import static org.jdbi.v3.core.qualifier.SampleQualifiers.foo;
-
 import java.util.List;
 
 import org.jdbi.v3.core.generic.GenericType;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.qualifier.SampleQualifiers.bar;
+import static org.jdbi.v3.core.qualifier.SampleQualifiers.foo;
 
 public class TestQualifiedType {
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiers.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiers.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.core.qualifier;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.jdbi.v3.core.qualifier.SampleQualifiers.bar;
-import static org.jdbi.v3.core.qualifier.SampleQualifiers.foo;
-
 import org.jdbi.v3.core.qualifier.SampleQualifiers.Bar;
 import org.jdbi.v3.core.qualifier.SampleQualifiers.Foo;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.qualifier.SampleQualifiers.bar;
+import static org.jdbi.v3.core.qualifier.SampleQualifiers.foo;
 
 public class TestQualifiers {
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/result/TestIterator.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestIterator.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.result;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.After;

--- a/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collector;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
@@ -28,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static java.util.stream.Collectors.toList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestReducing {

--- a/core/src/test/java/org/jdbi/v3/core/result/TestResultBearing.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestResultBearing.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.core.result;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestResultBearing {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/rule/PgDatabaseRule.java
+++ b/core/src/test/java/org/jdbi/v3/core/rule/PgDatabaseRule.java
@@ -15,6 +15,9 @@ package org.jdbi.v3.core.rule;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.opentable.db.postgres.junit.EmbeddedPostgresRules;
+import com.opentable.db.postgres.junit.PreparedDbRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.JdbiPreparer;
@@ -22,9 +25,6 @@ import org.jdbi.v3.core.spi.JdbiPlugin;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-
-import com.opentable.db.postgres.junit.EmbeddedPostgresRules;
-import com.opentable.db.postgres.junit.PreparedDbRule;
 
 public class PgDatabaseRule extends ExternalResource implements DatabaseRule<PgDatabaseRule> {
     private Jdbi db;

--- a/core/src/test/java/org/jdbi/v3/core/rule/SqliteDatabaseRule.java
+++ b/core/src/test/java/org/jdbi/v3/core/rule/SqliteDatabaseRule.java
@@ -18,6 +18,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.jdbi.v3.core.ConnectionFactory;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;

--- a/core/src/test/java/org/jdbi/v3/core/statement/ArgumentBinderTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/ArgumentBinderTest.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.statement;
 
 import java.sql.PreparedStatement;
 import java.util.Arrays;
+
 import org.jdbi.v3.core.argument.Argument;
 import org.junit.Before;
 import org.junit.Rule;

--- a/core/src/test/java/org/jdbi/v3/core/statement/StatementContextTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/StatementContextTest.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.statement;
 
 import java.sql.ResultSet;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMappers;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBatch.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.statement;
 
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBatchExceptionRewrite.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBatchExceptionRewrite.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.statement;
 
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBindBeanList.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBindBeanList.java
@@ -13,16 +13,16 @@
  */
 package org.jdbi.v3.core.statement;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.reflect.FieldMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.core.statement;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-
 import java.util.List;
 
 import org.jdbi.v3.core.Handle;
@@ -25,6 +22,9 @@ import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 public class TestBindList {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestCallable.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestCallable.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.statement;
 
 import java.sql.Types;
+
 import org.assertj.core.data.Offset;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestDefineList.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestDefineList.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.core.statement;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -25,6 +22,9 @@ import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 public class TestDefineList {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestDefineNamedBindings.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestDefineNamedBindings.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.core.statement;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Arrays;
 
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDefineNamedBindings {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestDefinedAttributeTemplateEngine.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestDefinedAttributeTemplateEngine.java
@@ -13,9 +13,10 @@
  */
 package org.jdbi.v3.core.statement;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestMessageFormatTemplateEngine.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestMessageFormatTemplateEngine.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.statement;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestParsedParameters.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestParsedParameters.java
@@ -13,12 +13,13 @@
  */
 package org.jdbi.v3.core.statement;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestParsedParameters {
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestParsedSql.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestParsedSql.java
@@ -13,11 +13,12 @@
  */
 package org.jdbi.v3.core.statement;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestParsedSql {
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
@@ -13,10 +13,11 @@
  */
 package org.jdbi.v3.core.statement;
 
-import com.google.common.collect.ImmutableMap;
 import java.beans.ConstructorProperties;
 import java.util.List;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatchGenerateKeysPostgres.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatchGenerateKeysPostgres.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.statement;
 
 import java.util.Date;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.JdbiPreparer;
 import org.jdbi.v3.core.Something;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
@@ -13,12 +13,13 @@
  */
 package org.jdbi.v3.core.statement;
 
-import com.google.common.collect.Maps;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+
+import com.google.common.collect.Maps;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.result.NoResultsException;
@@ -33,6 +34,7 @@ import org.junit.rules.ExpectedException;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestScript.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestScript.java
@@ -13,21 +13,20 @@
  */
 package org.jdbi.v3.core.statement;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.jdbi.v3.core.locator.ClasspathSqlLocator.getResourceOnClasspath;
-
 import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath;
+import static org.jdbi.v3.core.locator.ClasspathSqlLocator.getResourceOnClasspath;
 
 public class TestScript {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestSqlLoggerAttributesAndBinding.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestSqlLoggerAttributesAndBinding.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestSqlLoggerCallPoints.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestSqlLoggerCallPoints.java
@@ -18,6 +18,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.After;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestSqlLoggerToString.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestSqlLoggerToString.java
@@ -18,6 +18,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Objects;
 import java.util.Optional;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ArgumentFactory;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatementContext.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatementContext.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.core.statement;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStatementContext {
     @Rule

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.statement;
 
 import java.sql.Types;
 import java.util.stream.Collectors;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.result.NoResultsException;

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestTimingCollector.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestTimingCollector.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.statement;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.transaction;
 
 import java.sql.Connection;
+
 import org.jdbi.v3.core.Handle;
 import org.junit.Rule;
 import org.junit.Test;

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestSerializableTransactionRunner.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestSerializableTransactionRunner.java
@@ -18,6 +18,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactions.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactions.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.transaction;
 
 import java.io.IOException;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactionsAutoCommit.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactionsAutoCommit.java
@@ -17,6 +17,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.Test;

--- a/docs/src/test/java/jdbi/doc/ArgumentsTest.java
+++ b/docs/src/test/java/jdbi/doc/ArgumentsTest.java
@@ -17,6 +17,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.UUID;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;

--- a/docs/src/test/java/jdbi/doc/BatchTest.java
+++ b/docs/src/test/java/jdbi/doc/BatchTest.java
@@ -2,6 +2,7 @@ package jdbi.doc;
 
 import java.util.Arrays;
 import java.util.Collection;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.statement.Batch;

--- a/docs/src/test/java/jdbi/doc/CallTest.java
+++ b/docs/src/test/java/jdbi/doc/CallTest.java
@@ -1,8 +1,5 @@
 package jdbi.doc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath;
-
 import java.sql.Types;
 
 import org.jdbi.v3.core.Handle;
@@ -11,6 +8,9 @@ import org.jdbi.v3.postgres.PostgresDbRule;
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath;
 
 public class CallTest {
     @Rule

--- a/docs/src/test/java/jdbi/doc/FiveMinuteTourTest.java
+++ b/docs/src/test/java/jdbi/doc/FiveMinuteTourTest.java
@@ -13,9 +13,6 @@
  */
 package jdbi.doc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
@@ -27,6 +24,9 @@ import org.jdbi.v3.core.statement.StatementContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 public class FiveMinuteTourTest {
     private Jdbi jdbi;

--- a/docs/src/test/java/jdbi/doc/GeneratedKeysTest.java
+++ b/docs/src/test/java/jdbi/doc/GeneratedKeysTest.java
@@ -13,20 +13,20 @@
  */
 package jdbi.doc;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.List;
 
 import org.jdbi.v3.core.Jdbi;
-import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
+import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.postgres.PostgresPlugin;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
-import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class GeneratedKeysTest {
     @Rule

--- a/docs/src/test/java/jdbi/doc/IntroductionTest.java
+++ b/docs/src/test/java/jdbi/doc/IntroductionTest.java
@@ -13,8 +13,6 @@
  */
 package jdbi.doc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
 import java.util.Objects;
 
@@ -26,6 +24,8 @@ import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class IntroductionTest {
 

--- a/docs/src/test/java/jdbi/doc/ResultsTest.java
+++ b/docs/src/test/java/jdbi/doc/ResultsTest.java
@@ -13,9 +13,6 @@
  */
 package jdbi.doc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -36,6 +33,9 @@ import org.jdbi.v3.core.statement.StatementContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 public class ResultsTest {
     @Rule

--- a/docs/src/test/java/jdbi/doc/SqlObjectTest.java
+++ b/docs/src/test/java/jdbi/doc/SqlObjectTest.java
@@ -1,21 +1,21 @@
 package jdbi.doc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Optional;
 
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
-import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
-import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SqlObjectTest {
     @Rule

--- a/docs/src/test/java/jdbi/doc/StatementsTest.java
+++ b/docs/src/test/java/jdbi/doc/StatementsTest.java
@@ -1,7 +1,5 @@
 package jdbi.doc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -13,6 +11,8 @@ import org.jdbi.v3.core.statement.PreparedBatch;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StatementsTest {
     @Rule

--- a/docs/src/test/java/jdbi/doc/TransactionTest.java
+++ b/docs/src/test/java/jdbi/doc/TransactionTest.java
@@ -13,8 +13,6 @@
  */
 package jdbi.doc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -24,6 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
 
+import jdbi.doc.ResultsTest.User;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
@@ -42,7 +41,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import jdbi.doc.ResultsTest.User;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TransactionTest {
 

--- a/freemarker/src/main/java/org/jdbi/v3/freemarker/FreemarkerEngine.java
+++ b/freemarker/src/main/java/org/jdbi/v3/freemarker/FreemarkerEngine.java
@@ -13,15 +13,13 @@
  */
 package org.jdbi.v3.freemarker;
 
-import org.jdbi.v3.core.statement.TemplateEngine;
-
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
-
 import java.io.IOException;
 import java.io.StringWriter;
 
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.TemplateEngine;
 
 /**
  * Rewrites a Freemarker template, using the attributes on the {@link StatementContext} as template parameters.

--- a/freemarker/src/main/java/org/jdbi/v3/freemarker/internal/UseFreemarkerEngineImpl.java
+++ b/freemarker/src/main/java/org/jdbi/v3/freemarker/internal/UseFreemarkerEngineImpl.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.freemarker.internal;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.freemarker.FreemarkerEngine;

--- a/freemarker/src/main/java/org/jdbi/v3/freemarker/internal/UseFreemarkerSqlLocatorImpl.java
+++ b/freemarker/src/main/java/org/jdbi/v3/freemarker/internal/UseFreemarkerSqlLocatorImpl.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.freemarker.internal;
 
-import static org.jdbi.v3.freemarker.FreemarkerSqlLocator.findTemplate;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.core.statement.TemplateEngine;
@@ -28,8 +28,7 @@ import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
 import org.jdbi.v3.sqlobject.locator.SqlLocator;
 
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
+import static org.jdbi.v3.freemarker.FreemarkerSqlLocator.findTemplate;
 
 public class UseFreemarkerSqlLocatorImpl implements Configurer {
     @Override

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/BindBeanListTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/BindBeanListTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListNullPostgresTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListNullPostgresTest.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.freemarker;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.rule.PgDatabaseRule;

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerEngineTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerEngineTest.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.freemarker;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerSqlLocatorTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerSqlLocatorTest.java
@@ -17,6 +17,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.RowMapper;

--- a/gson2/src/main/java/org/jdbi/v3/gson2/GsonJsonMapper.java
+++ b/gson2/src/main/java/org/jdbi/v3/gson2/GsonJsonMapper.java
@@ -13,8 +13,9 @@
  */
 package org.jdbi.v3.gson2;
 
-import com.google.gson.JsonParseException;
 import java.lang.reflect.Type;
+
+import com.google.gson.JsonParseException;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.json.JsonMapper;

--- a/guava/src/main/java/org/jdbi/v3/guava/GuavaArguments.java
+++ b/guava/src/main/java/org/jdbi/v3/guava/GuavaArguments.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.guava;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.Arguments;

--- a/guava/src/main/java/org/jdbi/v3/guava/GuavaCollectors.java
+++ b/guava/src/main/java/org/jdbi/v3/guava/GuavaCollectors.java
@@ -13,6 +13,14 @@
  */
 package org.jdbi.v3.guava;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
 import com.google.common.base.Optional;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;
@@ -32,14 +40,6 @@ import com.google.common.collect.SetMultimap;
 import com.google.common.collect.TreeMultimap;
 import org.jdbi.v3.core.collector.CollectorFactory;
 import org.jdbi.v3.core.collector.OptionalCollectors;
-
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.util.Comparator;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collector;
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 import static org.jdbi.v3.core.collector.MapCollectors.toMap;

--- a/guava/src/test/java/org/jdbi/v3/guava/MultimapEntryMapperTest.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/MultimapEntryMapperTest.java
@@ -13,9 +13,10 @@
  */
 package org.jdbi.v3.guava;
 
+import java.util.Objects;
+
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
-import java.util.Objects;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
@@ -13,6 +13,13 @@
  */
 package org.jdbi.v3.guava;
 
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import com.google.common.base.Optional;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;
@@ -29,12 +36,6 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.TreeMultimap;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Map;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaMappers.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaMappers.java
@@ -13,18 +13,17 @@
  */
 package org.jdbi.v3.guava;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.UUID;
 
+import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestGuavaMappers {
     @Rule

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaOptional.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaOptional.java
@@ -13,10 +13,11 @@
  */
 package org.jdbi.v3.guava;
 
-import com.google.common.base.Optional;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Objects;
+
+import com.google.common.base.Optional;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.argument.Argument;

--- a/jackson2/src/main/java/org/jdbi/v3/jackson2/Jackson2Config.java
+++ b/jackson2/src/main/java/org/jdbi/v3/jackson2/Jackson2Config.java
@@ -14,7 +14,6 @@
 package org.jdbi.v3.jackson2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.meta.Beta;
 

--- a/jackson2/src/main/java/org/jdbi/v3/jackson2/JacksonJsonMapper.java
+++ b/jackson2/src/main/java/org/jdbi/v3/jackson2/JacksonJsonMapper.java
@@ -16,14 +16,13 @@ package org.jdbi.v3.jackson2;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.json.JsonMapper;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 class JacksonJsonMapper implements JsonMapper {
     @Override

--- a/jackson2/src/test/java/org/jdbi/v3/jackson2/TestJackson2Plugin.java
+++ b/jackson2/src/test/java/org/jdbi/v3/jackson2/TestJackson2Plugin.java
@@ -13,14 +13,13 @@
  */
 package org.jdbi.v3.jackson2;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.jdbi.v3.json.AbstractJsonMapperTest;
 import org.jdbi.v3.postgres.PostgresDbRule;
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.Rule;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 public class TestJackson2Plugin extends AbstractJsonMapperTest {
     @Rule

--- a/jodatime2/src/test/java/org/jdbi/v3/jodatime2/DateTimeTest.java
+++ b/jodatime2/src/test/java/org/jdbi/v3/jodatime2/DateTimeTest.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.jodatime2;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DateTimeTest {
     @Rule

--- a/jpa/src/main/java/org/jdbi/v3/jpa/JpaMapperFactory.java
+++ b/jpa/src/main/java/org/jdbi/v3/jpa/JpaMapperFactory.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.jpa;
 
-import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
-
 import java.lang.reflect.Type;
 import java.util.Optional;
 
@@ -23,6 +21,8 @@ import javax.persistence.Entity;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
+
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 
 /**
  * Create {@link JpaMapper}s for {@link Entity} annotated classes.

--- a/jpa/src/main/java/org/jdbi/v3/jpa/internal/BindJpaFactory.java
+++ b/jpa/src/main/java/org/jdbi/v3/jpa/internal/BindJpaFactory.java
@@ -18,6 +18,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
+
 import org.jdbi.v3.jpa.BindJpa;
 import org.jdbi.v3.jpa.EntityMemberAccessException;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;

--- a/jpa/src/main/java/org/jdbi/v3/jpa/internal/JpaClass.java
+++ b/jpa/src/main/java/org/jdbi/v3/jpa/internal/JpaClass.java
@@ -27,8 +27,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.stream.Stream;
+
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jpa/src/main/java/org/jdbi/v3/jpa/internal/JpaMember.java
+++ b/jpa/src/main/java/org/jdbi/v3/jpa/internal/JpaMember.java
@@ -20,13 +20,16 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import javax.persistence.Column;
+
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.jpa.EntityMemberAccessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Objects.requireNonNull;
+
 import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
 
 public class JpaMember {

--- a/jpa/src/test/java/org/jdbi/v3/jpa/JpaTest.java
+++ b/jpa/src/test/java/org/jdbi/v3/jpa/JpaTest.java
@@ -13,14 +13,14 @@
  */
 package org.jdbi.v3.jpa;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.MappedSuperclass;
+
 import org.assertj.core.api.AbstractListAssert;
 import org.jdbi.v3.core.qualifier.Reversed;
 import org.jdbi.v3.core.qualifier.ReversedStringArgumentFactory;
@@ -34,6 +34,8 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JpaTest {
     private static final String INSERT_BY_PROPERTY_NAME = "insert into something(id, name) values (:id, :name)";

--- a/jpa/src/test/java/org/jdbi/v3/jpa/PluginTest.java
+++ b/jpa/src/test/java/org/jdbi/v3/jpa/PluginTest.java
@@ -13,15 +13,16 @@
  */
 package org.jdbi.v3.jpa;
 
+import java.util.List;
+import java.util.Objects;
+
+import javax.persistence.Entity;
+
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Rule;
 import org.junit.Test;
-
-import javax.persistence.Entity;
-import java.util.List;
-import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/json/src/main/java/org/jdbi/v3/json/internal/JsonArgumentFactory.java
+++ b/json/src/main/java/org/jdbi/v3/json/internal/JsonArgumentFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.json.internal;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.config.ConfigRegistry;

--- a/json/src/main/java/org/jdbi/v3/json/internal/JsonColumnMapperFactory.java
+++ b/json/src/main/java/org/jdbi/v3/json/internal/JsonColumnMapperFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.json.internal;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.internal.JdbiOptionals;
 import org.jdbi.v3.core.mapper.ColumnMapper;

--- a/json/src/main/java/org/jdbi/v3/json/internal/StubJsonMapper.java
+++ b/json/src/main/java/org/jdbi/v3/json/internal/StubJsonMapper.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.json.internal;
 
 import java.lang.reflect.Type;
+
 import org.jdbi.v3.core.result.UnableToProduceResultException;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;

--- a/json/src/test/java/org/jdbi/v3/json/AbstractJsonMapperTest.java
+++ b/json/src/test/java/org/jdbi/v3/json/AbstractJsonMapperTest.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.json;
 
 import java.util.List;
 import java.util.Objects;
+
 import org.assertj.core.groups.Tuple;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.qualifier.QualifiedType;

--- a/noparameters/src/test/java/org/jdbi/v3/noparameters/TestSqlObjectNoParameterNames.java
+++ b/noparameters/src/test/java/org/jdbi/v3/noparameters/TestSqlObjectNoParameterNames.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.noparameters;
 
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.reflect.BeanMapper;

--- a/policy/src/main/resources/policy/checkstyle.xml
+++ b/policy/src/main/resources/policy/checkstyle.xml
@@ -52,6 +52,15 @@
         <module name="HideUtilityClassConstructor"/>
         <module name="IllegalImport"/>
         <module name="IllegalInstantiation"/>
+        <module name="ImportOrder">
+            <property name="groups" value="java,javax"/>
+            <property name="ordered" value="true"/>
+            <property name="option" value="bottom"/>
+            <property name="separated" value="true"/>
+            <property name="separatedStaticGroups" value="true"/>
+            <property name="staticGroups" value="java,javax"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
+        </module>
         <!--<module name="InnerAssignment"/>-->
         <module name="InnerTypeLast"/>
         <module name="InterfaceIsType"/>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <basepom.test.timeout>240</basepom.test.timeout>
 
         <dep.antlr.version>3.4</dep.antlr.version>
-        <dep.checkstyle.version>8.10</dep.checkstyle.version>
+        <dep.checkstyle.version>8.16</dep.checkstyle.version>
         <dep.dokka.version>0.9.17</dep.dokka.version>
         <dep.immutables.version>2.7.1</dep.immutables.version>
         <dep.jackson2.version>2.9.8</dep.jackson2.version>

--- a/postgres/src/main/java/org/jdbi/v3/postgres/DurationColumnMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/DurationColumnMapperFactory.java
@@ -13,14 +13,14 @@
  */
 package org.jdbi.v3.postgres;
 
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.postgresql.util.PGInterval;
-
-import java.lang.reflect.Type;
-import java.time.Duration;
-import java.util.Optional;
 
 /**
  * A column mapper which maps Postgres's {@link PGInterval} type to Java's {@link Duration}.

--- a/postgres/src/main/java/org/jdbi/v3/postgres/HStoreColumnMapper.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/HStoreColumnMapper.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.postgres;
 
-import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.core.mapper.ColumnMapper;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
+
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
 
 /**
  * A column mapper which maps Postgres' hstore type to Java's {@link Map}.

--- a/postgres/src/main/java/org/jdbi/v3/postgres/InetArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/InetArgumentFactory.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.postgres;
 
+import java.net.InetAddress;
+import java.sql.Types;
+
 import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.internal.strategies.LoggableSetObjectArgument;
 import org.jdbi.v3.core.config.ConfigRegistry;
-
-import java.net.InetAddress;
-import java.sql.Types;
 
 /**
  * Postgres version of argument factory for {@code InetAddress}.

--- a/postgres/src/main/java/org/jdbi/v3/postgres/JsonArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/JsonArgumentFactory.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.postgres;
 
 import java.sql.Types;
+
 import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.config.ConfigRegistry;

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PeriodArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PeriodArgumentFactory.java
@@ -13,14 +13,14 @@
  */
 package org.jdbi.v3.postgres;
 
+import java.sql.Types;
+import java.time.Period;
+
 import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.internal.strategies.LoggableSetObjectArgument;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.postgresql.util.PGInterval;
-
-import java.sql.Types;
-import java.time.Period;
 
 /**
  * Postgres version of argument factory for {@link Period}.

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PeriodColumnMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PeriodColumnMapperFactory.java
@@ -13,14 +13,14 @@
  */
 package org.jdbi.v3.postgres;
 
+import java.lang.reflect.Type;
+import java.time.Period;
+import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.postgresql.util.PGInterval;
-
-import java.lang.reflect.Type;
-import java.time.Period;
-import java.util.Optional;
 
 /**
  * A column mapper which maps Postgres's {@link PGInterval} type to Java's {@link Period}.

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestDuration.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestDuration.java
@@ -13,9 +13,10 @@
  */
 package org.jdbi.v3.postgres;
 
-import com.google.common.collect.ImmutableList;
 import java.time.Duration;
 import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestHStore.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestHStore.java
@@ -13,14 +13,11 @@
  */
 package org.jdbi.v3.postgres;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;
@@ -36,6 +33,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHStore {
 

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestInetAddressPg.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestInetAddressPg.java
@@ -13,8 +13,8 @@
  */
 package org.jdbi.v3.postgres;
 
-import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.argument.TestInetAddressH2;
+import org.jdbi.v3.core.rule.PgDatabaseRule;
 
 public class TestInetAddressPg extends TestInetAddressH2 { { dbRule = new PgDatabaseRule().withPlugin(new PostgresPlugin()); }
 

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestJavaTime.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestJavaTime.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.postgres;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -28,6 +26,8 @@ import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJavaTime {
 

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestJsonOperator.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestJsonOperator.java
@@ -13,11 +13,11 @@
  */
 package org.jdbi.v3.postgres;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJsonOperator {
     @Rule

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestMacAddr.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestMacAddr.java
@@ -13,14 +13,14 @@
  */
 package org.jdbi.v3.postgres;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMacAddr {
     @Rule

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestPeriod.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestPeriod.java
@@ -13,9 +13,10 @@
  */
 package org.jdbi.v3.postgres;
 
-import com.google.common.collect.ImmutableList;
 import java.time.Period;
 import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestQualifiedHStore.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestQualifiedHStore.java
@@ -13,12 +13,11 @@
  */
 package org.jdbi.v3.postgres;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.List;
+import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.List;
-import java.util.Map;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;
@@ -35,6 +34,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestQualifiedHStore {
 

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.postgres;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -37,6 +35,8 @@ import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSqlArrays {
     private static final String U_SELECT = "SELECT u FROM uuids";

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestTypedEnum.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestTypedEnum.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.postgres;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTypedEnum {
     @ClassRule

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestUuid.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestUuid.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.postgres;
 
 import java.util.Set;
 import java.util.UUID;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.SingleValue;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;

--- a/postgres/src/test/java/org/jdbi/v3/sqlobject/TestBatchGeneratedKeys.java
+++ b/postgres/src/test/java/org/jdbi/v3/sqlobject/TestBatchGeneratedKeys.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject;
 
 import java.util.Arrays;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;

--- a/postgres/src/test/java/org/jdbi/v3/sqlobject/TestJsonOperator.java
+++ b/postgres/src/test/java/org/jdbi/v3/sqlobject/TestJsonOperator.java
@@ -13,6 +13,9 @@
  */
 package org.jdbi.v3.sqlobject;
 
+import java.util.Collections;
+import java.util.Set;
+
 import com.google.common.collect.ImmutableSet;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.PgDatabaseRule;
@@ -25,9 +28,6 @@ import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring4/src/main/java/org/jdbi/v3/spring4/JdbiUtil.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/JdbiUtil.java
@@ -16,8 +16,8 @@ package org.jdbi.v3.spring4;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.internal.UtilityClassException;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;

--- a/spring4/src/main/java/org/jdbi/v3/spring4/SpringConnectionFactory.java
+++ b/spring4/src/main/java/org/jdbi/v3/spring4/SpringConnectionFactory.java
@@ -13,12 +13,13 @@
  */
 package org.jdbi.v3.spring4;
 
-import org.jdbi.v3.core.ConnectionFactory;
-import org.springframework.jdbc.datasource.DataSourceUtils;
-
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.jdbi.v3.core.ConnectionFactory;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 
 public class SpringConnectionFactory implements ConnectionFactory {
 

--- a/spring4/src/test/java/org/jdbi/v3/spring4/TestJdbiFactoryBean.java
+++ b/spring4/src/test/java/org/jdbi/v3/spring4/TestJdbiFactoryBean.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.spring4;
 
 import javax.sql.DataSource;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.SqlStatements;

--- a/sqlite/src/main/java/org/jdbi/v3/sqlite3/URLArgumentFactory.java
+++ b/sqlite/src/main/java/org/jdbi/v3/sqlite3/URLArgumentFactory.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlite3;
 
 import java.net.URL;
 import java.sql.Types;
+
 import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ArgumentFactory;

--- a/sqlite/src/main/java/org/jdbi/v3/sqlite3/URLColumnMapper.java
+++ b/sqlite/src/main/java/org/jdbi/v3/sqlite3/URLColumnMapper.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.sqlite3;
 
-import org.jdbi.v3.core.mapper.ColumnMapper;
-import org.jdbi.v3.core.statement.StatementContext;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
 
 class URLColumnMapper implements ColumnMapper<URL> {
 

--- a/sqlite/src/test/java/org/jdbi/v3/sqlite3/TestUrls.java
+++ b/sqlite/src/test/java/org/jdbi/v3/sqlite3/TestUrls.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlite3;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+
 import org.assertj.core.api.Assertions;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BridgeMethodHandlerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/BridgeMethodHandlerFactory.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 
 class BridgeMethodHandlerFactory implements HandlerFactory {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/DefaultMethodHandler.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.WeakHashMap;
+
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotatedHandlerDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotatedHandlerDecorator.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static java.util.stream.Collectors.toList;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -22,6 +20,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Applies decorations to method handlers, according to any {@link SqlMethodDecoratingAnnotation decorating annotations}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodHandlerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodHandlerFactory.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.internal.exceptions.Sneaky;
 
 import static java.util.stream.Collectors.toList;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.ExtensionFactory;
 import org.jdbi.v3.core.extension.ExtensionMethod;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterArgumentFactories.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterArgumentFactories.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterArgumentFactoriesImpl;
 
 @ConfiguringAnnotation(RegisterArgumentFactoriesImpl.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterBeanMappers.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterBeanMappers.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterBeanMappersImpl;
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterColumnMapperFactories.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterColumnMapperFactories.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterColumnMapperFactoriesImpl;
 
 @ConfiguringAnnotation(RegisterColumnMapperFactoriesImpl.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterColumnMappers.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterColumnMappers.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterColumnMappersImpl;
 
 @ConfiguringAnnotation(RegisterColumnMappersImpl.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterConstructorMappers.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterConstructorMappers.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterConstructorMappersImpl;
 
 @ConfiguringAnnotation(RegisterConstructorMappersImpl.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterFieldMappers.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterFieldMappers.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterFieldMappersImpl;
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterObjectArgumentFactories.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterObjectArgumentFactories.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterObjectArgumentFactoriesImpl;
 
 @ConfiguringAnnotation(RegisterObjectArgumentFactoriesImpl.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterObjectArgumentFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterObjectArgumentFactory.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.sql.Types;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterObjectArgumentFactoryImpl;
 
 /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterRowMapperFactories.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterRowMapperFactories.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterRowMapperFactoriesImpl;
 
 @ConfiguringAnnotation(RegisterRowMapperFactoriesImpl.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterRowMappers.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterRowMappers.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.config.internal.RegisterRowMappersImpl;
 
 @ConfiguringAnnotation(RegisterRowMappersImpl.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterArgumentFactoriesImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterArgumentFactoriesImpl.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactories;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterBeanMappersImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterBeanMappersImpl.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMappers;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorFactoryImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorFactoryImpl.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+
 import org.jdbi.v3.core.collector.CollectorFactory;
 import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.config.ConfigRegistry;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMapperFactoriesImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMapperFactoriesImpl.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapperFactories;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMappersImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMappersImpl.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.RegisterColumnMappers;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterConstructorMappersImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterConstructorMappersImpl.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMappers;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterFieldMappersImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterFieldMappersImpl.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.RegisterFieldMappers;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterObjectArgumentFactoriesImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterObjectArgumentFactoriesImpl.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.RegisterObjectArgumentFactories;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMapperFactoriesImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMapperFactoriesImpl.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapperFactories;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMappersImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMappersImpl.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.config.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.RegisterRowMappers;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseSqlParserImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseSqlParserImpl.java
@@ -21,7 +21,9 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
 import javax.annotation.Nullable;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.internal.exceptions.Sneaky;
 import org.jdbi.v3.core.statement.SqlParser;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseTemplateEngineImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseTemplateEngineImpl.java
@@ -21,7 +21,9 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
 import javax.annotation.Nullable;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.internal.exceptions.Sneaky;
 import org.jdbi.v3.core.statement.SqlStatements;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -17,8 +17,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import java.util.function.BiConsumer;
+
 import org.jdbi.v3.core.statement.SqlStatement;
 import org.jdbi.v3.sqlobject.customizer.internal.BindListFactory;
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindMethodsList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindMethodsList.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.sqlobject.customizer;
 
-import org.jdbi.v3.sqlobject.customizer.internal.BindMethodsListFactory;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.jdbi.v3.sqlobject.customizer.internal.BindMethodsListFactory;
 
 /**
  * Binds each method for each value in the annotated {@link Iterable} or array/varargs argument,

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/OutParameterList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/OutParameterList.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.jdbi.v3.sqlobject.customizer.internal.OutParameterListFactory;
 
 @SqlStatementCustomizingAnnotation(OutParameterListFactory.class)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/TimestampedConfig.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/TimestampedConfig.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject.customizer;
 
 import java.time.ZoneId;
+
 import org.jdbi.v3.core.config.JdbiConfig;
 
 /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindFactory.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject.customizer.internal;
 
-import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -26,6 +24,8 @@ import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
 import org.jdbi.v3.sqlobject.internal.ParameterUtil;
+
+import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
 
 public class BindFactory implements SqlStatementCustomizerFactory {
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -17,6 +17,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
+
 import org.jdbi.v3.core.internal.IterableLike;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindMethodsFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindMethodsFactory.java
@@ -13,14 +13,14 @@
  */
 package org.jdbi.v3.sqlobject.customizer.internal;
 
-import org.jdbi.v3.sqlobject.customizer.BindMethods;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
+
+import org.jdbi.v3.sqlobject.customizer.BindMethods;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
 
 public class BindMethodsFactory implements SqlStatementCustomizerFactory {
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindMethodsListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindMethodsListFactory.java
@@ -13,17 +13,17 @@
  */
 package org.jdbi.v3.sqlobject.customizer.internal;
 
-import org.jdbi.v3.core.internal.IterableLike;
-import org.jdbi.v3.sqlobject.customizer.BindMethodsList;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
-import org.jdbi.v3.sqlobject.internal.ParameterUtil;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+
+import org.jdbi.v3.core.internal.IterableLike;
+import org.jdbi.v3.sqlobject.customizer.BindMethodsList;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
+import org.jdbi.v3.sqlobject.internal.ParameterUtil;
 
 public final class BindMethodsListFactory implements SqlStatementCustomizerFactory {
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/MaxRowsFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/MaxRowsFactory.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.text.MessageFormat;
+
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.sqlobject.customizer.MaxRows;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizer;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/OutParameterListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/OutParameterListFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.customizer.internal;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+
 import org.jdbi.v3.core.statement.Call;
 import org.jdbi.v3.sqlobject.customizer.OutParameter;
 import org.jdbi.v3.sqlobject.customizer.OutParameterList;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/TimestampedFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/TimestampedFactory.java
@@ -16,8 +16,8 @@ package org.jdbi.v3.sqlobject.customizer.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.time.OffsetDateTime;
-
 import java.time.ZoneId;
+
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
 import org.jdbi.v3.sqlobject.customizer.Timestamped;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/ParameterUtil.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/ParameterUtil.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.internal;
 
 import java.lang.reflect.Parameter;
 import java.util.Optional;
+
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 public class ParameterUtil {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/UseAnnotationSqlLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/UseAnnotationSqlLocator.java
@@ -13,15 +13,15 @@
  */
 package org.jdbi.v3.sqlobject.locator;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation;
 import org.jdbi.v3.sqlobject.locator.internal.UseAnnotationSqlLocatorImpl;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Configures SQL Object to use AnnotationSqlLocator (the default SqlLocator).

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/UseClasspathSqlLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/UseClasspathSqlLocator.java
@@ -13,16 +13,16 @@
  */
 package org.jdbi.v3.sqlobject.locator;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.jdbi.v3.core.locator.ClasspathSqlLocator;
 import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation;
 import org.jdbi.v3.sqlobject.locator.internal.UseClasspathSqlLocatorImpl;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Configures SQL Object to locate SQL using the {@link ClasspathSqlLocator#findSqlOnClasspath(Class, String)} method.

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/BindParameterCustomizerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/BindParameterCustomizerFactory.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.sqlobject.statement;
 
-import java.lang.reflect.Type;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
 import org.jdbi.v3.sqlobject.customizer.internal.BindFactory;
 
 /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ParameterCustomizerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ParameterCustomizerFactory.java
@@ -13,11 +13,11 @@
  */
 package org.jdbi.v3.sqlobject.statement;
 
-import java.lang.reflect.Type;
-import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+
+import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
 
 public interface ParameterCustomizerFactory {
     /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject.statement.internal;
 
-import static java.util.stream.Stream.concat;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -43,6 +41,8 @@ import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
 import org.jdbi.v3.sqlobject.statement.ParameterCustomizerFactory;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
+
+import static java.util.stream.Stream.concat;
 
 /**
  * Base handler for annotations' implementation classes.

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.sqlobject.statement.internal;
 
-import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
-import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Iterator;
@@ -23,12 +20,16 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.result.ResultIterator;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.sqlobject.SingleValue;
+
+import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
+import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
 
 /**
  * Helper class used by the {@link CustomizingStatementHandler}s to assemble

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlUpdateHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlUpdateHandler.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject.statement.internal;
 
-import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
-
 import java.lang.reflect.Method;
 import java.util.function.Function;
 
@@ -28,6 +26,8 @@ import org.jdbi.v3.sqlobject.UnableToCreateSqlObjectException;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
+
+import static org.jdbi.v3.core.qualifier.Qualifiers.getQualifiers;
 
 public class SqlUpdateHandler extends CustomizingStatementHandler<Update> {
     private final Function<Update, Object> returner;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/BindSomething.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/BindSomething.java
@@ -20,8 +20,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-
 import java.lang.reflect.Type;
+
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizingAnnotation;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/BindTime.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/BindTime.java
@@ -20,6 +20,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.time.Clock;
 import java.time.OffsetDateTime;
+
 import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/GenericMapMapperFactoryTest.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/GenericMapMapperFactoryTest.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.CaseStrategy;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
@@ -32,6 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static java.util.Collections.emptySet;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatchingSingleValue.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatchingSingleValue.java
@@ -13,23 +13,24 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static java.util.Arrays.stream;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.h2.H2DatabasePlugin;
-import org.jdbi.v3.sqlobject.statement.BatchChunkSize;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.statement.BatchChunkSize;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static java.util.Arrays.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBatchingSingleValue {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanBinder.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanBinder.java
@@ -13,12 +13,10 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -27,6 +25,8 @@ import org.jdbi.v3.sqlobject.subpackage.PrivateImplementationFactory;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBeanBinder {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanMapper.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.ValueType;
 import org.jdbi.v3.core.mapper.ValueTypeMapper;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindAutomaticNames.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindAutomaticNames.java
@@ -13,18 +13,18 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBindAutomaticNames {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindBean.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindBean.java
@@ -13,10 +13,8 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.sql.Types;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.ValueType;
@@ -33,6 +31,9 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestBindBean {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindExpression.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindExpression.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindFields.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindFields.java
@@ -14,8 +14,6 @@
 
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.customizer.BindFields;
@@ -24,6 +22,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBindFields {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindFunctions.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindFunctions.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
@@ -23,6 +21,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBindFunctions {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindListParameter.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindListParameter.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject;
 import java.util.List;
 import java.util.UUID;
 
+import com.google.common.collect.Lists;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
@@ -24,8 +25,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.collect.Lists;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMap.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMap.java
@@ -13,8 +13,9 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
@@ -32,6 +33,7 @@ import org.junit.rules.ExpectedException;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBindMap {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethods.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethods.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.lang.reflect.Method;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -38,6 +36,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBindMethods {
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethodsList.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethodsList.java
@@ -13,6 +13,11 @@
  */
 package org.jdbi.v3.sqlobject;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.reflect.FieldMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -24,11 +29,6 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
@@ -13,14 +13,10 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.guava.api.Assertions.assertThat;
-
 import java.util.SortedSet;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -32,6 +28,9 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.Assertions.assertThat;
 
 public class TestCollectorFactory {
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestColumnMappers.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestColumnMappers.java
@@ -17,6 +17,7 @@ package org.jdbi.v3.sqlobject;
 import java.net.URI;
 import java.util.Calendar;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.ValueType;
 import org.jdbi.v3.core.generic.GenericType;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConcurrentUpdatingQuery.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConcurrentUpdatingQuery.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestConcurrentUpdatingQuery {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConsumer.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConsumer.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -28,6 +26,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestConsumer {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCreateSqlObjectAnnotation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCreateSqlObjectAnnotation.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject;
 
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCustomBinder.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCustomBinder.java
@@ -13,17 +13,17 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCustomBinder {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefaultMethods.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefaultMethods.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.lang.reflect.Method;
 
 import org.jdbi.v3.core.Something;
@@ -27,6 +25,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDefaultMethods {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefineListParameter.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefineListParameter.java
@@ -14,24 +14,24 @@
 
 package org.jdbi.v3.sqlobject;
 
-import org.jdbi.v3.core.rule.H2DatabaseRule;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.customizer.DefineList;
-import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
-import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDocumentation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDocumentation.java
@@ -13,12 +13,13 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
@@ -37,6 +38,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestEnumMapping.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestEnumMapping.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -25,6 +23,8 @@ import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestEnumMapping {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestFieldMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestFieldMapper.java
@@ -15,6 +15,7 @@
 package org.jdbi.v3.sqlobject;
 
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.ValueType;
 import org.jdbi.v3.core.mapper.ValueTypeMapper;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestFoldToObjectGraph.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestFoldToObjectGraph.java
@@ -13,13 +13,14 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGetGeneratedKeysHsqlDb.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGetGeneratedKeysHsqlDb.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGetGeneratedKeysPostgres.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGetGeneratedKeysPostgres.java
@@ -19,6 +19,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
+
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.statement.StatementContext;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGuavaCollectors.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGuavaCollectors.java
@@ -13,8 +13,9 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import com.google.common.collect.ImmutableList;
 import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.guava.GuavaPlugin;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestInClauseExpansion.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestInClauseExpansion.java
@@ -13,20 +13,20 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
 
 import com.google.common.collect.ImmutableSet;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static java.util.Arrays.asList;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInClauseExpansion {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestInheritedAnnotations.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestInheritedAnnotations.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -29,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInheritedAnnotations {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMixinInterfaces.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMixinInterfaces.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject;
 
 import java.util.UUID;
+
 import org.h2.jdbcx.JdbcDataSource;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestModifiers.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestModifiers.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject;
 
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNewApiOnDbiAndHandle.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNewApiOnDbiAndHandle.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject;
 import java.sql.Connection;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.h2.jdbcx.JdbcDataSource;
 import org.jdbi.v3.core.ConnectionException;
 import org.jdbi.v3.core.Handle;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestObjectMethods.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestObjectMethods.java
@@ -13,17 +13,17 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestObjectMethods {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOnDemandSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOnDemandSqlObject.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+
 import org.h2.jdbcx.JdbcDataSource;
 import org.jdbi.v3.core.CloseException;
 import org.jdbi.v3.core.Handle;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOptional.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOptional.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject;
 
 import java.util.List;
 import java.util.Optional;
+
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOutParameterAnnotation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestOutParameterAnnotation.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject;
 
 import java.sql.Types;
+
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.statement.OutParameters;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPaging.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPaging.java
@@ -13,8 +13,9 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
@@ -29,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPaging {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPositionalBinder.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPositionalBinder.java
@@ -13,10 +13,11 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPostgresBugs.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPostgresBugs.java
@@ -13,23 +13,23 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 
-import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.transaction.Transaction;
-import org.jdbi.v3.sqlobject.transaction.Transactional;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.transaction.Transaction;
+import org.jdbi.v3.sqlobject.transaction.Transactional;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPostgresBugs {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestQualifiers.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestQualifiers.java
@@ -13,19 +13,15 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.qualifier.QualifiedConstructorParamThing;
@@ -60,6 +56,12 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import static java.util.stream.Collectors.toList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TestQualifiers {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReadOnly.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReadOnly.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject;
 
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.transaction.TransactionException;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReentrancy.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReentrancy.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject;
 
 import java.util.List;
 import java.util.UUID;
+
 import org.h2.jdbcx.JdbcDataSource;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterArgumentFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterArgumentFactory.java
@@ -13,16 +13,14 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ArgumentFactory;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -30,6 +28,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterArgumentFactory {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterConstructorMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterConstructorMapper.java
@@ -13,10 +13,8 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Something;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -24,6 +22,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterConstructorMapper {
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterJoinRowMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterJoinRowMapper.java
@@ -13,24 +13,23 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.stream.Stream;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.mapper.JoinRow;
 import org.jdbi.v3.core.mapper.JoinRowMapperTest;
 import org.jdbi.v3.core.mapper.JoinRowMapperTest.Article;
 import org.jdbi.v3.core.mapper.JoinRowMapperTest.User;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterJoinRowMapper;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterJoinRowMapper {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterRowMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterRowMapperFactory.java
@@ -18,6 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 import org.jdbi.v3.core.mapper.RowMapper;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredGenericReturnAndParam.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredGenericReturnAndParam.java
@@ -13,6 +13,10 @@
  */
 package org.jdbi.v3.sqlobject;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -22,10 +26,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredMappersWork.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredMappersWork.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningMap.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningMap.java
@@ -13,10 +13,11 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import java.util.Map;
 import java.util.Objects;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.KeyColumn;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQuery.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQuery.java
@@ -13,20 +13,20 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
-import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.UseRowMapper;
+import org.jdbi.v3.core.result.ResultIterable;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestReturningQuery {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQueryResults.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQueryResults.java
@@ -13,21 +13,21 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Iterator;
 import java.util.List;
 
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestReturningQueryResults {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlCall.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlCall.java
@@ -13,16 +13,14 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlCall;
@@ -31,6 +29,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSqlCall {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecorators.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecorators.java
@@ -18,6 +18,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -27,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static java.util.Arrays.asList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSqlMethodDecorators {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObject.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject;
 
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
@@ -37,6 +38,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import static java.util.Collections.emptyList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.READ_COMMITTED;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectFactory.java
@@ -13,11 +13,11 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestSqlObjectFactory {
     private SqlObjectFactory factory = new SqlObjectFactory();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectMethodBehavior.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectMethodBehavior.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject;
 
 import java.sql.Connection;
 import java.util.concurrent.Callable;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.ExtensionMethod;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestStream.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestStream.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject;
 
 import java.util.stream.Stream;
+
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTimestamped.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTimestamped.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.SqlLogger;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTimingCollector.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTimingCollector.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.extension.ExtensionMethod;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactionAnnotation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactionAnnotation.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactional.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactional.java
@@ -22,22 +22,21 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.common.collect.ImmutableSet;
 import org.h2.jdbcx.JdbcDataSource;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
-import org.jdbi.v3.core.transaction.TransactionException;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.transaction.TransactionException;
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.jdbi.v3.sqlobject.transaction.Transactional;
-import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableSet;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseClasspathSqlLocator.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseClasspathSqlLocator.java
@@ -13,12 +13,10 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.locator.UseClasspathSqlLocator;
@@ -26,6 +24,8 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUseClasspathSqlLocator {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestVariousOddities.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestVariousOddities.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/Article.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/Article.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
 public class Article {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/Comment.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/Comment.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject.config;
 
 import java.util.Objects;
+
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
 public class Comment {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/LongValueColumnMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/LongValueColumnMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/LongValueColumnMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/LongValueColumnMapperFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/LongValueRowMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/LongValueRowMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/LongValueRowMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/LongValueRowMapperFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/StringValueColumnMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/StringValueColumnMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/StringValueColumnMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/StringValueColumnMapperFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/StringValueRowMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/StringValueRowMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/StringValueRowMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/StringValueRowMapperFactory.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterBeanMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterBeanMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.util.List;
 import java.util.Optional;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.SqlObject;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterColumnMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterColumnMapper.java
@@ -13,9 +13,8 @@
  */
 package org.jdbi.v3.sqlobject.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
@@ -23,6 +22,8 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterColumnMapper {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterColumnMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterColumnMapperFactory.java
@@ -13,9 +13,8 @@
  */
 package org.jdbi.v3.sqlobject.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
@@ -23,6 +22,8 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterColumnMapperFactory {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterConstructorMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterConstructorMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.util.List;
 import java.util.Optional;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.SqlObject;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterFieldMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterFieldMapper.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.config;
 
 import java.util.List;
 import java.util.Optional;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.SqlObject;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterObjectArgumentFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterObjectArgumentFactory.java
@@ -13,9 +13,8 @@
  */
 package org.jdbi.v3.sqlobject.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
@@ -23,6 +22,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterObjectArgumentFactory {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterRowMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterRowMapper.java
@@ -13,9 +13,8 @@
  */
 package org.jdbi.v3.sqlobject.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.JoinRow;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -24,6 +23,8 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterRowMapper {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterRowMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestRegisterRowMapperFactory.java
@@ -13,9 +13,8 @@
  */
 package org.jdbi.v3.sqlobject.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.JoinRow;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -24,6 +23,8 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterRowMapperFactory {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseConfiguredDefaultParameterCustomizerFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseConfiguredDefaultParameterCustomizerFactory.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.sqlobject.config;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
@@ -26,8 +28,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseCustomHandlerFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseCustomHandlerFactory.java
@@ -13,6 +13,10 @@
  */
 package org.jdbi.v3.sqlobject.config;
 
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
@@ -30,10 +34,6 @@ import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.lang.reflect.Method;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseSqlParser.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseSqlParser.java
@@ -13,15 +13,13 @@
  */
 package org.jdbi.v3.sqlobject.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.jdbi.v3.core.Jdbi;
-import org.jdbi.v3.core.statement.ColonPrefixSqlParser;
-import org.jdbi.v3.core.statement.HashPrefixSqlParser;
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.core.statement.ColonPrefixSqlParser;
+import org.jdbi.v3.core.statement.HashPrefixSqlParser;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
@@ -30,6 +28,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUseSqlParser {
     @Rule

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/TestMaxRows.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/TestMaxRows.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.customizer;
 
 import java.util.List;
 import java.util.Map;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.MapMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/locator/TestSqlLocator.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/locator/TestSqlLocator.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject.locator;
 
 import java.util.List;
+
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.config.JdbiConfig;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/subpackage/SomethingDao.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/subpackage/SomethingDao.java
@@ -15,11 +15,11 @@ package org.jdbi.v3.sqlobject.subpackage;
 
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
-import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 
 @RegisterRowMapper(SomethingMapper.class)
 public interface SomethingDao {

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
@@ -13,8 +13,8 @@
  */
 package org.jdbi.v3.stringtemplate4;
 
-import org.jdbi.v3.core.statement.TemplateEngine;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.TemplateEngine;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateSqlLocator.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateSqlLocator.java
@@ -17,6 +17,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
 import org.jdbi.v3.core.locator.internal.ClasspathBuilder;

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/internal/UseStringTemplateEngineImpl.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/internal/UseStringTemplateEngineImpl.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.stringtemplate4.internal;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.sqlobject.config.Configurer;

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/internal/UseStringTemplateSqlLocatorImpl.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/internal/UseStringTemplateSqlLocatorImpl.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.stringtemplate4.internal;
 
-import static org.jdbi.v3.stringtemplate4.StringTemplateSqlLocator.findStringTemplateGroup;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
@@ -27,6 +25,8 @@ import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
 import org.jdbi.v3.sqlobject.locator.SqlLocator;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
+
+import static org.jdbi.v3.stringtemplate4.StringTemplateSqlLocator.findStringTemplateGroup;
 
 public class UseStringTemplateSqlLocatorImpl implements Configurer {
     @Override

--- a/stringtemplate4/src/test/java/org/jdbi/v3/core/statement/TestDefineNamedBindingsST.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/core/statement/TestDefineNamedBindingsST.java
@@ -13,12 +13,12 @@ package org.jdbi.v3.core.statement;
  * limitations under the License.
  */
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.stringtemplate4.StringTemplateEngine;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDefineNamedBindingsST {
     @Rule

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindBeanListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindBeanListTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullPostgresTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullPostgresTest.java
@@ -17,10 +17,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.core.Something;
-import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.core.rule.PgDatabaseRule;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.stringtemplate4.TestStringTemplateSqlLocator.SomethingMapper;
 import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullTest.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -18,8 +18,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestConditionalStringTemplateLocator.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestConditionalStringTemplateLocator.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.stringtemplate4;
 
 import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateGroupReference.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateGroupReference.java
@@ -13,19 +13,19 @@
  */
 package org.jdbi.v3.stringtemplate4;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
 
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
-import org.jdbi.v3.sqlobject.customizer.Define;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStringTemplateGroupReference {
     @Rule

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateLoading.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateLoading.java
@@ -13,6 +13,11 @@
  */
 package org.jdbi.v3.stringtemplate4;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
@@ -21,11 +26,6 @@ import org.jdbi.v3.stringtemplate4.TestStringTemplateSqlLocator.Wombat;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateSqlLocator.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateSqlLocator.java
@@ -13,28 +13,28 @@
  */
 package org.jdbi.v3.stringtemplate4;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
-import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
-import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
-import org.jdbi.v3.sqlobject.customizer.Define;
-import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStringTemplateSqlLocator {
     @Rule

--- a/testing/src/main/java/org/jdbi/v3/testing/EmbeddedH2JdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/EmbeddedH2JdbiRule.java
@@ -14,7 +14,9 @@
 package org.jdbi.v3.testing;
 
 import java.util.UUID;
+
 import javax.sql.DataSource;
+
 import org.h2.jdbcx.JdbcConnectionPool;
 
 class EmbeddedH2JdbiRule extends JdbiRule {

--- a/testing/src/main/java/org/jdbi/v3/testing/EmbeddedPostgresJdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/EmbeddedPostgresJdbiRule.java
@@ -15,11 +15,10 @@ package org.jdbi.v3.testing;
 
 import javax.sql.DataSource;
 
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-
 import com.opentable.db.postgres.junit.EmbeddedPostgresRules;
 import com.opentable.db.postgres.junit.SingleInstancePostgresRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 class EmbeddedPostgresJdbiRule extends JdbiRule {
     private final SingleInstancePostgresRule embeddedPg;

--- a/testing/src/main/java/org/jdbi/v3/testing/EmbeddedSqliteJdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/EmbeddedSqliteJdbiRule.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.testing;
 
 import javax.sql.DataSource;
+
 import org.sqlite.SQLiteDataSource;
 
 class EmbeddedSqliteJdbiRule extends JdbiRule {

--- a/testing/src/main/java/org/jdbi/v3/testing/ExternalPostgresJdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/ExternalPostgresJdbiRule.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.testing;
 
 import javax.sql.DataSource;
+
 import org.postgresql.ds.PGSimpleDataSource;
 
 class ExternalPostgresJdbiRule extends JdbiRule {

--- a/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
@@ -13,15 +13,17 @@
  */
 package org.jdbi.v3.testing;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.sql.DataSource;
+
 import org.flywaydb.core.Flyway;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 import org.junit.rules.ExternalResource;
-import java.util.concurrent.locks.ReentrantLock;
-import javax.sql.DataSource;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * JUnit {@code @Rule} to manage a Jdbi instance pointed to a managed database.

--- a/testing/src/test/java/org/jdbi/v3/testing/JdbiRuleTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/JdbiRuleTest.java
@@ -13,15 +13,16 @@
  */
 package org.jdbi.v3.testing;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.UUID;
+
 import javax.sql.DataSource;
 
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JdbiRuleTest {
     @Test

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrCollectorFactory.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrCollectorFactory.java
@@ -13,6 +13,11 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.stream.Collector;
+
 import io.vavr.Lazy;
 import io.vavr.Tuple;
 import io.vavr.collection.Array;
@@ -42,11 +47,6 @@ import io.vavr.collection.TreeSet;
 import io.vavr.collection.Vector;
 import io.vavr.control.Option;
 import org.jdbi.v3.core.collector.CollectorFactory;
-
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Optional;
-import java.util.stream.Collector;
 
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrGenericMapUtil.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrGenericMapUtil.java
@@ -13,6 +13,9 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+
 import io.vavr.Tuple2;
 import io.vavr.collection.Map;
 import io.vavr.collection.Multimap;
@@ -20,9 +23,6 @@ import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.internal.UtilityClassException;
 import org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.TypeParameter;
 import org.jdbi.v3.lib.internal.com_google_guava.guava.v21_0.TypeToken;
-
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
 
 /**
  * a helper similar to {@link org.jdbi.v3.core.generic.GenericTypes} but for Vavr Maps

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrOptionMapper.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrOptionMapper.java
@@ -13,17 +13,17 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.lang.reflect.Type;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+
 import io.vavr.control.Option;
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;
 import org.jdbi.v3.core.statement.StatementContext;
-
-import java.lang.reflect.Type;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Optional;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrTupleRowMapperFactory.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrTupleRowMapperFactory.java
@@ -13,6 +13,11 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.sql.SQLException;
+import java.util.Optional;
+
 import io.vavr.CheckedFunction1;
 import io.vavr.Tuple;
 import io.vavr.Tuple0;
@@ -33,11 +38,6 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.RowMappers;
 import org.jdbi.v3.core.mapper.SingleColumnMapper;
-
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.sql.SQLException;
-import java.util.Optional;
 
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 import static org.jdbi.v3.core.generic.GenericTypes.resolveType;

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrValueArgumentFactory.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrValueArgumentFactory.java
@@ -13,6 +13,9 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.lang.reflect.Type;
+import java.util.Optional;
+
 import io.vavr.Lazy;
 import io.vavr.Value;
 import io.vavr.control.Either;
@@ -23,9 +26,6 @@ import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.config.ConfigRegistry;
-
-import java.lang.reflect.Type;
-import java.util.Optional;
 
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrMapCollectorWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrMapCollectorWithDB.java
@@ -13,6 +13,9 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.collection.HashMap;
@@ -29,9 +32,6 @@ import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Objects;
-import java.util.Optional;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.util.Objects;
+
 import io.vavr.collection.Set;
 import io.vavr.control.Option;
 import org.jdbi.v3.core.Handle;
@@ -23,8 +25,6 @@ import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleRowMapperFactory.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleRowMapperFactory.java
@@ -13,6 +13,10 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.lang.reflect.Type;
+import java.sql.SQLException;
+import java.util.Optional;
+
 import io.vavr.Tuple;
 import io.vavr.Tuple0;
 import io.vavr.Tuple1;
@@ -30,10 +34,6 @@ import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.lang.reflect.Type;
-import java.sql.SQLException;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrValueArgumentFactory.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrValueArgumentFactory.java
@@ -13,6 +13,9 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.lang.reflect.Type;
+import java.util.Optional;
+
 import io.vavr.Lazy;
 import io.vavr.NotImplementedError;
 import io.vavr.control.Either;
@@ -24,9 +27,6 @@ import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.generic.GenericType;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.lang.reflect.Type;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrValueArgumentFactoryWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrValueArgumentFactoryWithDB.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.vavr;
 
+import java.util.List;
+
 import io.vavr.Lazy;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
@@ -24,8 +26,6 @@ import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
This is intended to be a reasonable compromise between Eclipse and IntelliJ standards.  Enforcing import order adds some pain but reduces diff churn due to fighting IDEs and IMO the benefits outweigh the unfortunate cost.