### PR TITLE
restore validation of bitstring content

### DIFF
--- a/postgres/src/main/java/org/jdbi/v3/postgres/internal/BitStringEnumSetColumnMapper.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/internal/BitStringEnumSetColumnMapper.java
@@ -16,7 +16,6 @@ package org.jdbi.v3.postgres.internal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.EnumSet;
-import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
 import org.jdbi.v3.core.mapper.ColumnMapper;
@@ -45,18 +44,18 @@ public class BitStringEnumSetColumnMapper<E extends Enum<E>> implements ColumnMa
         }
 
         return IntStream.range(0, bits.length())
-            .peek(checkIfBitIn(bits))
-            .filter(i -> bits.charAt(i) == '1')
+            .filter(i -> {
+                char bit = bits.charAt(i);
+                switch (bit) {
+                case '1':
+                    return true;
+                case '0':
+                    return false;
+                default:
+                    throw new IllegalArgumentException("bit string \"" + bits + "\" contains non-bit character " + bit);
+                }
+            })
             .mapToObj(i -> enumConstants[i])
             .collect(toCollection(() -> EnumSet.noneOf(enumType)));
-    }
-
-    private static IntConsumer checkIfBitIn(String bits) {
-        return i -> {
-            char bit = bits.charAt(i);
-            if (bit != '0' && bit != '1') {
-                throw new IllegalArgumentException("bit string \"" + bits + "\" contains non-bit character " + bit);
-            }
-        };
     }
 }

--- a/postgres/src/main/java/org/jdbi/v3/postgres/internal/BitStringEnumSetColumnMapper.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/internal/BitStringEnumSetColumnMapper.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.postgres.internal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.EnumSet;
+import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
 import org.jdbi.v3.core.mapper.ColumnMapper;
@@ -44,8 +45,18 @@ public class BitStringEnumSetColumnMapper<E extends Enum<E>> implements ColumnMa
         }
 
         return IntStream.range(0, bits.length())
+            .peek(checkIfBitIn(bits))
             .filter(i -> bits.charAt(i) == '1')
             .mapToObj(i -> enumConstants[i])
             .collect(toCollection(() -> EnumSet.noneOf(enumType)));
+    }
+
+    private static IntConsumer checkIfBitIn(String bits) {
+        return i -> {
+            char bit = bits.charAt(i);
+            if (bit != '0' && bit != '1') {
+                throw new IllegalArgumentException("bit string \"" + bits + "\" contains non-bit character " + bit);
+            }
+        };
     }
 }


### PR DESCRIPTION
1fdb5a32a4044e33f6f20a32ddd78887f2796b4f removed the validation entirely, this PR restores the validation (but more performantly) and adds the test for it.