### PR TITLE
Expose Qualified(Argument/Mapper)Factories registration API

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,9 @@
 - New Features
   - Handle.getJdbi gets owning Jdbi instance
   - sqlobject's `EmptyHandling` enum backported to core for invocations of `SqlStatement.bindList`
+- New Beta Features
+  - added `register` methods for qualified factories on `Configurable`,
+    `ColumnMappers`, and `ArgumentFactories`
 - Bug Fixes
   - onDemand invocations @CreateSqlObject create new on-demand SqlObjects
   - onDemand SqlObject.withHandle / Transactional.inTransaction are now safe to call even outside an on-demand context

--- a/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
@@ -78,7 +78,14 @@ public class Arguments implements JdbiConfig<Arguments> {
         return register(QualifiedArgumentFactory.adapt(factory));
     }
 
-    private Arguments register(QualifiedArgumentFactory factory) {
+    /**
+     * Registers the given qualified argument factory.
+     * If more than one of the registered factories supports a given parameter type, the last-registered factory wins.
+     * @param factory the qualified factory to add
+     * @return this
+     */
+    @Beta
+    public Arguments register(QualifiedArgumentFactory factory) {
         factories.add(0, factory);
         return this;
     }

--- a/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.Arguments;
+import org.jdbi.v3.core.argument.QualifiedArgumentFactory;
 import org.jdbi.v3.core.array.SqlArrayArgumentStrategy;
 import org.jdbi.v3.core.array.SqlArrayType;
 import org.jdbi.v3.core.array.SqlArrayTypeFactory;
@@ -32,6 +33,7 @@ import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.core.mapper.MapEntryMappers;
+import org.jdbi.v3.core.mapper.QualifiedColumnMapperFactory;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.RowMappers;
@@ -140,6 +142,17 @@ public interface Configurable<This> {
      * @return this
      */
     default This registerArgument(ArgumentFactory factory) {
+        return configure(Arguments.class, c -> c.register(factory));
+    }
+
+    /**
+     * Convenience method for {@code getConfig(Arguments.class).register(factory)}
+     *
+     * @param factory qualified argument factory
+     * @return this
+     */
+    @Beta
+    default This registerArgument(QualifiedArgumentFactory factory) {
         return configure(Arguments.class, c -> c.register(factory));
     }
 
@@ -279,6 +292,17 @@ public interface Configurable<This> {
      * @return this
      */
     default This registerColumnMapper(ColumnMapperFactory factory) {
+        return configure(ColumnMappers.class, c -> c.register(factory));
+    }
+
+    /**
+     * Convenience method for {@code getConfig(ColumnMappers.class).register(factory)}
+     *
+     * @param factory column mapper factory
+     * @return this
+     */
+    @Beta
+    default This registerColumnMapper(QualifiedColumnMapperFactory factory) {
         return configure(ColumnMappers.class, c -> c.register(factory));
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
@@ -127,7 +127,16 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
         return register(QualifiedColumnMapperFactory.adapt(factory));
     }
 
-    private ColumnMappers register(QualifiedColumnMapperFactory factory) {
+    /**
+     * Register a qualified column mapper factory.
+     * <p>
+     * Column mappers may be reused by {@link RowMapper} to map individual columns.
+     *
+     * @param factory the qualified column mapper factory
+     * @return this
+     */
+    @Beta
+    public ColumnMappers register(QualifiedColumnMapperFactory factory) {
         factories.add(0, factory);
         cache.clear();
         return this;

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
@@ -136,7 +137,7 @@ public class PostgresPlugin implements JdbiPlugin {
         jdbi.registerColumnMapper(new PGobjectColumnMapperFactory());
 
         // legacy unqualified HSTORE
-        jdbi.registerArgument(new HStoreArgumentFactory()::build);
+        jdbi.registerArgument((ArgumentFactory) new HStoreArgumentFactory()::build);
         jdbi.registerColumnMapper(new GenericType<Map<String, String>>() {}, new HStoreColumnMapper());
 
         // optional integration


### PR DESCRIPTION
We forgot to expose this to users, they can't currently register their own qualified factories.

Apparently this introduces some ambiguity on existing calls (separate commit), despite `Type` and `QualifiedType` being pretty distinct from each other...