### PR TITLE
QualifiedType performance

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/collector/SetCollectorFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/SetCollectorFactory.java
@@ -25,8 +25,9 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collector;
 
+import org.jdbi.v3.core.internal.CollectionCollectors;
+
 import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toSet;
 
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
@@ -35,7 +36,7 @@ class SetCollectorFactory implements CollectorFactory {
     private final Map<Class<?>, Collector<?, ?, ?>> collectors = new IdentityHashMap<>();
 
     SetCollectorFactory() {
-        collectors.put(Set.class, toSet());
+        collectors.put(Set.class, CollectionCollectors.toUnmodifiableSet());
         collectors.put(HashSet.class, toCollection(HashSet::new));
         collectors.put(LinkedHashSet.class, toCollection(LinkedHashSet::new));
         collectors.put(SortedSet.class, toCollection(TreeSet::new));

--- a/core/src/main/java/org/jdbi/v3/core/internal/AnnotationFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/AnnotationFactory.java
@@ -84,7 +84,11 @@ public class AnnotationFactory {
 
             if ("equals".equals(name) && method.getParameterCount() == 1
                 && Object.class.equals(method.getParameterTypes()[0])) {
-                Annotation that = (Annotation) args[0];
+                Object arg = args[0];
+                if (!(arg instanceof Annotation)) {
+                    return false;
+                }
+                Annotation that = (Annotation) arg;
                 return annotationType.equals(that.annotationType()) && valuesEqual(annotationType, proxy, that);
             }
 

--- a/core/src/main/java/org/jdbi/v3/core/internal/CollectionCollectors.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/CollectionCollectors.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.internal;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+import org.jdbi.v3.core.internal.exceptions.Unchecked;
+
+@SuppressWarnings("rawtypes")
+public final class CollectionCollectors {
+    private static final Supplier<Collector> SET_COLLECTOR;
+    static {
+        SET_COLLECTOR = factory();
+    }
+
+    private CollectionCollectors() {}
+
+    private static Supplier<Collector> factory() {
+        try {
+            MethodHandle mh = MethodHandles.publicLookup()
+                    .findStatic(Collectors.class, "toUnmodifiableSet", MethodType.methodType(Collector.class));
+            return Unchecked.supplier(() -> (Collector) mh.invokeExact());
+        } catch (final ReflectiveOperationException ignore) {
+            // ignored for java 8+9 compat
+        }
+        return () -> Collectors.collectingAndThen(
+                Collectors.toSet(),
+                Collections::unmodifiableSet);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Collector<T, ?, Set<T>> toUnmodifiableSet() {
+        return SET_COLLECTOR.get();
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
@@ -27,8 +27,8 @@ import org.jdbi.v3.core.internal.AnnotationFactory;
 import org.jdbi.v3.meta.Beta;
 
 import static java.util.Collections.emptySet;
-import static java.util.Collections.unmodifiableSet;
-import static java.util.stream.Collectors.toSet;
+
+import static org.jdbi.v3.core.internal.CollectionCollectors.toUnmodifiableSet;
 
 /**
  * A {@link java.lang.reflect.Type} qualified by a set of qualifier annotations. Two qualified types are equal to each other
@@ -73,9 +73,9 @@ public final class QualifiedType<T> {
         return (QualifiedType<T>) of(type.getType());
     }
 
-    private QualifiedType(Type type, Set<? extends Annotation> qualifiers) {
+    private QualifiedType(Type type, Set<Annotation> qualifiers) {
         this.type = type;
-        this.qualifiers = unmodifiableSet(qualifiers);
+        this.qualifiers = qualifiers;
     }
 
     /**
@@ -85,7 +85,7 @@ public final class QualifiedType<T> {
      * @return the QualifiedType
      */
     public QualifiedType<T> with(Annotation... newQualifiers) {
-        return new QualifiedType<>(type, Arrays.stream(newQualifiers).collect(toSet()));
+        return new QualifiedType<>(type, Arrays.stream(newQualifiers).collect(toUnmodifiableSet()));
     }
 
     /**
@@ -97,9 +97,9 @@ public final class QualifiedType<T> {
      */
     @SafeVarargs
     public final QualifiedType<T> with(Class<? extends Annotation>... newQualifiers) {
-        Set<? extends Annotation> annotations = Arrays.stream(newQualifiers)
+        Set<Annotation> annotations = Arrays.stream(newQualifiers)
             .map(AnnotationFactory::create)
-            .collect(toSet());
+            .collect(toUnmodifiableSet());
         return new QualifiedType<>(type, annotations);
     }
 
@@ -109,7 +109,7 @@ public final class QualifiedType<T> {
      * @param newQualifiers the qualifiers for the new qualified type.
      */
     public QualifiedType<T> withAnnotations(Iterable<? extends Annotation> newQualifiers) {
-        return new QualifiedType<>(type, StreamSupport.stream(newQualifiers.spliterator(), false).collect(toSet()));
+        return new QualifiedType<>(type, StreamSupport.stream(newQualifiers.spliterator(), false).collect(toUnmodifiableSet()));
     }
 
     /**
@@ -118,9 +118,9 @@ public final class QualifiedType<T> {
      * @param newQualifiers the qualifiers for the new qualified type.
      */
     public QualifiedType<T> withAnnotationClasses(Iterable<Class<? extends Annotation>> newQualifiers) {
-        Set<? extends Annotation> annotations = StreamSupport.stream(newQualifiers.spliterator(), false)
+        Set<Annotation> annotations = StreamSupport.stream(newQualifiers.spliterator(), false)
             .map(AnnotationFactory::create)
-            .collect(toSet());
+            .collect(toUnmodifiableSet());
         return new QualifiedType<>(type, annotations);
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
@@ -39,6 +39,8 @@ public class Qualifiers implements JdbiConfig<Qualifiers> {
     private static final JdbiCache<AnnotatedElement[], Set<Annotation>> QUALIFIER_CACHE = JdbiCaches.declare(
             elements -> elements.length == 1 ? elements[0] : new HashSet<>(Arrays.asList(elements)),
             (Function<AnnotatedElement[], Set<Annotation>>) Qualifiers::getQualifiers);
+    private static final JdbiCache<AnnotatedElement, QualifiedType<?>> QUALIFIED_TYPE_CACHE = JdbiCaches.declare(
+            type -> QualifiedType.of((Type) type).withAnnotations(getQualifiers(type)));
     private ConfigRegistry registry;
 
     public Qualifiers() {}
@@ -49,7 +51,11 @@ public class Qualifiers implements JdbiConfig<Qualifiers> {
     }
 
     public <ELEM extends AnnotatedElement & Type> QualifiedType<?> qualifiedTypeOf(ELEM type) {
-        return QualifiedType.of(type).withAnnotations(findFor(type));
+        if (registry == null) {
+            return QualifiedType.of(type).withAnnotations(getQualifiers(type));
+        } else {
+            return QUALIFIED_TYPE_CACHE.get(type, registry);
+        }
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
@@ -17,7 +17,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -27,9 +26,8 @@ import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiCache;
 import org.jdbi.v3.core.config.JdbiCaches;
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.internal.CollectionCollectors;
 import org.jdbi.v3.meta.Beta;
-
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Utility class for type qualifiers supported by Jdbi core.
@@ -71,12 +69,12 @@ public class Qualifiers implements JdbiConfig<Qualifiers> {
     }
 
     private static Set<Annotation> getQualifiers(AnnotatedElement... elements) {
-        return Collections.unmodifiableSet(Arrays.stream(elements)
+        return Arrays.stream(elements)
                 .filter(Objects::nonNull)
                 .map(AnnotatedElement::getAnnotations)
                 .flatMap(Arrays::stream)
                 .filter(anno -> anno.annotationType().isAnnotationPresent(Qualifier.class))
-                .collect(toSet()));
+                .collect(CollectionCollectors.toUnmodifiableSet());
     }
 
     @Override


### PR DESCRIPTION
Once we're done constructing it, hold it in a JdbiCache for later use to save re-computation effort
When on Java 10+, use `Collectors.toUnmodifiableSet()` as it's much more performant than `Collections.unmodifiableSet(HashSet(...))`

Significantly faster and replaces both #1751 and #1755 as they're no longer needed.