### PR TITLE
PreparedBatch.execute() closes context

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# 3.9.1
+- Bug Fixes
+  - fix minor PreparedBatch statement leak
+
 # 3.9.0
 - New Features
   - `ResultIterable<T>.map(Function<T, U>)` returns a `ResultIterable<U>` with elements transformed

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -63,7 +63,11 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
      * @return the number of rows modified or inserted per batch part.
      */
     public int[] execute() {
-        return internalBatchExecute().updateCounts;
+        try {
+            return internalBatchExecute().updateCounts;
+        } finally {
+            getContext().close();
+        }
     }
 
     public ResultIterator<Integer> executeAndGetModCount() {

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
@@ -577,4 +577,8 @@ public class StatementContext implements Closeable {
     public ExtensionMethod getExtensionMethod() {
         return extensionMethod;
     }
+
+    boolean isClosed() {
+        return cleanables.isEmpty();
+    }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
@@ -49,7 +49,9 @@ public class TestPreparedBatch {
 
     @Test
     public void emptyBatch() {
-        assertThat(h.prepareBatch("insert into something (id, name) values (:id, :name)").execute()).isEmpty();
+        final PreparedBatch batch = h.prepareBatch("insert into something (id, name) values (:id, :name)");
+        assertThat(batch.execute()).isEmpty();
+        assertThat(batch.getContext().isClosed()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Note that previously, the batch (per jdbc) would still be closed with the Handle.
But of course we can do better.

Fixes #1567