### PR TITLE
forbid hidden fields

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -85,8 +85,8 @@ public class Handle implements Closeable, Configurable<Handle> {
         this.config.set(config);
     }
 
-    void setConfigThreadLocal(ThreadLocal<ConfigRegistry> config) {
-        this.config = config;
+    void setConfigThreadLocal(ThreadLocal<ConfigRegistry> configThreadLocal) {
+        this.config = configThreadLocal;
     }
 
     /**
@@ -550,8 +550,8 @@ public class Handle implements Closeable, Configurable<Handle> {
         this.extensionMethod.set(extensionMethod);
     }
 
-    void setExtensionMethodThreadLocal(ThreadLocal<ExtensionMethod> extensionMethod) {
-        this.extensionMethod = requireNonNull(extensionMethod);
+    void setExtensionMethodThreadLocal(ThreadLocal<ExtensionMethod> extensionMethodThreadLocal) {
+        this.extensionMethod = requireNonNull(extensionMethodThreadLocal);
     }
 
     interface ConnectionCloser {

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -55,13 +55,13 @@ public class Handle implements Closeable, Configurable<Handle> {
     private final Connection connection;
     private final boolean forceEndTransactions;
 
-    private ThreadLocal<ConfigRegistry> config;
-    private ThreadLocal<ExtensionMethod> extensionMethod;
+    private ThreadLocal<ConfigRegistry> localConfig;
+    private ThreadLocal<ExtensionMethod> localExtensionMethod;
     private StatementBuilder statementBuilder;
 
     private boolean closed = false;
 
-    Handle(ConfigRegistry config,
+    Handle(ConfigRegistry localConfig,
            ConnectionCloser closer,
            TransactionHandler transactions,
            StatementBuilder statementBuilder,
@@ -70,23 +70,23 @@ public class Handle implements Closeable, Configurable<Handle> {
         this.transactions = transactions;
         this.connection = connection;
 
-        this.config = ThreadLocal.withInitial(() -> config);
-        this.extensionMethod = new ThreadLocal<>();
+        this.localConfig = ThreadLocal.withInitial(() -> localConfig);
+        this.localExtensionMethod = new ThreadLocal<>();
         this.statementBuilder = statementBuilder;
         this.forceEndTransactions = !transactions.isInTransaction(this);
     }
 
     @Override
     public ConfigRegistry getConfig() {
-        return config.get();
+        return localConfig.get();
     }
 
     void setConfig(ConfigRegistry config) {
-        this.config.set(config);
+        this.localConfig.set(config);
     }
 
-    void setConfigThreadLocal(ThreadLocal<ConfigRegistry> configThreadLocal) {
-        this.config = configThreadLocal;
+    void setLocalConfig(ThreadLocal<ConfigRegistry> configThreadLocal) {
+        this.localConfig = configThreadLocal;
     }
 
     /**
@@ -130,7 +130,7 @@ public class Handle implements Closeable, Configurable<Handle> {
         }
 
         boolean wasInTransaction = false;
-        if (forceEndTransactions && config.get().get(Handles.class).isForceEndTransactions()) {
+        if (forceEndTransactions && localConfig.get().get(Handles.class).isForceEndTransactions()) {
             try {
                 wasInTransaction = isInTransaction();
             } catch (Exception e) {
@@ -138,8 +138,8 @@ public class Handle implements Closeable, Configurable<Handle> {
             }
         }
 
-        extensionMethod.remove();
-        config.remove();
+        localExtensionMethod.remove();
+        localConfig.remove();
 
         if (wasInTransaction) {
             try {
@@ -543,15 +543,15 @@ public class Handle implements Closeable, Configurable<Handle> {
      * @return the extension method currently bound to the handle's context
      */
     public ExtensionMethod getExtensionMethod() {
-        return extensionMethod.get();
+        return localExtensionMethod.get();
     }
 
     void setExtensionMethod(ExtensionMethod extensionMethod) {
-        this.extensionMethod.set(extensionMethod);
+        this.localExtensionMethod.set(extensionMethod);
     }
 
-    void setExtensionMethodThreadLocal(ThreadLocal<ExtensionMethod> extensionMethodThreadLocal) {
-        this.extensionMethod = requireNonNull(extensionMethodThreadLocal);
+    void setLocalExtensionMethod(ThreadLocal<ExtensionMethod> extensionMethodThreadLocal) {
+        this.localExtensionMethod = requireNonNull(extensionMethodThreadLocal);
     }
 
     interface ConnectionCloser {

--- a/core/src/main/java/org/jdbi/v3/core/LazyHandleSupplier.java
+++ b/core/src/main/java/org/jdbi/v3/core/LazyHandleSupplier.java
@@ -55,13 +55,13 @@ class LazyHandleSupplier implements HandleSupplier, AutoCloseable {
                     throw new IllegalStateException("Handle is closed");
                 }
 
-                Handle handle = db.open();
+                Handle newHandle = db.open();
                 // share extension method thread local with handle,
                 // so extension methods set in other threads are preserved
-                handle.setExtensionMethodThreadLocal(localExtensionMethod);
-                handle.setConfigThreadLocal(localConfig);
+                newHandle.setExtensionMethodThreadLocal(localExtensionMethod);
+                newHandle.setConfigThreadLocal(localConfig);
 
-                this.handle = handle;
+                this.handle = newHandle;
             }
         }
     }

--- a/core/src/main/java/org/jdbi/v3/core/LazyHandleSupplier.java
+++ b/core/src/main/java/org/jdbi/v3/core/LazyHandleSupplier.java
@@ -58,8 +58,8 @@ class LazyHandleSupplier implements HandleSupplier, AutoCloseable {
                 Handle newHandle = db.open();
                 // share extension method thread local with handle,
                 // so extension methods set in other threads are preserved
-                newHandle.setExtensionMethodThreadLocal(localExtensionMethod);
-                newHandle.setConfigThreadLocal(localConfig);
+                newHandle.setLocalExtensionMethod(localExtensionMethod);
+                newHandle.setLocalConfig(localConfig);
 
                 this.handle = newHandle;
             }

--- a/core/src/main/java/org/jdbi/v3/core/SingleConnectionFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/SingleConnectionFactory.java
@@ -32,5 +32,5 @@ class SingleConnectionFactory implements ConnectionFactory {
     }
 
     @Override
-    public void closeConnection(Connection connection) {}
+    public void closeConnection(Connection toClose) {}
 }

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
@@ -71,8 +71,8 @@ public class ObjectFieldArguments extends ObjectPropertyNamedArgumentFinder {
     }
 
     @Override
