### PR TITLE
Properties: use getExactReturnType instead of resolving the type

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
   - Immutables: find builder set method even with @ColumnName
   - CachingSqlParser: default limit to 1000 parsed statements, #1658
   - bom: don't inherit from parent #1656
+  - bean mapping: improve detection of incomplete wildcard types
 
 # 3.12.0
   - `EnumSet` can be bound and mapped as a bitstring to a Postgres `varbit` column

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ImmutablesPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ImmutablesPropertiesFactory.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.leangen.geantyref.GenericTypeReflector;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiCache;
 import org.jdbi.v3.core.config.JdbiCaches;
@@ -133,7 +134,7 @@ public interface ImmutablesPropertiesFactory {
         protected ImmutablesPojoProperty<T> createProperty(String name, Method m) {
             final Class<?> builderClass = builder.get().getClass();
             try {
-                final Type propertyType = GenericTypes.resolveType(m.getGenericReturnType(), getType());
+                final Type propertyType = GenericTypeReflector.getExactReturnType(m, getType());
                 return new ImmutablesPojoProperty<T>(
                         name,
                         QualifiedType.of(propertyType).withAnnotations(config.get(Qualifiers.class).findFor(m)),

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
@@ -92,4 +92,25 @@ public class TestEnums {
         assertThat(dbRule.getSharedHandle().createQuery("select 'BrIaN'").mapTo(SomethingElse.Name.class).one())
             .isEqualTo(SomethingElse.Name.brian);
     }
+
+    @Test
+    public void testGenericEnumBindBean() {
+        dbRule.getSharedHandle().useTransaction(h -> {
+            assertThat(h.createQuery("select :e.val")
+                    .bindBean("e", new E<SomethingElse.Name>(SomethingElse.Name.brian))
+                    .mapTo(SomethingElse.Name.class)
+                    .one())
+                .isEqualTo(SomethingElse.Name.brian);
+        });
+    }
+
+    public static class E<T extends SomethingElse.Name> {
+        private final T val;
+        E(final T val) {
+            this.val = val;
+        }
+        public T getVal() {
+            return val;
+        }
+    }
 }


### PR DESCRIPTION
it seems to be more reliable regarding figuring out base types in case of incomplete wildcards.

Fixes #1646