### PR TITLE
POC to discuss/refine: @Nonnull mapper

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
   - sqlobject's `EmptyHandling` enum backported to core for invocations of `SqlStatement.bindList`
   - `@Qualified` allows you to assign any annotation without its own `@Qualifier` (such as `@javax.annotation.Nonnull`)
     as a qualifier on an SQLObject. 
+  - `NonnullColumnMapperFactory`, for all your `@javax.annotation.Nonnull` column needs.
 - Bug Fixes
   - onDemand invocations @CreateSqlObject create new on-demand SqlObjects
   - onDemand SqlObject.withHandle / Transactional.inTransaction are now safe to call even outside an on-demand context

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 - New Features
   - Handle.getJdbi gets owning Jdbi instance
   - sqlobject's `EmptyHandling` enum backported to core for invocations of `SqlStatement.bindList`
+  - `@Qualified` allows you to assign any annotation without its own `@Qualifier` (such as `@javax.annotation.Nonnull`)
+    as a qualifier on an SQLObject. 
 - Bug Fixes
   - onDemand invocations @CreateSqlObject create new on-demand SqlObjects
   - onDemand SqlObject.withHandle / Transactional.inTransaction are now safe to call even outside an on-demand context

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,8 @@
 - Beta API Changes
   - add GenericTypes.box
   - QualifiedType: rename mapType -> flatMapType, add a proper mapType
+  - added `register` methods for qualified factories on `Configurable`,
+    `ColumnMappers`, and `ArgumentFactories`
 
 # 3.8.2
 - Improvements

--- a/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
@@ -78,7 +78,14 @@ public class Arguments implements JdbiConfig<Arguments> {
         return register(QualifiedArgumentFactory.adapt(factory));
     }
 
