### PR TITLE
@Qualified

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,9 @@
 - New Beta Features
   - added `register` methods for qualified factories on `Configurable`,
     `ColumnMappers`, and `ArgumentFactories`
+  - `@Qualified` is a qualifier-carrier that allows you to assign any annotation
+    without its own `@Qualifier` (such as `@javax.annotation.Nonnull`)
+    as a qualifier where you couldn't before (e.g. bean mapping, SqlObject, ...)
 - Bug Fixes
   - onDemand invocations @CreateSqlObject create new on-demand SqlObjects
   - onDemand SqlObject.withHandle / Transactional.inTransaction are now safe to call even outside an on-demand context

--- a/core/src/main/java/org/jdbi/v3/core/config/JdbiCache.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/JdbiCache.java
@@ -31,4 +31,6 @@ public interface JdbiCache<K, V> {
     default V get(K key, StatementContext ctx) {
         return get(key, ctx.getConfig());
     }
+
+    void clear(ConfigRegistry config);
 }

--- a/core/src/main/java/org/jdbi/v3/core/config/JdbiCaches.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/JdbiCaches.java
@@ -62,6 +62,11 @@ public final class JdbiCaches implements JdbiConfig<JdbiCaches> {
                         .computeIfAbsent(this, x -> new ConcurrentHashMap<>())
                         .computeIfAbsent(keyNormalizer.apply(key), x -> computer.apply(config, key));
             }
+
+            @Override
+            public void clear(ConfigRegistry config) {
+                config.get(JdbiCaches.class).caches.computeIfPresent(this, (dis, cache) -> new ConcurrentHashMap<>());
+            }
         };
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualified.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualified.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.qualifier;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.jdbi.v3.meta.Beta;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation is recognized by Jdbi as a "container" of qualifying annotations. Use this when you
+ * want to use an annotation as a qualifier on SQL Objects but are unable to add @{@link Qualifier} to the annotation's source.
+ *
+ * An example use case is putting @{@link javax.annotation.Nonnull} as a qualifier on an SQL Object's fields/methods.
+ */
+@Beta
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD, CONSTRUCTOR, TYPE})
+public @interface Qualified {
+    Class<? extends Annotation>[] value();
+}

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualified.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualified.java
@@ -27,10 +27,12 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * This annotation is recognized by Jdbi as a "container" of qualifying annotations. Use this when you
- * want to use an annotation as a qualifier on SQL Objects but are unable to add @{@link Qualifier} to the annotation's source.
+ * Qualifies a target with the given annotation. Use this when you want to use an annotation as a qualifier
+ * but are unable to add @{@link Qualifier} to the annotation's source.
  *
  * An example use case is putting @{@link javax.annotation.Nonnull} as a qualifier on an SQL Object's fields/methods.
