### PR TITLE
Fix package declaration for RegisterKotlinMappers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # 3.14.0
   - immutables: support getter with @ColumnName, #1704
   - postgres: simple CRUD support for LargeObject API
+  - kotlin-sqlobject: fix package declaration of RegisterKotlinMappers
 
 # 3.13.0
   - Kotlin: respect default values in methods when passed null, #1690

--- a/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/RegisterKotlinMapper.kt
+++ b/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/RegisterKotlinMapper.kt
@@ -14,7 +14,6 @@
 package org.jdbi.v3.sqlobject.kotlin
 
 import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation
-import org.jdbi.v3.sqlobject.config.RegisterKotlinMappers
 import java.lang.annotation.ElementType
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy

--- a/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/RegisterKotlinMappers.kt
+++ b/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/RegisterKotlinMappers.kt
@@ -11,8 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.sqlobject.config
+package org.jdbi.v3.sqlobject.kotlin
 
+import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation
 import org.jdbi.v3.sqlobject.kotlin.RegisterKotlinMapper
 import org.jdbi.v3.sqlobject.kotlin.RegisterKotlinMappersImpl
 import java.lang.annotation.ElementType

--- a/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/RegisterKotlinMappersImpl.kt
+++ b/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/RegisterKotlinMappersImpl.kt
@@ -15,7 +15,6 @@ package org.jdbi.v3.sqlobject.kotlin
 
 import org.jdbi.v3.core.config.ConfigRegistry
 import org.jdbi.v3.sqlobject.config.Configurer
-import org.jdbi.v3.sqlobject.config.RegisterKotlinMappers
 import java.lang.reflect.Method
 
 class RegisterKotlinMappersImpl : Configurer {


### PR DESCRIPTION
Unfortunately this is a (small) breaking change.
But it's clearly an error, and totally breaks using Jdbi on the modulepath, so it's gotta get fixed.

Fixes #1696