### PR TITLE
QualifiedArgumentFactory$Preparable: only compute prePreparedTypes once

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+# 3.14.4
+  - fix performance regression on statement preparation, #1732
+
 # 3.14.3
   - fix ThreadLocal leak warning for Tomcat
   - AnnotationFactory: try to use class's ClassLoader before going to TCCL

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/BeanBindingBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/BeanBindingBenchmark.java
@@ -57,7 +57,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Measurement(time = 5)
 @Warmup(time = 2)
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Fork(1)
+@Fork(4)
 public class BeanBindingBenchmark {
     private static final int INNER_LOOPS = 10_000;
     private final Random random = new Random();

--- a/core/src/main/java/org/jdbi/v3/core/argument/QualifiedArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/QualifiedArgumentFactory.java
@@ -102,7 +102,16 @@ public interface QualifiedArgumentFactory {
          */
         static QualifiedArgumentFactory.Preparable adapt(ConfigRegistry config, ArgumentFactory.Preparable factory) {
             return new Preparable() {
-                Set<Annotation> qualifiers = config.get(Qualifiers.class).findFor(factory.getClass());
+                Set<Annotation> qualifiers =
+                        config.get(Qualifiers.class)
+                        .findFor(factory.getClass());
+
+                Collection<QualifiedType<?>> prePreparedTypes = Collections.unmodifiableList(
+                        factory.prePreparedTypes().stream()
+                            .map(QualifiedType::of)
+                            .map(qt -> qt.withAnnotations(qualifiers))
+                            .collect(Collectors.toList()));
+
                 @Override
                 public Optional<Argument> build(QualifiedType<?> type, Object value, ConfigRegistry cfg) {
                     return type.getQualifiers().equals(qualifiers)
@@ -119,10 +128,7 @@ public interface QualifiedArgumentFactory {
 
                 @Override
                 public Collection<QualifiedType<?>> prePreparedTypes() {
-                    return factory.prePreparedTypes().stream()
-                            .map(QualifiedType::of)
-                            .map(qt -> qt.withAnnotations(qualifiers))
-                            .collect(Collectors.toList());
+                    return prePreparedTypes;
                 }
 
                 @Override


### PR DESCRIPTION
Fixes #1732 (hopefully?)