### PR TITLE
AnnotationFactory: prefer class's ClassLoader to TCCL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # 3.14.3
   - fix ThreadLocal leak warning for Tomcat
+  - AnnotationFactory: try to use class's ClassLoader before going to TCCL
 
 # 3.14.2
   - FreeBuilder documentation

--- a/core/src/main/java/org/jdbi/v3/core/internal/AnnotationFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/AnnotationFactory.java
@@ -49,12 +49,15 @@ public class AnnotationFactory {
                         annotationType.getSimpleName()));
         });
 
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         Class<?>[] interfaces = {annotationType};
         InvocationHandler invocationHandler = getInvocationHandler(annotationType, values);
 
         @SuppressWarnings("unchecked")
-        T annotation = (T) Proxy.newProxyInstance(classLoader, interfaces, invocationHandler);
+        T annotation = (T) Proxy.newProxyInstance(
+                Optional.ofNullable(annotationType.getClassLoader())
+                        .orElseGet(Thread.currentThread()::getContextClassLoader),
+                interfaces,
+                invocationHandler);
 
         return annotation;
     }


### PR DESCRIPTION
When running Jdbi from a thread pool that has a unexpected thread context class loader, AnnotationFactory fails:

```
Caused by: java.lang.IllegalArgumentException: org.jdbi.v3.json.Json referenced from a method is not visible from class loader
at java.lang.reflect.Proxy$ProxyBuilder.ensureVisible (Proxy.java:867)
at java.lang.reflect.Proxy$ProxyBuilder.validateProxyInterfaces (Proxy.java:690)
at java.lang.reflect.Proxy$ProxyBuilder.<init> (Proxy.java:636)
at java.lang.reflect.Proxy$ProxyBuilder.<init> (Proxy.java:644)
at java.lang.reflect.Proxy.lambda$getProxyConstructor$0 (Proxy.java:424)
at jdk.internal.loader.AbstractClassLoaderValue$Memoizer.get (AbstractClassLoaderValue.java:329)
at jdk.internal.loader.AbstractClassLoaderValue.extractValue (AbstractClassLoaderValue.java:277)
at jdk.internal.loader.AbstractClassLoaderValue.computeIfAbsent (AbstractClassLoaderValue.java:218)
at java.lang.reflect.Proxy.getProxyConstructor (Proxy.java:422)
at java.lang.reflect.Proxy.newProxyInstance (Proxy.java:1015)
at org.jdbi.v3.core.internal.AnnotationFactory.create (AnnotationFactory.java:57)
at org.jdbi.v3.core.internal.AnnotationFactory.create (AnnotationFactory.java:38)
at java.util.stream.ReferencePipeline$3$1.accept (ReferencePipeline.java:195)
at java.util.Spliterators$ArraySpliterator.forEachRemaining (Spliterators.java:948)
at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:484)
at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:474)
at java.util.stream.ReduceOps$ReduceOp.evaluateSequential (ReduceOps.java:913)
at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:234)
at java.util.stream.ReferencePipeline.collect (ReferencePipeline.java:578)
at org.jdbi.v3.core.qualifier.QualifiedType.with (QualifiedType.java:102)
```
I think this should be better behavior in the presence of multiple classloaders that can't see each other but share thread pools... (!!!)