### PR TITLE
build: dokka skips non-doc Travis same as javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,7 @@
                     <version>${dep.dokka.version}</version>
                     <configuration>
                         <jdkVersion>8</jdkVersion>
+                        <skip>${maven.javadoc.skip}</skip>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Fixes #1413 