### PR TITLE
Properly look up Builder classes for FreeBuilder classes

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/freebuilder/JdbiFreeBuilders.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/freebuilder/JdbiFreeBuilders.java
@@ -122,7 +122,7 @@ public class JdbiFreeBuilders implements JdbiConfig<JdbiFreeBuilders> {
     private <S> Class builderClass(Class<S> spec) {
         final String builderName;
         if (spec.getEnclosingClass() == null) {
-            builderName = spec.getPackage().getName() + "." + spec.getSimpleName() + "." + "Builder";
+            builderName = spec.getPackage().getName() + "." + spec.getSimpleName() + "$" + "Builder";
         } else {
             String enclosingName = spec.getEnclosingClass().getSimpleName();
             builderName = spec.getPackage().getName() + "." + enclosingName + "$" + spec.getSimpleName() + "$" + "Builder";

--- a/core/src/test/java/org/jdbi/v3/core/mapper/FreeBuildersTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/FreeBuildersTest.java
@@ -39,7 +39,8 @@ public class FreeBuildersTest {
                 IsIsIsIs.class,
                 SubValue.class,
                 Train.class,
-                UnmappableValue.class)
+                UnmappableValue.class,
+                UnnestedFreeBuilder.class)
         );
 
     private Jdbi jdbi;
@@ -89,7 +90,26 @@ public class FreeBuildersTest {
                 .containsExactly("Zephyr", 8, true);
         }
     }
+
     // end::example[]
+
+    @Test
+    public void testUnnestedFreeBuilder() {
+        final UnnestedFreeBuilder unnestedFreeBuilder = new UnnestedFreeBuilder.Builder().setTest("foo").build();
+        h.execute("create table unnested_free_builders(test varchar)");
+
+        assertThat(
+            h.createUpdate("insert into unnested_free_builders(test) values (:test)")
+            .bindPojo(unnestedFreeBuilder)
+            .execute())
+        .isEqualTo(1);
+
+        assertThat(
+            h.createQuery("select * from unnested_free_builders")
+            .mapTo(UnnestedFreeBuilder.class)
+            .one())
+        .isEqualTo(unnestedFreeBuilder);
+    }
 
     public interface BaseValue<T> {
         T t();

--- a/core/src/test/java/org/jdbi/v3/core/mapper/UnnestedFreeBuilder.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/UnnestedFreeBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import org.inferred.freebuilder.FreeBuilder;
+
+@FreeBuilder
+public abstract class UnnestedFreeBuilder {
+    public abstract String getTest();
+
+    public static class Builder extends UnnestedFreeBuilder_Builder {}
+}


### PR DESCRIPTION
Found this bug while trying use this new API released in 3.14.0 in our production app. My implementation did not correctly lookup the builder class in FreeBuilder classes that are not inner classes. This was missed because all the classes in the tests were defined within the test class itself, mea culpa.

