### PR TITLE
SqlParsers: use `caffeine` cache

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
 - Bug Fixes
   - onDemand invocations @CreateSqlObject create new on-demand SqlObjects
   - onDemand SqlObject.withHandle / Transactional.inTransaction are now safe to call even outside an on-demand context
+  - SqlParsers no longer retain all statements and instead use a `caffeine` cache
 
 # 3.9.1
 - Bug Fixes

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,6 +69,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
             <scope>test</scope>

--- a/core/src/main/java/org/jdbi/v3/core/statement/CachingSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/CachingSqlParser.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import org.jdbi.v3.meta.Beta;
+
+abstract class CachingSqlParser implements SqlParser {
+    private final LoadingCache<String, ParsedSql> parsedSqlCache;
+
+    CachingSqlParser(Caffeine<Object, Object> cache) {
+        parsedSqlCache = cache.build(this::internalParse);
+    }
+
+    @Override
+    public ParsedSql parse(String sql, StatementContext ctx) {
+        try {
+            return parsedSqlCache.get(sql);
+        } catch (IllegalArgumentException e) {
+            throw new UnableToCreateStatementException("Exception parsing for named parameter replacement", e, ctx);
+        }
+    }
+
+    @Beta
+    public CacheStats cacheStats() {
+        return parsedSqlCache.stats();
+    }
+
+    abstract ParsedSql internalParse(String sql);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,17 @@
                 <version>21.0</version>
             </dependency>
             <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>2.8.0</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>error_prone_annotations</artifactId>
+                        <groupId>com.google.errorprone</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>io.vavr</groupId>
                 <artifactId>vavr</artifactId>
                 <version>0.9.1</version>


### PR DESCRIPTION
Fixes #1528

We can worry about minimizing the size later, rather than continue to have this problem persist.