### PR TITLE
Pass generic types to Jackson

### DIFF
--- a/jackson2/src/main/java/org/jdbi/v3/jackson2/JacksonJsonMapper.java
+++ b/jackson2/src/main/java/org/jdbi/v3/jackson2/JacksonJsonMapper.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
@@ -27,7 +26,10 @@ class JacksonJsonMapper implements JsonMapper {
     @Override
     public String toJson(Type type, Object value, ConfigRegistry config) {
         try {
-            return getMapper(config).writeValueAsString(value);
+            ObjectMapper mapper = getMapper(config);
+            return mapper
+                    .writerFor(mapper.constructType(type))
+                    .writeValueAsString(value);
         } catch (JsonProcessingException e) {
             throw new UnableToProduceResultException(e);
         }
@@ -36,12 +38,8 @@ class JacksonJsonMapper implements JsonMapper {
     @Override
     public Object fromJson(Type type, String json, ConfigRegistry config) {
         try {
-            return getMapper(config).readValue(json, new TypeReference<Object>() {
-                @Override
-                public Type getType() {
-                    return type;
-                }
-            });
+            ObjectMapper mapper = getMapper(config);
+            return mapper.readValue(json, mapper.constructType(type));
         } catch (IOException e) {
             throw new UnableToProduceResultException(e);
         }

--- a/jackson2/src/test/java/org/jdbi/v3/jackson2/TestJackson2Plugin.java
+++ b/jackson2/src/test/java/org/jdbi/v3/jackson2/TestJackson2Plugin.java
@@ -13,15 +13,24 @@
  */
 package org.jdbi.v3.jackson2;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.jdbi.v3.json.AbstractJsonMapperTest;
+import org.jdbi.v3.json.Json;
 import org.jdbi.v3.postgres.PostgresDbRule;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJackson2Plugin extends AbstractJsonMapperTest {
+
     @Rule
     public JdbiRule db = PostgresDbRule.rule();
 
@@ -29,5 +38,54 @@ public class TestJackson2Plugin extends AbstractJsonMapperTest {
     public void before() {
         jdbi = db.getJdbi().installPlugin(new Jackson2Plugin());
         jdbi.getConfig(Jackson2Config.class).setMapper(new ObjectMapper().registerModule(new ParameterNamesModule()));
+    }
+
+    @Test
+    public void testGenericPolymorphicType() {
+        db.getJdbi().useHandle(h -> {
+            ContainerDao dao = h.attach(ContainerDao.class);
+
+            dao.table();
+
+            Container<Contained> c1 = new Container<>();
+            c1.setContained(new A());
+
+            dao.insert(c1);
+
+            assertThat(dao.get().getContained()).isInstanceOf(A.class);
+        });
+    }
+
+    private interface ContainerDao {
+
+        @SqlUpdate("create table json(contained varchar)")
+        void table();
+
+        @SqlUpdate("insert into json(contained) values(:json)")
+        void insert(@Bind @Json Container<Contained> json);
+
+        @SqlQuery("select * from json limit 1")
+        @Json
+        Container<Contained> get();
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+    public interface Contained {}
+
+    public static class A implements Contained {}
+
+    public static class B implements Contained {}
+
+    public static class Container<T> {
+
+        private T contained;
+
+        public T getContained() {
+            return contained;
+        }
+
+        public void setContained(T contained) {
+            this.contained = contained;
+        }
     }
 }

--- a/jackson2/src/test/java/org/jdbi/v3/jackson2/TestJackson2Plugin.java
+++ b/jackson2/src/test/java/org/jdbi/v3/jackson2/TestJackson2Plugin.java
@@ -62,7 +62,7 @@ public class TestJackson2Plugin extends AbstractJsonMapperTest {
         void table();
 
         @SqlUpdate("insert into json(contained) values(:json)")
-        void insert(@Bind @Json Container<Contained> json);
+        void insert(@Bind("json") @Json Container<Contained> json);
 
         @SqlQuery("select * from json limit 1")
         @Json


### PR DESCRIPTION
This modifies JDBI's `JacksonJsonMapper` so that generic types are passed to `ObjectMapper`.

Allows serializing Jackson polymorphic types when the base type is specified as a generic argument. E.g., `Foo<Bar>` where `Bar` has `JsonTypeInfo` annotation. Otherwise Jackson will see this type as simply `Foo` and will not be aware of the `JsonTypeInfo` on the contained type. 