### PR TITLE
Prettify truncated StatementExceptionS to signal modifications

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementExceptions.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementExceptions.java
@@ -135,7 +135,13 @@ public class StatementExceptions implements JdbiConfig<StatementExceptions> {
         protected abstract String render(StatementException exc, StatementContext ctx);
     }
 
-    private static String limit(String s, int len) {
-        return s.substring(0, Math.min(len, s.length()));
+    @SuppressWarnings("PMD.UseStringBufferForStringAppends")
+    protected static String limit(String s, int len) {
+        String truncated = s.substring(0, Math.min(len, s.length()));
+        boolean isTruncated = len < s.length();
+        if (isTruncated) {
+            truncated += "[...]";
+        }
+        return truncated;
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatementExceptions.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatementExceptions.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.statement.StatementExceptions.limit;
+
+public class TestStatementExceptions {
+    @Test
+    public final void testLimit() {
+        String exception = "This is a very long exception that is used for testing";
+
+        assertThat(limit(exception, 0)).isEqualTo("[...]");
+        assertThat(limit(exception, 10)).isEqualTo("This is a [...]");
+        assertThat(limit(exception, 20)).isEqualTo("This is a very long [...]");
+        assertThat(limit(exception, 53)).isEqualTo("This is a very long exception that is used for testin[...]");
+        assertThat(limit(exception, 54)).isEqualTo("This is a very long exception that is used for testing");
+        assertThat(limit(exception, 99)).isEqualTo("This is a very long exception that is used for testing");
+    }
+}


### PR DESCRIPTION
I think it's important to make it clear to a casual reader of the logs that a logged statement was truncated. Due to the nature of SQL statemenets, this may not immediately be obvious, for example a statement cut off (at the `|`) like this: "`SELECT ... FROM ...| WHERE ...`" would still be a valid SQL statement.

Adding a "`[...]`" to the end of the Statement if anything is cut off makes this more evident.

The following test case statements demonstrate the result. I didn't think those were worth adding to the PR as code:

```
String exception = "This is a very very long exception that I use for testing";

assertEquals("[...]",
		StatementExceptions.limit(exception, 0));
assertEquals("This is a [...]",
		StatementExceptions.limit(exception, 10));
assertEquals("This is a very very [...]",
		StatementExceptions.limit(exception, 20));
assertEquals("This is a very very long exception that I use for testin[...]",
		StatementExceptions.limit(exception, 56));
assertEquals("This is a very very long exception that I use for testing",
		StatementExceptions.limit(exception, 57));
assertEquals("This is a very very long exception that I use for testing",
		StatementExceptions.limit(exception, 60));
```