### PR TITLE
json: remove use of StatementContext, simplify mapper / argument lambdas

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/result/UnableToProduceResultException.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/UnableToProduceResultException.java
@@ -22,8 +22,16 @@ import org.jdbi.v3.core.statement.StatementException;
 public class UnableToProduceResultException extends StatementException {
     private static final long serialVersionUID = 1L;
 
-    public UnableToProduceResultException(Exception e, StatementContext ctx) {
-        super(e, ctx);
+    public UnableToProduceResultException(Throwable cause) {
+        super(cause);
+    }
+
+    public UnableToProduceResultException(String message) {
+        super(message);
+    }
+
+    public UnableToProduceResultException(Exception cause, StatementContext ctx) {
+        super(cause, ctx);
     }
 
     public UnableToProduceResultException(String message, StatementContext ctx) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementException.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementException.java
@@ -23,6 +23,11 @@ public abstract class StatementException extends JdbiException {
 
     private final StatementContext statementContext;
 
+    public StatementException(Throwable cause) {
+        super(cause);
+        statementContext = null;
+    }
+
     public StatementException(String string, Throwable throwable, StatementContext ctx) {
         super(string, throwable);
         this.statementContext = ctx;

--- a/core/src/main/java/org/jdbi/v3/core/statement/UnableToCreateStatementException.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/UnableToCreateStatementException.java
@@ -19,12 +19,16 @@ package org.jdbi.v3.core.statement;
 public class UnableToCreateStatementException extends StatementException {
     private static final long serialVersionUID = 1L;
 
-    public UnableToCreateStatementException(String string, Throwable throwable, StatementContext ctx) {
-        super(string, throwable, ctx);
+    public UnableToCreateStatementException(String string, Throwable cause, StatementContext ctx) {
+        super(string, cause, ctx);
     }
 
-    public UnableToCreateStatementException(String string, Throwable throwable) {
-        super(string, throwable);
+    public UnableToCreateStatementException(String string, Throwable cause) {
+        super(string, cause);
+    }
+
+    public UnableToCreateStatementException(Throwable cause) {
+        super(cause);
     }
 
     public UnableToCreateStatementException(String string) {
@@ -35,7 +39,7 @@ public class UnableToCreateStatementException extends StatementException {
         super(string, ctx);
     }
 
-    public UnableToCreateStatementException(Exception e, StatementContext ctx) {
-        super(e, ctx);
+    public UnableToCreateStatementException(Exception cause, StatementContext ctx) {
+        super(cause, ctx);
     }
 }

--- a/gson2/src/main/java/org/jdbi/v3/gson2/GsonJsonMapper.java
+++ b/gson2/src/main/java/org/jdbi/v3/gson2/GsonJsonMapper.java
@@ -15,23 +15,17 @@ package org.jdbi.v3.gson2;
 
 import java.lang.reflect.Type;
 
-import com.google.gson.JsonParseException;
-import org.jdbi.v3.core.result.UnableToProduceResultException;
-import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.json.JsonMapper;
 
 class GsonJsonMapper implements JsonMapper {
     @Override
-    public String toJson(Type type, Object value, StatementContext ctx) {
-        return ctx.getConfig(Gson2Config.class).getGson().toJson(value);
+    public String toJson(Type type, Object value, ConfigRegistry config) {
+        return config.get(Gson2Config.class).getGson().toJson(value);
     }
 
     @Override
-    public Object fromJson(Type type, String json, StatementContext ctx) {
-        try {
-            return ctx.getConfig(Gson2Config.class).getGson().fromJson(json, type);
-        } catch (JsonParseException e) {
-            throw new UnableToProduceResultException(e, ctx);
-        }
+    public Object fromJson(Type type, String json, ConfigRegistry config) {
+        return config.get(Gson2Config.class).getGson().fromJson(json, type);
     }
 }

--- a/jackson2/src/main/java/org/jdbi/v3/jackson2/JacksonJsonMapper.java
+++ b/jackson2/src/main/java/org/jdbi/v3/jackson2/JacksonJsonMapper.java
@@ -19,36 +19,35 @@ import java.lang.reflect.Type;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
-import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.json.JsonMapper;
 
 class JacksonJsonMapper implements JsonMapper {
     @Override
-    public String toJson(Type type, Object value, StatementContext ctx) {
+    public String toJson(Type type, Object value, ConfigRegistry config) {
         try {
-            return getMapper(ctx).writeValueAsString(value);
+            return getMapper(config).writeValueAsString(value);
         } catch (JsonProcessingException e) {
-            throw new UnableToCreateStatementException(e, ctx);
+            throw new UnableToProduceResultException(e);
         }
     }
 
     @Override
-    public Object fromJson(Type type, String json, StatementContext ctx) {
+    public Object fromJson(Type type, String json, ConfigRegistry config) {
         try {
-            return getMapper(ctx).readValue(json, new TypeReference<Object>() {
+            return getMapper(config).readValue(json, new TypeReference<Object>() {
                 @Override
                 public Type getType() {
                     return type;
                 }
             });
         } catch (IOException e) {
-            throw new UnableToProduceResultException(e, ctx);
+            throw new UnableToProduceResultException(e);
         }
     }
 
-    private ObjectMapper getMapper(StatementContext ctx) {
-        return ctx.getConfig(Jackson2Config.class).getMapper();
+    private ObjectMapper getMapper(ConfigRegistry config) {
+        return config.get(Jackson2Config.class).getMapper();
     }
 }

--- a/json/src/main/java/org/jdbi/v3/json/JsonConfig.java
+++ b/json/src/main/java/org/jdbi/v3/json/JsonConfig.java
@@ -14,7 +14,7 @@
 package org.jdbi.v3.json;
 
 import org.jdbi.v3.core.config.JdbiConfig;
-import org.jdbi.v3.json.internal.StubJsonMapper;
+import org.jdbi.v3.json.internal.UnimplementedJsonMapper;
 import org.jdbi.v3.meta.Beta;
 
 @Beta
@@ -22,7 +22,7 @@ public class JsonConfig implements JdbiConfig<JsonConfig> {
     private JsonMapper mapper;
 
     public JsonConfig() {
-        mapper = new StubJsonMapper();
+        mapper = new UnimplementedJsonMapper();
     }
 
     private JsonConfig(JsonConfig other) {

--- a/json/src/main/java/org/jdbi/v3/json/JsonMapper.java
+++ b/json/src/main/java/org/jdbi/v3/json/JsonMapper.java
@@ -15,7 +15,7 @@ package org.jdbi.v3.json;
 
 import java.lang.reflect.Type;
 
-import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.meta.Beta;
 
 /**
@@ -28,6 +28,6 @@ import org.jdbi.v3.meta.Beta;
  */
 @Beta
 public interface JsonMapper {
-    String toJson(Type type, Object value, StatementContext ctx);
-    Object fromJson(Type type, String json, StatementContext ctx);
+    String toJson(Type type, Object value, ConfigRegistry config);
+    Object fromJson(Type type, String json, ConfigRegistry config);
 }

--- a/json/src/main/java/org/jdbi/v3/json/internal/UnimplementedJsonMapper.java
+++ b/json/src/main/java/org/jdbi/v3/json/internal/UnimplementedJsonMapper.java
@@ -15,13 +15,13 @@ package org.jdbi.v3.json.internal;
 
 import java.lang.reflect.Type;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
-import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.json.JsonConfig;
 import org.jdbi.v3.json.JsonMapper;
 
-public class StubJsonMapper implements JsonMapper {
+public class UnimplementedJsonMapper implements JsonMapper {
     private static final String NO_IMPL_INSTALLED = String.format(
         "you need to install (see %s) a %s impl, like jdbi3-jackson2 or jdbi3-gson2",
         JsonConfig.class.getSimpleName(),
@@ -29,12 +29,12 @@ public class StubJsonMapper implements JsonMapper {
     );
 
     @Override
-    public String toJson(Type type, Object value, StatementContext ctx) {
+    public String toJson(Type type, Object value, ConfigRegistry config) {
         throw new UnableToCreateStatementException(NO_IMPL_INSTALLED);
     }
 
     @Override
-    public Object fromJson(Type type, String json, StatementContext ctx) {
-        throw new UnableToProduceResultException(NO_IMPL_INSTALLED, ctx);
+    public Object fromJson(Type type, String json, ConfigRegistry config) {
+        throw new UnableToProduceResultException(NO_IMPL_INSTALLED);
     }
 }

--- a/json/src/test/java/org/jdbi/v3/json/JsonPluginTest.java
+++ b/json/src/test/java/org/jdbi/v3/json/JsonPluginTest.java
@@ -13,10 +13,9 @@
  */
 package org.jdbi.v3.json;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.qualifier.QualifiedType;
-import org.jdbi.v3.core.rule.DatabaseRule;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
-import org.jdbi.v3.core.statement.StatementContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,7 +31,7 @@ import static org.mockito.Mockito.when;
 
 public class JsonPluginTest {
     @Rule
-    public DatabaseRule db = new H2DatabaseRule().withPlugin(new JsonPlugin());
+    public H2DatabaseRule db = new H2DatabaseRule().withPlugin(new JsonPlugin());
     @Rule
     public MockitoRule mockito = MockitoJUnit.rule();
     @Mock
@@ -49,8 +48,8 @@ public class JsonPluginTest {
         Object instance = new Foo();
         String json = "foo";
 
-        when(jsonMapper.toJson(eq(Foo.class), eq(instance), any(StatementContext.class))).thenReturn(json);
-        when(jsonMapper.fromJson(eq(Foo.class), eq(json), any(StatementContext.class))).thenReturn(instance);
+        when(jsonMapper.toJson(eq(Foo.class), eq(instance), any(ConfigRegistry.class))).thenReturn(json);
+        when(jsonMapper.fromJson(eq(Foo.class), eq(json), any(ConfigRegistry.class))).thenReturn(instance);
 
         Object result = db.getJdbi().withHandle(h -> {
             h.createUpdate("insert into foo(bar) values(:foo)")
@@ -66,8 +65,8 @@ public class JsonPluginTest {
         });
 
         assertThat(result).isSameAs(instance);
-        verify(jsonMapper).fromJson(eq(Foo.class), eq(json), any(StatementContext.class));
-        verify(jsonMapper).toJson(eq(Foo.class), eq(instance), any(StatementContext.class));
+        verify(jsonMapper).fromJson(eq(Foo.class), eq(json), any(ConfigRegistry.class));
+        verify(jsonMapper).toJson(eq(Foo.class), eq(instance), any(ConfigRegistry.class));
     }
 
     public static class Foo {


### PR DESCRIPTION
we actually only need the ConfigRegistry instead, and that lets us move
a fair amount of work out of the lambdas in the json handling, which should be a minor performance improvement