### PR TITLE
fix #1572: backport EmptyHandling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # 3.10.0
 - New Features
   - Handle.getJdbi gets owning Jdbi instance
+  - sqlobject's `EmptyHandling` enum backported to core for invocations of `SqlStatement.bindList`
 - Bug Fixes
   - onDemand invocations @CreateSqlObject create new on-demand SqlObjects
   - onDemand SqlObject.withHandle / Transactional.inTransaction are now safe to call even outside an on-demand context

--- a/core/src/main/java/org/jdbi/v3/core/internal/IterableLike.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/IterableLike.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -115,31 +114,6 @@ public class IterableLike {
      */
     public static Iterable<Object> iterable(Object iterable) {
         return () -> of(iterable);
-    }
-
-    /**
-     * Attempt to determine if a iterable-like is empty, preferably without iterating.
-     * @param obj the iterable-like to check for emptiness
-     * @return emptiness to fill your heart
-     */
-    public static boolean isEmpty(final Object obj) {
-        if (obj == null) {
-            throw new IllegalArgumentException("cannot determine emptiness of null");
-        }
-
-        if (obj instanceof Collection) {
-            return ((Collection<?>) obj).isEmpty();
-        }
-
-        if (obj instanceof Iterable) {
-            return !((Iterable<?>) obj).iterator().hasNext();
-        }
-
-        if (obj.getClass().isArray()) {
-            return Array.getLength(obj) == 0;
-        }
-
-        throw new IllegalArgumentException(getTypeWarning(obj.getClass()));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/EmptyHandling.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/EmptyHandling.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import java.util.function.BiConsumer;
+
+/**
+ * describes what should be done if the value passed to {@link SqlStatement#bindList} is null or empty
+ */
+public enum EmptyHandling implements BiConsumer<SqlStatement, String> {
+    /**
+     * <p>Render nothing in the query.</p>
+     * <p>
+     * {@code select * from things where x in ()}
+     */
+    BLANK {
+        @Override
+        public void accept(SqlStatement stmt, String key) {
+            stmt.define(key, "");
+        }
+    },
+    /**
+     * <p>Render the keyword {@code null} in the query, useful e.g. in postgresql where "in ()" is invalid syntax.</p>
+     * <p>
+     * {@code select * from things where x in (null)}
+     */
+    NULL_KEYWORD {
+        @Override
+        public void accept(SqlStatement stmt, String key) {
+            stmt.define(key, "null");
+        }
+    },
+    /**
+     * <p>Define a {@code null} value, leaving the result up to the {@link org.jdbi.v3.core.statement.TemplateEngine} to decide.</p>
+     * <p>
+     * This value was specifically added to <a href="https://github.com/jdbi/jdbi/issues/1377">make conditionals work better with <code>StringTemplate</code></a>.
+     */
+    DEFINE_NULL {
+        @Override
+        public void accept(SqlStatement stmt, String key) {
+            stmt.define(key, null);
+        }
+    },
+    /**
+     * Throw IllegalArgumentException.
+     */
+    THROW {
+        @Override
+        public void accept(SqlStatement stmt, String key) {
+            throw new IllegalArgumentException("argument is null or empty; this is forbidden on this call to `bindList`");
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
@@ -148,60 +148,10 @@ public class IterableLikeTest {
     }
 
     private static Object[] toArray(final Iterator<?> iterator) {
-        final List<Object> out = new ArrayList<Object>();
+        final List<Object> out = new ArrayList<>();
         while (iterator.hasNext()) {
             out.add(iterator.next());
         }
         return out.toArray();
-    }
-
-    @Test
-    public void testIsEmptyPrimitiveArray() {
-        assertThat(IterableLike.isEmpty(new int[]{1, 2, 3})).isFalse();
-    }
-
-    @Test
-    public void testIsEmptyEmptyPrimitiveArray() {
-        assertThat(IterableLike.isEmpty(new int[]{})).isTrue();
-    }
-
-    @Test
-    public void testIsEmptyObjectArray() {
-        assertThat(IterableLike.isEmpty(new Object[]{"1", "2", "3"})).isFalse();
-    }
-
-    @Test
-    public void testIsEmptyEmptyObjectArray() {
-        assertThat(IterableLike.isEmpty(new Object[]{})).isTrue();
-    }
-
-    @Test
-    public void testIsEmptyList() {
-        final List<String> in = new ArrayList<String>();
-        in.add("1");
-        in.add("2");
-        in.add("3");
-
-        assertThat(IterableLike.isEmpty(in)).isFalse();
-    }
-
-    @Test
-    public void testIsEmptyEmptyList() {
-        assertThat(IterableLike.isEmpty(new ArrayList<String>())).isTrue();
-    }
-
-    @Test
-    public void testIsEmptyObject() {
-        assertThatThrownBy(() -> IterableLike.isEmpty(new Object())).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void testIsEmptyPrimitive() {
-        assertThatThrownBy(() -> IterableLike.isEmpty(5)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void testIsEmptyNull() {
-        assertThatThrownBy(() -> IterableLike.isEmpty(null)).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
@@ -23,8 +23,11 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static java.util.Collections.emptyList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
 
 public class TestBindList {
     @Rule
@@ -39,6 +42,26 @@ public class TestBindList {
         handle.execute("create table thing (id identity primary key, foo varchar(50), bar varchar(50), baz varchar(50))");
         handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 1, "foo1", "bar1", "baz1");
         handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 2, "foo2", "bar2", "baz2");
+    }
+
+    @Test
+    public void testNullVararg() {
+        String out = handle.createQuery("select (<empty>)")
+            .bindList(NULL_KEYWORD, "empty", (Object[]) null)
+            .mapTo(String.class)
+            .one();
+
+        assertThat(out).isNull();
+    }
+
+    @Test
+    public void testEmptyList() {
+        String out = handle.createQuery("select (<empty>)")
+            .bindList(NULL_KEYWORD, "empty", emptyList())
+            .mapTo(String.class)
+            .one();
+
+        assertThat(out).isNull();
     }
 
     @Test

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListTest.java
@@ -197,7 +197,7 @@ public class BindListTest {
 
     @UseFreemarkerEngine
     private interface SomethingByIterableHandleThrow {
-        @SqlQuery("select id, name from something where id in (${ids])")
+        @SqlQuery("select id, name from something where id in (${ids})")
         List<Something> get(@BindList(onEmpty = THROW) Iterable<Integer> ids);
     }
 
@@ -207,12 +207,12 @@ public class BindListTest {
     public void testSomethingByIteratorHandleDefault() {
         final SomethingByIteratorHandleDefault s = handle.attach(SomethingByIteratorHandleDefault.class);
 
-        assertThatThrownBy(() -> s.get(Arrays.asList(1, 2).iterator())).isInstanceOf(IllegalArgumentException.class);
+        assertThat(s.get(Arrays.asList(1, 2).iterator())).hasSameElementsAs(expectedSomethings);
     }
 
     @UseFreemarkerEngine
     private interface SomethingByIteratorHandleDefault {
-        @SqlQuery("select id, name from something where id in (${ids])")
+        @SqlQuery("select id, name from something where id in (${ids})")
         List<Something> get(@BindList Iterator<Integer> ids);
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -38,12 +38,6 @@ public final class BindListFactory implements SqlStatementCustomizerFactory {
                         + "and parameter name data is not present in the class file, for: "
                         + param.getDeclaringExecutable() + "::" + param));
 
-        return (stmt, arg) -> {
-            if (arg == null || IterableLike.isEmpty(arg)) {
-                bindList.onEmpty().define(stmt, name);
-            } else {
-                stmt.bindList(name, IterableLike.toList(arg));
-            }
-        };
+        return (stmt, arg) -> stmt.bindList(bindList.onEmpty().getCoreImpl(), name, arg == null ? null : IterableLike.toList(arg));
     }
 }

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -204,7 +204,7 @@ public class BindListTest {
     public void testSomethingByIteratorHandleDefault() {
         final SomethingByIteratorHandleDefault s = handle.attach(SomethingByIteratorHandleDefault.class);
 
-        assertThatThrownBy(() -> s.get(Arrays.asList(1, 2).iterator())).isInstanceOf(IllegalArgumentException.class);
+        assertThat(s.get(Arrays.asList(1, 2).iterator())).hasSameElementsAs(expectedSomethings);
     }
 
     @UseStringTemplateEngine


### PR DESCRIPTION
Implemented the EmptyHandling enum in core, leaving out the deprecated value and redesigning the new API to accept an interface (making the enum a convenience, not a restriction).