### PR TITLE
WIP concept of nicer json mapping DSL for fluent API

### DIFF
--- a/json/src/main/java/org/jdbi/v3/json/JsonArgument.java
+++ b/json/src/main/java/org/jdbi/v3/json/JsonArgument.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.json;
+
+import org.jdbi.v3.core.argument.ArgumentFactory;
+
+public class JsonArgument {
+    public static ArgumentFactory of(Class<?> cls) {
+        throw new UnsupportedOperationException("TODO move/use JsonArgumentFactory from pg plugin?");
+    }
+}

--- a/json/src/main/java/org/jdbi/v3/json/JsonMapper.java
+++ b/json/src/main/java/org/jdbi/v3/json/JsonMapper.java
@@ -16,6 +16,8 @@ package org.jdbi.v3.json;
 import java.lang.reflect.Type;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.meta.Beta;
 
 /**
@@ -28,6 +30,17 @@ import org.jdbi.v3.meta.Beta;
  */
 @Beta
 public interface JsonMapper {
+
+    /**
+     *
+     * @param cls
+     * @param <T>
+     * @return RowMapper for single columnar result
+     */
+    static <T> RowMapper<T> of(Class<T> cls) {
+       throw new UnsupportedOperationException("TODO this could/should behave similar to ConstructorMapper class");
+    }
+
     String toJson(Type type, Object value, ConfigRegistry config);
     Object fromJson(Type type, String json, ConfigRegistry config);
 }

--- a/json/src/test/java/org/jdbi/v3/json/AbstractJsonMapperTest.java
+++ b/json/src/test/java/org/jdbi/v3/json/AbstractJsonMapperTest.java
@@ -66,6 +66,26 @@ public abstract class AbstractJsonMapperTest {
     }
 
     @Test
+    public void testFluentApiWithRegisteredArgumentAndMapper() {
+        jdbi.useHandle(h -> {
+            h.execute("create table subjects (id serial primary key, subject json not null)");
+
+            JsonBean in = new JsonBean("nom", 10);
+            h.createUpdate("insert into subjects(id, subject) values(1, :bean)")
+                .registerArgument(JsonArgument.of(JsonBean.class))
+                .bind("bean", in)
+                .execute();
+
+            JsonBean out = h.createQuery("select subject from subjects")
+                .registerRowMapper(JsonMapper.of(JsonBean.class))
+                .mapTo(JsonBean.class)
+                .one();
+
+            assertThat(out).isEqualTo(in);
+        });
+    }
+
+    @Test
     public void testFluentApiWithNesting() {
         jdbi.useHandle(h -> {
             h.execute("create table bean (id serial primary key, nested1 json, nested2 json)");


### PR DESCRIPTION
Hey folks,

since we work a lot with postgres and are experimenting with json, I revisited the plugins after using jdbi a lot with the "stringtype=unspecified" hack.

I am happy to see that there are json plugins which seem to work nicely with postgres.

One caveat I found reading the docs is that the SQLObject API reads a lot nicer than the fluent API. Since I work mostly with the latter, I was pondering if there is a way to achieve a similarly nice user experience as with the `ConstructorMapper` class. 

```
h.registerRowMapper(ConstructorMapper.of(MyType.class))
  .createQuery(...)
  ....
```

I came up with the following draft, which would probably require moving the existing Argumentfactory of the postgres plugin to the json plugin (which may be a "hack" atm anyway, see `PostgresPlugin` class.

I am willing to work on this, if of interest, but I could use some hint on how to best implement the RowMapper(-factory?) for the jsonmapper 
