### PR TITLE
bump org.postgresql:postgresql to 4.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.2.4</version>
+                <version>42.2.8</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Bump the dependency  `org.postgresql:postgresql` to `4.2.8`. For the currently used version `4.2.4` a vulnerability is reported by https://github.com/jeremylong/DependencyCheck.