### PR TITLE
DefineNamedBindings: use a proxy Statement rather than inspecting for `NullArgument`

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/ArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ArgumentFactory.java
@@ -24,8 +24,6 @@ import org.jdbi.v3.core.statement.StatementContext;
  * an {@link Argument} that binds the value to a prepared statement.
  *
  * Make sure to override {@link Object#toString} in your {@link Argument} instances if you want to be able to log their values with an {@link org.jdbi.v3.core.statement.SqlLogger}.
- *
- * Note that {@code null} is handled specially in a few cases, and a few {@code Jdbi} features assume you'll return an instance of {@link NullArgument} when you intend to bind null.
  */
 @FunctionalInterface
 public interface ArgumentFactory {

--- a/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Unchecked.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Unchecked.java
@@ -38,6 +38,17 @@ public class Unchecked {
         };
     }
 
+    @SuppressWarnings("PMD.DoNotUseThreads")
+    public static Runnable runnable(CheckedRunnable checkedRunnable) {
+        return () -> {
+            try {
+                checkedRunnable.run();
+            } catch (Throwable t) {
+                throw Sneaky.throwAnyway(t);
+            }
+        };
+    }
+
     public static <T> SneakyCallable<T> callable(CheckedCallable<T> checkedCallable) {
         return () -> {
             try {
@@ -81,5 +92,9 @@ public class Unchecked {
     public interface SneakyCallable<T> extends Callable<T> {
         @Override
         T call(); // no 'throws Exception'
+    }
+
+    public interface CheckedRunnable {
+        void run() throws Exception;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/DefineNamedBindingsStatementCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/DefineNamedBindingsStatementCustomizer.java
@@ -13,20 +13,48 @@
  */
 package org.jdbi.v3.core.statement;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import java.util.Set;
 
-import org.jdbi.v3.core.argument.NullArgument;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.internal.exceptions.Unchecked;
 
 class DefineNamedBindingsStatementCustomizer implements StatementCustomizer {
     @Override
-    public void beforeTemplating(PreparedStatement stmt, StatementContext ctx) throws SQLException {
+    public void beforeTemplating(PreparedStatement stmt, StatementContext ctx) {
         final Set<String> alreadyDefined = ctx.getAttributes().keySet();
         final Binding binding = ctx.getBinding();
+        final SetNullHandler handler = new SetNullHandler();
         binding.getNames().stream()
             .filter(name -> !alreadyDefined.contains(name))
             .forEach(name -> binding.findForName(name, ctx).ifPresent(
-                    a -> ctx.define(name, a instanceof NullArgument ? false : true)));
+                    a -> handler.define(name, a, ctx)));
+    }
+
+    private static class SetNullHandler implements InvocationHandler {
+        private final PreparedStatement fakeStmt = (PreparedStatement)
+                Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class<?>[] {PreparedStatement.class}, this);
+        private boolean setNull;
+        private boolean setCalled;
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            setCalled = method.getName().startsWith("set");
+            boolean argNull = args.length > 1 && args[1] == null;
+            setNull = "setNull".equals(method.getName()) || argNull;
+            return null;
+        }
+
+        void define(String name, Argument arg, StatementContext ctx) {
+            setNull = false;
+            setCalled = false;
+            Unchecked.runnable(() -> arg.apply(1, fakeStmt, ctx)).run();
+            if (setCalled) {
+                ctx.define(name, !setNull);
+            }
+        }
     }
 }

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -1623,13 +1623,14 @@ handle.createQuery("select * from emotion where emoticon = <sticker>;")
 Bindings and definitions are usually separate.  You can link them in a limited manner
 using the `stmt.defineNamedBindings()` or `@DefineNamedBindings` customizers.
 For each bound parameter (including bean properties), this will define a boolean which is `true` if the
-binding is present and not `null` (a `NullArgument`, specifically).  You can use this to
+binding is present and not `null`.  You can use this to
 craft conditional updates and query clauses.
 
 For example,
 [source,java]
 ----
 class MyBean {
+    long id();
     String getA();
     String getB();
     Instant getModified();


### PR DESCRIPTION
Fixes #1416 