### PR TITLE
Revert "Address CVE-2019-12814"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dep.checkstyle.version>8.16</dep.checkstyle.version>
         <dep.dokka.version>0.9.17</dep.dokka.version>
         <dep.immutables.version>2.7.1</dep.immutables.version>
-        <dep.jackson2.version>2.9.9.1</dep.jackson2.version>
+        <dep.jackson2.version>2.9.8</dep.jackson2.version>
         <dep.jetbrainsAnnotations.version>13.0</dep.jetbrainsAnnotations.version>
         <dep.kotlin.version>1.2.31</dep.kotlin.version>
         <dep.plugin.checkstyle.version>3.0.0</dep.plugin.checkstyle.version>


### PR DESCRIPTION
This reverts commit d3cf8ebc330a8a6e8dbbdd02f9d890f3d18df720.

2.9.9.1 is apparently not available in Maven Central -- all the builds started failing with this commit, pushed to master.

cc @brianm do you know what happened to this release?
https://travis-ci.org/jdbi/jdbi/builds/561463779