### PR TITLE
Support postgres JSON operators

### DIFF
--- a/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/SqlScriptLexer.g4
+++ b/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/SqlScriptLexer.g4
@@ -17,8 +17,7 @@ lexer grammar SqlScriptLexer;
 COMMENT
     : '--' ~('\n'|'\r')* |
       '//' ~('\n'|'\r')* |
-      '#' ~('>'|'\r'|'\n') ~('\n'|'\r')* |
-      '#' ('\n'|'\r')
+      {_input.LA(2) != '>'}? '#' ~('\n'|'\r')* // Exception for Postgres #> and #>> JSON operators
      { skip(); }
     ;
 

--- a/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/SqlScriptLexer.g4
+++ b/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/SqlScriptLexer.g4
@@ -17,7 +17,8 @@ lexer grammar SqlScriptLexer;
 COMMENT
     : '--' ~('\n'|'\r')* |
       '//' ~('\n'|'\r')* |
-      '#'  ~('\n'|'\r')*
+      '#' ~('>'|'\r'|'\n') ~('\n'|'\r')* |
+      '#' ('\n'|'\r')
      { skip(); }
     ;
 

--- a/core/src/test/resources/script/postgres-json-operator.sql
+++ b/core/src/test/resources/script/postgres-json-operator.sql
@@ -1,0 +1,25 @@
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- insert some data
+INSERT INTO something (data) VALUES ('{"something":"here"}');
+INSERT INTO something (data) VALUES ('{"something":"else"}');
+
+--delete data
+# this is still a comment
+#
+DELETE FROM
+    something
+WHERE
+    data #>> '{something}' = 'here'


### PR DESCRIPTION
Fixes #1519 by requiring `#comment` token to have a non-`>` character after the `#` character. Adds a test to make sure that comments continue to work while the JSON operator now starts to function.

Postgres JSON operators are described at https://www.postgresql.org/docs/11/functions-json.html