### PR TITLE
AnnotationSqlLocator: computation is surprisingly expensive due to

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/AnnotationSqlLocator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/locator/AnnotationSqlLocator.java
@@ -14,6 +14,8 @@
 package org.jdbi.v3.sqlobject.locator;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
@@ -22,9 +24,11 @@ import org.jdbi.v3.sqlobject.internal.SqlAnnotations;
  * Locates SQL on the SQL method annotations like <code>@SqlQuery("foo")</code>. This is the default SqlLocator.
  */
 public class AnnotationSqlLocator implements SqlLocator {
+    private final ConcurrentMap<Method, String> located = new ConcurrentHashMap<>();
+
     @Override
     public String locate(Class<?> sqlObjectType, Method method, ConfigRegistry config) {
-        return SqlAnnotations.getAnnotationValue(method)
-            .orElseThrow(() -> new IllegalStateException("Sql annotation missing query"));
+        return located.computeIfAbsent(method, m -> SqlAnnotations.getAnnotationValue(m)
+            .orElseThrow(() -> new IllegalStateException("Sql annotation missing query")));
     }
 }


### PR DESCRIPTION
annotation and stream usage, so cache it

~20% improvement on H2 sqlobject insert bean benchmark