### PR TITLE
Basepom 31

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # 3.12.1
   - Bean binding: ignore getter methods with parameters
   - Immutables: find builder set method even with @ColumnName
+  - CachingSqlParser: default limit to 1000 parsed statements, #1658
 
 # 3.12.0
   - `EnumSet` can be bound and mapped as a bitstring to a Postgres `varbit` column

--- a/core/src/main/java/org/jdbi/v3/core/statement/CachingSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/CachingSqlParser.java
@@ -21,6 +21,11 @@ import org.jdbi.v3.meta.Beta;
 abstract class CachingSqlParser implements SqlParser {
     private final LoadingCache<String, ParsedSql> parsedSqlCache;
 
+    CachingSqlParser() {
+        this(Caffeine.newBuilder()
+                     .maximumSize(1_000));
+    }
+
     CachingSqlParser(Caffeine<Object, Object> cache) {
         parsedSqlCache = cache.build(this::internalParse);
     }

--- a/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
@@ -38,9 +38,7 @@ import static org.jdbi.v3.core.internal.lexer.ColonStatementLexer.QUOTED_TEXT;
  */
 public class ColonPrefixSqlParser extends CachingSqlParser {
 
-    public ColonPrefixSqlParser() {
-        this(Caffeine.newBuilder());
-    }
+    public ColonPrefixSqlParser() {}
 
     @Beta
     public ColonPrefixSqlParser(Caffeine<Object, Object> cache) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
@@ -35,9 +35,7 @@ import static org.jdbi.v3.core.internal.lexer.HashStatementLexer.QUOTED_TEXT;
  */
 public class HashPrefixSqlParser extends CachingSqlParser {
 
-    public HashPrefixSqlParser() {
-        this(Caffeine.newBuilder());
-    }
+    public HashPrefixSqlParser() {}
 
     @Beta
     public HashPrefixSqlParser(final Caffeine<Object, Object> cache) {

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>basepom-oss</artifactId>
         <groupId>org.basepom</groupId>
-        <version>30</version>
+        <version>31</version>
     </parent>
 
     <groupId>org.jdbi</groupId>


### PR DESCRIPTION
last java 8 compatible release - more upgrades will need fixes especially to dokka