### PR TITLE
Split SqlObject classpath locator to it's own class

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/ClasspathSqlLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/ClasspathSqlLocator.java
@@ -1,0 +1,23 @@
+package org.jdbi.v3.sqlobject.locator;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
+
+import java.lang.reflect.Method;
+import java.util.function.Function;
+
+/**
+ * @see org.jdbi.v3.core.locator.ClasspathSqlLocator
+ */
+public class ClasspathSqlLocator implements SqlLocator {
+    @Override
+    public String locate(Class<?> sqlObjectType, Method method, ConfigRegistry config) {
+        Function<String, String> valueOrMethodNameToSql = key -> {
+            String filename = key.isEmpty() ? method.getName() : key;
+            return org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath(sqlObjectType, filename);
+        };
+
+        return SqlAnnotations.getAnnotationValue(method, valueOrMethodNameToSql)
+            .orElseThrow(() -> new IllegalStateException(String.format("method %s has no query annotations", method)));
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/ClasspathSqlLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/ClasspathSqlLocator.java
@@ -1,10 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jdbi.v3.sqlobject.locator;
-
-import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
 
 import java.lang.reflect.Method;
 import java.util.function.Function;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
 
 /**
  * @see org.jdbi.v3.core.locator.ClasspathSqlLocator

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/SqlObjectClasspathSqlLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/SqlObjectClasspathSqlLocator.java
@@ -22,7 +22,7 @@ import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
 /**
  * @see org.jdbi.v3.core.locator.ClasspathSqlLocator
  */
-public class ClasspathSqlLocator implements SqlLocator {
+public class SqlObjectClasspathSqlLocator implements SqlLocator {
     @Override
     public String locate(Class<?> sqlObjectType, Method method, ConfigRegistry config) {
         Function<String, String> valueOrMethodNameToSql = key -> {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/SqlObjectClasspathSqlLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/SqlObjectClasspathSqlLocator.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.locator.ClasspathSqlLocator;
 import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
 
 /**
@@ -27,7 +28,7 @@ public class SqlObjectClasspathSqlLocator implements SqlLocator {
     public String locate(Class<?> sqlObjectType, Method method, ConfigRegistry config) {
         Function<String, String> valueOrMethodNameToSql = key -> {
             String filename = key.isEmpty() ? method.getName() : key;
-            return org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath(sqlObjectType, filename);
+            return ClasspathSqlLocator.findSqlOnClasspath(sqlObjectType, filename);
         };
 
         return SqlAnnotations.getAnnotationValue(method, valueOrMethodNameToSql)

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/internal/UseClasspathSqlLocatorImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/internal/UseClasspathSqlLocatorImpl.java
@@ -15,32 +15,20 @@ package org.jdbi.v3.sqlobject.locator.internal;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.locator.ClasspathSqlLocator;
 import org.jdbi.v3.sqlobject.SqlObjects;
 import org.jdbi.v3.sqlobject.config.Configurer;
-import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
+import org.jdbi.v3.sqlobject.locator.ClasspathSqlLocator;
 
 public class UseClasspathSqlLocatorImpl implements Configurer {
     @Override
     public void configureForType(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType) {
-        registry.get(SqlObjects.class).setSqlLocator(UseClasspathSqlLocatorImpl::locate);
+        registry.get(SqlObjects.class).setSqlLocator(new ClasspathSqlLocator());
     }
 
     @Override
     public void configureForMethod(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType, Method method) {
         configureForType(registry, annotation, sqlObjectType);
-    }
-
-    private static String locate(Class<?> sqlObjectType, Method method, @SuppressWarnings("unused") ConfigRegistry config) {
-        Function<String, String> valueOrMethodNameToSql = key -> {
-            String filename = key.isEmpty() ? method.getName() : key;
-            return ClasspathSqlLocator.findSqlOnClasspath(sqlObjectType, filename);
-        };
-
-        return SqlAnnotations.getAnnotationValue(method, valueOrMethodNameToSql)
-            .orElseThrow(() -> new IllegalStateException(String.format("method %s has no query annotations", method)));
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/internal/UseClasspathSqlLocatorImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/internal/UseClasspathSqlLocatorImpl.java
@@ -19,12 +19,12 @@ import java.lang.reflect.Method;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.SqlObjects;
 import org.jdbi.v3.sqlobject.config.Configurer;
-import org.jdbi.v3.sqlobject.locator.ClasspathSqlLocator;
+import org.jdbi.v3.sqlobject.locator.SqlObjectClasspathSqlLocator;
 
 public class UseClasspathSqlLocatorImpl implements Configurer {
     @Override
     public void configureForType(ConfigRegistry registry, Annotation annotation, Class<?> sqlObjectType) {
-        registry.get(SqlObjects.class).setSqlLocator(new ClasspathSqlLocator());
+        registry.get(SqlObjects.class).setSqlLocator(new SqlObjectClasspathSqlLocator());
     }
 
     @Override


### PR DESCRIPTION
This allows setting it project-wide via the SqlObjects config (like for AnnotationSqlLocator) without having to copy the code in the project (as the locate function was private).

Not sure if some things should be renamed as this can get confusing with the other ClasspathSqlLocator in jdbi3-core.