### PR TITLE
Avoid tomcat warnings about thread-local leak.

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -93,6 +93,8 @@ public class Handle implements Closeable, Configurable<Handle> {
     }
 
     void setLocalConfig(ThreadLocal<ConfigRegistry> configThreadLocal) {
+        // Without explicit remove the Tomcats thread-local leak detector gives superfluous warnings
+        this.localConfig.remove();
         this.localConfig = configThreadLocal;
     }
 


### PR DESCRIPTION
Removes localConfig thread-local before discarding the reference.

The JDK ThreadLocal implementation uses weak references, which persist until garbage collector actually removes the objects. Therefore Tomcat leak detector discovers these thread-local objects and gives unnecessary warnings.

> SEVERE [main] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [test] created a ThreadLocal with key of type [java.lang.ThreadLocal.SuppliedThreadLocal] (value [java.lang.ThreadLocal$SuppliedThreadLocal@4f5125ed]) and a value of type [org.jdbi.v3.core.config.ConfigRegistry] (value [org.jdbi.v3.core.config.ConfigRegistry@6a69f138]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.

While there is no actual leak, investigating such noise wastes time and adding `localConfig.remove()` call avoids these warnings.