### PR TITLE
fix javadoc building

### DIFF
--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec mvn clean deploy -Ppublish-docs -Dbasepom.javadoc.skip=false -DskipTests
+exec mvn clean deploy -Dpublish-docs -Dtoolchain -Dbasepom.javadoc.skip=false -DskipTests

--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec mvn clean deploy -Ppublish-docs -Dbasepom.javadoc.skip=false
+exec mvn clean deploy -Ppublish-docs -Dbasepom.javadoc.skip=false -DskipTests

--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec mvn clean deploy -Ppublish-docs
+exec mvn clean deploy -Ppublish-docs -Dbasepom.javadoc.skip=false

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -3132,10 +3132,10 @@ public interface DocumentDao {
     class FolderDocReducer implements LinkedHashMapRowReducer<Integer, Folder> { // <4>
         @Override
         public void accumulate(Map<Integer, Folder> map, RowView rowView) {
-            Folder f = map.computeIfAbsent(rowView.getColumn("f_id", Integer.class), // <2>
+            Folder f = map.computeIfAbsent(rowView.getColumn("f_id", Integer.class), // <5>
                                            id -> rowView.getRow(Folder.class));
 
-            if (rowView.getColumn("d_id", Integer.class) != null) { // <3>
+            if (rowView.getColumn("d_id", Integer.class) != null) { // <6>
                 f.getDocuments().add(rowView.getRow(Document.class));
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -571,6 +571,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-toolchains-plugin</artifactId>
                     <version>1.1</version>
+                    <configuration>
+                        <toolchains>
+                            <jdk>
+                                <version>1.8</version>
+                                <vendor>oracle</vendor>
+                            </jdk>
+                        </toolchains>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>com.github.ekryd.sortpom</groupId>
@@ -703,52 +711,10 @@
 
     <profiles>
         <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>[1.8,1.9)</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-toolchains-plugin</artifactId>
-                            <configuration>
-                                <toolchains>
-                                    <jdk>
-                                        <version>1.8</version>
-                                        <vendor>oracle</vendor>
-                                    </jdk>
-                                </toolchains>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
             <id>jdk9</id>
             <activation>
                 <jdk>[1.9,)</jdk>
             </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-toolchains-plugin</artifactId>
-                            <configuration>
-                                <toolchains>
-                                    <jdk>
-                                        <version>1.9</version>
-                                        <vendor>oracle</vendor>
-                                    </jdk>
-                                </toolchains>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
             <properties>
                 <basepom.check.skip-coverage>true</basepom.check.skip-coverage>
                 <basepom.check.skip-pmd>true</basepom.check.skip-pmd>

--- a/pom.xml
+++ b/pom.xml
@@ -757,11 +757,6 @@
                                 </dependency>
                             </dependencies>
                         </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <version>2.21.0</version>
-                        </plugin>
                     </plugins>
                 </pluginManagement>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -746,17 +746,6 @@
                                 </toolchains>
                             </configuration>
                         </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-dependency-plugin</artifactId>
-                            <dependencies>
-                                <dependency>
-                                    <groupId>org.ow2.asm</groupId>
-                                    <artifactId>asm</artifactId>
-                                    <version>6.1</version>
-                                </dependency>
-                            </dependencies>
-                        </plugin>
                     </plugins>
                 </pluginManagement>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -769,7 +769,6 @@
                 <basepom.check.skip-coverage>true</basepom.check.skip-coverage>
                 <basepom.check.skip-pmd>true</basepom.check.skip-pmd>
                 <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
-                <project.build.targetJdk>9</project.build.targetJdk>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
javadocs are currently not being built, see https://github.com/jdbi/jdbi.github.io/issues/5
javadocs don't build on jdk11 currently so toolchain it to jdk8 for now, and clean up some transitional profile stuff that isn't needed now that jdk9 is dead.