### PR TITLE
Let user configure if db null => java primitive default value or exception

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 - New Features
   - `ResultIterable<T>.map(Function<T, U>)` returns a `ResultIterable<U>` with elements transformed
     using the given mapper function.
+  - `ColumnMappers.setNullPrimitivesToDefaults(boolean)` allows you to decide if database nulls
+    should become Java primitive defaults or a mapping exception.
 - Bug Fixes
   - Immutables integration doesn't respect @Value.Default for primitives that are nulled in the db
 - Improvements

--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
@@ -34,6 +34,7 @@ import org.jdbi.v3.meta.Beta;
 public class ColumnMappers implements JdbiConfig<ColumnMappers> {
     private final List<QualifiedColumnMapperFactory> factories = new CopyOnWriteArrayList<>();
     private final ConcurrentHashMap<QualifiedType<?>, ColumnMapper<?>> cache = new ConcurrentHashMap<>();
+    private boolean nullPrimitivesToDefaults = true;
     private ConfigRegistry registry;
 
     public ColumnMappers() {
@@ -58,6 +59,7 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
     private ColumnMappers(ColumnMappers that) {
         factories.addAll(that.factories);
         cache.putAll(that.cache);
+        nullPrimitivesToDefaults = that.nullPrimitivesToDefaults;
     }
 
     /**
@@ -193,6 +195,17 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
         mapper.ifPresent(m -> cache.put(type, m));
 
         return mapper;
+    }
+
+    /**
+     * @return {@code true} if database {@code null}s should translate to the Java defaults for primitives, or throw an exception otherwise
+     */
+    public boolean getNullPrimitivesToDefaults() {
+        return nullPrimitivesToDefaults;
+    }
+
+    public void setNullPrimitivesToDefaults(boolean nullPrimitivesToDefaults) {
+        this.nullPrimitivesToDefaults = nullPrimitivesToDefaults;
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
@@ -34,7 +34,7 @@ import org.jdbi.v3.meta.Beta;
 public class ColumnMappers implements JdbiConfig<ColumnMappers> {
     private final List<QualifiedColumnMapperFactory> factories = new CopyOnWriteArrayList<>();
     private final ConcurrentHashMap<QualifiedType<?>, ColumnMapper<?>> cache = new ConcurrentHashMap<>();
-    private boolean nullPrimitivesToDefaults = true;
+    private boolean coalesceNullPrimitivesToDefaults = true;
     private ConfigRegistry registry;
 
     public ColumnMappers() {
@@ -59,7 +59,7 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
     private ColumnMappers(ColumnMappers that) {
         factories.addAll(that.factories);
         cache.putAll(that.cache);
-        nullPrimitivesToDefaults = that.nullPrimitivesToDefaults;
+        coalesceNullPrimitivesToDefaults = that.coalesceNullPrimitivesToDefaults;
     }
 
     /**
@@ -199,13 +199,15 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
 
     /**
      * @return {@code true} if database {@code null}s should translate to the Java defaults for primitives, or throw an exception otherwise
+     *
+     * Default value is true: nulls will be coalesced to defaults
      */
-    public boolean getNullPrimitivesToDefaults() {
-        return nullPrimitivesToDefaults;
+    public boolean getCoalesceNullPrimitivesToDefaults() {
+        return coalesceNullPrimitivesToDefaults;
     }
 
-    public void setNullPrimitivesToDefaults(boolean nullPrimitivesToDefaults) {
-        this.nullPrimitivesToDefaults = nullPrimitivesToDefaults;
+    public void setCoalesceNullPrimitivesToDefaults(boolean coalesceNullPrimitivesToDefaults) {
+        this.coalesceNullPrimitivesToDefaults = coalesceNullPrimitivesToDefaults;
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/mapper/PrimitiveMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/PrimitiveMapperFactory.java
@@ -62,8 +62,11 @@ class PrimitiveMapperFactory implements ColumnMapperFactory {
     private static <T> ColumnMapper<T> primitiveMapper(ColumnGetter<T> getter) {
         return (r, i, ctx) -> {
             T value = getter.get(r, i);
-            if (r.wasNull() && !ctx.getConfig(ColumnMappers.class).getNullPrimitivesToDefaults()) {
-                throw new UnableToProduceResultException("a Java primitive value was attempted to be mapped from a database null value");
+            if (r.wasNull() && !ctx.getConfig(ColumnMappers.class).getCoalesceNullPrimitivesToDefaults()) {
+                String msg = String.format("Database null values are not allowed for Java primitives by the current configuration:"
+                    + " could not map column %s (%s)."
+                    + " Change your result type to a boxed primitive to resolve.", i, r.getMetaData().getColumnLabel(i));
+                throw new UnableToProduceResultException(msg);
             } else {
                 return value;
             }

--- a/core/src/test/java/org/jdbi/v3/core/mapper/PrimitiveMapperFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/PrimitiveMapperFactoryTest.java
@@ -27,7 +27,7 @@ public class PrimitiveMapperFactoryTest {
 
     @Test
     public void defaultConfiguration() {
-        assertThat(db.getJdbi().getConfig(ColumnMappers.class).getNullPrimitivesToDefaults()).isTrue();
+        assertThat(db.getJdbi().getConfig(ColumnMappers.class).getCoalesceNullPrimitivesToDefaults()).isTrue();
     }
 
     @Test
@@ -44,19 +44,20 @@ public class PrimitiveMapperFactoryTest {
     @Test
     public void forbidNullPrimitives() {
         assertThatThrownBy(() -> db.getJdbi().withHandle(h ->
-            h.configure(ColumnMappers.class, mappers -> mappers.setNullPrimitivesToDefaults(false))
-                .createQuery("select null")
+            h.configure(ColumnMappers.class, mappers -> mappers.setCoalesceNullPrimitivesToDefaults(false))
+                .createQuery("select null as foo")
                 .mapTo(int.class)
                 .one()
         ))
             .isInstanceOf(UnableToProduceResultException.class)
-            .hasMessage("a Java primitive value was attempted to be mapped from a database null value");
+            .hasMessageContaining("Database null values are not allowed for Java primitives")
+            .hasMessageContaining("column 1 (FOO)");
     }
 
     @Test
     public void doesntApplyToBoxed() {
         Integer value = db.getJdbi().withHandle(h ->
-            h.configure(ColumnMappers.class, mappers -> mappers.setNullPrimitivesToDefaults(false))
+            h.configure(ColumnMappers.class, mappers -> mappers.setCoalesceNullPrimitivesToDefaults(false))
                 .createQuery("select null")
                 .mapTo(Integer.class)
                 .one()

--- a/core/src/test/java/org/jdbi/v3/core/mapper/PrimitiveMapperFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/PrimitiveMapperFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import org.jdbi.v3.core.result.UnableToProduceResultException;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PrimitiveMapperFactoryTest {
+    @Rule
+    public H2DatabaseRule db = new H2DatabaseRule();
+
+    @Test
+    public void defaultConfiguration() {
+        assertThat(db.getJdbi().getConfig(ColumnMappers.class).getNullPrimitivesToDefaults()).isTrue();
+    }
+
+    @Test
+    public void primitivesToDefaults() {
+        int value = db.getJdbi().withHandle(h ->
+            h.createQuery("select null")
+                .mapTo(int.class)
+                .one()
+        );
+
+        assertThat(value).isZero();
+    }
+
+    @Test
+    public void forbidNullPrimitives() {
+        assertThatThrownBy(() -> db.getJdbi().withHandle(h ->
+            h.configure(ColumnMappers.class, mappers -> mappers.setNullPrimitivesToDefaults(false))
+                .createQuery("select null")
+                .mapTo(int.class)
+                .one()
+        ))
+            .isInstanceOf(UnableToProduceResultException.class)
+            .hasMessage("a Java primitive value was attempted to be mapped from a database null value");
+    }
+
+    @Test
+    public void doesntApplyToBoxed() {
+        Integer value = db.getJdbi().withHandle(h ->
+            h.configure(ColumnMappers.class, mappers -> mappers.setNullPrimitivesToDefaults(false))
+                .createQuery("select null")
+                .mapTo(Integer.class)
+                .one()
+        );
+
+        assertThat(value).isNull();
+    }
+}


### PR DESCRIPTION
fixes #1270 

I've been wanting to patch this since day 1 of using Jdbi because I don't like stray/default values sneaking into my resultsets as a result of a bug producing nulls where there shouldn't be any... It doesn't really make sense to just assume one wants a null to become an arbitrary-ish value when explicitly working with types that don't support nulls.