-    protected NamedArgumentFinder getNestedArgumentFinder(Object bean) {
-        return new ObjectFieldArguments(null, bean);
+    protected NamedArgumentFinder getNestedArgumentFinder(Object source) {
+        return new ObjectFieldArguments(null, source);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
@@ -71,8 +71,8 @@ public class ObjectFieldArguments extends ObjectPropertyNamedArgumentFinder {
     }
 
     @Override
-    protected NamedArgumentFinder getNestedArgumentFinder(Object obj) {
-        return new ObjectFieldArguments(null, obj);
+    protected NamedArgumentFinder getNestedArgumentFinder(Object bean) {
+        return new ObjectFieldArguments(null, bean);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
@@ -73,8 +73,8 @@ public class ObjectMethodArguments extends MethodReturnValueNamedArgumentFinder 
     }
 
     @Override
-    protected NamedArgumentFinder getNestedArgumentFinder(Object bean) {
-        return new ObjectMethodArguments(null, bean);
+    protected NamedArgumentFinder getNestedArgumentFinder(Object source) {
+        return new ObjectMethodArguments(null, source);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
@@ -73,8 +73,8 @@ public class ObjectMethodArguments extends MethodReturnValueNamedArgumentFinder 
     }
 
     @Override
-    protected NamedArgumentFinder getNestedArgumentFinder(Object obj) {
-        return new ObjectMethodArguments(null, obj);
+    protected NamedArgumentFinder getNestedArgumentFinder(Object bean) {
+        return new ObjectMethodArguments(null, bean);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/argument/internal/ObjectPropertyNamedArgumentFinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/internal/ObjectPropertyNamedArgumentFinder.java
@@ -29,7 +29,7 @@ import org.jdbi.v3.core.statement.UnableToCreateStatementException;
  * optional prefix.
  */
 public abstract class ObjectPropertyNamedArgumentFinder implements NamedArgumentFinder {
-    final String prefix;
+    private final String prefix;
     protected final Object obj;
 
     private final Map<String, Optional<NamedArgumentFinder>> childArgumentFinders = new ConcurrentHashMap<>();

--- a/core/src/main/java/org/jdbi/v3/core/array/InferredSqlArrayTypeFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/InferredSqlArrayTypeFactory.java
@@ -26,18 +26,18 @@ import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
  * {@link UnsupportedOperationException} will be thrown.
  */
 class InferredSqlArrayTypeFactory implements SqlArrayTypeFactory {
-    private final Type elementType;
+    private final Type inferredElementType;
     private final SqlArrayType<?> arrayType;
 
     InferredSqlArrayTypeFactory(SqlArrayType<?> arrayType) {
-        this.elementType = findGenericParameter(arrayType.getClass(), SqlArrayType.class)
+        this.inferredElementType = findGenericParameter(arrayType.getClass(), SqlArrayType.class)
                 .orElseThrow(() -> new UnsupportedOperationException("Must use a concretely typed SqlArrayType here"));
         this.arrayType = arrayType;
     }
 
     @Override
     public Optional<SqlArrayType<?>> build(Type elementType, ConfigRegistry config) {
-        return this.elementType.equals(elementType)
+        return this.inferredElementType.equals(elementType)
                 ? Optional.of(arrayType)
                 : Optional.empty();
     }

--- a/core/src/main/java/org/jdbi/v3/core/collector/OptionalBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/OptionalBuilder.java
@@ -20,21 +20,21 @@ class OptionalBuilder<T, O> {
     private final Supplier<O> empty;
     private final Function<T, O> factory;
 
-    boolean set;
-    T value;
+    private boolean set;
+    private T value;
 
     OptionalBuilder(Supplier<O> empty, Function<T, O> factory) {
         this.empty = empty;
         this.factory = factory;
     }
 
-    void set(T value) {
+    void set(T newValue) {
         if (set) {
-            throw tooManyValues(this.value, value);
+            throw tooManyValues(value, newValue);
         }
 
-        this.value = value;
-        this.set = true;
+        value = newValue;
+        set = true;
     }
 
     O build() {

--- a/core/src/main/java/org/jdbi/v3/core/enums/Enums.java
+++ b/core/src/main/java/org/jdbi/v3/core/enums/Enums.java
@@ -40,11 +40,11 @@ public class Enums implements JdbiConfig<Enums> {
 
     /**
      * Sets the default strategy for mapping and binding enums.
-     * @param strategy the new strategy
+     * @param enumStrategy the new strategy
      * @return this Enums instance, for chaining
      */
-    public Enums setEnumStrategy(EnumStrategy strategy) {
-        this.strategy = strategy;
+    public Enums setEnumStrategy(EnumStrategy enumStrategy) {
+        this.strategy = enumStrategy;
         return this;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -150,10 +150,10 @@ public class FieldMapper<T> implements RowMapper<T> {
 
                     findColumnIndex(paramName, columnNames, columnNameMatchers, () -> debugName(field))
                         .ifPresent(index -> {
-                            QualifiedType<?> type = QualifiedType.of(field.getGenericType())
+                            QualifiedType<?> fieldType = QualifiedType.of(field.getGenericType())
                                 .withAnnotations(ctx.getConfig(Qualifiers.class).findFor(field));
                             @SuppressWarnings("unchecked")
-                            ColumnMapper<?> mapper = ctx.findColumnMapperFor(type)
+                            ColumnMapper<?> mapper = ctx.findColumnMapperFor(fieldType)
                                 .orElse((ColumnMapper) (r, n, c) -> r.getObject(n));
                             fields.add(new FieldData(field, new SingleColumnMapper<>(mapper, index + 1)));
                             unmatchedColumns.remove(columnNames.get(index));

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
@@ -80,23 +80,23 @@ public final class QualifiedType<T> {
     /**
      * Returns a QualifiedType that has the same type as this instance, but with <b>only</b> the given qualifiers.
      *
-     * @param qualifiers the qualifiers for the new qualified type.
+     * @param newQualifiers the qualifiers for the new qualified type.
      * @return the QualifiedType
      */
-    public QualifiedType<T> with(Annotation... qualifiers) {
-        return new QualifiedType<>(type, Arrays.stream(qualifiers).collect(toSet()));
+    public QualifiedType<T> with(Annotation... newQualifiers) {
+        return new QualifiedType<>(type, Arrays.stream(newQualifiers).collect(toSet()));
     }
 
     /**
      * Returns a QualifiedType that has the same type as this instance, but with <b>only</b> the given qualifiers.
      *
-     * @param qualifiers the qualifiers for the new qualified type.
+     * @param newQualifiers the qualifiers for the new qualified type.
      * @throws IllegalArgumentException if any of the given qualifier types have annotation attributes.
      * @return the QualifiedType
      */
     @SafeVarargs
-    public final QualifiedType<T> with(Class<? extends Annotation>... qualifiers) {
-        Set<? extends Annotation> annotations = Arrays.stream(qualifiers)
+    public final QualifiedType<T> with(Class<? extends Annotation>... newQualifiers) {
+        Set<? extends Annotation> annotations = Arrays.stream(newQualifiers)
             .map(AnnotationFactory::create)
             .collect(toSet());
         return new QualifiedType<>(type, annotations);
@@ -105,19 +105,19 @@ public final class QualifiedType<T> {
     /**
      * @return a QualifiedType that has the same type as this instance, but with <b>only</b> the given qualifiers.
      *
-     * @param qualifiers the qualifiers for the new qualified type.
+     * @param newQualifiers the qualifiers for the new qualified type.
      */
-    public QualifiedType<T> withAnnotations(Iterable<? extends Annotation> qualifiers) {
-        return new QualifiedType<>(type, StreamSupport.stream(qualifiers.spliterator(), false).collect(toSet()));
+    public QualifiedType<T> withAnnotations(Iterable<? extends Annotation> newQualifiers) {
+        return new QualifiedType<>(type, StreamSupport.stream(newQualifiers.spliterator(), false).collect(toSet()));
     }
 
     /**
      * @return a QualifiedType that has the same type as this instance, but with <b>only</b> the given qualifiers.
      *
-     * @param qualifiers the qualifiers for the new qualified type.
+     * @param newQualifiers the qualifiers for the new qualified type.
      */
-    public QualifiedType<T> withAnnotationClasses(Iterable<Class<? extends Annotation>> qualifiers) {
-        Set<? extends Annotation> annotations = StreamSupport.stream(qualifiers.spliterator(), false)
+    public QualifiedType<T> withAnnotationClasses(Iterable<Class<? extends Annotation>> newQualifiers) {
+        Set<? extends Annotation> annotations = StreamSupport.stream(newQualifiers.spliterator(), false)
             .map(AnnotationFactory::create)
             .collect(toSet());
         return new QualifiedType<>(type, annotations);

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
@@ -127,11 +127,11 @@ public class ResultProducers implements JdbiConfig<ResultProducers> {
     /**
      * Normally a query that doesn't return a result set throws an exception.
      * With this option, we will replace it with an empty result set instead.
-     * @param allowNoResults the new allowNoResults setting
+     * @param allowed the new allowNoResults setting
      * @return this
      */
-    public ResultProducers allowNoResults(boolean allowNoResults) {
-        this.allowNoResults = allowNoResults;
+    public ResultProducers allowNoResults(boolean allowed) {
+        this.allowNoResults = allowed;
         return this;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/Binding.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Binding.java
@@ -100,11 +100,11 @@ public class Binding {
 
     @Override
     public String toString() {
-        String positionals = this.positionals.entrySet().stream()
+        String positionalsDescription = positionals.entrySet().stream()
             .map(x -> x.getKey().toString() + ':' + x.getValue())
             .collect(Collectors.joining(","));
 
-        String named = this.named.entrySet().stream()
+        String namedDescription = named.entrySet().stream()
             .map(x -> x.getKey() + ':' + x.getValue())
             .collect(Collectors.joining(","));
 
@@ -112,7 +112,7 @@ public class Binding {
             .map(Object::toString)
             .collect(Collectors.joining(","));
 
-        return "{positional:{" + positionals + "}, named:{" + named + "}, finder:[" + found + "]}";
+        return "{positional:{" + positionalsDescription + "}, named:{" + namedDescription + "}, finder:[" + found + "]}";
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -117,9 +117,9 @@ public class Call extends SqlStatement<Call> {
         }
 
         @Override
-        public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException {
-            ((CallableStatement) statement).registerOutParameter(position, sqlType);
-            this.position = position;
+        public void apply(int newPosition, PreparedStatement statement, StatementContext ctx) throws SQLException {
+            ((CallableStatement) statement).registerOutParameter(newPosition, sqlType);
+            this.position = newPosition;
         }
 
         public Object map(CallableStatement statement) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -122,10 +122,10 @@ public class Call extends SqlStatement<Call> {
             this.position = position;
         }
 
-        public Object map(CallableStatement stmt) {
+        public Object map(CallableStatement statement) {
             try {
                 if (mapper != null) {
-                    return mapper.map(position, stmt);
+                    return mapper.map(position, statement);
                 }
                 switch (sqlType) {
                     case Types.CLOB:
@@ -134,28 +134,28 @@ public class Call extends SqlStatement<Call> {
                     case Types.LONGVARCHAR:
                     case Types.NCLOB:
                     case Types.NVARCHAR:
-                        return stmt.getString(position);
+                        return statement.getString(position);
                     case Types.BLOB:
                     case Types.VARBINARY:
-                        return stmt.getBytes(position);
+                        return statement.getBytes(position);
                     case Types.SMALLINT:
-                        return stmt.getShort(position);
+                        return statement.getShort(position);
                     case Types.INTEGER:
-                        return stmt.getInt(position);
+                        return statement.getInt(position);
                     case Types.BIGINT:
-                        return stmt.getLong(position);
+                        return statement.getLong(position);
                     case Types.TIMESTAMP:
                         case Types.TIME:
-                        return stmt.getTimestamp(position);
+                        return statement.getTimestamp(position);
                     case Types.DATE:
-                        return stmt.getDate(position);
+                        return statement.getDate(position);
                     case Types.FLOAT:
-                        return stmt.getFloat(position);
+                        return statement.getFloat(position);
                     case Types.DECIMAL:
                     case Types.DOUBLE:
-                        return stmt.getDouble(position);
+                        return statement.getDouble(position);
                     default:
-                        return stmt.getObject(position);
+                        return statement.getObject(position);
                 }
             } catch (SQLException e) {
                 throw new UnableToExecuteStatementException("Could not get OUT parameter from statement", e, getContext());

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -117,15 +117,15 @@ public class Call extends SqlStatement<Call> {
         }
 
         @Override
-        public void apply(int newPosition, PreparedStatement statement, StatementContext ctx) throws SQLException {
-            ((CallableStatement) statement).registerOutParameter(newPosition, sqlType);
-            this.position = newPosition;
+        public void apply(int outPosition, PreparedStatement statement, StatementContext ctx) throws SQLException {
+            ((CallableStatement) statement).registerOutParameter(outPosition, sqlType);
+            this.position = outPosition;
         }
 
-        public Object map(CallableStatement statement) {
+        public Object map(CallableStatement stmt) {
             try {
                 if (mapper != null) {
-                    return mapper.map(position, statement);
+                    return mapper.map(position, stmt);
                 }
                 switch (sqlType) {
                     case Types.CLOB:
@@ -134,28 +134,28 @@ public class Call extends SqlStatement<Call> {
                     case Types.LONGVARCHAR:
                     case Types.NCLOB:
                     case Types.NVARCHAR:
-                        return statement.getString(position);
+                        return stmt.getString(position);
                     case Types.BLOB:
                     case Types.VARBINARY:
-                        return statement.getBytes(position);
+                        return stmt.getBytes(position);
                     case Types.SMALLINT:
-                        return statement.getShort(position);
+                        return stmt.getShort(position);
                     case Types.INTEGER:
-                        return statement.getInt(position);
+                        return stmt.getInt(position);
                     case Types.BIGINT:
-                        return statement.getLong(position);
+                        return stmt.getLong(position);
                     case Types.TIMESTAMP:
                         case Types.TIME:
-                        return statement.getTimestamp(position);
+                        return stmt.getTimestamp(position);
                     case Types.DATE:
-                        return statement.getDate(position);
+                        return stmt.getDate(position);
                     case Types.FLOAT:
-                        return statement.getFloat(position);
+                        return stmt.getFloat(position);
                     case Types.DECIMAL:
                     case Types.DOUBLE:
-                        return statement.getDouble(position);
+                        return stmt.getDouble(position);
                     default:
-                        return statement.getObject(position);
+                        return stmt.getObject(position);
                 }
             } catch (SQLException e) {
                 throw new UnableToExecuteStatementException("Could not get OUT parameter from statement", e, getContext());

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -83,7 +83,7 @@ public class Call extends SqlStatement<Call> {
      */
     public OutParameters invoke() {
         try {
-            final PreparedStatement stmt = this.internalExecute();
+            this.internalExecute();
             OutParameters out = new OutParameters();
             for (OutParamArgument param : params) {
                 Object obj = param.map((CallableStatement) stmt);

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -1526,14 +1526,14 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
         ParsedSql parsedSql = getConfig(SqlStatements.class)
                 .getSqlParser()
                 .parse(renderedSql, ctx);
-        String sql = parsedSql.getSql();
+        String parsedPlainSql = parsedSql.getSql();
         ctx.setParsedSql(parsedSql);
 
         try {
             if (getClass().isAssignableFrom(Call.class)) {
-                stmt = handle.getStatementBuilder().createCall(handle.getConnection(), sql, ctx);
+                stmt = handle.getStatementBuilder().createCall(handle.getConnection(), parsedPlainSql, ctx);
             } else {
-                stmt = handle.getStatementBuilder().create(handle.getConnection(), sql, ctx);
+                stmt = handle.getStatementBuilder().create(handle.getConnection(), parsedPlainSql, ctx);
             }
 
             // The statement builder might (or might not) clean up the statement when called. E.g. the

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -222,11 +222,11 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * Defaults to false: unused bindings are not allowed.
      *
      * @see org.jdbi.v3.core.argument.Argument
-     * @param allowUnusedBindings the new setting
+     * @param unusedBindingAllowed the new setting
      * @return this
      */
-    public SqlStatements setUnusedBindingAllowed(boolean allowUnusedBindings) {
-        this.allowUnusedBindings = allowUnusedBindings;
+    public SqlStatements setUnusedBindingAllowed(boolean unusedBindingAllowed) {
+        this.allowUnusedBindings = unusedBindingAllowed;
         return this;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
@@ -553,10 +553,10 @@ public class StatementContext implements Closeable {
     public void close() {
         SQLException exception = null;
         try {
-            List<Cleanable> cleanables = new ArrayList<>(this.cleanables);
-            this.cleanables.clear();
-            Collections.reverse(cleanables);
-            for (Cleanable cleanable : cleanables) {
+            List<Cleanable> cleanablesCopy = new ArrayList<>(cleanables);
+            cleanables.clear();
+            Collections.reverse(cleanablesCopy);
+            for (Cleanable cleanable : cleanablesCopy) {
                 try {
                     cleanable.close();
                 } catch (SQLException e) {

--- a/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
@@ -51,6 +51,7 @@ public class TestJdbi {
         assertThat(connection.isClosed()).isFalse();
     }
 
+    @Test
     public void testConnectionFactoryCtor() {
         Jdbi db = Jdbi.create(() -> {
             try {

--- a/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.jdbi.v3.core.statement.StatementCustomizers;
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -30,15 +29,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestJdbi {
     @Rule
     public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
-
-    private Handle handle;
-
-    @After
-    public void doTearDown() throws Exception {
-        if (handle != null) {
-            handle.close();
-        }
-    }
 
     @Test
     public void testDataSourceConstructor() {
@@ -104,10 +94,10 @@ public class TestJdbi {
     }
 
     @Test
-    public void testGlobalStatementCustomizers() throws Exception {
+    public void testGlobalStatementCustomizers() {
         dbRule.getJdbi().addCustomizer(StatementCustomizers.maxRows(1));
 
-        handle = dbRule.openHandle();
+        Handle handle = dbRule.openHandle();
 
         handle.execute("insert into something (id, name) values (?, ?)", 1, "hello");
         handle.execute("insert into something (id, name) values (?, ?)", 2, "world");

--- a/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
+++ b/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
@@ -131,8 +131,6 @@ public class TestH2SqlArrays {
 
     @Test
     public void testEnumArrays() {
-        Handle h = dbRule.openHandle();
-
         GenericType<List<TestEnum>> testEnumList = new GenericType<List<TestEnum>>() {};
 
         assertThat(h.select("select ?")
@@ -144,5 +142,4 @@ public class TestH2SqlArrays {
     public enum TestEnum {
         FOO, BAR, BAZ
     }
-
 }

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
@@ -73,9 +73,9 @@ public class BeanMapperTest {
     public void testColumnNameAnnotation() {
         handle.registerRowMapper(BeanMapper.factory(ColumnNameBean.class));
 
-        handle.execute("insert into something (id, name) values (1, 'foo')");
+        sharedHandle.execute("insert into something (id, name) values (1, 'foo')");
 
-        ColumnNameBean bean = handle.createQuery("select * from something")
+        ColumnNameBean bean = sharedHandle.createQuery("select * from something")
                 .mapTo(ColumnNameBean.class)
                 .one();
 
@@ -87,9 +87,9 @@ public class BeanMapperTest {
     public void testNested() {
         handle.registerRowMapper(BeanMapper.factory(NestedBean.class));
 
-        handle.execute("insert into something (id, name) values (1, 'foo')");
+        sharedHandle.execute("insert into something (id, name) values (1, 'foo')");
 
-        assertThat(handle
+        assertThat(sharedHandle
             .createQuery("select id, name from something")
             .mapTo(NestedBean.class)
             .one())
@@ -102,16 +102,16 @@ public class BeanMapperTest {
         handle.getConfig(ReflectionMappers.class).setStrictMatching(true);
         handle.registerRowMapper(BeanMapper.factory(NestedBean.class));
 
-        handle.execute("insert into something (id, name) values (1, 'foo')");
+        sharedHandle.execute("insert into something (id, name) values (1, 'foo')");
 
-        assertThat(handle
+        assertThat(sharedHandle
             .createQuery("select id, name from something")
             .mapTo(NestedBean.class)
             .one())
             .extracting("nested.id", "nested.name")
             .containsExactly(1, "foo");
 
-        assertThatThrownBy(() -> handle
+        assertThatThrownBy(() -> sharedHandle
             .createQuery("select id, name, 1 as other from something")
             .mapTo(NestedBean.class)
             .one())
@@ -156,9 +156,9 @@ public class BeanMapperTest {
     public void testNestedPrefix() {
         handle.registerRowMapper(BeanMapper.factory(NestedPrefixBean.class));
 
-        handle.execute("insert into something (id, name) values (1, 'foo')");
+        sharedHandle.execute("insert into something (id, name) values (1, 'foo')");
 
-        assertThat(handle
+        assertThat(sharedHandle
             .createQuery("select id nested_id, name nested_name from something")
             .mapTo(NestedPrefixBean.class)
             .one())
@@ -171,23 +171,23 @@ public class BeanMapperTest {
         handle.getConfig(ReflectionMappers.class).setStrictMatching(true);
         handle.registerRowMapper(BeanMapper.factory(NestedPrefixBean.class));
 
-        handle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
+        sharedHandle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
 
-        assertThat(handle
+        assertThat(sharedHandle
             .createQuery("select id nested_id, name nested_name, integerValue from something")
             .mapTo(NestedPrefixBean.class)
             .one())
             .extracting("nested.id", "nested.name", "integerValue")
             .containsExactly(1, "foo", 5);
 
-        assertThatThrownBy(() -> handle
+        assertThatThrownBy(() -> sharedHandle
             .createQuery("select id nested_id, name nested_name, 1 as other from something")
             .mapTo(NestedPrefixBean.class)
             .one())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("could not match properties for columns: [other]");
 
-        assertThatThrownBy(() -> handle
+        assertThatThrownBy(() -> sharedHandle
             .createQuery("select id nested_id, name nested_name, 1 as nested_other from something")
             .mapTo(NestedPrefixBean.class)
             .one())

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
@@ -56,7 +56,7 @@ public class FieldMapperTest {
     public void testColumnNameAnnotation() {
         handle.execute("insert into something (id, name) values (1, 'foo')");
 
-        ColumnNameThing thing = handle.createQuery("select * from something")
+        ColumnNameThing thing = sharedHandle.createQuery("select * from something")
                 .map(FieldMapper.of(ColumnNameThing.class))
                 .one();
 
@@ -68,7 +68,7 @@ public class FieldMapperTest {
     public void testNested() {
         handle.execute("insert into something (id, name) values (1, 'foo')");
 
-        assertThat(handle
+        assertThat(sharedHandle
             .registerRowMapper(FieldMapper.factory(NestedThing.class))
             .select("SELECT id, name FROM something")
             .mapTo(NestedThing.class)
@@ -82,9 +82,9 @@ public class FieldMapperTest {
         handle.getConfig(ReflectionMappers.class).setStrictMatching(true);
         handle.registerRowMapper(FieldMapper.factory(NestedThing.class));
 
-        handle.execute("insert into something (id, name) values (1, 'foo')");
+        sharedHandle.execute("insert into something (id, name) values (1, 'foo')");
 
-        assertThat(handle
+        assertThat(sharedHandle
             .registerRowMapper(FieldMapper.factory(NestedThing.class))
             .select("select id, name from something")
             .mapTo(NestedThing.class)
@@ -92,7 +92,7 @@ public class FieldMapperTest {
             .extracting("nested.i", "nested.s")
             .containsExactly(1, "foo");
 
-        assertThatThrownBy(() -> handle
+        assertThatThrownBy(() -> sharedHandle
             .createQuery("select id, name, 1 as other from something")
             .mapTo(NestedThing.class)
             .one())
@@ -180,7 +180,7 @@ public class FieldMapperTest {
     public void testNestedPrefix() {
         handle.execute("insert into something (id, name) values (1, 'foo')");
 
-        assertThat(handle
+        assertThat(sharedHandle
             .registerRowMapper(FieldMapper.factory(NestedPrefixThing.class))
             .select("select id nested_id, name nested_name from something")
             .mapTo(NestedPrefixThing.class)
@@ -194,23 +194,23 @@ public class FieldMapperTest {
         handle.getConfig(ReflectionMappers.class).setStrictMatching(true);
         handle.registerRowMapper(FieldMapper.factory(NestedPrefixThing.class));
 
-        handle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
+        sharedHandle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
 
-        assertThat(handle
+        assertThat(sharedHandle
             .createQuery("select id nested_id, name nested_name, integerValue from something")
             .mapTo(NestedPrefixThing.class)
             .one())
             .extracting("nested.i", "nested.s", "integerValue")
             .containsExactly(1, "foo", 5);
 
-        assertThatThrownBy(() -> handle
+        assertThatThrownBy(() -> sharedHandle
             .createQuery("select id nested_id, name nested_name, 1 as other from something")
             .mapTo(NestedPrefixThing.class)
             .one())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("could not match fields for columns: [other]");
 
-        assertThatThrownBy(() -> handle
+        assertThatThrownBy(() -> sharedHandle
             .createQuery("select id nested_id, name nested_name, 1 as nested_other from something")
             .mapTo(NestedPrefixThing.class)
             .one())

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
@@ -56,7 +56,7 @@ public class FieldMapperTest {
     public void testColumnNameAnnotation() {
         handle.execute("insert into something (id, name) values (1, 'foo')");
 
-        ColumnNameThing thing = sharedHandle.createQuery("select * from something")
+        ColumnNameThing thing = handle.createQuery("select * from something")
                 .map(FieldMapper.of(ColumnNameThing.class))
                 .one();
 
@@ -68,7 +68,7 @@ public class FieldMapperTest {
     public void testNested() {
         handle.execute("insert into something (id, name) values (1, 'foo')");
 
-        assertThat(sharedHandle
+        assertThat(handle
             .registerRowMapper(FieldMapper.factory(NestedThing.class))
             .select("SELECT id, name FROM something")
             .mapTo(NestedThing.class)
@@ -82,9 +82,9 @@ public class FieldMapperTest {
         handle.getConfig(ReflectionMappers.class).setStrictMatching(true);
         handle.registerRowMapper(FieldMapper.factory(NestedThing.class));
 
-        sharedHandle.execute("insert into something (id, name) values (1, 'foo')");
+        handle.execute("insert into something (id, name) values (1, 'foo')");
 
-        assertThat(sharedHandle
+        assertThat(handle
             .registerRowMapper(FieldMapper.factory(NestedThing.class))
             .select("select id, name from something")
             .mapTo(NestedThing.class)
@@ -92,7 +92,7 @@ public class FieldMapperTest {
             .extracting("nested.i", "nested.s")
             .containsExactly(1, "foo");
 
-        assertThatThrownBy(() -> sharedHandle
+        assertThatThrownBy(() -> handle
             .createQuery("select id, name, 1 as other from something")
             .mapTo(NestedThing.class)
             .one())
@@ -180,7 +180,7 @@ public class FieldMapperTest {
     public void testNestedPrefix() {
         handle.execute("insert into something (id, name) values (1, 'foo')");
 
-        assertThat(sharedHandle
+        assertThat(handle
             .registerRowMapper(FieldMapper.factory(NestedPrefixThing.class))
             .select("select id nested_id, name nested_name from something")
             .mapTo(NestedPrefixThing.class)
@@ -194,23 +194,23 @@ public class FieldMapperTest {
         handle.getConfig(ReflectionMappers.class).setStrictMatching(true);
         handle.registerRowMapper(FieldMapper.factory(NestedPrefixThing.class));
 
-        sharedHandle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
+        handle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
 
-        assertThat(sharedHandle
+        assertThat(handle
             .createQuery("select id nested_id, name nested_name, integerValue from something")
             .mapTo(NestedPrefixThing.class)
             .one())
             .extracting("nested.i", "nested.s", "integerValue")
             .containsExactly(1, "foo", 5);
 
-        assertThatThrownBy(() -> sharedHandle
+        assertThatThrownBy(() -> handle
             .createQuery("select id nested_id, name nested_name, 1 as other from something")
             .mapTo(NestedPrefixThing.class)
             .one())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("could not match fields for columns: [other]");
 
-        assertThatThrownBy(() -> sharedHandle
+        assertThatThrownBy(() -> handle
             .createQuery("select id nested_id, name nested_name, 1 as nested_other from something")
             .mapTo(NestedPrefixThing.class)
             .one())

--- a/core/src/test/java/org/jdbi/v3/core/rule/PgDatabaseRule.java
+++ b/core/src/test/java/org/jdbi/v3/core/rule/PgDatabaseRule.java
@@ -67,8 +67,8 @@ public class PgDatabaseRule extends ExternalResource implements DatabaseRule<PgD
         return this;
     }
 
-    public PgDatabaseRule withPreparer(JdbiPreparer preparer) {
-        this.preparer = preparer;
+    public PgDatabaseRule withPreparer(JdbiPreparer newPreparer) {
+        this.preparer = newPreparer;
         return this;
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
@@ -60,16 +60,16 @@ public class TestBindList {
 
     @Test
     public void testBindListWithHashPrefixParser() {
-        handle.registerRowMapper(FieldMapper.factory(Thing.class));
+        handle
+            .registerRowMapper(FieldMapper.factory(Thing.class))
+            .setSqlParser(new HashPrefixSqlParser());
 
         handle.createUpdate("insert into thing (<columns>) values (<values>)")
-            .setSqlParser(new HashPrefixSqlParser())
             .defineList("columns", "id", "foo")
             .bindList("values", 3, "abc")
             .execute();
 
         List<Thing> list = handle.createQuery("select id, foo from thing where id in (<ids>)")
-            .setSqlParser(new HashPrefixSqlParser())
             .bindList("ids", 1, 3)
             .mapTo(Thing.class)
             .list();

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
@@ -16,7 +16,6 @@ package org.jdbi.v3.core.statement;
 import java.util.List;
 
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.mapper.reflect.FieldMapper;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Before;
@@ -61,25 +60,25 @@ public class TestBindList {
 
     @Test
     public void testBindListWithHashPrefixParser() {
-        Jdbi jdbi = Jdbi.create(dbRule.getConnectionFactory());
-        jdbi.setSqlParser(new HashPrefixSqlParser());
-        jdbi.useHandle(handle -> {
-            handle.registerRowMapper(FieldMapper.factory(Thing.class));
-            handle.createUpdate("insert into thing (<columns>) values (<values>)")
-                  .defineList("columns", "id", "foo")
-                  .bindList("values", 3, "abc")
-                  .execute();
+        handle.registerRowMapper(FieldMapper.factory(Thing.class));
 
-            List<Thing> list = handle.createQuery("select id, foo from thing where id in (<ids>)")
-                                     .bindList("ids", 1, 3)
-                                     .mapTo(Thing.class)
-                                     .list();
-            assertThat(list)
-                    .extracting(Thing::getId, Thing::getFoo, Thing::getBar, Thing::getBaz)
-                    .containsExactly(
-                            tuple(1, "foo1", null, null),
-                            tuple(3, "abc", null, null));
-        });
+        handle.createUpdate("insert into thing (<columns>) values (<values>)")
+            .setSqlParser(new HashPrefixSqlParser())
+            .defineList("columns", "id", "foo")
+            .bindList("values", 3, "abc")
+            .execute();
+
+        List<Thing> list = handle.createQuery("select id, foo from thing where id in (<ids>)")
+            .setSqlParser(new HashPrefixSqlParser())
+            .bindList("ids", 1, 3)
+            .mapTo(Thing.class)
+            .list();
+
+        assertThat(list)
+            .extracting(Thing::getId, Thing::getFoo, Thing::getBar, Thing::getBaz)
+            .containsExactly(
+                tuple(1, "foo1", null, null),
+                tuple(3, "abc", null, null));
     }
 
     public static class Thing {

--- a/docs/src/test/java/jdbi/doc/FiveMinuteTourTest.java
+++ b/docs/src/test/java/jdbi/doc/FiveMinuteTourTest.java
@@ -33,6 +33,7 @@ public class FiveMinuteTourTest {
     private Handle handle;
 
     @Before
+    @SuppressWarnings("checkstyle:hiddenfield")
     public void setUp() {
         // tag::createJdbi[]
         // H2 in-memory database

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.stream.Collector;
-import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.google.common.base.Optional;
@@ -43,6 +43,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static java.util.stream.Collectors.toList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.guava.api.Assertions.assertThat;
@@ -56,12 +58,10 @@ public class TestGuavaCollectors {
 
     @Before
     public void addData() {
-        ImmutableList.Builder<Integer> expected = ImmutableList.builder();
-        for (int i = 0; i < 10; i++) {
-            dbRule.getSharedHandle().execute("insert into something(name, intValue) values (?, ?)", Integer.toString(i), i);
-            expected.add(i);
-        }
-        this.expected = expected.build();
+        expected = IntStream.range(0, 10)
+            .peek(i -> dbRule.getSharedHandle().execute("insert into something(name, intValue) values (?, ?)", Integer.toString(i), i))
+            .boxed()
+            .collect(toList());
     }
 
     @Test
@@ -97,7 +97,7 @@ public class TestGuavaCollectors {
 
         assertThat(set).containsExactlyElementsOf(expected.stream()
                 .sorted(comparator)
-                .collect(Collectors.toList()));
+                .collect(toList()));
     }
 
     @Test

--- a/json/src/main/java/org/jdbi/v3/json/JsonConfig.java
+++ b/json/src/main/java/org/jdbi/v3/json/JsonConfig.java
@@ -29,8 +29,8 @@ public class JsonConfig implements JdbiConfig<JsonConfig> {
         this.mapper = other.mapper;
     }
 
-    public JsonConfig setJsonMapper(JsonMapper mapper) {
-        this.mapper = mapper;
+    public JsonConfig setJsonMapper(JsonMapper jsonMapper) {
+        this.mapper = jsonMapper;
         return this;
     }
 

--- a/policy/src/main/resources/policy/checkstyle.xml
+++ b/policy/src/main/resources/policy/checkstyle.xml
@@ -49,6 +49,12 @@
         <module name="EqualsAvoidNull"/>
         <module name="EqualsHashCode"/>
         <module name="GenericWhitespace"/>
+        <module name="HiddenField">
+            <property name="ignoreConstructorParameter" value="true"/>
+            <property name="ignoreSetter" value="true"/>
+            <property name="setterCanReturnItsClass" value="true"/>
+            <property name="ignoreAbstractMethods" value="true"/>
+        </module>
         <module name="HideUtilityClassConstructor"/>
         <module name="IllegalImport"/>
         <module name="IllegalInstantiation"/>

--- a/policy/src/main/resources/policy/checkstyle.xml
+++ b/policy/src/main/resources/policy/checkstyle.xml
@@ -16,6 +16,8 @@
 <module name="Checker">
     <property name="fileExtensions" value="java,properties,xml"/>
 
+    <module name="SuppressWarningsFilter" />
+
     <module name="NewlineAtEndOfFile">
         <property name="lineSeparator" value="lf"/>
     </module>
@@ -104,6 +106,7 @@
         <module name="StringLiteralEquality"/>
         <module name="SuperClone"/>
         <module name="SuperFinalize"/>
+        <module name="SuppressWarningsHolder" />
         <module name="TodoComment"/>
         <module name="TypecastParenPad"/>
         <module name="TypeName"/>

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestHStore.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestHStore.java
@@ -67,10 +67,10 @@ public class TestHStore {
 
     @Test
     public void testReadsViaFluentAPI() {
-        List<Map<String, String>> caps = handle.createQuery("select caps from campaigns order by id")
+        List<Map<String, String>> initialCaps = handle.createQuery("select caps from campaigns order by id")
                 .mapTo(STRING_MAP)
                 .list();
-        assertThat(caps).isEqualTo(ImmutableList.of(
+        assertThat(initialCaps).isEqualTo(ImmutableList.of(
                 ImmutableMap.of("yearly", "10000", "monthly", "5000", "daily", "200"),
                 ImmutableMap.of("yearly", "1000", "monthly", "200", "daily", "20")
        ));

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestQualifiedHStore.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestQualifiedHStore.java
@@ -68,10 +68,10 @@ public class TestQualifiedHStore {
 
     @Test
     public void testReadsViaFluentAPI() {
-        List<Map<String, String>> caps = handle.createQuery("select caps from campaigns order by id")
+        List<Map<String, String>> initialCaps = handle.createQuery("select caps from campaigns order by id")
                 .mapTo(QualifiedType.of(STRING_MAP).with(HStore.class))
                 .list();
-        assertThat(caps).isEqualTo(ImmutableList.of(
+        assertThat(initialCaps).isEqualTo(ImmutableList.of(
                 ImmutableMap.of("yearly", "10000", "monthly", "5000", "daily", "200"),
                 ImmutableMap.of("yearly", "1000", "monthly", "200", "daily", "20")
        ));

--- a/spring4/src/test/java/org/jdbi/v3/spring4/TestJdbiFactoryBean.java
+++ b/spring4/src/test/java/org/jdbi/v3/spring4/TestJdbiFactoryBean.java
@@ -44,8 +44,8 @@ public class TestJdbiFactoryBean {
     }
 
     @Autowired
-    public void setDataSource(DataSource ds) {
-        this.ds = ds;
+    public void setDataSource(DataSource dataSource) {
+        this.ds = dataSource;
     }
 
     @Autowired

--- a/spring4/src/test/java/org/jdbi/v3/spring4/TestJdbiFactoryBean.java
+++ b/spring4/src/test/java/org/jdbi/v3/spring4/TestJdbiFactoryBean.java
@@ -61,8 +61,8 @@ public class TestJdbiFactoryBean {
     @Test
     public void testFailsViaException() {
         assertThatExceptionOfType(ForceRollback.class).isThrownBy(() -> {
-            service.inPropagationRequired(jdbi -> {
-                Handle h = JdbiUtil.getHandle(jdbi);
+            service.inPropagationRequired(aJdbi -> {
+                Handle h = JdbiUtil.getHandle(aJdbi);
                 final int count = h.execute("insert into something (id, name) values (7, 'ignored')");
                 if (count == 1) {
                     throw new ForceRollback();
@@ -118,8 +118,8 @@ public class TestJdbiFactoryBean {
                 throw new ForceRollback();
             });
         });
-        service.inPropagationRequired(jdbi -> {
-            final Handle h = JdbiUtil.getHandle(jdbi);
+        service.inPropagationRequired(aJdbi -> {
+            final Handle h = JdbiUtil.getHandle(aJdbi);
             int count = h.createQuery("select count(*) from something").mapTo(Integer.class).one();
             assertThat(count).isEqualTo(0);
         });

--- a/sqlite/src/test/java/org/jdbi/v3/sqlite3/TestUrls.java
+++ b/sqlite/src/test/java/org/jdbi/v3/sqlite3/TestUrls.java
@@ -35,7 +35,7 @@ public class TestUrls {
         Jdbi jdbi = Jdbi.create("jdbc:sqlite::memory:");
         jdbi.installPlugin(new SQLitePlugin());
         handle = jdbi.open();
-        handle.useTransaction(handle -> handle.execute("CREATE TABLE foo(url URL);"));
+        handle.useTransaction(h -> h.execute("CREATE TABLE foo(url URL);"));
     }
 
     @After

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
@@ -138,7 +138,7 @@ abstract class CustomizingStatementHandler<StatementType extends SqlStatement<St
     }
 
     @Override
-    public Object invoke(Object target, Object[] args, HandleSupplier hs) throws Exception {
+    public Object invoke(Object target, Object[] args, HandleSupplier hs) {
         final Handle h = hs.getHandle();
         final String locatedSql = locateSql(h);
         final StatementType stmt = createStatement(h, locatedSql);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBeanMapper.java
@@ -66,21 +66,21 @@ public class TestBeanMapper {
         List<TestBean> listBeansPrefix();
     }
 
-    Handle h;
-    TestDao dao;
+    private Handle h;
+    private TestDao testDao;
 
     @Before
     public void createTable() {
         h = dbRule.openHandle();
         h.createUpdate("create table testBean (valueType varchar(50))").execute();
-        dao = h.attach(TestDao.class);
+        testDao = h.attach(TestDao.class);
     }
 
     @Test
     public void testMapBean() {
         h.createUpdate("insert into testBean (valueType) values ('foo')").execute();
 
-        List<TestBean> beans = dao.listBeans();
+        List<TestBean> beans = testDao.listBeans();
         assertThat(beans).extracting(TestBean::getValueType).containsExactly(ValueType.valueOf("foo"));
     }
 
@@ -88,7 +88,7 @@ public class TestBeanMapper {
     public void testMapBeanPrefix() {
         h.createUpdate("insert into testBean (valueType) values ('foo')").execute();
 
-        List<TestBean> beans = dao.listBeansPrefix();
+        List<TestBean> beans = testDao.listBeansPrefix();
         assertThat(beans).extracting(TestBean::getValueType).containsExactly(ValueType.valueOf("foo"));
     }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindBean.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindBean.java
@@ -92,10 +92,10 @@ public class TestBindBean {
         handle.execute("create table beans (id integer, value_type varchar, fromField varchar, fromGetter varchar)");
         handle.registerArgument(new ValueTypeArgumentFactory());
 
-        BeanDao dao = handle.attach(BeanDao.class);
+        BeanDao beanDao = handle.attach(BeanDao.class);
 
-        dao.insert(new Bean(1, ValueType.valueOf("foo")));
-        assertThat(dao.getById(1)).extracting(Bean::getId, Bean::getValueType)
+        beanDao.insert(new Bean(1, ValueType.valueOf("foo")));
+        assertThat(beanDao.getById(1)).extracting(Bean::getId, Bean::getValueType)
                 .containsExactly(1, ValueType.valueOf("foo"));
     }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMixinInterfaces.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestMixinInterfaces.java
@@ -76,7 +76,7 @@ public class TestMixinInterfaces {
     @Test
     public void testUseHandle() {
         WithGetHandle g = handle.attach(WithGetHandle.class);
-        g.useHandle(handle -> handle.execute("insert into something(id, name) values (9, 'James')"));
+        g.useHandle(h -> h.execute("insert into something(id, name) values (9, 'James')"));
 
         assertThat(handle.createQuery("select name from something where id = 9")
                 .mapTo(String.class)

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodAnnotations.java
@@ -67,7 +67,7 @@ public class TestSqlMethodAnnotations {
     public @interface Foo {
         class Impl implements Handler {
             @Override
-            public Object invoke(Object target, Object[] args, HandleSupplier handle) {
+            public Object invoke(Object target, Object[] args, HandleSupplier h) {
                 return "foo";
             }
         }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecorators.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlMethodDecorators.java
@@ -38,19 +38,19 @@ public class TestSqlMethodDecorators {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private Handle handle;
+    private Handle testHandle;
 
     private static final ThreadLocal<List<String>> INVOCATIONS = ThreadLocal.withInitial(ArrayList::new);
 
     @Before
     public void setUp() {
-        handle = dbRule.getSharedHandle();
+        testHandle = dbRule.getSharedHandle();
         INVOCATIONS.get().clear();
     }
 
     @Test
     public void testUnordered() {
-        Dao dao = handle.attach(Dao.class);
+        Dao dao = testHandle.attach(Dao.class);
         dao.unordered();
 
         assertThat(INVOCATIONS.get()).isIn(asList("foo", "bar", "method"), asList("bar", "foo", "method"));
@@ -58,7 +58,7 @@ public class TestSqlMethodDecorators {
 
     @Test
     public void testOrderedFooBar() {
-        Dao dao = handle.attach(Dao.class);
+        Dao dao = testHandle.attach(Dao.class);
         dao.orderedFooBar();
 
         assertThat(INVOCATIONS.get()).containsExactly("foo", "bar", "method");
@@ -66,7 +66,7 @@ public class TestSqlMethodDecorators {
 
     @Test
     public void testOrderedBarFoo() {
-        Dao dao = handle.attach(Dao.class);
+        Dao dao = testHandle.attach(Dao.class);
         dao.orderedBarFoo();
 
         assertThat(INVOCATIONS.get()).containsExactly("bar", "foo", "method");
@@ -74,7 +74,7 @@ public class TestSqlMethodDecorators {
 
     @Test
     public void testOrderedFooBarOnType() {
-        OrderedOnType dao = handle.attach(OrderedOnType.class);
+        OrderedOnType dao = testHandle.attach(OrderedOnType.class);
         dao.orderedFooBarOnType();
 
         assertThat(INVOCATIONS.get()).containsExactly("foo", "bar", "method");
@@ -82,7 +82,7 @@ public class TestSqlMethodDecorators {
 
     @Test
     public void testOrderedFooBarOnTypeOverriddenToBarFooOnMethod() {
-        OrderedOnType dao = handle.attach(OrderedOnType.class);
+        OrderedOnType dao = testHandle.attach(OrderedOnType.class);
         dao.orderedBarFooOnMethod();
 
         assertThat(INVOCATIONS.get()).containsExactly("bar", "foo", "method");
@@ -90,7 +90,7 @@ public class TestSqlMethodDecorators {
 
     @Test
     public void testAbortingDecorator() {
-        Dao dao = handle.attach(Dao.class);
+        Dao dao = testHandle.attach(Dao.class);
         dao.abortingDecorator();
 
         assertThat(INVOCATIONS.get()).containsExactly("foo", "abort");
@@ -98,23 +98,23 @@ public class TestSqlMethodDecorators {
 
     @Test
     public void testRegisteredDecorator() {
-        handle.getConfig(HandlerDecorators.class).register(
+        testHandle.getConfig(HandlerDecorators.class).register(
                 (base, sqlObjectType, method) ->
                         (obj, args, handle) -> {
                             invoked("custom");
                             return base.invoke(obj, args, handle);
                         });
 
-        handle.attach(Dao.class).orderedFooBar();
+        testHandle.attach(Dao.class).orderedFooBar();
 
         assertThat(INVOCATIONS.get()).containsExactly("custom", "foo", "bar", "method");
     }
 
     @Test
     public void testRegisteredDecoratorReturnsBase() {
-        handle.getConfig(HandlerDecorators.class).register((base, sqlObjectType, method) -> base);
+        testHandle.getConfig(HandlerDecorators.class).register((base, sqlObjectType, method) -> base);
 
-        handle.attach(Dao.class).orderedFooBar();
+        testHandle.attach(Dao.class).orderedFooBar();
 
         assertThat(INVOCATIONS.get()).containsExactly("foo", "bar", "method");
     }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObject.java
@@ -119,47 +119,47 @@ public class TestSqlObject {
 
     @Test
     public void testNestedTransactionsCollapseIntoSingleTransaction() {
-        Handle handle = Mockito.spy(dbRule.getSharedHandle());
-        Dao dao = handle.attach(Dao.class);
+        Handle spyHandle = Mockito.spy(dbRule.getSharedHandle());
+        Dao dao = spyHandle.attach(Dao.class);
 
         dao.threeNestedTransactions();
-        verify(handle, times(1)).begin();
-        verify(handle, times(1)).commit();
+        verify(spyHandle, times(1)).begin();
+        verify(spyHandle, times(1)).commit();
 
         dao.twoNestedTransactions();
-        verify(handle, times(2)).begin();
-        verify(handle, times(2)).commit();
+        verify(spyHandle, times(2)).begin();
+        verify(spyHandle, times(2)).commit();
     }
 
     @Test
     public void testNestedTransactionWithSameIsolation() {
-        Handle handle = Mockito.spy(dbRule.getSharedHandle());
-        Dao dao = handle.attach(Dao.class);
+        Handle spyHandle = Mockito.spy(dbRule.getSharedHandle());
+        Dao dao = spyHandle.attach(Dao.class);
 
         dao.nestedTransactionWithSameIsolation();
-        verify(handle, times(1)).begin();
-        verify(handle, times(1)).commit();
+        verify(spyHandle, times(1)).begin();
+        verify(spyHandle, times(1)).commit();
     }
 
     @Test
     public void testNestedTransactionWithDifferentIsoltion() {
-        Handle handle = Mockito.spy(dbRule.getSharedHandle());
-        Dao dao = handle.attach(Dao.class);
+        Handle spyHandle = Mockito.spy(dbRule.getSharedHandle());
+        Dao dao = spyHandle.attach(Dao.class);
 
         assertThatThrownBy(dao::nestedTransactionWithDifferentIsolation).isInstanceOf(TransactionException.class);
     }
 
     @Test
     public void testSqlUpdateWithTransaction() {
-        Handle handle = Mockito.spy(dbRule.getSharedHandle());
-        Dao dao = handle.attach(Dao.class);
+        Handle spyHandle = Mockito.spy(dbRule.getSharedHandle());
+        Dao dao = spyHandle.attach(Dao.class);
 
         dao.insert(1, "foo");
-        verify(handle, never()).begin();
+        verify(spyHandle, never()).begin();
         assertThat(dao.findById(1)).isEqualTo(new Something(1, "foo"));
 
         assertThat(dao.insertTransactional(2, "bar")).isEqualTo(1);
-        verify(handle, times(1)).begin();
+        verify(spyHandle, times(1)).begin();
         assertThat(dao.findById(2)).isEqualTo(new Something(2, "bar"));
     }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseCustomHandlerFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseCustomHandlerFactory.java
@@ -52,7 +52,7 @@ public class TestUseCustomHandlerFactory {
             @Override
             public Optional<Handler> buildHandler(Class<?> sqlObjectType, Method method) {
                 return getImplementation(sqlObjectType, method).map(m ->
-                        (Handler) (target, args, handle) -> m.invoke(null, Stream.concat(Stream.of(target), Stream.of(args)).toArray())
+                    (target, args, h) -> m.invoke(null, Stream.concat(Stream.of(target), Stream.of(args)).toArray())
                );
             }
 

--- a/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
@@ -122,8 +122,8 @@ public abstract class JdbiRule extends ExternalResource {
     /**
      * Run database migration.
      */
-    public JdbiRule withMigration(final Migration migration) {
-        this.migration = migration;
+    public JdbiRule withMigration(final Migration newMigration) {
+        this.migration = newMigration;
         return this;
     }
 

--- a/testing/src/main/java/org/jdbi/v3/testing/Migration.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/Migration.java
@@ -62,8 +62,8 @@ public class Migration {
     /**
      * Add flyway migration schemas.
      */
-    public Migration withSchemas(final String... schemas) {
-        this.schemas.addAll(Arrays.asList(schemas));
+    public Migration withSchemas(final String... moreSchemas) {
+        this.schemas.addAll(Arrays.asList(moreSchemas));
         return this;
     }
 


### PR DESCRIPTION
#1516 inspired me to do this. I think forbidding shadowing reduces the possibility of confusion. Having 2 distinct variables with essentially the same name within any given context is a dangerous enough concept on its own.

The cleanup revealed a few cases of odd design that I fixed collaterally, like some objects passing their own fields to their own instance methods for no reason. The "special" changes are in separate commits, the rest are basically renames. I'm very much open to ideas for better names for any of them, I've lacked the contextual knowledge for a lot of them.

I checked and found only a single backward-incompatible change, see below.