### PR TITLE
Mark postgres driver jar as provided

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 #3.7.1
 - New Features
   - Initial Java Module System support via Automatic-Module-Name
+- Improvements
+  - Postgres JDBC driver is now <scope>provided</scope> to avoid fighting with servlet containers.
 
 #3.7.0
 - New Features

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -57,6 +57,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
End user applications should bring their own Postgres driver, not rely on a transitive dependency through our plugin.  And it breaks servlet environments if you accidentally load the driver twice, once in a parent classloader and once in a child classloader.

Fixes #1503