-    private Arguments register(QualifiedArgumentFactory factory) {
+    /**
+     * Registers the given qualified argument factory.
+     * If more than one of the registered factories supports a given parameter type, the last-registered factory wins.
+     * @param factory the qualified factory to add
+     * @return this
+     */
+    @Beta
+    public Arguments register(QualifiedArgumentFactory factory) {
         factories.add(0, factory);
         return this;
     }

--- a/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.Arguments;
+import org.jdbi.v3.core.argument.QualifiedArgumentFactory;
 import org.jdbi.v3.core.array.SqlArrayArgumentStrategy;
 import org.jdbi.v3.core.array.SqlArrayType;
 import org.jdbi.v3.core.array.SqlArrayTypeFactory;
@@ -32,6 +33,7 @@ import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.core.mapper.MapEntryMappers;
+import org.jdbi.v3.core.mapper.QualifiedColumnMapperFactory;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.RowMappers;
@@ -140,6 +142,17 @@ public interface Configurable<This> {
      * @return this
      */
     default This registerArgument(ArgumentFactory factory) {
+        return configure(Arguments.class, c -> c.register(factory));
+    }
+
+    /**
+     * Convenience method for {@code getConfig(Arguments.class).register(factory)}
+     *
+     * @param factory qualified argument factory
+     * @return this
+     */
+    @Beta
+    default This registerArgument(QualifiedArgumentFactory factory) {
         return configure(Arguments.class, c -> c.register(factory));
     }
 
@@ -279,6 +292,17 @@ public interface Configurable<This> {
      * @return this
      */
     default This registerColumnMapper(ColumnMapperFactory factory) {
+        return configure(ColumnMappers.class, c -> c.register(factory));
+    }
+
+    /**
+     * Convenience method for {@code getConfig(ColumnMappers.class).register(factory)}
+     *
+     * @param factory column mapper factory
+     * @return this
+     */
+    @Beta
+    default This registerColumnMapper(QualifiedColumnMapperFactory factory) {
         return configure(ColumnMappers.class, c -> c.register(factory));
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
@@ -127,7 +127,16 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
         return register(QualifiedColumnMapperFactory.adapt(factory));
     }
 
-    private ColumnMappers register(QualifiedColumnMapperFactory factory) {
+    /**
+     * Register a qualified column mapper factory.
+     * <p>
+     * Column mappers may be reused by {@link RowMapper} to map individual columns.
+     *
+     * @param factory the qualified column mapper factory
+     * @return this
+     */
+    @Beta
+    public ColumnMappers register(QualifiedColumnMapperFactory factory) {
         factories.add(0, factory);
         cache.clear();
         return this;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/NonnullColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/NonnullColumnMapperFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import java.lang.annotation.Annotation;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+import org.jdbi.v3.meta.Beta;
+
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Column mapper that handles any {@link Nonnull} {@link QualifiedType}.
+ *
+ * {@code @Nonnull} is stripped from the received qualified type,
+ * the actual column mapper for the remaining qualified type is resolved,
+ * and the mapped value is checked, throwing {@link NullPointerException} if null.
+ *
+ * This allows you to query for any column type and make {@code null} explicitly forbidden as a result,
+ * for when declarative programming is your cup of tea.
+ *
+ * This factory should be registered by calling {@link ColumnMappers#addNonNullQualifier(Class)} as late as possible.
+ */
+@Beta
+class NonnullColumnMapperFactory implements QualifiedColumnMapperFactory {
+    @Override
+    public Optional<ColumnMapper<?>> build(QualifiedType<?> type, ConfigRegistry config) {
+        return config.get(ColumnMappers.class)
+            .getNonNullQualifiers()
+            .stream()
+            .map(nonNull -> stripFrom(nonNull, type))
+            .filter(Objects::nonNull)
+            .findFirst()
+            .flatMap(config.get(ColumnMappers.class)::findFor)
+            .map(mapper -> (r, i, ctx) -> Objects.requireNonNull(mapper.map(r, i, ctx), "type annotated with non-null qualifier got a null value"));
+    }
+
+    @Nullable
+    private static <T> QualifiedType<T> stripFrom(Class<? extends Annotation> toStrip, QualifiedType<T> type) {
+        if (!type.hasQualifier(toStrip)) {
+            return null;
+        }
+
+        Set<Annotation> allExceptToStrip = type.getQualifiers().stream()
+            .filter(q -> !toStrip.isInstance(q))
+            .collect(toSet());
+
+        return type.withAnnotations(allExceptToStrip);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualified.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualified.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.qualifier;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.jdbi.v3.meta.Beta;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation is recognized by Jdbi as a "container" of qualifying annotations. Use this when you
+ * want to use an annotation as a qualifier on SQL Objects but are unable to add @{@link Qualifier} to the annotation's source.
+ *
+ * An example use case is putting @{@link javax.annotation.Nonnull} as a qualifier on an SQL Object's fields/methods.
+ */
+@Beta
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD, CONSTRUCTOR, TYPE})
+public @interface Qualified {
+    Class<? extends Annotation>[] value();
+}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/NonnullColumnMapperFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/NonnullColumnMapperFactoryTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import javax.annotation.Nonnull;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NonnullColumnMapperFactoryTest {
+    private static final int NULL = 0, NONNULL = 1;
+
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule();
+
+    @Before
+    public void before() {
+        db.getJdbi()
+            .configure(ColumnMappers.class, mappers -> mappers.addNonNullQualifier(Nonnull.class))
+            .useHandle(h -> {
+                h.createUpdate("create table foo(id int primary key, value int)").execute();
+                h.createUpdate("insert into foo(id, value) values(:id, null)").bind("id", NULL).execute();
+                h.createUpdate("insert into foo(id, value) values(:id, 1)").bind("id", NONNULL).execute();
+            });
+    }
+
+    @Test
+    public void referenceBehavior() {
+        Handle h = db.getJdbi().open();
+
+        assertThat(h.createQuery("select value from foo where id = :id")
+            .bind("id", NULL)
+            .mapTo(Integer.class)
+            .one()).isNull();
+        assertThat(h.createQuery("select value from foo where id = :id")
+            .bind("id", NONNULL)
+            .mapTo(Integer.class)
+            .one()).isNotNull();
+    }
+
+    @Test
+    public void nonNullBehavior() {
+        QualifiedType<Integer> nonNullInt = QualifiedType.of(Integer.class).with(Nonnull.class);
+
+        Handle h = db.getJdbi().open();
+
+        assertThatThrownBy(
+            () -> h.createQuery("select value from foo where id = :id")
+                .bind("id", NULL)
+                .mapTo(nonNullInt)
+                .one())
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("type annotated with non-null qualifier got a null value");
+
+        assertThat(h.createQuery("select value from foo where id = :id")
+            .bind("id", NONNULL)
+            .mapTo(nonNullInt)
+            .one()).isNotNull();
+    }
+}

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2586,7 +2586,7 @@ and setter parameters.
 - `@MapTo`
 - `@BindJpa` and `JpaMapper` respect qualifiers on getters and setters.
 - `@BindKotlin`, `bindKotlin()`, and `KotlinMapper` respect qualifiers on constructor parameters, getters, setters, and setter parameters.
-
+- `link:{jdbidocs}/core/mapper/NonnullColumnMapperFactory.html[@javax.annotation.Nonnull]` (via `link:{jdbidocs}/core/qualifier/Qualified.html[@Qualified]` for SQL Objects)
 
 == SQL Objects
 

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
@@ -136,7 +137,7 @@ public class PostgresPlugin implements JdbiPlugin {
         jdbi.registerColumnMapper(new PGobjectColumnMapperFactory());
 
         // legacy unqualified HSTORE
-        jdbi.registerArgument(new HStoreArgumentFactory()::build);
+        jdbi.registerArgument((ArgumentFactory) new HStoreArgumentFactory()::build);
         jdbi.registerColumnMapper(new GenericType<Map<String, String>>() {}, new HStoreColumnMapper());
 
         // optional integration

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/NonNullMapperTest.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/NonNullMapperTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import javax.annotation.Nonnull;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.ColumnMappers;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.FieldMapper;
+import org.jdbi.v3.core.qualifier.Qualified;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NonNullMapperTest {
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule().withSomething().withPlugin(new SqlObjectPlugin());
+
+    private Jdbi jdbi;
+
+    @Before
+    public void before() {
+        jdbi = db.getJdbi()
+            .registerRowMapper(NullableItem.class, FieldMapper.of(NullableItem.class))
+            .registerRowMapper(NonNullItem.class, FieldMapper.of(NonNullItem.class));
+    }
+
+    @Test
+    public void unmarkedFieldCanBeNull() {
+        NullableItem item = jdbi.withHandle(h -> h.createQuery("select null as col").mapTo(NullableItem.class).one());
+
+        assertThat(item.col).isNull();
+    }
+
+    @Test
+    public void markedFieldWithoutMapperIsMisleading() {
+        NonNullItem item = jdbi.withHandle(h -> h.createQuery("select null as col").mapTo(NonNullItem.class).one());
+
+        assertThat(item.col)
+            .describedAs("your IDE would wrongly claim this field to never be null")
+            .isNull();
+    }
+
+    @Test
+    public void nonNullIsRespected() {
+        jdbi.getConfig(ColumnMappers.class).addNonNullQualifier(Nonnull.class);
+
+        jdbi.useHandle(h -> assertThatThrownBy(h.createQuery("select null as col").mapTo(NonNullItem.class)::one).isInstanceOf(NullPointerException.class));
+    }
+
+    public static class NullableItem {
+        @ColumnName("col")
+        private Integer col;
+    }
+
+    public static class NonNullItem {
+        @ColumnName("col")
+        @Qualified(Nonnull.class)
+        @Nonnull
+        private Integer col;
+    }
+}


### PR DESCRIPTION
Light-hearted idea I had as a fun concept, but I could see it having value for users who like declarative approaches, and to serve as an example of qualified factories.

If the `NonnullMapper` idea is shot down, we should at least salvage the API changes so users can actually start using qualified mappers and arguments...

One of the new `register` methods created an API ambiguity:
![image](https://user-images.githubusercontent.com/3950300/59983071-71db6d80-961b-11e9-86f0-3b99daa8a113.png)
Changing this to what it should be (`registerArgument(new HStoreArgumentFactory())`) causes test failures. Smells like a fishy design to me but I'm tapped out to tackle it for the moment.