### PR TITLE
DurationColumnMapperFactory uses BigDecimal for math operations to av…

### DIFF
--- a/postgres/src/main/java/org/jdbi/v3/postgres/DurationArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/DurationArgumentFactory.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.postgres;
 
+import java.math.BigDecimal;
 import java.sql.Types;
 import java.time.Duration;
 
@@ -68,7 +69,9 @@ public class DurationArgumentFactory extends AbstractArgumentFactory<Duration> {
             throw new IllegalArgumentException(
                     String.format("duration %s too precise to represented as postgres interval", d));
         }
-        double seconds = d.getSeconds() + d.getNano() / 1e9;
+        double seconds = BigDecimal.valueOf(d.getSeconds())
+                .add(BigDecimal.valueOf(d.getNano()).movePointLeft(9))
+                .doubleValue();
         final PGInterval interval = new PGInterval(0, 0, (int) days, hours, minutes, seconds);
         if (isNegative) {
             interval.scale(-1);

--- a/postgres/src/main/java/org/jdbi/v3/postgres/DurationColumnMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/DurationColumnMapperFactory.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.postgres;
 
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -56,7 +57,10 @@ public class DurationColumnMapperFactory implements ColumnMapperFactory {
                                 interval.getValue()));
             }
             final long secondsLong = (long) seconds;
-            final long nanos = (long) ((seconds - secondsLong) * 1e9);
+            final long nanos = ((BigDecimal.valueOf(seconds)
+                .subtract(BigDecimal.valueOf(secondsLong)))
+                .movePointRight(9))
+                .longValue();
             return Duration.ofDays(interval.getDays())
                     .plusHours(interval.getHours())
                     .plusMinutes(interval.getMinutes())

--- a/postgres/src/main/java/org/jdbi/v3/postgres/DurationColumnMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/DurationColumnMapperFactory.java
@@ -57,10 +57,10 @@ public class DurationColumnMapperFactory implements ColumnMapperFactory {
                                 interval.getValue()));
             }
             final long secondsLong = (long) seconds;
-            final long nanos = ((BigDecimal.valueOf(seconds)
-                .subtract(BigDecimal.valueOf(secondsLong)))
-                .movePointRight(9))
-                .longValue();
+            final long nanos = BigDecimal.valueOf(seconds)
+                    .subtract(BigDecimal.valueOf(secondsLong))
+                    .movePointRight(9)
+                    .longValue();
             return Duration.ofDays(interval.getDays())
                     .plusHours(interval.getHours())
                     .plusMinutes(interval.getMinutes())

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestDuration.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestDuration.java
@@ -153,6 +153,16 @@ public class TestDuration {
             .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    public void testFloatingPointMath() {
+        handle.execute("insert into intervals(id, foo) values(?, interval '.129428s')", 13);
+        final Duration d = handle.createQuery("select foo from intervals where id=?")
+            .bind(0, 13)
+            .mapTo(Duration.class)
+            .one();
+        assertThat(d).isEqualTo(Duration.ofNanos(129_428_000));
+    }
+
     // We guard against reading intervals with seconds too big or too small (i.e., more extreme than Long minimum and
     // maximum values), but it's unclear how to actually create such intervals in Postgres.
 }


### PR DESCRIPTION
I found an issue where certain interval values would be off by a microsecond when converted to a duration by jdbi. This PR fixes the issue.

Also, this is my first time contributing to this project, please let me know if I need to do anything differently, Thanks 