### PR TITLE
Fix Immutables byte[] properties

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ImmutablesPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ImmutablesPropertiesFactory.java
@@ -140,8 +140,8 @@ public class ImmutablesPropertiesFactory {
                         QualifiedType.of(propertyType).with(Qualifiers.getQualifiers(m)),
                         m,
                         alwaysSet(),
-                        MethodHandles.lookup().unreflect(m),
-                        findBuilderSetter(builderClass, name, propertyType));
+                        MethodHandles.lookup().unreflect(m).asFixedArity(),
+                        findBuilderSetter(builderClass, name, propertyType).asFixedArity());
             } catch (IllegalAccessException | NoSuchMethodException e) {
                 throw new IllegalArgumentException("Failed to inspect method " + m, e);
             }
@@ -200,8 +200,8 @@ public class ImmutablesPropertiesFactory {
                         QualifiedType.of(propertyType).with(Qualifiers.getQualifiers(m)),
                         m,
                         isSetMethod(name),
-                        MethodHandles.lookup().unreflect(m),
-                        MethodHandles.lookup().findVirtual(impl, setterName(name), MethodType.methodType(impl, GenericTypes.getErasedType(propertyType))));
+                        MethodHandles.lookup().unreflect(m).asFixedArity(),
+                        MethodHandles.lookup().findVirtual(impl, setterName(name), MethodType.methodType(impl, GenericTypes.getErasedType(propertyType))).asFixedArity());
             } catch (IllegalAccessException | NoSuchMethodException e) {
                 throw new IllegalArgumentException("Failed to inspect method " + m, e);
             }

--- a/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
@@ -36,7 +36,8 @@ public class ImmutablesTest {
             .registerImmutable(SubValue.class)
             .registerImmutable(FooBarBaz.class)
             .registerModifiable(FooBarBaz.class)
-            .registerImmutable(Getter.class));
+            .registerImmutable(Getter.class)
+            .registerImmutable(ByteArray.class));
 
     private Jdbi jdbi;
     private Handle h;
@@ -160,5 +161,24 @@ public class ImmutablesTest {
                 .mapTo(Getter.class)
                 .findOnly())
             .isEqualTo(expected);
+    }
+
+    @Value.Immutable
+    public interface ByteArray {
+        byte[] value();
+    }
+
+    @Test
+    public void testByteArray() {
+        final byte[] value = new byte[] {(byte) 42, (byte) 24};
+        h.execute("create table bytearr(value bytea)");
+        h.createUpdate("insert into bytearr(value) values(:value)")
+            .bindPojo(ImmutableByteArray.builder().value(value).build())
+            .execute();
+        assertThat(h.createQuery("select * from bytearr")
+                .mapTo(ByteArray.class)
+                .findOnly()
+                .value())
+            .containsExactly(value);
     }
 }


### PR DESCRIPTION
Immutables helpfully transcribes `byte[]` to `byte...` on the builder methods, which causes `MethodHandles.unreflect` to create an unexpected _varargs argument collector_ method handle.  This ends up leading to a super confusing

```
java.lang.ClassCastException: [B cannot be cast to java.lang.Number
	at sun.invoke.util.ValueConversions.primitiveConversion(ValueConversions.java:242)
	at sun.invoke.util.ValueConversions.unboxByte(ValueConversions.java:85)
	at org.jdbi.v3.core.internal.exceptions.Unchecked.lambda$5(Unchecked.java:86)
	at org.jdbi.v3.core.mapper.ImmutablesTest.testUnreflect(ImmutablesTest.java:205)
```

when the reflection machinery attempts to unbox a `byte[]`.