### PR TITLE
Extend qualtyp api for collection<class<>>

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
@@ -66,7 +66,7 @@ public class ObjectFieldArguments extends ObjectPropertyNamedArgumentFinder {
 
         try {
             QualifiedType<?> type = QualifiedType.of(field.getGenericType())
-                                    .with(getQualifiers(field));
+                                    .withAnnotations(getQualifiers(field));
             Object value = field.get(obj);
 
             return Optional.of(new TypedValue(type, value));

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
@@ -76,7 +76,7 @@ public class ObjectMethodArguments extends MethodReturnValueNamedArgumentFinder 
         }
 
         QualifiedType<?> type = QualifiedType.of(method.getGenericReturnType())
-                                .with(getQualifiers(method));
+                                .withAnnotations(getQualifiers(method));
         Object value = invokeMethod(method, ctx);
 
         return Optional.of(new TypedValue(type, value));

--- a/core/src/main/java/org/jdbi/v3/core/internal/EnumStrategies.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/EnumStrategies.java
@@ -48,7 +48,7 @@ public class EnumStrategies implements JdbiConfig<EnumStrategies> {
         Class<?> erasedType = getErasedType(type.getType());
         return JdbiOptionals.findFirstPresent(
             () -> doFindStrategy(type),
-            () -> doFindStrategy(QualifiedType.of(erasedType).with(getQualifiers(erasedType)))
+            () -> doFindStrategy(QualifiedType.of(erasedType).withAnnotations(getQualifiers(erasedType)))
         ).orElseGet(() -> registry.get(Enums.class).getDefaultStrategy());
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/InferredColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/InferredColumnMapperFactory.java
@@ -37,7 +37,7 @@ class InferredColumnMapperFactory implements QualifiedColumnMapperFactory {
         this.maps = QualifiedType.of(
             findGenericParameter(mapper.getClass(), ColumnMapper.class)
                 .orElseThrow(() -> new UnsupportedOperationException("Must use a concretely typed ColumnMapper here")))
-            .with(getQualifiers(mapper.getClass()));
+            .withAnnotations(getQualifiers(mapper.getClass()));
         this.mapper = mapper;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -221,7 +221,7 @@ public class ConstructorMapper<T> implements RowMapper<T> {
                 if (columnIndex.isPresent()) {
                     int colIndex = columnIndex.getAsInt();
                     final QualifiedType<?> type = QualifiedType.of(parameter.getParameterizedType())
-                        .with(getQualifiers(parameter));
+                        .withAnnotations(getQualifiers(parameter));
                     mappers[i] = ctx.findColumnMapperFor(type)
                         .map(mapper -> new SingleColumnMapper<>(mapper, colIndex + 1))
                         .orElseThrow(() -> new IllegalArgumentException(

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -148,7 +148,7 @@ public class FieldMapper<T> implements RowMapper<T> {
                     findColumnIndex(paramName, columnNames, columnNameMatchers, () -> debugName(field))
                         .ifPresent(index -> {
                             QualifiedType<?> type = QualifiedType.of(field.getGenericType())
-                                .with(getQualifiers(field));
+                                .withAnnotations(getQualifiers(field));
                             @SuppressWarnings("unchecked")
                             ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
                                 .orElse((ColumnMapper) (r, n, c) -> r.getObject(n));

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BeanPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BeanPropertiesFactory.java
@@ -160,7 +160,7 @@ public class BeanPropertiesFactory {
                     Optional.ofNullable(descriptor.getReadMethod())
                         .map(Method::getGenericReturnType)
                         .orElseGet(() -> descriptor.getWriteMethod().getGenericParameterTypes()[0]))
-                    .with(
+                    .withAnnotations(
                         getQualifiers(descriptor.getReadMethod(), descriptor.getWriteMethod(), setterParam));
             }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ImmutablesPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ImmutablesPropertiesFactory.java
@@ -137,7 +137,7 @@ public class ImmutablesPropertiesFactory {
                 final Type propertyType = GenericTypes.resolveType(m.getGenericReturnType(), getType());
                 return new ImmutablesPojoProperty<T>(
                         name,
-                        QualifiedType.of(propertyType).with(Qualifiers.getQualifiers(m)),
+                        QualifiedType.of(propertyType).withAnnotations(Qualifiers.getQualifiers(m)),
                         m,
                         alwaysSet(),
                         MethodHandles.lookup().unreflect(m).asFixedArity(),
@@ -197,7 +197,7 @@ public class ImmutablesPropertiesFactory {
             try {
                 return new ImmutablesPojoProperty<T>(
                         name,
-                        QualifiedType.of(propertyType).with(Qualifiers.getQualifiers(m)),
+                        QualifiedType.of(propertyType).withAnnotations(Qualifiers.getQualifiers(m)),
                         m,
                         isSetMethod(name),
                         MethodHandles.lookup().unreflect(m).asFixedArity(),

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
@@ -16,20 +16,19 @@ package org.jdbi.v3.core.qualifier;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.StreamSupport;
 
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.internal.AnnotationFactory;
 import org.jdbi.v3.meta.Beta;
 
 import static java.util.Collections.emptySet;
-import static java.util.stream.Collectors.toList;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * A {@link java.lang.reflect.Type} qualified by a set of qualifier annotations. Two qualified types are equal to each other
@@ -73,23 +72,23 @@ public final class QualifiedType<T> {
         return (QualifiedType<T>) of(type.getType());
     }
 
-    private QualifiedType(Type type, Set<Annotation> qualifiers) {
+    private QualifiedType(Type type, Set<? extends Annotation> qualifiers) {
         this.type = type;
-        this.qualifiers = qualifiers;
+        this.qualifiers = unmodifiableSet(qualifiers);
     }
 
     /**
-     * Returns a QualifiedType that has the same type as this instance, but with the given qualifiers.
+     * Returns a QualifiedType that has the same type as this instance, but with <b>only</b> the given qualifiers.
      *
      * @param qualifiers the qualifiers for the new qualified type.
      * @return the QualifiedType
      */
     public QualifiedType<T> with(Annotation... qualifiers) {
-        return with(Arrays.asList(qualifiers));
+        return new QualifiedType<>(type, Arrays.stream(qualifiers).collect(toSet()));
     }
 
     /**
-     * Returns a QualifiedType that has the same type as this instance, but with the given qualifiers.
+     * Returns a QualifiedType that has the same type as this instance, but with <b>only</b> the given qualifiers.
      *
      * @param qualifiers the qualifiers for the new qualified type.
      * @throws IllegalArgumentException if any of the given qualifier types have annotation attributes.
@@ -97,16 +96,31 @@ public final class QualifiedType<T> {
      */
     @SafeVarargs
     public final QualifiedType<T> with(Class<? extends Annotation>... qualifiers) {
-        return with(Arrays.stream(qualifiers).map(AnnotationFactory::create).collect(toList()));
+        Set<? extends Annotation> annotations = Arrays.stream(qualifiers)
+            .map(AnnotationFactory::create)
+            .collect(toSet());
+        return new QualifiedType<>(type, annotations);
     }
 
     /**
-     * @return a QualifiedType that has the same type as this instance, but with the given qualifiers.
+     * @return a QualifiedType that has the same type as this instance, but with <b>only</b> the given qualifiers.
      *
      * @param qualifiers the qualifiers for the new qualified type.
      */
-    public QualifiedType<T> with(Collection<? extends Annotation> qualifiers) {
-        return new QualifiedType<>(type, Collections.unmodifiableSet(new HashSet<>(qualifiers)));
+    public QualifiedType<T> withAnnotations(Iterable<? extends Annotation> qualifiers) {
+        return new QualifiedType<>(type, StreamSupport.stream(qualifiers.spliterator(), false).collect(toSet()));
+    }
+
+    /**
+     * @return a QualifiedType that has the same type as this instance, but with <b>only</b> the given qualifiers.
+     *
+     * @param qualifiers the qualifiers for the new qualified type.
+     */
+    public QualifiedType<T> withAnnotationClasses(Iterable<Class<? extends Annotation>> qualifiers) {
+        Set<? extends Annotation> annotations = StreamSupport.stream(qualifiers.spliterator(), false)
+            .map(AnnotationFactory::create)
+            .collect(toSet());
+        return new QualifiedType<>(type, annotations);
     }
 
     /**

--- a/jpa/src/main/java/org/jdbi/v3/jpa/internal/JpaMember.java
+++ b/jpa/src/main/java/org/jdbi/v3/jpa/internal/JpaMember.java
@@ -44,7 +44,7 @@ public class JpaMember {
     JpaMember(Class<?> clazz, Column column, Field field) {
         this.clazz = requireNonNull(clazz);
         this.columnName = nameOf(column, field.getName());
-        this.qualifiedType = QualifiedType.of(field.getGenericType()).with(getQualifiers(field));
+        this.qualifiedType = QualifiedType.of(field.getGenericType()).withAnnotations(getQualifiers(field));
         field.setAccessible(true);
         this.accessor = field::get;
         this.mutator = field::set;
@@ -61,7 +61,7 @@ public class JpaMember {
         setter.setAccessible(true);
 
         this.qualifiedType = QualifiedType.of(getter.getGenericReturnType())
-            .with(getQualifiers(getter, setter, setterParam));
+            .withAnnotations(getQualifiers(getter, setter, setterParam));
 
         this.accessor = getter::invoke;
         this.mutator = setter::invoke;

--- a/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/KotlinSqlStatementCustomizerFactory.kt
+++ b/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/KotlinSqlStatementCustomizerFactory.kt
@@ -32,7 +32,7 @@ class KotlinSqlStatementCustomizerFactory : ParameterCustomizerFactory {
                                     paramIdx: Int,
                                     type: Type): SqlStatementParameterCustomizer {
 
-        val qualifiedType = QualifiedType.of(type).with(getQualifiers(parameter))
+        val qualifiedType = QualifiedType.of(type).withAnnotations(getQualifiers(parameter))
         val bindName = if (parameter.isNamePresent) {
             parameter.name
         } else {

--- a/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinMapper.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinMapper.kt
@@ -166,7 +166,7 @@ class KotlinMapper(clazz: Class<*>, private val prefix: String = "") : RowMapper
             val columnIndex = findColumnIndex(parameterName, columnNames, columnNameMatchers) { parameter.name }
             if (columnIndex.isPresent) {
                 val type = QualifiedType.of(parameter.type.javaType)
-                    .with(getQualifiers(parameter))
+                    .withAnnotations(getQualifiers(parameter))
 
                 return ctx.findColumnMapperFor(type)
                     .map { mapper ->

--- a/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/internal/KotlinPropertyArguments.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/internal/KotlinPropertyArguments.kt
@@ -39,7 +39,7 @@ class KotlinPropertyArguments(obj: Any,
         val property: KProperty1<*, *> = properties[name] ?: return Optional.empty()
         val mutableProperty = property as? KMutableProperty1
         val type = QualifiedType.of(property.returnType.javaType)
-            .with(getQualifiers(
+            .withAnnotations(getQualifiers(
                 kClass.primaryConstructor?.parameters?.find { it.name == name },
                 property,
                 property.getter,

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindFactory.java
@@ -38,7 +38,7 @@ public class BindFactory implements SqlStatementCustomizerFactory {
         Bind b = (Bind) annotation;
         String nameFromAnnotation = b == null ? Bind.NO_VALUE : b.value();
         Optional<String> name = ParameterUtil.findParameterName(nameFromAnnotation, param);
-        QualifiedType<?> qualifiedType = QualifiedType.of(type).with(getQualifiers(param));
+        QualifiedType<?> qualifiedType = QualifiedType.of(type).withAnnotations(getQualifiers(param));
 
         return (stmt, arg) -> {
             stmt.bindByType(index, arg, qualifiedType);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
@@ -59,7 +59,7 @@ abstract class ResultReturner {
      */
     static ResultReturner forMethod(Class<?> extensionType, Method method) {
         Type returnType = GenericTypes.resolveType(method.getGenericReturnType(), extensionType);
-        QualifiedType<?> qualifiedReturnType = QualifiedType.of(returnType).with(getQualifiers(method));
+        QualifiedType<?> qualifiedReturnType = QualifiedType.of(returnType).withAnnotations(getQualifiers(method));
         Class<?> returnClass = getErasedType(returnType);
         if (Void.TYPE.equals(returnClass)) {
             return findConsumer(method)
@@ -298,7 +298,7 @@ abstract class ResultReturner {
                     .orElseThrow(() -> new IllegalStateException(
                         "Cannot reflect Consumer<T> element type T in method consumer parameter "
                             + parameterType)))
-                .with(getQualifiers(method.getParameters()[consumerIndex]));
+                .withAnnotations(getQualifiers(method.getParameters()[consumerIndex]));
         }
 
         @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlUpdateHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlUpdateHandler.java
@@ -43,7 +43,7 @@ public class SqlUpdateHandler extends CustomizingStatementHandler<Update> {
 
         QualifiedType<?> returnType = QualifiedType.of(
             GenericTypes.resolveType(method.getGenericReturnType(), sqlObjectType))
-            .with(getQualifiers(method));
+            .withAnnotations(getQualifiers(method));
 
         if (isGetGeneratedKeys) {
             ResultReturner magic = ResultReturner.forMethod(sqlObjectType, method);


### PR DESCRIPTION
Just an idea I had to "complete" the qualtyp api. We support `with`ing with `Annotation...`, `Class<Annotation>...`, and `Collection<Annotation>`, so we should logically also support `Collection<Class<Annotation>>` for those times when you have a `Set` of qualifier classes and the like. Users shouldn't have to reduce highlevel collections to arrays or know about `AnnotationFactory`.

The problem is the type erasure across method overloads, so if we really wanna be able to support more than 1 thing we need to name methods differently based on their arguments.

I'm open to name changes and other thoughts.