### PR TITLE
Initial V2 vs V3 benchmark for both fluent and sqlobject

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -29,7 +29,7 @@
         <basepom.check.skip-checkstyle>true</basepom.check.skip-checkstyle>
         <basepom.check.skip-pmd>true</basepom.check.skip-pmd>
         <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
-        <jmh.version>1.21</jmh.version>
+        <jmh.version>1.25</jmh.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <moduleName>org.jdbi.v3.benchmark</moduleName>
         <uberjar.name>benchmarks</uberjar.name>
@@ -52,12 +52,30 @@
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-postgres</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi</artifactId>
+            <version>2.78</version>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-pg-embedded</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
         </dependency>
 
         <dependency>
@@ -65,12 +83,6 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>${jmh.version}</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/AbstractSqlObjectBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/AbstractSqlObjectBenchmark.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@Measurement(time = 10, iterations = 10)
+@Warmup(time = 10, iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(4)
+public abstract class AbstractSqlObjectBenchmark {
+    static final String INSERT = "INSERT INTO tbl (name, description) VALUES (:name, :description)";
+    static final String SELECT = "SELECT id, name, description FROM tbl WHERE id = :id";
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/BaseSqlObjectV2Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/BaseSqlObjectV2Benchmark.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import java.io.Closeable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.BindBean;
+import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.skife.jdbi.v2.util.LongColumnMapper;
+
+public abstract class BaseSqlObjectV2Benchmark extends AbstractSqlObjectBenchmark {
+    private DBI jdbi;
+    protected Handle handle;
+    private DaoV2 dao;
+    private long rowOne;
+
+    protected abstract DBI createJdbi();
+    protected abstract void createTable();
+
+    @Setup(Level.Iteration)
+    public void setup() throws Throwable {
+        jdbi = createJdbi();
+        jdbi.registerMapper(new DaoV2.TestDataMapper());
+
+        handle = jdbi.open();
+        dao = handle.attach(DaoV2.class);
+        createTable();
+        insertRow();
+    }
+
+    @TearDown(Level.Iteration)
+    public void tearDown() {
+        if (handle != null) {
+            handle.close();
+            handle = null;
+        }
+        jdbi = null;
+    }
+
+    private void insertRow() {
+        rowOne = dao.insertTestDataGetKeyBean(new TestContent("row one", "the first row"));
+    }
+
+    @Benchmark
+    public DaoV2 attach() {
+        return handle.attach(DaoV2.class);
+    }
+
+    @Benchmark
+    public long fluentInsertGeneratedKeyBindBean() {
+        return handle.createStatement(INSERT)
+                    .bindFromProperties(TestContent.TEST_CONTENT)
+                    .executeAndReturnGeneratedKeys(LongColumnMapper.WRAPPER)
+                    .first();
+    }
+
+    @Benchmark
+    public long sqlobjectInsertGeneratedKeyBindBean() {
+        return dao.insertTestDataGetKeyBean(TestContent.TEST_CONTENT);
+    }
+
+    @Benchmark
+    public int sqlobjectInsertRowCountBindBean() {
+        return dao.insertTestDataRowCountBean(TestContent.TEST_CONTENT);
+    }
+
+    @Benchmark
+    public long fluentInsertGeneratedKeyValues() {
+        return handle.createStatement(INSERT)
+                     .bind("name", TestContent.TEST_CONTENT.getName())
+                     .bind("description", TestContent.TEST_CONTENT.getDescription())
+                     .executeAndReturnGeneratedKeys(LongColumnMapper.WRAPPER)
+                     .first();
+    }
+
+    @Benchmark
+    public long sqlobjectInsertGeneratedKeyValues() {
+        return dao.insertTestDataGetKeyValues(
+                TestContent.TEST_CONTENT.getName(), TestContent.TEST_CONTENT.getDescription());
+    }
+
+    @Benchmark
+    public int sqlobjectInsertRowCountValues() {
+        return dao.insertTestDataRowCountValues(
+                TestContent.TEST_CONTENT.getName(), TestContent.TEST_CONTENT.getDescription());
+    }
+
+    @Benchmark
+    public TestData fluentSelectOne() {
+        return handle.createQuery(SELECT)
+                     .bind("id", rowOne)
+                     .mapTo(TestData.class)
+                     .first();
+    }
+
+    @Benchmark
+    public TestData sqlobjectSelectOne() {
+        return dao.getTestData(rowOne);
+    }
+
+    public interface DaoV2 extends Closeable {
+        @GetGeneratedKeys
+        @SqlUpdate(INSERT)
+        long insertTestDataGetKeyBean(@BindBean TestContent testContent);
+
+        @SqlUpdate(INSERT)
+        int insertTestDataRowCountBean(@BindBean TestContent testContent);
+
+        @GetGeneratedKeys
+        @SqlUpdate(INSERT)
+        long insertTestDataGetKeyValues(@Bind("name") String name, @Bind("description") String description);
+
+        @SqlUpdate(INSERT)
+        int insertTestDataRowCountValues(@Bind("name") String name, @Bind("description") String description);
+
+        @SqlQuery(SELECT)
+        TestData getTestData(@Bind("id") long id);
+
+        @Override
+        void close();
+
+        class TestDataMapper extends BaseTestDataMapper implements ResultSetMapper<TestData> {
+            @Override
+            public TestData map(final int row, final ResultSet r, final StatementContext ctx) throws SQLException {
+                return mapInternal(r);
+            }
+        }
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/BaseSqlObjectV3Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/BaseSqlObjectV3Benchmark.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+
+public abstract class BaseSqlObjectV3Benchmark extends AbstractSqlObjectBenchmark {
+    private Jdbi jdbi;
+    protected Handle handle;
+    private DaoV3 dao;
+    private long rowOne;
+
+    protected abstract Jdbi createJdbi();
+    protected abstract void createTable();
+
+    private void insertRow() {
+        rowOne = handle.attach(DaoV3.class)
+                .insertTestDataGetKeyBean(new TestContent("row one", "the first row"));
+    }
+
+    @Setup(Level.Iteration)
+    public void setup() throws Throwable {
+        jdbi = createJdbi();
+        jdbi.installPlugin(new SqlObjectPlugin());
+        jdbi.registerRowMapper(new DaoV3.TestDataMapper());
+
+        handle = jdbi.open();
+        dao = handle.attach(DaoV3.class);
+        createTable();
+        insertRow();
+    }
+
+    @TearDown(Level.Iteration)
+    public void close() {
+        if (handle != null) {
+            handle.close();
+            handle = null;
+        }
+        jdbi = null;
+    }
+
+    @Benchmark
+    public DaoV3 attach() {
+        return handle.attach(DaoV3.class);
+    }
+
+    @Benchmark
+    public long fluentInsertGeneratedKeyBindBean() {
+        return handle.createUpdate(INSERT)
+                     .bindBean(TestContent.TEST_CONTENT)
+                     .executeAndReturnGeneratedKeys()
+                     .mapTo(long.class)
+                     .one();
+    }
+
+    @Benchmark
+    public long sqlobjectInsertGeneratedKeyBindBean() {
+        return dao.insertTestDataGetKeyBean(TestContent.TEST_CONTENT);
+    }
+
+    @Benchmark
+    public int sqlobjectInsertRowCountBindBean() {
+        return dao.insertTestDataRowCountBean(TestContent.TEST_CONTENT);
+    }
+
+    @Benchmark
+    public long fluentInsertGeneratedKeyValues() {
+        return handle.createUpdate(INSERT)
+                     .bind("name", TestContent.TEST_CONTENT.getName())
+                     .bind("description", TestContent.TEST_CONTENT.getDescription())
+                     .executeAndReturnGeneratedKeys()
+                     .mapTo(long.class)
+                     .one();
+    }
+
+    @Benchmark
+    public long sqlobjectInsertGeneratedKeyValues() {
+        return dao.insertTestDataGetKeyValues(
+                    TestContent.TEST_CONTENT.getName(), TestContent.TEST_CONTENT.getDescription());
+    }
+
+    @Benchmark
+    public int sqlobjectInsertRowCountValues() {
+        return dao.insertTestDataRowCountValues(
+                    TestContent.TEST_CONTENT.getName(), TestContent.TEST_CONTENT.getDescription());
+    }
+
+    @Benchmark
+    public TestData fluentSelectOne() {
+        return handle.createQuery(SELECT)
+                     .bind("id", rowOne)
+                     .mapTo(TestData.class)
+                     .one();
+    }
+
+    @Benchmark
+    public TestData sqlobjectSelectOne() {
+        return dao.getTestData(rowOne);
+    }
+
+    public interface DaoV3 {
+        @GetGeneratedKeys
+        @SqlUpdate(INSERT)
+        long insertTestDataGetKeyBean(@BindBean TestContent testContent);
+
+        @SqlUpdate(INSERT)
+        int insertTestDataRowCountBean(@BindBean TestContent testContent);
+
+        @GetGeneratedKeys
+        @SqlUpdate(INSERT)
+        long insertTestDataGetKeyValues(@Bind("name") String name, @Bind("description") String description);
+
+        @SqlUpdate(INSERT)
+        int insertTestDataRowCountValues(@Bind("name") String name, @Bind("description") String description);
+
+        @SqlQuery(SELECT)
+        TestData getTestData(@Bind("id") long id);
+
+        class TestDataMapper extends BaseTestDataMapper implements RowMapper<TestData> {
+            @Override
+            public TestData map(final ResultSet r, final StatementContext ctx) throws SQLException {
+                return mapInternal(r);
+            }
+        }
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/BaseTestDataMapper.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/BaseTestDataMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class BaseTestDataMapper {
+    protected TestData mapInternal(final ResultSet r) throws SQLException {
+        final long id = r.getLong(1);
+        final String name = r.getString(2);
+        final String description = r.getString(3);
+
+        final TestContent content = new TestContent(name, description);
+
+        return new TestData(id, content);
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/H2SqlObjectV2Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/H2SqlObjectV2Benchmark.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import java.util.UUID;
+
+import org.h2.Driver;
+import org.skife.jdbi.v2.DBI;
+
+public class H2SqlObjectV2Benchmark extends BaseSqlObjectV2Benchmark {
+    static {
+        Driver.load();
+    }
+
+    @Override
+    protected DBI createJdbi() {
+        return new DBI("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10");
+    }
+
+    @Override
+    protected void createTable() {
+        handle.execute("drop table if exists tbl");
+        handle.execute("create table tbl (id identity, name varchar, description varchar)");
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/H2SqlObjectV3Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/H2SqlObjectV3Benchmark.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import java.util.UUID;
+
+import org.h2.Driver;
+import org.jdbi.v3.core.Jdbi;
+
+public class H2SqlObjectV3Benchmark extends BaseSqlObjectV3Benchmark {
+    static {
+        Driver.load();
+    }
+
+    @Override
+    protected Jdbi createJdbi() {
+        return Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10");
+    }
+
+    @Override
+    protected void createTable() {
+        handle.execute("drop table if exists tbl");
+        handle.execute("create table tbl (id identity, name varchar, description varchar)");
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/PGSqlObjectV2Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/PGSqlObjectV2Benchmark.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import com.opentable.db.postgres.embedded.PreparedDbProvider;
+import org.jdbi.v3.core.internal.exceptions.Unchecked;
+import org.skife.jdbi.v2.DBI;
+
+public class PGSqlObjectV2Benchmark extends BaseSqlObjectV2Benchmark {
+    static final PreparedDbProvider PROVIDER = PreparedDbProvider.forPreparer(p -> {});
+
+    @Override
+    protected DBI createJdbi() {
+        return Unchecked.supplier(() -> new DBI(PROVIDER.createDataSource())).get();
+    }
+
+    @Override
+    protected void createTable() {
+        handle.execute("drop table if exists tbl");
+        handle.execute("create table tbl (id serial primary key, name varchar, description varchar)");
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/PGSqlObjectV3Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/PGSqlObjectV3Benchmark.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.internal.exceptions.Unchecked;
+import org.jdbi.v3.postgres.PostgresPlugin;
+
+public class PGSqlObjectV3Benchmark extends BaseSqlObjectV3Benchmark {
+    @Override
+    protected Jdbi createJdbi() {
+        return Unchecked.supplier(() -> Jdbi.create(PGSqlObjectV2Benchmark.PROVIDER.createDataSource())
+                .installPlugin(new PostgresPlugin())).get();
+    }
+
+    @Override
+    protected void createTable() {
+        handle.execute("drop table if exists tbl");
+        handle.execute("create table tbl (id serial primary key, name varchar, description varchar)");
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/TestContent.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/TestContent.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import java.util.StringJoiner;
+
+public class TestContent {
+    public static final TestContent TEST_CONTENT = new TestContent("test name", "test description");
+
+    private final String name;
+
+    private final String description;
+
+    public TestContent(final String name, final String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final TestContent that = (TestContent) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+        return description != null ? description.equals(that.description) : that.description == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (description != null ? description.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", TestContent.class.getSimpleName() + "[", "]")
+                .add("name='" + name + "'")
+                .add("description='" + description + "'")
+                .toString();
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/TestData.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/TestData.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark.sqlobject;
+
+import java.util.StringJoiner;
+
+public class TestData {
+
+    private final long id;
+
+    private final TestContent content;
+
+    public TestData(final long id, final TestContent content) {
+        this.id = id;
+        this.content = content;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public TestContent getContent() {
+        return content;
+    }
+
+    public String getName() {
+        return content.getName();
+    }
+
+    public String getDescription() {
+        return content.getDescription();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final TestData testData = (TestData) o;
+
+        if (id != testData.id) {
+            return false;
+        }
+        return content != null ? content.equals(testData.content) : testData.content == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (id ^ (id >>> 32));
+        result = 31 * result + (content != null ? content.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", TestData.class.getSimpleName() + "[", "]")
+                .add("id=" + id)
+                .add("content=" + content)
+                .toString();
+    }
+}


### PR DESCRIPTION
jmh 1.25

Inspired by #1732 

Currently, it looks like there's a significant bottleneck in creating copies of `ConfigRegistry` for every statement made.