### PR TITLE
Support binding of Java enums to SQL arrays out of the box

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayTypes.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.enums.internal.EnumSqlArrayTypeFactory;
 import org.jdbi.v3.core.internal.JdbiOptionals;
 
 /**
@@ -33,6 +34,8 @@ public class SqlArrayTypes implements JdbiConfig<SqlArrayTypes> {
 
     public SqlArrayTypes() {
         argumentStrategy = SqlArrayArgumentStrategy.SQL_ARRAY;
+
+        register(new EnumSqlArrayTypeFactory());
     }
 
     private SqlArrayTypes(SqlArrayTypes that) {

--- a/core/src/main/java/org/jdbi/v3/core/enums/internal/EnumMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/enums/internal/EnumMapperFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.enums.internal;
+
+import java.util.Optional;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.enums.EnumStrategy;
+import org.jdbi.v3.core.generic.GenericTypes;
+import org.jdbi.v3.core.internal.EnumStrategies;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.EnumMapper;
+import org.jdbi.v3.core.mapper.QualifiedColumnMapperFactory;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+
+public class EnumMapperFactory implements QualifiedColumnMapperFactory {
+    @Override
+    public Optional<ColumnMapper<?>> build(QualifiedType<?> givenType, ConfigRegistry config) {
+        return Optional.of(givenType.getType())
+            .map(GenericTypes::getErasedType)
+            .filter(Class::isEnum)
+            .map(clazz -> makeEnumArgument((QualifiedType<Enum>) givenType, (Class<Enum>) clazz, config));
+    }
+
+    private static <E extends Enum<E>> ColumnMapper<?> makeEnumArgument(QualifiedType<E> givenType, Class<E> enumClass, ConfigRegistry config) {
+        boolean byName = EnumStrategy.BY_NAME == config.get(EnumStrategies.class).findStrategy(givenType);
+
+        return byName
+            ? EnumMapper.byName(enumClass)
+            : EnumMapper.byOrdinal(enumClass);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.jdbi.v3.core.array.SqlArrayMapperFactory;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.enums.internal.EnumMapperFactory;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.internal.JdbiOptionals;
 import org.jdbi.v3.core.qualifier.QualifiedType;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/EnumMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/EnumMapper.java
@@ -36,8 +36,8 @@ import org.jdbi.v3.core.statement.StatementContext;
  * @see Enums
  * @see EnumByName
  * @see EnumByOrdinal
- * @see EnumMapperFactory
  */
+// TODO jdbi4: move to enums package
 public abstract class EnumMapper<E extends Enum<E>> implements ColumnMapper<E> {
     private static final Map<Class<? extends Enum<?>>, ColumnMapper<? extends Enum<?>>> BY_NAME_MAPPER_CACHE =
         ExpiringMap.builder().expiration(10, TimeUnit.MINUTES).expirationPolicy(ExpirationPolicy.ACCESSED).build();

--- a/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
+++ b/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
@@ -128,4 +128,21 @@ public class TestH2SqlArrays {
             .isInstanceOf(LinkedHashSet.class)
             .containsExactly(testUuids);
     }
+
+    @Test
+    public void testEnumArrays() {
+        Handle h = dbRule.openHandle();
+
+        GenericType<List<TestEnum>> testEnumList = new GenericType<List<TestEnum>>() {};
+
+        assertThat(h.select("select ?")
+            .bindByType(0, Arrays.asList(TestEnum.values()), testEnumList)
+            .mapTo(testEnumList).findOnly())
+            .containsExactly(TestEnum.values());
+    }
+
+    public enum TestEnum {
+        FOO, BAR, BAZ
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.12.0</version>
+                <version>3.12.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixes #1477 

* Add `EnumSqlArrayTypeFactory`, which respects the `Enums.enumStrategy` configuration property.
* Register the above factory out-of-the-box
* Remove redundant use of optionals in EnumMapperFactory private methods
* Move EnumMapperFactory to an `enums.internal` package
* Upgrade assertj-core dependency version, which was failing the build