### PR TITLE
Bump flyway version to latest

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>5.2.4</version>
+            <version>6.1.1</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Flyway 6.1.1 is the latest version.
It doesn't break any test, and it will do good to users who already use this latest versions in their projects.