### PR TITLE
Immutables: respect `@Value.Default` when mapping nulled primitives

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 - New Features
   - `ResultIterable<T>.map(Function<T, U>)` returns a `ResultIterable<U>` with elements transformed
     using the given mapper function.
+- Bug Fixes
+  - Immutables integration doesn't respect @Value.Default for primitives that are nulled in the db
 
 # 3.8.2
 - Improvements

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,9 @@
     using the given mapper function.
 - Bug Fixes
   - Immutables integration doesn't respect @Value.Default for primitives that are nulled in the db
+- Beta API Changes
+  - add GenericTypes.box
+  - QualifiedType: rename mapType -> flatMapType, add a proper mapType
 
 # 3.8.2
 - Improvements

--- a/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
@@ -160,4 +160,14 @@ public class GenericTypes {
     public static Type parameterizeClass(Class<?> clazz, Type... arguments) {
         return TypeFactory.parameterizedClass(clazz, arguments);
     }
+
+    /**
+     * Perform boxing conversion on a {@code Type}, if it is a primitive type.
+     * Otherwise return the input argument.
+     * @param type the type to box
+     * @return the boxed type, or the input type if it is not a primitive
+     */
+    public static Type box(Type type) {
+        return GenericTypeReflector.box(type);
+    }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-import io.leangen.geantyref.GenericTypeReflector;
 import org.jdbi.v3.core.annotation.Unmappable;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.generic.GenericTypes;
@@ -36,7 +35,6 @@ import org.jdbi.v3.core.mapper.reflect.ColumnNameMatcher;
 import org.jdbi.v3.core.mapper.reflect.ReflectionMappers;
 import org.jdbi.v3.core.mapper.reflect.internal.PojoProperties.PojoBuilder;
 import org.jdbi.v3.core.mapper.reflect.internal.PojoProperties.PojoProperty;
-import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -107,7 +105,7 @@ public class PojoMapper<T> implements RowMapper<T> {
                 findColumnIndex(paramName, columnNames, columnNameMatchers, () -> debugName(property))
                     .ifPresent(index -> {
                         @SuppressWarnings({ "unchecked", "rawtypes" })
-                        ColumnMapper<?> mapper = ctx.findColumnMapperFor(box(property.getQualifiedType()))
+                        ColumnMapper<?> mapper = ctx.findColumnMapperFor(property.getQualifiedType().mapType(GenericTypes::box))
                             .orElseGet(() -> (ColumnMapper) defaultColumnMapper(property));
 
                         mappers.add(new SingleColumnMapper<>(mapper, index + 1));
@@ -148,10 +146,6 @@ public class PojoMapper<T> implements RowMapper<T> {
 
             return pojo.build();
         });
-    }
-
-    private static QualifiedType<?> box(QualifiedType<?> qualifiedType) {
-        return qualifiedType.mapType(t -> Optional.of(GenericTypeReflector.box(t))).get();
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
@@ -145,7 +145,19 @@ public final class QualifiedType<T> {
      * @param mapper a mapping function to apply to the type
      * @return an optional qualified type with the mapped type and the same qualifiers
      */
-    public Optional<QualifiedType<?>> mapType(Function<Type, Optional<Type>> mapper) {
+    public QualifiedType<?> mapType(Function<Type, Type> mapper) {
+        return new QualifiedType<>(mapper.apply(type), qualifiers);
+    }
+
+    /**
+     * Apply the provided mapping function to the type, and if non-empty is returned,
+     * return an {@code Optional<QualifiedType<?>>} with the returned type, and the same
+     * qualifiers as this instance.
+     *
+     * @param mapper a mapping function to apply to the type
+     * @return an optional qualified type with the mapped type and the same qualifiers
+     */
+    public Optional<QualifiedType<?>> flatMapType(Function<Type, Optional<Type>> mapper) {
         return mapper.apply(type).map(mappedType -> new QualifiedType<>(mappedType, qualifiers));
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
@@ -35,12 +35,14 @@ public class ImmutablesTest {
     @Rule
     public H2DatabaseRule dbRule = new H2DatabaseRule()
         .withConfig(JdbiImmutables.class, c -> c
-            .registerImmutable(SubValue.class)
-            .registerImmutable(FooBarBaz.class)
-            .registerModifiable(FooBarBaz.class)
-            .registerImmutable(Getter.class)
-            .registerImmutable(ByteArray.class)
-            .registerImmutable(DerivedProperty.class)
+            .registerImmutable(
+                    SubValue.class,
+                    FooBarBaz.class,
+                    Getter.class,
+                    ByteArray.class,
+                    DerivedProperty.class,
+                    Defaulty.class
+            ).registerModifiable(FooBarBaz.class)
         );
 
     private Jdbi jdbi;
@@ -232,5 +234,22 @@ public class ImmutablesTest {
 
     static class Boom extends RuntimeException {
         private static final long serialVersionUID = 1L;
+    }
+
+    @Test
+    public void testDefaultNotStoredInDb() {
+        assertThat(h.createQuery("select null as defaulted")
+                .mapTo(Defaulty.class)
+                .one())
+            .extracting(Defaulty::defaulted)
+            .isEqualTo(42);
+    }
+
+    @Value.Immutable
+    public interface Defaulty {
+        @Value.Default
+        default int defaulted() {
+            return 42;
+        }
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
@@ -133,7 +133,7 @@ abstract class ResultReturner {
 
         ResultIterableReturner(QualifiedType<?> returnType) {
             // extract T from Query<T>
-            elementType = returnType.mapType(type -> GenericTypes.findGenericParameter(type, ResultIterable.class))
+            elementType = returnType.flatMapType(type -> GenericTypes.findGenericParameter(type, ResultIterable.class))
                 .orElseThrow(() -> new IllegalStateException(
                     "Cannot reflect ResultIterable<T> element type T in method return type " + returnType));
         }
@@ -158,7 +158,7 @@ abstract class ResultReturner {
         private final QualifiedType<?> elementType;
 
         StreamReturner(QualifiedType<?> returnType) {
-            elementType = returnType.mapType(type -> GenericTypes.findGenericParameter(type, Stream.class))
+            elementType = returnType.flatMapType(type -> GenericTypes.findGenericParameter(type, Stream.class))
                 .orElseThrow(() -> new IllegalStateException(
                     "Cannot reflect Stream<T> element type T in method return type " + returnType));
         }
@@ -183,7 +183,7 @@ abstract class ResultReturner {
         private final QualifiedType<?> elementType;
 
         ResultIteratorReturner(QualifiedType<?> returnType) {
-            this.elementType = returnType.mapType(type -> GenericTypes.findGenericParameter(type, Iterator.class))
+            this.elementType = returnType.flatMapType(type -> GenericTypes.findGenericParameter(type, Iterator.class))
                 .orElseThrow(() -> new IllegalStateException(
                     "Cannot reflect ResultIterator<T> element type T in method return type " + returnType));
         }
@@ -208,7 +208,7 @@ abstract class ResultReturner {
         private final QualifiedType<?> elementType;
 
         IteratorReturner(QualifiedType<?> returnType) {
-            this.elementType = returnType.mapType(type -> GenericTypes.findGenericParameter(type, Iterator.class))
+            this.elementType = returnType.flatMapType(type -> GenericTypes.findGenericParameter(type, Iterator.class))
                 .orElseThrow(() -> new IllegalStateException(
                     "Cannot reflect Iterator<T> element type T in method return type " + returnType));
         }
@@ -281,7 +281,7 @@ abstract class ResultReturner {
         @Override
         protected QualifiedType<?> elementType(StatementContext ctx) {
             // if returnType is not supported by a collector factory, assume it to be a single-value return type.
-            return returnType.mapType(type -> ctx.findElementTypeFor(type))
+            return returnType.flatMapType(type -> ctx.findElementTypeFor(type))
                 .orElse(returnType);
         }
     }


### PR DESCRIPTION
also avoids NPE when trying to call a builder's setter when mapping reference types that are nullable in the db but nonnull with a default in Immutables-land.