### PR TITLE
Parsers use JdbiCaches instead of internal cache

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
@@ -37,10 +37,8 @@ import static org.jdbi.v3.core.internal.lexer.ColonStatementLexer.QUOTED_TEXT;
  * </p>
  */
 public class ColonPrefixSqlParser implements SqlParser {
-    private static final String CACHE_PREFIX = "ColonPrefixSqlParser:";
-
     private static final JdbiCache<String, ParsedSql> PARSED_SQL_CACHE =
-        JdbiCaches.declare(rawSql -> CACHE_PREFIX + rawSql, ColonPrefixSqlParser::internalParse);
+        JdbiCaches.declare(ColonPrefixSqlParser::internalParse);
 
     @Override
     public ParsedSql parse(String sql, StatementContext ctx) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
@@ -42,7 +42,11 @@ public class ColonPrefixSqlParser implements SqlParser {
 
     @Override
     public ParsedSql parse(String sql, StatementContext ctx) {
-        return PARSED_SQL_CACHE.get(sql, ctx);
+        try {
+            return PARSED_SQL_CACHE.get(sql, ctx);
+        } catch (IllegalArgumentException e) {
+            throw new UnableToCreateStatementException("Exception parsing for named parameter replacement", e, ctx);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
@@ -34,10 +34,8 @@ import static org.jdbi.v3.core.internal.lexer.HashStatementLexer.QUOTED_TEXT;
  * <code>#tokenName</code>.
  */
 public class HashPrefixSqlParser implements SqlParser {
-    private static final String CACHE_PREFIX = "HashPrefixSqlParser:";
-
     private static final JdbiCache<String, ParsedSql> PARSED_SQL_CACHE =
-        JdbiCaches.declare(rawSql -> CACHE_PREFIX + rawSql, HashPrefixSqlParser::internalParse);
+        JdbiCaches.declare(HashPrefixSqlParser::internalParse);
 
     @Override
     public ParsedSql parse(String sql, StatementContext ctx) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
@@ -39,7 +39,11 @@ public class HashPrefixSqlParser implements SqlParser {
 
     @Override
     public ParsedSql parse(String sql, StatementContext ctx) {
-        return PARSED_SQL_CACHE.get(sql, ctx);
+        try {
+            return PARSED_SQL_CACHE.get(sql, ctx);
+        } catch (IllegalArgumentException e) {
+            throw new UnableToCreateStatementException("Exception parsing for named parameter replacement", e, ctx);
+        }
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestColonPrefixSqlParser.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestColonPrefixSqlParser.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 
 public class TestColonPrefixSqlParser {
     private SqlParser parser;
@@ -27,7 +26,7 @@ public class TestColonPrefixSqlParser {
     @Before
     public void setUp() {
         parser = new ColonPrefixSqlParser();
-        ctx = mock(StatementContext.class);
+        ctx = StatementContextAccess.createContext();
     }
 
     @Test
@@ -93,6 +92,7 @@ public class TestColonPrefixSqlParser {
                 .appendNamedParameter("id")
                 .build());
     }
+
     @Test
     public void testOddCharacters() {
         assertThat(parser.parse("~* :boo ':nope' _%&^& *@ :id", ctx))

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestEscapedCharacters.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestEscapedCharacters.java
@@ -13,16 +13,23 @@
  */
 package org.jdbi.v3.core.statement;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 public class TestEscapedCharacters {
-    private final ColonPrefixSqlParser parser = new ColonPrefixSqlParser();
+    private ColonPrefixSqlParser parser;
+    private StatementContext ctx;
+
+    @Before
+    public void setUp() {
+        parser = new ColonPrefixSqlParser();
+        ctx = StatementContextAccess.createContext();
+    }
 
     private String parseString(final String src) {
-        return parser.parse(src, mock(StatementContext.class)).getSql();
+        return parser.parse(src, ctx).getSql();
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestHashPrefixSqlParser.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestHashPrefixSqlParser.java
@@ -17,7 +17,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 public class TestHashPrefixSqlParser {
     private SqlParser parser;
@@ -26,7 +25,7 @@ public class TestHashPrefixSqlParser {
     @Before
     public void setUp() {
         this.parser = new HashPrefixSqlParser();
-        ctx = mock(StatementContext.class);
+        ctx = StatementContextAccess.createContext();
     }
 
     @Test
@@ -72,6 +71,13 @@ public class TestHashPrefixSqlParser {
             .isEqualTo(ParsedSql.builder().append("select * from something\n where id = ")
                 .appendNamedParameter("\u0087\u008e\u0092\u0097\u009c")
                 .build());
+    }
+
+    @Test
+    public void testCachesRewrittenStatements() {
+        String sql = "insert into something (id, name) values (#id, #name)";
+        ParsedSql parsed = parser.parse(sql, ctx);
+        assertThat(parsed).isSameAs(parser.parse(sql, ctx));
     }
 
     @Test


### PR DESCRIPTION
Instead of relying on internal cache, the in-built parsers are able to utilize the global JdbiCaches to cache their parsed queries.

See discussion at https://github.com/jdbi/jdbi/issues/1523