### PR TITLE
benchmark: Enum mapping case sensitivity

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -85,6 +85,19 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration combine.children="append">
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>

--- a/benchmark/src/main/java/org/jdbi/v3/core/EnumBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/core/EnumBenchmark.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.jdbi.v3.testing.JdbiRule;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Measurement(time = 5)
+@Warmup(time = 2)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+public class EnumBenchmark {
+    private JdbiRule db;
+    private Jdbi jdbi;
+
+    @Setup
+    public void setup() throws Throwable {
+        db = JdbiRule.h2();
+        db.before();
+        jdbi = db.getJdbi();
+        Random r = new Random();
+        jdbi.useHandle(h -> {
+            h.execute("create table sensitive (value varchar)");
+            h.execute("create table insensitive (value varchar)");
+            SwedishChef[] values = SwedishChef.values();
+            for (int i = 0; i < 1000; i++) {
+                SwedishChef element = values[r.nextInt(values.length)];
+                h.execute("insert into sensitive(value) values(?)", element);
+                h.execute("insert into insensitive(value) values(?)", randomizeCase(r, element.name()));
+            }
+        });
+    }
+
+    private String randomizeCase(Random r, String name) {
+        return name.chars()
+            .map(c -> r.nextBoolean() ? Character.toUpperCase(c) : Character.toLowerCase(c))
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
+    }
+
+    @TearDown
+    public void close() {
+        db.after();
+    }
+
+    @Benchmark
+    public List<SwedishChef> mapEnumCaseInsensitive() {
+        return run("insensitive");
+    }
+
+    @Benchmark
+    public List<SwedishChef> mapEnumCaseSensitive() {
+        return run("sensitive");
+    }
+
+    private List<SwedishChef> run(String table) {
+        return jdbi.withHandle(h -> h.createQuery("select value from " + table).mapTo(SwedishChef.class).list());
+    }
+    public enum SwedishChef {
+        NOLL, ETT, TVA, TRE, FYRA, FEM, SEX, SJU, ATTA, NIO, TIO
+    }
+}

--- a/policy/src/main/resources/policy/spotbugs-exclude.xml
+++ b/policy/src/main/resources/policy/spotbugs-exclude.xml
@@ -16,7 +16,7 @@
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.5/spotbugs/etc/findbugsfilter.xsd">
     <Match>
-        <Package name="~org\.jdbi\.v3\.core\.internal\.lexer\.*" />
+        <Package name="org.jdbi.v3.core.internal.lexer" />
     </Match>
     <Match>
         <Package name="~.*\.generated" />

--- a/policy/src/main/resources/policy/spotbugs-exclude.xml
+++ b/policy/src/main/resources/policy/spotbugs-exclude.xml
@@ -19,6 +19,6 @@
         <Package name="~org\.jdbi\.v3\.core\.internal\.lexer\.*" />
     </Match>
     <Match>
-        <Package name="~\.*\.generated\.*" />
+        <Package name="~.*\.generated" />
     </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -603,6 +603,7 @@
                         <rulesets>
                             <ruleset>policy/pmd.xml</ruleset>
                         </rulesets>
+                        <compileSourceRoots>${project.build.sourceDirectory}</compileSourceRoots>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
I wanted to quantify the penalty for using enums case insensitively, so I wrote a basic benchmark.  I tested it against the code in `master` (roughly 3.6.0) versus the latest version of #1427 

Full results
master: https://gist.github.com/stevenschlansker/afc65d80f895fa1000f6e383d16cc2bc
#1427: https://gist.github.com/stevenschlansker/c9baae77be3775868a88474074e04999

Short version: there's a dramatic performance regression in microbenchmark both in the case-insensitive compare as well as the normal case sensitive compare.

Before:
```
EnumBenchmark.mapEnumCaseInsensitive         thrpt    5   2424.413 ± 108.752  ops/s
EnumBenchmark.mapEnumCaseSensitive thrpt 5 12461.018 ± 302.860 ops/s
```

After:
```
EnumBenchmark.mapEnumCaseInsensitive         thrpt    5   335.997 ±  57.533  ops/s
EnumBenchmark.mapEnumCaseSensitive thrpt 5 6441.229 ± 117.578 ops/s
```

While microbenchmark performance isn't the only criteria we're going by, I think it's worth investigating such a dramatic regression.