### PR TITLE
Update to AssertJ 3.12

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
@@ -81,7 +81,7 @@ public class TestClosingHandle {
             .mapToMap()
             .iterator();
 
-        assertThat(it).hasSize(2);
+        assertThat(it).toIterable().hasSize(2);
         assertThat(h.isClosed()).isFalse();
     }
 
@@ -95,7 +95,7 @@ public class TestClosingHandle {
             .mapToMap()
             .iterator();
 
-        assertThat(it).hasSize(2);
+        assertThat(it).toIterable().hasSize(2);
         assertThat(h.isClosed()).isTrue();
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
@@ -30,14 +30,14 @@ public class IterableLikeTest {
     public void testIntArray() {
         final Iterator<Object> it = IterableLike.of(new int[]{1, 2, 3});
 
-        assertThat(it).containsExactly(1, 2, 3);
+        assertThat(it).toIterable().contains(1, 2, 3);
     }
 
     @Test
     public void testEmptyArray() {
         final Iterator<Object> it = IterableLike.of(new int[]{});
 
-        assertThat(it).isEmpty();
+        assertThat(it).isExhausted();
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
@@ -132,8 +132,7 @@ public class ImmutablesTest {
                 .mapTo(ImmutableFooBarBaz.class)
                 .findOnly())
             .extracting("id", "foo", "bar", "baz")
-        // FIXME: https://github.com/joel-costigliola/assertj-core/pull/1360
-            .containsExactly(1, "foo", 42, 1.0);
+            .containsExactly(1, Optional.of("foo"), OptionalInt.of(42), OptionalDouble.of(1.0));
     }
 
     @Value.Immutable

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.11.1</version>
+                <version>3.12.0</version>
             </dependency>
 
             <dependency>

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestJavaTime.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestJavaTime.java
@@ -22,7 +22,6 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.assertj.core.data.TemporalUnitOffset;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.testing.JdbiRule;
@@ -51,11 +50,7 @@ public class TestJavaTime {
 
     private TemporalUnitOffset getAllowableOffset() {
         // PostgreSQL seems to not have as much precision on Windows as it does on Linux.
-        if (SystemUtils.IS_OS_WINDOWS) {
-            return within(0, ChronoUnit.MICROS);
-        } else {
-            return within(0, ChronoUnit.NANOS);
-        }
+        return within(0, ChronoUnit.MICROS);
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDocumentation.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDocumentation.java
@@ -136,7 +136,7 @@ public class TestDocumentation {
             h.execute("insert into something (id, name) values (2, 'Keith')");
 
             ResultIterable<String> names = h.createQuery("select name from something order by id").mapTo(String.class);
-            assertThat(names.iterator()).containsExactly("Brian", "Keith");
+            assertThat(names.iterator()).toIterable().containsExactly("Brian", "Keith");
         }
     }
 
@@ -180,7 +180,7 @@ public class TestDocumentation {
             assertThat(sq.findNamesBetween(1, 4)).containsExactly("Robert", "Patrick");
 
             Iterator<String> names = sq.findAllNames();
-            assertThat(names).containsExactly("Brian", "Robert", "Patrick", "Maniax");
+            assertThat(names).toIterable().containsExactly("Brian", "Robert", "Patrick", "Maniax");
         }
     }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestQualifiers.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestQualifiers.java
@@ -159,8 +159,10 @@ public class TestQualifiers {
         assertThat(dao.resultIterableNames())
             .containsExactly("oof", "rab", "zab");
         assertThat(dao.resultIteratorNames())
+            .toIterable()
             .containsExactly("oof", "rab", "zab");
         assertThat(dao.iteratorNames())
+            .toIterable()
             .containsExactly("oof", "rab", "zab");
         assertThat(dao.streamNames())
             .containsExactly("oof", "rab", "zab");

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQueryResults.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReturningQueryResults.java
@@ -56,7 +56,7 @@ public class TestReturningQueryResults {
 
         dbRule.getJdbi().useExtension(Spiffy.class, spiffy -> {
             Iterator<Something> itty = spiffy.findByIdRange(2, 10);
-            assertThat(itty).containsOnlyOnce(new Something(7, "Tim"), new Something(3, "Diego"));
+            assertThat(itty).toIterable().containsOnlyOnce(new Something(7, "Tim"), new Something(3, "Diego"));
         });
     }
 


### PR DESCRIPTION
'TestJavaTime' in the PostgreSQL module fails on Windows but works on
Linux. I think this is caused by the embedded Postgres being used, anyone have an input on this?

Example failing test output:
```
org.junit.ComparisonFailure: 
Expected :2019-02-18T18:06:07.957086900Z
Actual   :2019-02-18T18:06:07.957087Z
```

EDIT: By the way the tests will randomly pass/fail.