### PR TITLE
feature: enable forbidding binding null as a primitive

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # 3.13.0
   - Kotlin: respect default values in methods when passed null, #1690
+  - `Arguments.bindingNullToPrimitivesPermitted` helps you catch
+  erroneous binding of `null` to a primitive type
 
 # 3.12.2
   - Bean binding: ignore getter methods with parameters

--- a/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
@@ -43,6 +43,7 @@ public class Arguments implements JdbiConfig<Arguments> {
 
     private ConfigRegistry registry;
     private Argument untypedNullArgument = new NullArgument(Types.OTHER);
+    private boolean bindingNullToPrimitivesPermitted = true;
 
     public Arguments(ConfigRegistry registry) {
         this.registry = registry;
@@ -76,6 +77,7 @@ public class Arguments implements JdbiConfig<Arguments> {
         factories.addAll(that.factories);
         preparedFactories = new ConcurrentHashMap<>(that.preparedFactories);
         untypedNullArgument = that.untypedNullArgument;
+        bindingNullToPrimitivesPermitted = that.bindingNullToPrimitivesPermitted;
     }
 
     /**
@@ -188,6 +190,20 @@ public class Arguments implements JdbiConfig<Arguments> {
      */
     public Argument getUntypedNullArgument() {
         return untypedNullArgument;
+    }
+
+    /**
+     * @return if binding {@code null} to a variable declared as a primitive type is allowed
+     */
+    public boolean isBindingNullToPrimitivesPermitted() {
+        return bindingNullToPrimitivesPermitted;
+    }
+
+    /**
+     * @param bindingNullToPrimitivesPermitted if binding {@code null} to a variable declared as a primitive type should be allowed
+     */
+    public void setBindingNullToPrimitivesPermitted(boolean bindingNullToPrimitivesPermitted) {
+        this.bindingNullToPrimitivesPermitted = bindingNullToPrimitivesPermitted;
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/v3/core/argument/PrimitivesArgumentFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/PrimitivesArgumentFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jdbi.v3.core.argument;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PrimitivesArgumentFactoryTest {
+    @Rule
+    public H2DatabaseRule dbRule = new H2DatabaseRule();
+
+    private Handle handle;
+
+    @Before
+    public void getHandle() {
+        handle = dbRule.getSharedHandle();
+    }
+
+    @Test
+    public void bindingNullToPrimitiveThrows() {
+        assertThat(handle.getConfig(Arguments.class).isBindingNullToPrimitivesPermitted()).isTrue();
+
+        assertThat(handle.createQuery("select :foo").bindByType("foo", null, int.class).mapTo(int.class).one())
+            .describedAs("binding a null binds the primitive's default")
+            .isZero();
+
+        handle.getConfig(Arguments.class).setBindingNullToPrimitivesPermitted(false);
+
+        assertThatThrownBy(() -> handle.createQuery("select :foo").bindByType("foo", null, int.class).mapTo(int.class).one())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("binding null to a primitive int is forbidden by configuration, declare a boxed type instead");
+
+        assertThat(handle.createQuery("select :foo").bindByType("foo", null, Integer.class).mapTo(Integer.class).one())
+            .describedAs("binding a null to a boxed type is fine")
+            .isNull();
+    }
+}


### PR DESCRIPTION
I.e. `.bindByType("foo", null, int.class)` becomes illegal if opted in. I recommend reviewing commit per commit since a method rename is involved.