### PR TITLE
ResultProducers: give access to returned result object, clean up api a bit

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
   - postgres: simple CRUD support for LargeObject API
   - kotlin-sqlobject: fix package declaration of RegisterKotlinMappers
   - LocalTransactionHandler: bind more closely to Handle for performance and to avoid leaks
+  - ResultProducers: give access to produced result on context
 
 # 3.13.0
   - Kotlin: respect default values in methods when passed null, #1690

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
@@ -131,7 +131,7 @@ public interface ResultBearing {
         return scanResultSet((supplier, ctx) -> {
             RowMapper<T> mapper = ctx.findMapperFor(type)
                     .orElseThrow(() -> new NoSuchMapperException("No mapper registered for type " + type));
-            return ResultIterable.of(supplier, mapper, ctx);
+            return ResultIterables.of(supplier, mapper, ctx);
         });
     }
 
@@ -142,7 +142,6 @@ public interface ResultBearing {
      * @param <T>  the bean type to map the result set rows to
      * @return a {@link ResultIterable} of the given type.
      */
-    @SuppressWarnings("deprecation")
     default <T> ResultIterable<T> mapToBean(Class<T> type) {
         return map(BeanMapper.of(type));
     }
@@ -167,7 +166,7 @@ public interface ResultBearing {
      */
     @Beta
     default <T> ResultIterable<Map<String, T>> mapToMap(Class<T> valueType) {
-        return scanResultSet((supplier, ctx) -> ResultIterable.of(supplier, GenericMapMapperFactory.getMapperForValueType(valueType, ctx.getConfig()), ctx));
+        return scanResultSet((supplier, ctx) -> ResultIterables.of(supplier, GenericMapMapperFactory.getMapperForValueType(valueType, ctx.getConfig()), ctx));
     }
 
     /**
@@ -180,7 +179,7 @@ public interface ResultBearing {
      */
     @Beta
     default <T> ResultIterable<Map<String, T>> mapToMap(GenericType<T> valueType) {
-        return scanResultSet((supplier, ctx) -> ResultIterable.of(supplier, GenericMapMapperFactory.getMapperForValueType(valueType, ctx.getConfig()), ctx));
+        return scanResultSet((supplier, ctx) -> ResultIterables.of(supplier, GenericMapMapperFactory.getMapperForValueType(valueType, ctx.getConfig()), ctx));
     }
 
     /**
@@ -202,7 +201,7 @@ public interface ResultBearing {
      * @return a {@link ResultIterable} of type {@code <T>}.
      */
     default <T> ResultIterable<T> map(RowMapper<T> mapper) {
-        return scanResultSet((supplier, ctx) -> ResultIterable.of(supplier, mapper, ctx));
+        return scanResultSet((supplier, ctx) -> ResultIterables.of(supplier, mapper, ctx));
     }
 
     /**
@@ -402,7 +401,7 @@ public interface ResultBearing {
                     .orElseThrow(() -> new ElementTypeNotFoundException("Unknown element type for container type " + containerType));
             RowMapper<?> mapper = ctx.findMapperFor(elementType)
                     .orElseThrow(() -> new NoSuchMapperException("No mapper registered for element type " + elementType));
-            return ResultIterable.of(rs, mapper, ctx).collect(collector);
+            return ResultIterables.of(rs, mapper, ctx).collect(collector);
         });
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultIterables.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultIterables.java
@@ -1,0 +1,72 @@
+package org.jdbi.v3.core.result;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+final class ResultIterables {
+    private ResultIterables() {}
+    /**
+     * Returns a ResultIterable backed by the given result set supplier, mapper, and context.
+     *
+     * @param supplier result set supplier
+     * @param mapper   row mapper
+     * @param ctx      statement context
+     * @param <T>      the mapped type
+     * @return the result iterable
+     */
+    static <T> ResultIterable<T> of(Supplier<ResultSet> supplier, RowMapper<T> mapper, StatementContext ctx) {
+        return new Impl<T>(() -> {
+            try {
+                return new ResultSetResultIterator<>(supplier.get(), mapper, ctx);
+            } catch (SQLException e) {
+                try {
+                    ctx.close();
+                } catch (Exception e1) {
+                    e.addSuppressed(e1);
+                }
+                throw new ResultSetException("Unable to iterator result set", e, ctx);
+            }
+        }, ctx);
+    }
+
+    /**
+     * Returns a ResultIterable backed by the given iterator.
+     * @param iterator the result iterator
+     * @param <T> iterator element type
+     * @return a ResultIterable
+     */
+    static <T> ResultIterable<T> of(Supplier<ResultIterator<T>> iterator, StatementContext ctx) {
+        return new Impl<T>(iterator, ctx);
+    }
+
+    static <T> T stash(StatementContext ctx, T result) {
+        if (ctx != null) { // in case someone uses the deprecated factory
+            ctx.getConfig(ResultProducers.class).setResult(result);
+        }
+        return result;
+    }
+
+    static class Impl<T> implements ResultIterable<T> {
+        private final Supplier<ResultIterator<T>> iteratorSupplier;
+        private final StatementContext ctx;
+
+        Impl(Supplier<ResultIterator<T>> iteratorSupplier, StatementContext ctx) {
+            this.iteratorSupplier = iteratorSupplier;
+            this.ctx = ctx;
+        }
+
+        @Override
+        public ResultIterator<T> iterator() {
+            return iteratorSupplier.get();
+        }
+
+        @Override
+        public StatementContext statementContext() {
+            return ctx;
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 
 import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.meta.Beta;
 
 /**
  * Commonly used ResultProducer implementations.
@@ -27,6 +28,7 @@ import org.jdbi.v3.core.statement.StatementContext;
 public class ResultProducers implements JdbiConfig<ResultProducers> {
 
     private boolean allowNoResults;
+    private Object result;
 
     public ResultProducers() {
         this(false);
@@ -133,5 +135,21 @@ public class ResultProducers implements JdbiConfig<ResultProducers> {
     public ResultProducers allowNoResults(boolean allowed) {
         this.allowNoResults = allowed;
         return this;
+    }
+
+    @Beta
+    public ResultProducers setResult(Object result) {
+        this.result = result;
+        return this;
+    }
+
+    /**
+     * Return the result of a Jdbi operation, after mapping and collecting, after statement execution.
+     * Only available when Jdbi consumes the result, not if you stream it out.
+     * @return the result if available, otherwise {@code null}
+     */
+    @Beta
+    public Object result() {
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #1709