### PR TITLE
Add Kotlin sqlobject extensions taking a KClass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dependency-reduced-pom.xml
+.flattened-pom.xml
 GPATH
 GRTAGS
 GTAGS

--- a/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/Extensions.kt
+++ b/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/Extensions.kt
@@ -15,12 +15,20 @@ package org.jdbi.v3.sqlobject.kotlin
 
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.Jdbi
+import kotlin.reflect.KClass
 
 inline fun <reified T : Any> Jdbi.onDemand(): T {
     return this.onDemand(T::class.java)
+}
+
+fun <T : Any> Jdbi.onDemand(kclass: KClass<T>): T {
+    return this.onDemand(kclass.java)
 }
 
 inline fun <reified T : Any> Handle.attach(): T {
     return this.attach(T::class.java)
 }
 
+fun <T : Any> Handle.attach(kclass: KClass<T>): T {
+    return this.attach(kclass.java)
+}

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/v3/kotlin/KotlinSqlObjectPluginTest.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/v3/kotlin/KotlinSqlObjectPluginTest.kt
@@ -107,8 +107,18 @@ class KotlinSqlObjectPluginTest {
     }
 
     @Test
+    fun testDaoCanAttachViaDbiOnDemandWithKClassArgument() {
+        commonTest(db.jdbi.onDemand(ThingDao::class))
+    }
+
+    @Test
     fun testDaoCanAttachViaHandleAttach() {
         commonTest(db.sharedHandle.attach<ThingDao>())
+    }
+
+    @Test
+    fun testDaoCanAttachViaHandleAttachWithKClassArgument() {
+        commonTest(db.sharedHandle.attach(ThingDao::class))
     }
 
     @Test
@@ -118,7 +128,6 @@ class KotlinSqlObjectPluginTest {
 
         val found = dao.insertAndFind(brian)
         assertEquals(brian, found)
-
     }
 
     @Test


### PR DESCRIPTION
It's not always possible to use the reified type versions of these extensions (because you're passed a `KClass` instance, for example). In such a case, one must ordinarily use the standard java versions of `onDemand` and `attach`, like so:

```
val sqlObject = jdbi.onDemand(kclass.java)
```

As a small convenience, I've added the obvious extensions, which can be used like this:

```
val sqlObject = jdbi.onDemand(kclass)
```