### PR TITLE
pass the type arg to gson for serialization

### DIFF
--- a/gson2/src/main/java/org/jdbi/v3/gson2/GsonJsonMapper.java
+++ b/gson2/src/main/java/org/jdbi/v3/gson2/GsonJsonMapper.java
@@ -21,7 +21,7 @@ import org.jdbi.v3.json.JsonMapper;
 class GsonJsonMapper implements JsonMapper {
     @Override
     public String toJson(Type type, Object value, ConfigRegistry config) {
-        return config.get(Gson2Config.class).getGson().toJson(value);
+        return config.get(Gson2Config.class).getGson().toJson(value, type);
     }
 
     @Override

--- a/gson2/src/test/java/org/jdbi/v3/gson2/TestGson2Plugin.java
+++ b/gson2/src/test/java/org/jdbi/v3/gson2/TestGson2Plugin.java
@@ -13,11 +13,23 @@
  */
 package org.jdbi.v3.gson2;
 
+import java.io.IOException;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.json.AbstractJsonMapperTest;
+import org.jdbi.v3.json.Json;
 import org.jdbi.v3.postgres.PostgresDbRule;
 import org.jdbi.v3.testing.JdbiRule;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestGson2Plugin extends AbstractJsonMapperTest {
     @Rule
@@ -26,5 +38,67 @@ public class TestGson2Plugin extends AbstractJsonMapperTest {
     @Before
     public void before() {
         jdbi = db.getJdbi().installPlugin(new Gson2Plugin());
+    }
+
+    @Test
+    public void typeCanBeOverridden() {
+        db.getJdbi().useHandle(h -> {
+            h.createUpdate("create table users(usr json)").execute();
+
+            Gson gson = new GsonBuilder()
+                .registerTypeAdapter(SuperUser.class, new SuperUserAdapter())
+                .registerTypeAdapter(SubUser.class, new SubUserAdapter())
+                .create();
+            h.getConfig(Gson2Config.class).setGson(gson);
+
+            h.createUpdate("insert into users(usr) values(:user)")
+                // declare that the subuser should be mapped as a superuser
+                .bindByType("user", new SubUser(), QualifiedType.of(SuperUser.class).with(Json.class))
+                .execute();
+
+            User subuser = h.createQuery("select usr from users")
+                .mapTo(QualifiedType.of(User.class).with(Json.class))
+                .findOnly();
+
+            assertThat(subuser.name)
+                .describedAs("instead of being bound via getClass(), the object was bound according to the type param")
+                .isEqualTo("super");
+        });
+    }
+
+    public static class User {
+        private final String name;
+
+        public User(String name) {
+            this.name = name;
+        }
+    }
+
+    private static class SuperUser {}
+
+    private static class SubUser extends SuperUser {}
+
+    private static class SuperUserAdapter extends TypeAdapter<SuperUser> {
+        @Override
+        public void write(JsonWriter out, SuperUser user) throws IOException {
+            out.beginObject().name("name").value("super").endObject();
+        }
+
+        @Override
+        public SuperUser read(JsonReader in) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class SubUserAdapter extends TypeAdapter<SubUser> {
+        @Override
+        public void write(JsonWriter out, SubUser user) throws IOException {
+            out.beginObject().name("name").value("sub").endObject();
+        }
+
+        @Override
+        public SubUser read(JsonReader in) {
+            throw new UnsupportedOperationException();
+        }
     }
 }


### PR DESCRIPTION
If you remove the type arg, you'll see that mapping happens according to the `getClass()` type of the value, regardless of the type specified in our API call. Since gson offers passing the type as an arg, we should do so, as users will expect it.