### PR TITLE
Isolate H2DatabaseRule legacy table creation

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestClosingHandle {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     private Handle h;
 

--- a/core/src/test/java/org/jdbi/v3/core/TestHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestHandle.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHandle {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Test
     public void testInTransaction() {

--- a/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestJdbi {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     private Handle handle;
 

--- a/core/src/test/java/org/jdbi/v3/core/TestOptional.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestOptional.java
@@ -40,7 +40,7 @@ public class TestOptional {
         + "order by id";
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/core/src/test/java/org/jdbi/v3/core/TestTooManyCursors.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestTooManyCursors.java
@@ -35,7 +35,7 @@ import org.junit.Test;
  */
 public class TestTooManyCursors {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Test
     public void testFoo() {

--- a/core/src/test/java/org/jdbi/v3/core/TestUri.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestUri.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestUri {
     private static final URI TEST_URI = URI.create("http://example.invalid/wat.jpg");
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Test
     public void testUri() {

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentFactory.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestArgumentFactory {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Test
     public void testRegisterOnJdbi() {

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestNamedParams.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestNamedParams.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestNamedParams {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Test
     public void testInsert() {

--- a/core/src/test/java/org/jdbi/v3/core/internal/lexer/TestDefineIdentifierPrefix.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/lexer/TestDefineIdentifierPrefix.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDefineIdentifierPrefix {
     @Rule
-    public H2DatabaseRule db = new H2DatabaseRule();
+    public H2DatabaseRule db = new H2DatabaseRule().withSomething();
 
     @Test
     public void testParse() {

--- a/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestClasspathSqlLocator {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/core/src/test/java/org/jdbi/v3/core/mapper/MapOptionalTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/MapOptionalTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 public class MapOptionalTest {
     @Rule
-    public H2DatabaseRule db = new H2DatabaseRule();
+    public H2DatabaseRule db = new H2DatabaseRule().withSomething();
 
     @Test
     public void testMapOptional() {

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestEnums {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     public static class SomethingElse {
         public enum Name {

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestRegisteredMappers.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestRegisteredMappers.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.mock;
 
 public class TestRegisteredMappers {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
     private Jdbi db;
 
     @Before

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
@@ -47,7 +47,7 @@ public class BeanMapperTest {
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Mock
     ResultSet resultSet;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
@@ -47,7 +47,7 @@ public class FieldMapperTest {
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Mock
     ResultSet resultSet;

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestCustomQualifier.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestCustomQualifier.java
@@ -40,7 +40,7 @@ import static org.jdbi.v3.core.qualifier.Reverser.reverse;
 public class TestCustomQualifier {
 
     @Rule
-    public DatabaseRule dbRule = new H2DatabaseRule();
+    public DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Test
     public void registerArgumentFactory() {

--- a/core/src/test/java/org/jdbi/v3/core/result/TestIterator.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestIterator.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIterator {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     private Handle h;
 

--- a/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestReducing {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Before
     public void setUp() {

--- a/core/src/test/java/org/jdbi/v3/core/rule/H2DatabaseRule.java
+++ b/core/src/test/java/org/jdbi/v3/core/rule/H2DatabaseRule.java
@@ -34,6 +34,10 @@ public class H2DatabaseRule extends ExternalResource implements DatabaseRule<H2D
     private Handle sharedHandle;
     private boolean installPlugins = false;
     private final List<JdbiPlugin> plugins = new ArrayList<>();
+    /**
+     * @deprecated data setup is not this class' concern
+     */
+    @Deprecated
     private boolean withSomething = false;
 
     @Override
@@ -69,10 +73,7 @@ public class H2DatabaseRule extends ExternalResource implements DatabaseRule<H2D
 
     /**
      * create the legacy {@code something} table
-     *
-     * @deprecated data setup is not this class' concern
      */
-    @Deprecated
     public H2DatabaseRule withSomething() {
         withSomething = true;
         return this;

--- a/core/src/test/java/org/jdbi/v3/core/rule/H2DatabaseRule.java
+++ b/core/src/test/java/org/jdbi/v3/core/rule/H2DatabaseRule.java
@@ -34,6 +34,7 @@ public class H2DatabaseRule extends ExternalResource implements DatabaseRule<H2D
     private Handle sharedHandle;
     private boolean installPlugins = false;
     private final List<JdbiPlugin> plugins = new ArrayList<>();
+    private boolean withSomething = false;
 
     @Override
     protected void before() throws Throwable {
@@ -44,9 +45,11 @@ public class H2DatabaseRule extends ExternalResource implements DatabaseRule<H2D
         plugins.forEach(db::installPlugin);
         sharedHandle = db.open();
         con = sharedHandle.getConnection();
-        try (Statement s = con.createStatement()) {
-            // TODO legacy...
-            s.execute("create table something (id identity primary key, name varchar(50), integerValue integer, intValue integer)");
+
+        if (withSomething) {
+            try (Statement s = con.createStatement()) {
+                s.execute("create table something (id identity primary key, name varchar(50), integerValue integer, intValue integer)");
+            }
         }
     }
 
@@ -61,6 +64,17 @@ public class H2DatabaseRule extends ExternalResource implements DatabaseRule<H2D
 
     public H2DatabaseRule withPlugins() {
         installPlugins = true;
+        return this;
+    }
+
+    /**
+     * create the legacy {@code something} table
+     *
+     * @deprecated data setup is not this class' concern
+     */
+    @Deprecated
+    public H2DatabaseRule withSomething() {
+        withSomething = true;
         return this;
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBatch.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestBatch {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Test
     public void testBasics() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPositionalParameterBinding.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPositionalParameterBinding.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestPositionalParameterBinding {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     private Handle h;
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 public class TestPreparedBatch {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     private Handle h;
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
@@ -42,7 +42,7 @@ import static org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath;
 
 public class TestQueries {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestScript.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestScript.java
@@ -30,7 +30,7 @@ import static org.jdbi.v3.core.locator.ClasspathSqlLocator.getResourceOnClasspat
 
 public class TestScript {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Test
     public void testScriptStuff() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatementContext.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatementContext.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStatementContext {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Test
     public void testFoo() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestStatements {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     private Handle h;
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestTimingCollector.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestTimingCollector.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTimingCollector {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     private Handle h;
 

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactions.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactions.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestTransactions {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     int begin, commit, rollback;
 

--- a/docs/src/test/java/jdbi/doc/KotlinPluginTest.kt
+++ b/docs/src/test/java/jdbi/doc/KotlinPluginTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.assertEquals
 class KotlinPluginTest {
     @Rule @JvmField
     val db = H2DatabaseRule()
+        .withSomething()
         .withPlugin(SqlObjectPlugin())
         .withPlugin(KotlinPlugin())
         .withPlugin(KotlinSqlObjectPlugin())

--- a/docs/src/test/java/jdbi/doc/SqlObjectTest.java
+++ b/docs/src/test/java/jdbi/doc/SqlObjectTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SqlObjectTest {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     // tag::defn[]
     @RegisterRowMapper(SomethingMapper.class)

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/BindBeanListTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/BindBeanListTest.java
@@ -40,7 +40,7 @@ public class BindBeanListTest {
     private List<Something> expectedSomethings;
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Before
     public void before() {

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListTest.java
@@ -41,7 +41,7 @@ public class BindListTest {
     private List<Something> expectedSomethings;
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Before
     public void before() {

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerEngineTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerEngineTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FreemarkerEngineTest {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerSqlLocatorTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/FreemarkerSqlLocatorTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FreemarkerSqlLocatorTest {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
@@ -50,7 +50,7 @@ import static org.assertj.guava.api.Assertions.entry;
 
 public class TestGuavaCollectors {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugins();
 
     private Collection<Integer> expected;
 

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaOptional.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaOptional.java
@@ -38,7 +38,7 @@ public class TestGuavaOptional {
         + "order by id";
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugins();
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/jpa/src/test/java/org/jdbi/v3/jpa/JpaTest.java
+++ b/jpa/src/test/java/org/jdbi/v3/jpa/JpaTest.java
@@ -47,7 +47,7 @@ public class JpaTest {
     private static final String NAME_ANNOTATION_NAME = "bar";
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     interface Thing {
         int getId();

--- a/jpa/src/test/java/org/jdbi/v3/jpa/PluginTest.java
+++ b/jpa/src/test/java/org/jdbi/v3/jpa/PluginTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class PluginTest {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugins();
 
     @Entity
     static class Thing {

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/v3/kotlin/KotlinSqlObjectPluginTest.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/v3/kotlin/KotlinSqlObjectPluginTest.kt
@@ -34,7 +34,7 @@ import kotlin.test.assertFails
 
 class KotlinSqlObjectPluginTest {
     @Rule @JvmField
-    val db = H2DatabaseRule().withPlugins()
+    val db = H2DatabaseRule().withSomething().withPlugins()
 
     data class Thing(val id: Int, val name: String,
                      val nullable: String?,

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinPluginTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinPluginTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertEquals
 
 class KotlinPluginTest {
     @Rule @JvmField
-    val db = H2DatabaseRule().withPlugins()
+    val db = H2DatabaseRule().withSomething().withPlugins()
 
     data class Thing(val id: Int, val name: String,
                      val nullable: String?,

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinQualifierTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinQualifierTest.kt
@@ -33,7 +33,7 @@ class KotlinQualifierTest {
 
     @Rule
     @JvmField
-    val dbRule: H2DatabaseRule = H2DatabaseRule().withPlugin(KotlinPlugin())
+    val dbRule: H2DatabaseRule = H2DatabaseRule().withSomething().withPlugin(KotlinPlugin())
 
     private lateinit var handle: Handle
 

--- a/noparameters/src/test/java/org/jdbi/v3/noparameters/TestSqlObjectNoParameterNames.java
+++ b/noparameters/src/test/java/org/jdbi/v3/noparameters/TestSqlObjectNoParameterNames.java
@@ -36,7 +36,7 @@ import static org.junit.Assume.assumeFalse;
 
 public class TestSqlObjectNoParameterNames {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     Handle h;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestBatching {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
     private Handle handle;
 
     @Before

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanBinder.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanBinder.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBeanBinder {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindAutomaticNames.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindAutomaticNames.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBindAutomaticNames {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
     private Handle handle;
 
     @Before

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindBean.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindBean.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestBindBean {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindExpression.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindExpression.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBindExpression {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Test
     public void testExpression() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindFunctions.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindFunctions.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBindFunctions {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMap.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMap.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBindMap {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
@@ -35,7 +35,7 @@ import static org.assertj.guava.api.Assertions.assertThat;
 public class TestCollectorFactory {
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin()).withPlugin(new GuavaPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin()).withPlugin(new GuavaPlugin());
 
     @Test
     public void testExists() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConsumer.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConsumer.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestConsumer {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Test
     public void testReturnStream() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCreateSqlObjectAnnotation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCreateSqlObjectAnnotation.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class TestCreateSqlObjectAnnotation {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCustomBinder.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCustomBinder.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCustomBinder {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Test
     public void testFoo() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefaultMethods.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefaultMethods.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDefaultMethods {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Test
     public void testDefaultMethod() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDocumentation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDocumentation.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class TestDocumentation {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Test
     public void testFiveMinuteFluentApi() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGetGeneratedKeys.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestGetGeneratedKeys.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestGetGeneratedKeys {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     public interface DAO {
         @SqlUpdate("insert into something (name) values (:name)")

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestInClauseExpansion.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestInClauseExpansion.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInClauseExpansion {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins(); // Guava
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugins(); // Guava
     private Handle handle;
 
     @Before

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMistypedNamedParameter.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMistypedNamedParameter.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestMistypedNamedParameter {
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Dao dao;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestModifiers.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestModifiers.java
@@ -37,7 +37,7 @@ import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.READ_UNCOMM
 
 public class TestModifiers {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
     private Handle handle;
 
     @Before

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNull.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNull.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestNull {
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private DAO dao;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestObjectMethods.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestObjectMethods.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestObjectMethods {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPaging.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPaging.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPaging {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin()).withPlugin(new GuavaPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin()).withPlugin(new GuavaPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPolymorphicReturn.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPolymorphicReturn.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestPolymorphicReturn {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private SheepDao dao;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPositionalBinder.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPositionalBinder.java
@@ -43,7 +43,6 @@ public class TestPositionalBinder {
         handle = dbRule.getSharedHandle();
         somethingDao = handle.attach(SomethingDao.class);
 
-        handle.execute("drop table something");
         handle.execute("create table something (something_id int primary key, name varchar(100), code int)");
         handle.execute("insert into something(something_id, name, code) values (1, 'Brian', 12)");
         handle.execute("insert into something(something_id, name, code) values (2, 'Keith', 27)");

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPrimitiveQueryResult.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPrimitiveQueryResult.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPrimitiveQueryResult {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestQualifiers.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestQualifiers.java
@@ -65,7 +65,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TestQualifiers {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterArgumentFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterArgumentFactory.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterArgumentFactory {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
     private Jdbi db;
 
     @Before

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterConstructorMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterConstructorMapper.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestRegisterConstructorMapper {
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Dao dao;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterRowMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterRowMapperFactory.java
@@ -38,7 +38,7 @@ import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 
 public class TestRegisterRowMapperFactory {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Test
     public void testSimple() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredGenericReturnAndParam.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredGenericReturnAndParam.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisteredGenericReturnAndParam {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Test
     public void testRegisterGenericRowMapperAnnotationWorks() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredMappersWork.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredMappersWork.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestRegisteredMappersWork {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     public interface BooleanDao {
         @SqlQuery("select 1+1 = 2")

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQuery.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQuery.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestReturningQuery {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
     private Handle handle;
 
     @Before

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQueryResults.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQueryResults.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestReturningQueryResults {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
     private Handle handle;
 
     @Before

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlCall.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlCall.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSqlCall {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObject.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verify;
 
 public class TestSqlObject {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestStatements.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestStatements.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStatements {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Test
     public void testInsert() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestStream.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestStream.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStream {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Test
     public void testReturnStream() {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTimingCollector.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTimingCollector.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestTimingCollector {
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugins();
 
     private final CustomTimingCollector timingCollector = new CustomTimingCollector();
     private DAO dao;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactionAnnotation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactionAnnotation.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class TestTransactionAnnotation {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseClasspathSqlLocator.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseClasspathSqlLocator.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestUseClasspathSqlLocator {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestVariousOddities.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestVariousOddities.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestVariousOddities {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseConfiguredDefaultParameterCustomizerFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseConfiguredDefaultParameterCustomizerFactory.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUseConfiguredDefaultParameterCustomizerFactory {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseCustomHandlerFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseCustomHandlerFactory.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUseCustomHandlerFactory {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseSqlParser.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseSqlParser.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUseSqlParser {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindBeanListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindBeanListTest.java
@@ -40,7 +40,7 @@ public class BindBeanListTest {
     private List<Something> expectedSomethings;
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Before
     public void before() {

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullTest.java
@@ -40,7 +40,7 @@ public class BindListNullTest {
     private Handle handle;
 
     @Rule
-    public final H2DatabaseRule dbRule = new H2DatabaseRule();
+    public final H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
 
     @Before
     public void before() {

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -41,7 +41,7 @@ import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.VOID;
 
 public class BindListTest {
     @Rule
-    public final H2DatabaseRule h2 = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public final H2DatabaseRule h2 = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
     private List<Something> expectedSomethings;

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestConditionalStringTemplateLocator.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestConditionalStringTemplateLocator.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestConditionalStringTemplateLocator {
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     @Before
     public void setUp() {

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateGroupReference.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateGroupReference.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStringTemplateGroupReference {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateLoading.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateLoading.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStringTemplateLoading {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateSqlLocator.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateSqlLocator.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStringTemplateSqlLocator {
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
 
     private Handle handle;
 

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrCollectorFactoryWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrCollectorFactoryWithDB.java
@@ -50,7 +50,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestVavrCollectorFactoryWithDB {
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugins();
 
     private Seq<Integer> expected = List.range(0, 10);
     private Map<Integer, String> expectedMap = expected.toMap(i -> new Tuple2<>(i, i + "asString"));

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestVavrOptionMapperWithDB {
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugins();
 
     @Before
     public void addData() {

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleRowMapperFactoryWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleRowMapperFactoryWithDB.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestVavrTupleRowMapperFactoryWithDB {
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugins();
 
     @Before
     public void addData() {

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrValueArgumentFactoryWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrValueArgumentFactoryWithDB.java
@@ -39,7 +39,7 @@ public class TestVavrValueArgumentFactoryWithDB {
     private static final Something BRIANSOMETHING = new Something(2, "brian");
 
     @Rule
-    public H2DatabaseRule dbRule = new H2DatabaseRule().withPlugins();
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething().withPlugins();
 
     @Before
     public void createTestData() {


### PR DESCRIPTION
Of 150–160 tests using `H2DatabaseRule`, only 93 actually use the legacy `something` table it automatically creates.

This PR isolates the creation of the table to a `withSomething()` config method, makes it opt-in so the current and any new tests built on it will explicitly depend on it, and existing tests that don't depend on it no longer cause it to be created.

A `DatabaseRule`'s job is to set up a connection, not to spawn cookie cutter test materials. Half the time it goes unused since a good test is encapsulated and manages its own setup, and it can influence test writers to write their tests to suit the existing table rather than letting the test data takes its own natural form (e.g. different datatypes or more expressive names). For this reason I've marked the method `@Deprecated`, but it's a soft preference so if someone _really_ objects I'm ok with leaving it open to guiltless use.

Scratch 1 `TODO` off the list 😃 