### PR TITLE
limiting editorconfig resolution isnt useful

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-root = true
-
 [*]
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
Editorconfig rules are resolved nearest-to-file-first, but bubble down all the way from the filesystem root (or wherever `root=true`). It's a thing to put editorconfig in your filesystem root for elementary defaults you want to apply everywhere, until overridden inside folders that contextually "know better", i.e. project rules.

TLDR: if we don't care about an editorconfig rule, we shouldn't prevent the user's own setting for it from being applied.