### PR TITLE
EnumSetCollectorFactory: ecj compile fix

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/collector/EnumSetCollectorFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/EnumSetCollectorFactory.java
@@ -39,10 +39,15 @@ class EnumSetCollectorFactory implements CollectorFactory {
         return findGenericParameter(containerType, EnumSet.class);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Collector<?, ?, ?> build(Type containerType) {
-        Class<? extends Enum> componentType = (Class<? extends Enum>) findGenericParameter(containerType, EnumSet.class)
+        return build0(containerType);
+    }
+
+    // exists to give ecj a more static type to check against
+    @SuppressWarnings("unchecked")
+    private <E extends Enum<E>> Collector<E, ?, ?> build0(Type containerType) {
+        Class<E> componentType = (Class<E>) findGenericParameter(containerType, EnumSet.class)
             .map(GenericTypes::getErasedType)
             .orElseThrow(() -> new IllegalStateException("Cannot determine EnumSet element type"));
 


### PR DESCRIPTION
Eclipse's `ecj` is unhappy with the `EnumSet::add` of a wildcard type and causes an error.
Factoring it out into a named type `E` and making the return type `Collector<E` gives it just enough more information to make it happy.