### PR TITLE
Support Immutables getter methods with @ColumnName

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
@@ -44,7 +44,8 @@ public class ImmutablesTest {
                     DerivedProperty.class,
                     Defaulty.class,
                     IsIsIsIs.class,
-                    AlternateColumnName.class
+                    AlternateColumnName.class,
+                    GetterWithColumnName.class
             ).registerModifiable(FooBarBaz.class)
         );
 
@@ -292,5 +293,21 @@ public class ImmutablesTest {
     public interface AlternateColumnName {
         @ColumnName("TheAnswer")
         int answer();
+    }
+
+    @Test
+    public void testGetterWithColumnName() {
+        assertThat(h.createQuery("select :answer as the_answer")
+            .bindBean(ImmutableGetterWithColumnName.builder().answer(42).build())
+            .mapTo(GetterWithColumnName.class)
+            .one())
+            .extracting(GetterWithColumnName::getAnswer)
+            .isEqualTo(42);
+    }
+
+    @Value.Immutable
+    public interface GetterWithColumnName {
+        @ColumnName("the_answer")
+        int getAnswer();
     }
 }


### PR DESCRIPTION
https://github.com/jdbi/jdbi/pull/1661 allows Immutables property to be annotated with `@ColumnName`, but it requires the setter name to be either the exact getter name, or `set` + column name. None of the two works for the following common scenario:

```java
    @Value.Immutable
    public interface GetterWithColumnName {
        @ColumnName("some_foo_column")
        int getFoo();
    }
```

For the example above, the setter must be named `getFoo` or `setsome_foo_column`, both are kinda awkward and not directly supported by Immutables.

This PR addresses it by trying to extract the default Immutables setter name from the getter name.

Also a couple of minor cleanups, such as removing the obsolete `SuppressWarnings`.