+ *
+ * @see Qualifier
  */
 @Beta
 @Retention(RUNTIME)

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.qualifier;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -121,6 +122,31 @@ public final class QualifiedType<T> {
             .map(AnnotationFactory::create)
             .collect(toSet());
         return new QualifiedType<>(type, annotations);
+    }
+
+    /**
+     * @return a QualifiedType that has the same type and qualifiers as this instance, <b>except</b>> the given qualifier.
+     *
+     * @param unwanted the qualifier class to remove.
+     */
+    public QualifiedType<T> remove(Class<? extends Annotation> unwanted) {
+        Set<Annotation> filtered = qualifiers.stream()
+            .filter(qual -> !unwanted.isInstance(qual))
+            .collect(toSet());
+
+        return new QualifiedType<>(type, filtered);
+    }
+
+    /**
+     * @return a QualifiedType that has the same type and qualifiers as this instance, <b>plus</b>> the given qualifier.
+     *
+     * @param additional the qualifier class to add.
+     */
+    public QualifiedType<T> add(Class<? extends Annotation> additional) {
+        Set<Annotation> combined = new HashSet<>(qualifiers);
+        combined.add(AnnotationFactory.create(additional));
+
+        return new QualifiedType<>(type, combined);
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifier.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifier.java
@@ -24,6 +24,7 @@ import org.jdbi.v3.meta.Beta;
  * Annotation used to identify type qualifying annotations. Use this to annotate an annotation.
  *
  * @see NVarchar as an example
+ * @see Qualified for annotations you cannot add this annotation to
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
@@ -64,17 +64,15 @@ public class Qualifiers implements JdbiConfig<Qualifiers> {
      * which searches for annotations themselves annotated with {@link Qualifier}.
      *
      * Resolvers should return static results that don't vary over time; therefore their results are cached.
-     * Adding a resolver will clear the local qualifier resolution cache, but is currently not guaranteed to have any effect on {@code SqlObjects}.
-     * Add any resolvers you may need <em>before</em> using any qualifiers-related features!
+     * Adding a resolver will clear the local qualifier resolution cache, but {@code SqlObjects} and other features
+     * may have their own caching mechanisms. Add any resolvers you may need <strong>before</strong> using any qualifiers-related features!
      *
      * @param resolver the resolver to be included in qualifier resolution
      * @return this
      */
     public Qualifiers addResolver(Function<AnnotatedElement, Set<Annotation>> resolver) {
         resolvers.add(resolver);
-        if (registry != null) {
-            QUALIFIER_CACHE.clear(registry);
-        }
+        QUALIFIER_CACHE.clear(registry);
         return this;
     }
 
@@ -114,7 +112,7 @@ public class Qualifiers implements JdbiConfig<Qualifiers> {
 
     private static Set<Annotation> inspectQualifiedCarrier(AnnotatedElement element) {
         return Arrays.stream(element.getAnnotations())
-            .filter(anno -> anno instanceof Qualified)
+            .filter(Qualified.class::isInstance)
             .map(Qualified.class::cast)
             .map(Qualified::value)
             .flatMap(Arrays::stream)

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
@@ -18,6 +18,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Function;
@@ -26,6 +27,7 @@ import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiCache;
 import org.jdbi.v3.core.config.JdbiCaches;
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.internal.AnnotationFactory;
 import org.jdbi.v3.meta.Beta;
 
 import static java.util.stream.Collectors.toSet;
@@ -43,6 +45,7 @@ public class Qualifiers implements JdbiConfig<Qualifiers> {
 
     public Qualifiers() {
         resolvers.add(Qualifiers::getQualifierAnnotations);
+        resolvers.add(Qualifiers::inspectQualifiedCarrier);
     }
 
     private Qualifiers(Qualifiers other) {
@@ -106,6 +109,16 @@ public class Qualifiers implements JdbiConfig<Qualifiers> {
     private static Set<Annotation> getQualifierAnnotations(AnnotatedElement element) {
         return Arrays.stream(element.getAnnotations())
             .filter(anno -> anno.annotationType().isAnnotationPresent(Qualifier.class))
+            .collect(toSet());
+    }
+
+    private static Set<Annotation> inspectQualifiedCarrier(AnnotatedElement element) {
+        return Arrays.stream(element.getAnnotations())
+            .filter(anno -> anno instanceof Qualified)
+            .map(Qualified.class::cast)
+            .map(Qualified::value)
+            .flatMap(Arrays::stream)
+            .map(AnnotationFactory::create)
             .collect(toSet());
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
@@ -36,8 +36,8 @@ import static java.util.stream.Collectors.toSet;
 @Beta
 public class Qualifiers implements JdbiConfig<Qualifiers> {
     private static final JdbiCache<AnnotatedElement[], Set<Annotation>> QUALIFIER_CACHE = JdbiCaches.declare(
-            elements -> elements.length == 1 ? elements[0] : new HashSet<>(Arrays.asList(elements)),
-            (Function<AnnotatedElement[], Set<Annotation>>) Qualifiers::getQualifiers);
+        elements -> elements.length == 1 ? elements[0] : new HashSet<>(Arrays.asList(elements)),
+        (Function<AnnotatedElement[], Set<Annotation>>) Qualifiers::getQualifiers);
     private ConfigRegistry registry;
 
     public Qualifiers() {}
@@ -49,6 +49,7 @@ public class Qualifiers implements JdbiConfig<Qualifiers> {
 
     /**
      * Returns the set of qualifying annotations on the given elements.
+     *
      * @param elements the annotated elements. Null elements are ignored.
      * @return the set of qualifying annotations on the given elements.
      */
@@ -61,11 +62,11 @@ public class Qualifiers implements JdbiConfig<Qualifiers> {
 
     private static Set<Annotation> getQualifiers(AnnotatedElement... elements) {
         return Collections.unmodifiableSet(Arrays.stream(elements)
-                .filter(Objects::nonNull)
-                .map(AnnotatedElement::getAnnotations)
-                .flatMap(Arrays::stream)
-                .filter(anno -> anno.annotationType().isAnnotationPresent(Qualifier.class))
-                .collect(toSet()));
+            .filter(Objects::nonNull)
+            .map(AnnotatedElement::getAnnotations)
+            .flatMap(Arrays::stream)
+            .filter(anno -> anno.annotationType().isAnnotationPresent(Qualifier.class))
+            .collect(toSet()));
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
@@ -51,4 +51,36 @@ public class TestQualifiedType {
             .isNotEqualTo(QualifiedType.of(String.class).with(foo(1)))
             .isNotEqualTo(QualifiedType.of(String.class).with(bar("1")));
     }
+
+    @Test
+    public void testHas() {
+        QualifiedType nvarcharString = QualifiedType.of(String.class).with(NVarchar.class);
+
+        assertThat(nvarcharString.hasQualifier(NVarchar.class)).isTrue();
+        assertThat(nvarcharString.hasQualifier(Reversed.class)).isFalse();
+    }
+
+    @Test
+    public void testAdd() {
+        QualifiedType string = QualifiedType.of(String.class);
+
+        assertThat(string.hasQualifier(Reversed.class)).isFalse();
+
+        QualifiedType reversedString = string.add(Reversed.class);
+
+        assertThat(string.hasQualifier(Reversed.class)).isFalse();
+        assertThat(reversedString.hasQualifier(Reversed.class)).isTrue();
+    }
+
+    @Test
+    public void testRemove() {
+        QualifiedType<String> reversedString = QualifiedType.of(String.class).with(Reversed.class);
+
+        assertThat(reversedString.hasQualifier(Reversed.class)).isTrue();
+
+        QualifiedType string = reversedString.remove(Reversed.class);
+
+        assertThat(reversedString.hasQualifier(Reversed.class)).isTrue();
+        assertThat(string.hasQualifier(Reversed.class)).isFalse();
+    }
 }

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiers.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiers.java
@@ -13,56 +13,115 @@
  */
 package org.jdbi.v3.core.qualifier;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.jdbi.v3.core.internal.AnnotationFactory;
 import org.jdbi.v3.core.qualifier.SampleQualifiers.Bar;
 import org.jdbi.v3.core.qualifier.SampleQualifiers.Foo;
+import org.junit.Before;
 import org.junit.Test;
+
+import static java.util.Collections.singleton;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jdbi.v3.core.qualifier.SampleQualifiers.bar;
 import static org.jdbi.v3.core.qualifier.SampleQualifiers.foo;
 
 public class TestQualifiers {
+    private Qualifiers qualifiers;
+
+    @Before
+    public void before() {
+        qualifiers = new Qualifiers();
+    }
+
     @Test
     public void getQualifiers() throws Exception {
-        Qualifiers qualifiers = new Qualifiers();
-
         assertThat(foo(1))
             .isEqualTo(foo(1))
             .isNotEqualTo(foo(2));
 
-        assertThat(qualifiers.findFor(getClass().getDeclaredField("qualifiedField")))
+        assertThat(qualifiers.findFor(WithQualifiers.class.getDeclaredField("qualifiedField")))
             .containsExactly(foo(1));
 
-        assertThat(qualifiers.findFor(getClass().getDeclaredMethod("qualifiedMethod")))
+        assertThat(qualifiers.findFor(WithQualifiers.class.getDeclaredMethod("qualifiedMethod")))
             .containsExactly(foo(2));
 
-        assertThat(qualifiers.findFor(getClass().getDeclaredMethod("qualifiedParameter", String.class).getParameters()[0]))
+        assertThat(qualifiers.findFor(WithQualifiers.class.getDeclaredMethod("qualifiedParameter", String.class).getParameters()[0]))
             .containsExactly(foo(3));
 
-        assertThat(qualifiers.findFor(QualifiedClass.class))
+        assertThat(qualifiers.findFor(WithQualifiers.QualifiedClass.class))
             .containsExactly(foo(4));
 
-        assertThat(qualifiers.findFor(QualifiedClass.class.getDeclaredConstructor(String.class).getParameters()[0]))
+        assertThat(qualifiers.findFor(WithQualifiers.QualifiedClass.class.getDeclaredConstructor(String.class).getParameters()[0]))
             .containsExactly(foo(5));
 
-        assertThat(qualifiers.findFor(getClass().getDeclaredField("twoQualifiers")))
+        assertThat(qualifiers.findFor(WithQualifiers.class.getDeclaredField("twoQualifiers")))
             .containsExactlyInAnyOrder(foo(6), bar("six"));
     }
 
-    @Foo(1)
-    private String qualifiedField;
+    @Test
+    public void singleQualified() throws NoSuchMethodException {
+        Set<Annotation> annos = qualifiers.findFor(WithQualified.class.getMethod("nonNull"));
 
-    @Foo(2)
-    private void qualifiedMethod() {}
-
-    private void qualifiedParameter(@Foo(3) String param) {}
-
-    @Foo(4)
-    private static class QualifiedClass {
-        QualifiedClass(@Foo(5) String param) {}
+        assertThat(annos)
+            .extracting(Annotation::annotationType)
+            .containsExactly((Class) Nonnull.class);
     }
 
-    @Foo(6)
-    @Bar("six")
-    private String twoQualifiers;
+    @Test
+    public void multipleQualified() throws NoSuchMethodException {
+        Set<Annotation> annos = qualifiers.findFor(WithQualified.class.getMethod("both"));
+
+        assertThat(annos)
+            .extracting(Annotation::annotationType)
+            .containsExactlyInAnyOrder((Class) Nonnull.class, (Class) Nullable.class);
+    }
+
+    @Test
+    public void addResolver() throws NoSuchMethodException {
+        Method method = WithQualified.class.getMethod("none");
+
+        Set<Annotation> annos = qualifiers.findFor(method);
+        assertThat(annos).isEmpty();
+
+        qualifiers.addResolver(element -> singleton(AnnotationFactory.create(Nonnull.class)));
+
+        annos = qualifiers.findFor(method);
+        assertThat(annos).extracting(Annotation::annotationType).containsExactly((Class) Nonnull.class);
+    }
+
+    public static class WithQualifiers {
+        @Foo(1)
+        private String qualifiedField;
+
+        @Foo(2)
+        private void qualifiedMethod() {}
+
+        private void qualifiedParameter(@Foo(3) String param) {}
+
+        @Foo(4)
+        private static class QualifiedClass {
+            QualifiedClass(@Foo(5) String param) {}
+        }
+
+        @Foo(6)
+        @Bar("six")
+        private String twoQualifiers;
+    }
+
+    public interface WithQualified {
+        void none();
+
+        @Qualified(Nonnull.class)
+        void nonNull();
+
+        @Qualified({Nonnull.class, Nullable.class})
+        void both();
+    }
 }

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiers.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiers.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.internal.AnnotationFactory;
 import org.jdbi.v3.core.qualifier.SampleQualifiers.Bar;
 import org.jdbi.v3.core.qualifier.SampleQualifiers.Foo;
@@ -37,7 +38,7 @@ public class TestQualifiers {
 
     @Before
     public void before() {
-        qualifiers = new Qualifiers();
+        qualifiers = new ConfigRegistry().get(Qualifiers.class);
     }
 
     @Test

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2605,10 +2605,16 @@ and setter parameters.
 
 ==== Custom qualifiers
 
-There are always 2 parties involved in using qualifiers:
-the target (method, parameter, etc) and the handler (`ArgumentFactory`, etc). Generally, both need to be _qualified_ identically to interact with each other.
+Qualifiers can be applied to a few different kinds of _types_:
 
-In order to qualify either a target (in addition to `QualifiedType` mentioned earlier) or handler, there are two options:
+* on a method: qualifies return type
+* on a parameter: qualifies parameter type
+* on a type: qualifies the type the class operates on, usually;
+    ** on an ArgumentFactory, qualifies input argument type
+    ** on a ColumnMapper<T>, qualifies T
+    ** on a ColumnMapperFactory, qualifies the mapped type
+
+In order to qualify either a target (in addition to `QualifiedType` mentioned earlier) or executable "handler", there are two options:
 
 - create a custom annotation, meta-annotated with link:{jdbidocs}/core/qualifier/Qualifier.html[@Qualifier] (see any of our discussed qualifiers)
 - use an existing annotation (e.g. from a library) and thumb-tack it on using link:{jdbidocs}/core/qualifier/Qualified.html[@Qualified]
@@ -2625,7 +2631,7 @@ through class inspection, and is otherwise oblivious to qualifiers.
 
 The latter is treated as a _wildcard_ in terms of qualifiers,
 will receive _any_ target along with its qualifier data, and must use its own logic
-to decide to interact with a given value.
+to decide if and how to interact with a given value.
 
 Consider this transparent `@javax.annotation.NonNull` enforcer example:
 

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2603,6 +2603,47 @@ and setter parameters.
 - `@BindJpa` and `JpaMapper` respect qualifiers on getters and setters.
 - `@BindKotlin`, `bindKotlin()`, and `KotlinMapper` respect qualifiers on constructor parameters, getters, setters, and setter parameters.
 
+==== Custom qualifiers
+
+There are always 2 parties involved in using qualifiers:
+the target (method, parameter, etc) and the handler (`ArgumentFactory`, etc). Generally, both need to be _qualified_ identically to interact with each other.
+
+In order to qualify either a target (in addition to `QualifiedType` mentioned earlier) or handler, there are two options:
+
+- create a custom annotation, meta-annotated with link:{jdbidocs}/core/qualifier/Qualifier.html[@Qualifier] (see any of our discussed qualifiers)
+- use an existing annotation (e.g. from a library) and thumb-tack it on using link:{jdbidocs}/core/qualifier/Qualified.html[@Qualified]
+
+==== Qualified handlers
+
+Qualified targets can be handled by two types of handler implementations:
+
+- classic handlers (e.g. `ArgumentFactory`) that happen to be qualified themselves
+- or the `Qualified*` counterpart to these handlers (e.g. `QualifiedArgumentFactory`)
+
+The former will be matched to targets with the exact same type and qualifiers by Jdbi
+through class inspection, and is otherwise oblivious to qualifiers.
+
+The latter is treated as a _wildcard_ in terms of qualifiers,
+will receive _any_ target along with its qualifier data, and must use its own logic
+to decide to interact with a given value.
+
+Consider this transparent `@javax.annotation.NonNull` enforcer example:
+
+[source,java]
+----
+class NonnullColumnMapperFactory implements QualifiedColumnMapperFactory {
+    @Override
+    public Optional<ColumnMapper<?>> build(QualifiedType<?> type, ConfigRegistry config) {
+        if (!type.hasQualifier(Nonnull.class)) {
+            return Optional.empty();
+        }
+
+        return config.get(ColumnMappers.class)
+            .findFor(type.remove(Nonnull.class))
+            .map(actualMapper -> (r, i, ctx) -> Objects.requireNonNull(actualMapper.map(r, i, ctx), "type annotated with non-null qualifier got a null value"));
+    }
+}
+----
 
 == SQL Objects
 
@@ -3756,7 +3797,7 @@ dao.useTransaction(txn -> {
 });
 ----
 
-Interface `default` methods, and mix-ins such as 
+Interface `default` methods, and mix-ins such as
 link:{jdbidocs}/sqlobject/SqlObject.html[SqlObject^]
 and
 link:{jdbidocs}/sqlobject/transaction/Transactional.html[Transactional^],

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/QualifiedTest.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/QualifiedTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jdbi.v3.sqlobject;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.ColumnMappers;
+import org.jdbi.v3.core.mapper.NoSuchMapperException;
+import org.jdbi.v3.core.mapper.QualifiedColumnMapperFactory;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+import org.jdbi.v3.core.rule.SqliteDatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class QualifiedTest {
+    private static final QualifiedType<String> NONNULL_STRING = QualifiedType.of(String.class).with(Nonnull.class);
+
+    @Rule
+    public SqliteDatabaseRule db = new SqliteDatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    private Jdbi jdbi;
+
+    @Before
+    public void before() {
+        jdbi = db.getJdbi();
+    }
+
+    @Test
+    public void testWithoutEnforcerRegistered() {
+        assertThatThrownBy(() -> jdbi.withHandle(h -> h.createQuery("ascii shrug here").mapTo(NONNULL_STRING)))
+            .isInstanceOf(NoSuchMapperException.class);
+    }
+
+    @Test
+    public void testWithEnforcerRegistered() {
+        jdbi.registerColumnMapper(new NonNullEnforcer());
+
+        assertThatThrownBy(() -> jdbi.useHandle(h -> h.createQuery("select null as foo").mapTo(NONNULL_STRING).one()))
+            .isInstanceOf(NonNullEnforcer.IllegalNull.class);
+
+        assertThat((String) jdbi.withHandle(h -> h.createQuery("select 'abc' as foo").mapTo(NONNULL_STRING).one()))
+            .isEqualTo("abc");
+    }
+
+    public static class NonNullEnforcer implements QualifiedColumnMapperFactory {
+        /**
+         * because NPE could be something else
+         */
+        private static class IllegalNull extends RuntimeException {}
+
+        @Override
+        public Optional<ColumnMapper<?>> build(QualifiedType<?> type, ConfigRegistry config) {
+            if (!type.hasQualifier(Nonnull.class)) {
+                return Optional.empty();
+            }
+
+            return config.get(ColumnMappers.class)
+                .findFor(type.remove(Nonnull.class))
+                .map(original -> (ColumnMapper<?>) (r, columnNumber, ctx) -> {
+                    Object plain = original.map(r, columnNumber, ctx);
+                    if (plain == null) {
+                        throw new IllegalNull();
+                    }
+                    return plain;
+                });
+        }
+    }
+}


### PR DESCRIPTION
`core` can qualify a call with any annotation, but `sqlobject` requires `@Qualifier`, which cannot be added to external annotations. `@Qualified` fills that functional gap:
`@Qualified(NonNull.class) String getNonNullString();`