### PR TITLE
Fix remnant legacy related to #1388

### DIFF
--- a/freemarker/src/main/java/org/jdbi/v3/freemarker/internal/UseFreemarkerSqlLocatorImpl.java
+++ b/freemarker/src/main/java/org/jdbi/v3/freemarker/internal/UseFreemarkerSqlLocatorImpl.java
@@ -34,7 +34,7 @@ public class UseFreemarkerSqlLocatorImpl implements Configurer {
     @Override
     public void configureForType(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType) {
         SqlLocator locator = (type, method, config) -> {
-            String templateName = SqlAnnotations.getAnnotationValue(method, sql -> sql).orElseGet(method::getName);
+            String templateName = SqlAnnotations.getAnnotationValue(method).orElseGet(method::getName);
             findTemplate(sqlObjectType, templateName);
             return templateName;
         };

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/AnnotationSqlLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/AnnotationSqlLocator.java
@@ -24,7 +24,7 @@ import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
 public class AnnotationSqlLocator implements SqlLocator {
     @Override
     public String locate(Class<?> sqlObjectType, Method method, ConfigRegistry config) {
-        return SqlAnnotations.getAnnotationValue(method, sql -> sql)
-                .orElseThrow(() -> new IllegalStateException("Sql annotation missing query"));
+        return SqlAnnotations.getAnnotationValue(method)
+            .orElseThrow(() -> new IllegalStateException("Sql annotation missing query"));
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/internal/UseClasspathSqlLocatorImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/internal/UseClasspathSqlLocatorImpl.java
@@ -15,31 +15,32 @@ package org.jdbi.v3.sqlobject.locator.internal;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.locator.ClasspathSqlLocator;
 import org.jdbi.v3.sqlobject.SqlObjects;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
-import org.jdbi.v3.sqlobject.locator.SqlLocator;
 
 public class UseClasspathSqlLocatorImpl implements Configurer {
-    private static final SqlLocator SQL_LOCATOR = (sqlObjectType, method, config) -> {
-        return SqlAnnotations.getAnnotationValue(method,
-                name -> ClasspathSqlLocator.findSqlOnClasspath(sqlObjectType, defaultName(name, method))).orElseGet(method::getName);
-    };
-
     @Override
     public void configureForType(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType) {
-        registry.get(SqlObjects.class).setSqlLocator(SQL_LOCATOR);
-    }
-
-    private static String defaultName(String name, Method method) {
-        return name.isEmpty() ? method.getName() : name;
+        registry.get(SqlObjects.class).setSqlLocator(UseClasspathSqlLocatorImpl::locate);
     }
 
     @Override
     public void configureForMethod(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType, Method method) {
         configureForType(registry, annotation, sqlObjectType);
+    }
+
+    private static String locate(Class<?> sqlObjectType, Method method, @SuppressWarnings("unused") ConfigRegistry config) {
+        Function<String, String> valueOrMethodNameToSql = key -> {
+            String filename = key.isEmpty() ? method.getName() : key;
+            return ClasspathSqlLocator.findSqlOnClasspath(sqlObjectType, filename);
+        };
+
+        return SqlAnnotations.getAnnotationValue(method, valueOrMethodNameToSql)
+            .orElseThrow(() -> new IllegalStateException(String.format("method %s has no query annotations", method)));
     }
 }

--- a/sqlobject/src/test/resources/org/jdbi/v3/sqlobject/TestUseClasspathSqlLocator$Blanks/empty.sql
+++ b/sqlobject/src/test/resources/org/jdbi/v3/sqlobject/TestUseClasspathSqlLocator$Blanks/empty.sql
@@ -1,0 +1,15 @@
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/internal/UseStringTemplateSqlLocatorImpl.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/internal/UseStringTemplateSqlLocatorImpl.java
@@ -32,7 +32,7 @@ public class UseStringTemplateSqlLocatorImpl implements Configurer {
     @Override
     public void configureForType(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType) {
         SqlLocator locator = (type, method, config) -> {
-            String templateName = SqlAnnotations.getAnnotationValue(method, sql -> sql).orElseGet(method::getName);
+            String templateName = SqlAnnotations.getAnnotationValue(method).orElseGet(method::getName);
             STGroup group = findStringTemplateGroup(type);
             if (!group.isDefined(templateName)) {
                 throw new IllegalStateException("No StringTemplate group " + templateName + " for class " + sqlObjectType);


### PR DESCRIPTION
#1388 is a breadcrumb trail to legacy fallback code that I remove with this. The bad behavior could be triggered by an empty sql file (as opposed to a missing file according to #1388 , probably using an old version of the code).

Part of the fix is a refactor of the lookup logic, which was irregularly speckled with external concerns... I think the result is better structured and easier to understand.