### PR TITLE
TransactionHandler: add specialize

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
   - immutables: support getter with @ColumnName, #1704
   - postgres: simple CRUD support for LargeObject API
   - kotlin-sqlobject: fix package declaration of RegisterKotlinMappers
+  - LocalTransactionHandler: bind more closely to Handle for performance and to avoid leaks
 
 # 3.13.0
   - Kotlin: respect default values in methods when passed null, #1690

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -67,15 +67,15 @@ public class Handle implements Closeable, Configurable<Handle> {
            ConnectionCloser closer,
            TransactionHandler transactions,
            StatementBuilder statementBuilder,
-           Connection connection) {
+           Connection connection) throws SQLException {
         this.jdbi = jdbi;
         this.closer = closer;
-        this.transactions = transactions;
         this.connection = connection;
 
         this.localConfig = ThreadLocal.withInitial(() -> localConfig);
         this.localExtensionMethod = new ThreadLocal<>();
         this.statementBuilder = statementBuilder;
+        this.transactions = transactions.specialize(this);
         this.forceEndTransactions = !transactions.isInTransaction(this);
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -58,7 +58,7 @@ public class Jdbi implements Configurable<Jdbi> {
     private final ConfigRegistry config = new ConfigRegistry();
 
     private final ConnectionFactory connectionFactory;
-    private final AtomicReference<TransactionHandler> transactionhandler = new AtomicReference<>(new LocalTransactionHandler());
+    private final AtomicReference<TransactionHandler> transactionhandler = new AtomicReference<>(LocalTransactionHandler.binding());
     private final AtomicReference<StatementBuilderFactory> statementBuilderFactory = new AtomicReference<>(DefaultStatementBuilder.FACTORY);
 
     private final CopyOnWriteArrayList<JdbiPlugin> plugins = new CopyOnWriteArrayList<>();

--- a/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/SerializableTransactionRunner.java
@@ -35,7 +35,7 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
     private static final String SQLSTATE_TXN_SERIALIZATION_FAILED = "40001";
 
     public SerializableTransactionRunner() {
-        this(new LocalTransactionHandler());
+        this(LocalTransactionHandler.binding());
     }
 
     public SerializableTransactionRunner(TransactionHandler delegate) {
@@ -90,6 +90,11 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
         } finally {
             handle.setTransactionIsolation(initial);
         }
+    }
+
+    @Override
+    public TransactionHandler specialize(Handle handle) throws SQLException {
+        return new SerializableTransactionRunner(getDelegate().specialize(handle));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/transaction/TransactionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/TransactionHandler.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.core.transaction;
 
+import java.sql.SQLException;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleCallback;
 
@@ -112,4 +114,13 @@ public interface TransactionHandler {
                                              TransactionIsolationLevel level,
                                              HandleCallback<R, X> callback) throws X;
 
+    /**
+     * Bind a TransactionHandler to a Handle, to allow it to track handle-local state.
+     * @param handle the handle to bind to
+     * @return the bound TransactionHandler
+     * @throws SQLException bad things happened
+     */
+    default TransactionHandler specialize(final Handle handle) throws SQLException {
+        return this;
+    }
 }

--- a/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
+++ b/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.DefaultStatementBuilder;
@@ -30,7 +31,7 @@ public class HandleAccess {
      * useful for tests that do not actually hit
      * a database.
      */
-    public static Handle createHandle() {
+    public static Handle createHandle() throws SQLException {
         Connection fakeConnection = Mockito.mock(Connection.class);
 
         return new Handle(null, new ConfigRegistry(), Connection::close, new LocalTransactionHandler(),

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentsRegistry.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentsRegistry.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.argument;
 
 import java.lang.reflect.Type;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Optional;
 
 import org.jdbi.v3.core.Handle;
@@ -22,6 +23,7 @@ import org.jdbi.v3.core.HandleAccess;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.StatementContextAccess;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -38,11 +40,17 @@ public class TestArgumentsRegistry {
 
     private static final String I_AM_A_STRING = "I am a String";
 
-    private final Handle handle = HandleAccess.createHandle();
-    private final StatementContext ctx = StatementContextAccess.createContext(handle);
+    Handle handle;
+    StatementContext ctx;
 
     @Mock
     public PreparedStatement stmt;
+
+    @Before
+    public void setup() throws SQLException {
+        handle = HandleAccess.createHandle();
+        ctx = StatementContextAccess.createContext(handle);
+    }
 
     @Test
     public void testWaffleLong() throws Exception {

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperMockTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperMockTest.java
@@ -54,13 +54,15 @@ public class BeanMapperMockTest {
     @Mock
     ResultSetMetaData resultSetMetaData;
 
-    Handle handle = HandleAccess.createHandle();
-    StatementContext ctx = StatementContextAccess.createContext(handle);
+    Handle handle;
+    StatementContext ctx;
 
     RowMapper<SampleBean> mapper = BeanMapper.of(SampleBean.class);
 
     @Before
     public void setUpMocks() throws SQLException {
+        handle = HandleAccess.createHandle();
+        ctx = StatementContextAccess.createContext(handle);
         when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperMockTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperMockTest.java
@@ -52,13 +52,15 @@ public class FieldMapperMockTest {
     @Mock
     ResultSetMetaData resultSetMetaData;
 
-    Handle handle = HandleAccess.createHandle();
-    StatementContext ctx = StatementContextAccess.createContext(handle);
+    Handle handle;
+    StatementContext ctx;
 
     RowMapper<SampleBean> mapper = FieldMapper.of(SampleBean.class);
 
     @Before
     public void setUpMocks() throws SQLException {
+        handle = HandleAccess.createHandle();
+        ctx = StatementContextAccess.createContext(handle);
         when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
     }
 


### PR DESCRIPTION
specializes binds the transaction logic to a Handle, removing use of concurrent maps and thread locals.  should increase efficiency and remove the possibility to leak memory like:
Fixes #1697 