### PR TITLE
PropagateNull annotation for BeanMapper, ConstructorMapper, and FieldMapper

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/PropagateNull.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/PropagateNull.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Signals that the annotated element is required and mappers should return null if this element is null.
+ */
+@Retention(RUNTIME)
+@Target({PARAMETER, FIELD, METHOD})
+public @interface PropagateNull {}

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
@@ -28,6 +28,7 @@ import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;
+import org.jdbi.v3.core.mapper.PropagateNull;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.SingleColumnMapper;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
@@ -92,6 +93,8 @@ public class PojoMapper<T> implements RowMapper<T> {
                                                List<String> unmatchedColumns) {
         final List<RowMapper<?>> mappers = new ArrayList<>();
         final List<PojoProperty<T>> propList = new ArrayList<>();
+        final List<Boolean> propagateNulls = new ArrayList<>();
+        final List<Boolean> isPrimitive = new ArrayList<>();
 
         for (PojoProperty<T> property : getProperties(ctx.getConfig()).getProperties().values()) {
             Nested anno = property.getAnnotation(Nested.class).orElse(null);
@@ -110,6 +113,9 @@ public class PojoMapper<T> implements RowMapper<T> {
 
                         mappers.add(new SingleColumnMapper<>(mapper, index + 1));
                         propList.add(property);
+                        propagateNulls.add(property.getAnnotation(PropagateNull.class).isPresent());
+                        Type propertyType = property.getQualifiedType().getType();
+                        isPrimitive.add(propertyType instanceof Class && ((Class) propertyType).isPrimitive());
                         unmatchedColumns.remove(columnNames.get(index));
                     });
             } else {
@@ -121,6 +127,7 @@ public class PojoMapper<T> implements RowMapper<T> {
                         .ifPresent(nestedMapper -> {
                             mappers.add(nestedMapper);
                             propList.add(property);
+                            propagateNulls.add(property.getAnnotation(PropagateNull.class).isPresent());
                         });
                 }
             }
@@ -138,6 +145,9 @@ public class PojoMapper<T> implements RowMapper<T> {
                 PojoProperty<T> property = propList.get(i);
 
                 Object value = mapper.map(r, ctx);
+                if (propagateNulls.get(i) && (value == null || isPrimitive.get(i) && r.wasNull())) {
+                    return null;
+                }
 
                 pojo.set(property, value);
             }


### PR DESCRIPTION
Adds a new annotation called PropagateNull as a possible solution to nested null objects as in #1404. I initially attempted to use a wrapper that maps the underlying mapper, but this was cumbersome because of the weird result for the column names in any annotations that operated on the parent context. Moving the annotation to the child allows access to parameters in specialize0 and significantly simplifies the code changes. 

I also added the ugly wasNull check and primitive checks to allow propagating null for an entire object if a primitive mapped value is null. Happy to see any changes from contributors if the approach is generally agreed upon.