### PR TITLE
StatementExceptions: Deal with null RenderedSql

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/enums/DatabaseValue.java
+++ b/core/src/main/java/org/jdbi/v3/core/enums/DatabaseValue.java
@@ -18,7 +18,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.jdbi.v3.core.qualifier.Qualifier;
 import org.jdbi.v3.meta.Beta;
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementExceptions.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementExceptions.java
@@ -137,6 +137,9 @@ public class StatementExceptions implements JdbiConfig<StatementExceptions> {
 
     @SuppressWarnings("PMD.UseStringBufferForStringAppends")
     protected static String limit(String s, int len) {
+        if (s == null) {
+            return null;
+        }
         String truncated = s.substring(0, Math.min(len, s.length()));
         boolean isTruncated = len < s.length();
         if (isTruncated) {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatementExceptions.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatementExceptions.java
@@ -23,6 +23,7 @@ public class TestStatementExceptions {
     public final void testLimit() {
         String exception = "This is a very long exception that is used for testing";
 
+        assertThat(limit(null, 10)).isEqualTo(null);
         assertThat(limit(exception, 0)).isEqualTo("[...]");
         assertThat(limit(exception, 10)).isEqualTo("This is a [...]");
         assertThat(limit(exception, 20)).isEqualTo("This is a very long [...]");


### PR DESCRIPTION
I bumped into this when using `@SqlScript` with a resources file - `getRenderedSql()` returns null which causes an NPE and masks the proper exception (very confusing)