### PR TITLE
Arguments: don't prePrepare types, it's too expensive in the common case

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/ArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ArgumentFactory.java
@@ -57,6 +57,10 @@ public interface ArgumentFactory {
 
         Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config);
 
+        /**
+         * @deprecated no longer used
+         */
+        @Deprecated
         default Collection<? extends Type> prePreparedTypes() {
             return Collections.emptyList();
         }

--- a/core/src/main/java/org/jdbi/v3/core/argument/QualifiedArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/QualifiedArgumentFactory.java
@@ -90,6 +90,10 @@ public interface QualifiedArgumentFactory {
     interface Preparable extends QualifiedArgumentFactory {
         Optional<Function<Object, Argument>> prepare(QualifiedType<?> type, ConfigRegistry config);
 
+        /**
+         * @deprecated no longer used
+         */
+        @Deprecated
         default Collection<QualifiedType<?>> prePreparedTypes() {
             return Collections.emptyList();
         }


### PR DESCRIPTION
also, reduce some Streams usage in the hot path
~20% improvement on H2.fluentSelectOne