### PR TITLE
Document Kotlin compiler target version needed for ResultSet mapping

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -4094,6 +4094,13 @@ To use this plugin, add a Maven dependency:
 </dependency>
 ----
 
+Ensure the Kotlin compiler's https://kotlinlang.org/docs/reference/using-maven.html#attributes-specific-for-jvm[JVM target version] is set to 1.8:
+[source,xml,subs="specialchars"]
+----
+<kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+----
+
+
 Then install the plugin into your `Jdbi` instance:
 
 [source,kotlin]


### PR DESCRIPTION
This PR simply documents that for Kotlin ResultSet mapping helpers to work, the Kotlin compiler's JVM target version must be 1.8 instead of the default 1.6.  