### PR TITLE
Update documentation for Kotlin

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -4207,6 +4207,10 @@ name for a property or parameter explicitly, as well as the `@Nested` annotation
 that allows mapping nested Kotlin objects.
 
 [NOTE]
+Instead of using `@BindBean`, `bindBean()`, and `@RegisterBeanMapper` use `@BindKotlin`, `bindKotlin()`, and `KotlinMapper`
+for qualifiers on constrictor parameters, getter, setters, and setter parameters of Kotlin class.
+
+[NOTE]
 The `@ColumnName` annotation only applies while mapping SQL data into Java
 objects. When binding object properties (e.g. with `bindBean()`), bind the
 property name (`:id`) rather than the column name (`:user_id`).


### PR DESCRIPTION
Just a small update in documentation suggesting developers to use  `@BindKotlin`, `bindKotlin()` and `KotlinMapper` for kotlin classes.

Motivation for this PR:
I am using JDBI for a project and was using a data class which has a Boolean property whose name starts with `is` and somehow JDBI was not able to find the named argument parameter when i used `BindBean()` annotation.
Below example explains the motivation for this PR

Example:
```
data class Bar(
    val isFooBar: Boolean
)

@SqlBatch("""
INSERT INTO <tablename> (
    `is_foo_bar`
) VALUES (
    :bar.isFooBar
)
fun insertFoo(@BindBean("bar") fooList: List<Bar>)
""")
```

If we execute the above query it fails on finding the parameter by name `isFooBar` however `:bar.fooBar` works.

Solution to above was replacing `@BindBean` with `@BindKotlin`