### PR TITLE
SqlCall: OutParameters processing in Consumer or Function callback

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,9 @@
   - Handle.getJdbi gets owning Jdbi instance
   - SqlStatement (like Query) has new bindArray helper methods
   - sqlobject's `EmptyHandling` enum backported to core for invocations of `SqlStatement.bindList`
+  - OutParameters lets you `getRowSet` to view cursor-typed out parameters
+  - Call.invoke lets you process OutParameters before closing the statement with a Consumer or Function
+  - @SqlCall lets you process OutParameters before closing the statement by passing a Consumer or Function
   - installPlugin skips duplicate JdbiPlugins (according to Object.equals)
   - KotlinSqlObjectPlugin will install forgotten SqlObjectPlugin for you
   - ClasspathSqlLocator allows disabling comment stripping and deprecate static API
@@ -15,6 +18,7 @@
   - SqlParsers no longer retain all statements and instead use a `caffeine` cache
 - Compatibility
   - added a module that runs the Spring 4 integration tests against Spring 5 to monitor forward compatibility
+  - OutParameters no longer has a public constructor (this type should never really have been constructed anyway)
 
 # 3.9.1
 - Bug Fixes

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -19,6 +19,8 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.argument.Argument;
@@ -34,7 +36,7 @@ public class Call extends SqlStatement<Call> {
     }
 
     /**
-     * Register a positional output parameter
+     * Register a positional output parameter.
      * @param position the parameter position (zero-based)
      * @param sqlType an SQL type constant as defined by {@link java.sql.Types} or by the JDBC vendor.
      * @return self
@@ -44,7 +46,7 @@ public class Call extends SqlStatement<Call> {
     }
 
     /**
-     * Register a positional output parameter
+     * Register a positional output parameter.
      * @param position the parameter position (zero-based)
      * @param sqlType an SQL type constant as defined by {@link java.sql.Types} or by the JDBC vendor.
      * @param mapper a mapper which converts the {@link CallableStatement} to a desired output type.
@@ -56,7 +58,7 @@ public class Call extends SqlStatement<Call> {
     }
 
     /**
-     * Register a named output parameter
+     * Register a named output parameter.
      * @param name the parameter name
      * @param sqlType an SQL type constant as defined by {@link java.sql.Types} or by the JDBC vendor.
      * @return self
@@ -66,7 +68,7 @@ public class Call extends SqlStatement<Call> {
     }
 
     /**
-     * Register a named output parameter
+     * Register a named output parameter.
      * @param name the parameter name
      * @param sqlType an SQL type constant as defined by {@link java.sql.Types} or by the JDBC vendor.
      * @param mapper a mapper which converts the {@link CallableStatement} to a desired output type.
@@ -78,13 +80,32 @@ public class Call extends SqlStatement<Call> {
     }
 
     /**
-     * Invoke the callable statement
+     * Invoke the callable statement.  Note that the statement will be {@link #close()}d,
+     * so cursor-typed values may not work.
      * @return the output parameters resulting from the invocation.
      */
     public OutParameters invoke() {
+        return invoke(Function.identity());
+    }
+
+    /**
+     * Invoke the callable statement and process its {@link OutParameters} results.
+     */
+    public void invoke(Consumer<OutParameters> resultConsumer) {
+        invoke((Function<OutParameters, Void>) r -> {
+            resultConsumer.accept(r);
+            return null;
+        });
+    }
+
+    /**
+     * Invoke the callable statement and process its {@link OutParameters} results,
+     * returning a computed value of type {@code T}.
+     */
+    public <T> T invoke(Function<OutParameters, T> resultComputer) {
         try {
             internalExecute();
-            OutParameters out = new OutParameters();
+            OutParameters out = new OutParameters(getContext());
             for (OutParamArgument param : params) {
                 Object obj = param.map((CallableStatement) stmt);
 
@@ -96,7 +117,7 @@ public class Call extends SqlStatement<Call> {
                     out.getMap().put(param.name, obj);
                 }
             }
-            return out;
+            return resultComputer.apply(out);
         } finally {
             close();
         }

--- a/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
@@ -14,16 +14,24 @@
 package org.jdbi.v3.core.statement;
 
 import java.sql.Date;
+import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.jdbi.v3.core.result.ResultBearing;
 
 /**
  * Represents output from a Call (CallableStatement).
  * @see Call
  */
 public class OutParameters {
+    private final StatementContext ctx;
     private final Map<Object, Object> map = new HashMap<>();
+
+    OutParameters(StatementContext ctx) {
+        this.ctx = ctx;
+    }
 
     /**
      * Type-casting convenience method which obtains an object from the map, the
@@ -211,6 +219,14 @@ public class OutParameters {
 
     public Float getFloat(int pos) {
         return getNumber(pos).floatValue();
+    }
+
+    public ResultBearing getRowSet(String name) {
+        return ResultBearing.of(() -> getObject(name, ResultSet.class), ctx);
+    }
+
+    public ResultBearing getRowSet(int pos) {
+        return ResultBearing.of(() -> getObject(pos, ResultSet.class), ctx);
     }
 
     private Number getNumber(String name) {

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2418,6 +2418,12 @@ Now we can extract the result(s) from `OutParameters`:
 include::{exampledir}/CallTest.java[tags=getOutParameters]
 ----
 
+It is possible to return open cursors as a result-like object by declaring it
+as `Types.REF_CURSOR` and then inspecting it via `OutParameters.getRowSet()`.
+Usually this must be done in a transaction, and the results must be consumed
+before closing the statement by processing it using the `Call.invoke(Consumer)`
+or `Call.invoke(Function)` callback style.
+
 [WARNING]
 Due to design constraints within JDBC, the parameter data types available
 through `OutParameters` is limited to those types supported directly by JDBC.
@@ -3487,6 +3493,10 @@ OutParameters outParams = orderDao.prepareOrderFromCart(cartId);
 long orderId = outParams.getLong("orderId");
 double orderTotal = outParams.getDouble("orderTotal");
 ----
+
+By passing a `Consumer<OutParameters>` or a `Function<OutParameters, T>`,
+you may process the result before the statement is closed.  This is useful
+to process cursor-typed results.
 
 ==== @SqlScript
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -103,6 +104,9 @@ abstract class CustomizingStatementHandler<StatementType extends SqlStatement<St
                 throw new IllegalStateException(
                   "SQL Object methods with a Consumer parameter must have void return type.");
             }
+            return Stream.empty();
+        }
+        if (parameter.getType() == Function.class && this instanceof SqlCallHandler) {
             return Stream.empty();
         }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPostgresRefcursorProc.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestPostgresRefcursorProc.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.sql.Types;
+import java.util.function.Function;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.OutParameters;
+import org.jdbi.v3.sqlobject.customizer.OutParameter;
+import org.jdbi.v3.sqlobject.statement.SqlCall;
+import org.jdbi.v3.sqlobject.transaction.Transaction;
+import org.jdbi.v3.testing.JdbiRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPostgresRefcursorProc {
+    @Rule
+    public JdbiRule dbRule = JdbiRule.embeddedPostgres().withPlugins();
+
+    Handle handle;
+
+    @Before
+    public void setUp() {
+        handle = dbRule.getHandle();
+    }
+
+    @Test
+    public void multipleResultSetReturn() {
+        handle.execute("create function gather_data (head out refcursor, tail out refcursor) "
+            + "language plpgsql as $$ begin "
+                + "open head for select 1 union select 2; "
+                + "open tail for select 3 union select 4; end; $$");
+        assertThat(handle.attach(Dao.class).gatherData(op -> {
+            assertThat(op.getRowSet("head")
+                     .mapTo(int.class)
+                     .list())
+                .containsExactly(1, 2);
+            assertThat(op.getRowSet("tail")
+                    .mapTo(int.class)
+                    .list())
+                .containsExactly(3, 4);
+            return true;
+        })).isTrue();
+    }
+
+    public interface Dao {
+        @SqlCall("{call gather_data(:head, :tail)}")
+        @OutParameter(name = "head", sqlType = Types.REF_CURSOR)
+        @OutParameter(name = "tail", sqlType = Types.REF_CURSOR)
+        @Transaction
+        boolean gatherData(Function<OutParameters, Boolean> action);
+    }
+}


### PR DESCRIPTION
Add test returning multiple result sets from a Postgres stored function
Closes our oldest outstanding issue!!! :cake: 

Fixes #1392
Fixes #76