### PR TITLE
Use the new fluent configuration for Flyway

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>5.0.7</version>
+            <version>5.2.4</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
@@ -148,11 +148,12 @@ public abstract class JdbiRule extends ExternalResource {
     @Override
     public void before() throws Throwable {
         if (migration != null) {
-            final Flyway flyway = new Flyway();
-            flyway.setDataSource(getDataSource());
-            flyway.setLocations(migration.paths.toArray(new String[0]));
-            flyway.setSchemas(migration.schemas.toArray(new String[0]));
-            flyway.migrate();
+            Flyway.configure()
+                .dataSource(getDataSource())
+                .locations(migration.paths.toArray(new String[0]))
+                .schemas(migration.schemas.toArray(new String[0]))
+                .load()
+                .migrate();
         }
 
         jdbi = Jdbi.create(getDataSource());
@@ -166,11 +167,12 @@ public abstract class JdbiRule extends ExternalResource {
     @Override
     public void after() {
         if (migration != null && migration.cleanAfter) {
-            final Flyway flyway = new Flyway();
-            flyway.setDataSource(getDataSource());
-            flyway.setLocations(migration.paths.toArray(new String[0]));
-            flyway.setSchemas(migration.schemas.toArray(new String[0]));
-            flyway.clean();
+            Flyway.configure()
+                .dataSource(getDataSource())
+                .locations(migration.paths.toArray(new String[0]))
+                .schemas(migration.schemas.toArray(new String[0]))
+                .load()
+                .clean();
         }
         handle.close();
         jdbi = null;


### PR DESCRIPTION
Move to the new fluent configuration for Flyway as the classic configuration is being deprecated in `Flyway 6.x.x` (see https://github.com/flyway/flyway/issues/2218) and makes `jdbi3-testing` fail if projects use Flyway `6.0.0+`.