### PR TITLE
SqlObject: warm up argument bindings and return / collected types on first method call

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handler.java
@@ -13,7 +13,9 @@
  */
 package org.jdbi.v3.sqlobject;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.HandleSupplier;
+import org.jdbi.v3.meta.Beta;
 
 /**
  * Implements the contract of a SQL Object method.
@@ -30,4 +32,12 @@ public interface Handler {
      * @throws Exception any exception thrown by the method.
      */
     Object invoke(Object target, Object[] args, HandleSupplier handle) throws Exception;
+
+    /**
+     * Called after the method handler is constructed to pre-initialize any important
+     * configuration data structures.
+     * @param config the method configuration to warm
+     */
+    @Beta
+    default void warm(ConfigRegistry config) {}
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -235,11 +235,12 @@ public class SqlObjectFactory implements ExtensionFactory, OnDemandExtensions.Fa
 
         Map<Method, UnaryOperator<ConfigRegistry>> methodConfigurers =
             methodHandlers.keySet().stream().collect(
-                Collectors.toMap(Function.identity(),
-                method -> buildConfigurers(
-                    Stream.of(method),
-                    (configurer, config, annotation) ->
-                        configurer.configureForMethod(config, annotation, sqlObjectType, method))));
+                Collectors.toMap(
+                        Function.identity(),
+                        method -> buildConfigurers(
+                            Stream.of(method),
+                            (configurer, config, annotation) ->
+                                configurer.configureForMethod(config, annotation, sqlObjectType, method))));
 
         return new SqlObjectInitData(
                 sqlObjectType,

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementCustomizer.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementCustomizer.java
@@ -15,7 +15,9 @@ package org.jdbi.v3.sqlobject.customizer;
 
 import java.sql.SQLException;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.SqlStatement;
+import org.jdbi.v3.meta.Beta;
 
 /**
  * Used with {@link SqlStatementCustomizerFactory} to
@@ -29,4 +31,12 @@ public interface SqlStatementCustomizer {
      * @throws SQLException will abort statement creation
      */
     void apply(SqlStatement<?> q) throws SQLException;
+
+    /**
+     * Called after the customizer is instantiated but before any statement is available,
+     * to pre-initialize any configuration data structures.
+     * @param config the configuration registry to warm
+     */
+    @Beta
+    default void warm(ConfigRegistry config) {}
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementParameterCustomizer.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementParameterCustomizer.java
@@ -15,7 +15,9 @@ package org.jdbi.v3.sqlobject.customizer;
 
 import java.sql.SQLException;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.SqlStatement;
+import org.jdbi.v3.meta.Beta;
 
 /**
  * Customize a {@link SqlStatement} according to the value of an annotated parameter.
@@ -28,4 +30,12 @@ public interface SqlStatementParameterCustomizer {
      * @throws SQLException will abort statement creation
      */
     void apply(SqlStatement<?> stmt, Object arg) throws SQLException;
+
+    /**
+     * Called after the customizer is instantiated but before any statement is available,
+     * to pre-initialize any configuration data structures.
+     * @param config the configuration registry to warm
+     */
+    @Beta
+    default void warm(ConfigRegistry config) {}
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindBeanFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindBeanFactory.java
@@ -31,13 +31,13 @@ public class BindBeanFactory implements SqlStatementCustomizerFactory {
                                                               int index,
                                                               Type type) {
         BindBean bind = (BindBean) annotation;
-        return (stmt, bean) -> {
+        return PojoWarmingCustomizer.of(type, (stmt, bean) -> {
             String prefix = bind.value();
             if (prefix.isEmpty()) {
                 stmt.bindBean(bean);
             } else {
                 stmt.bindBean(prefix, bean);
             }
-        };
+        });
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindPojoFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindPojoFactory.java
@@ -31,13 +31,13 @@ public class BindPojoFactory implements SqlStatementCustomizerFactory {
                                                               int index,
                                                               Type type) {
         BindPojo bind = (BindPojo) annotation;
-        return (stmt, bean) -> {
+        return PojoWarmingCustomizer.of(type, (stmt, bean) -> {
             String prefix = bind.value();
             if (prefix.isEmpty()) {
                 stmt.bindPojo(bean);
             } else {
                 stmt.bindPojo(prefix, bean);
             }
-        };
+        });
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/PojoWarmingCustomizer.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/PojoWarmingCustomizer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.customizer.internal;
+
+import java.lang.reflect.Type;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.jdbi.v3.core.argument.Arguments;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.mapper.reflect.internal.PojoProperties;
+import org.jdbi.v3.core.mapper.reflect.internal.PojoProperties.PojoProperty;
+import org.jdbi.v3.core.mapper.reflect.internal.PojoTypes;
+import org.jdbi.v3.core.statement.SqlStatement;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
+
+public final class PojoWarmingCustomizer {
+    private PojoWarmingCustomizer() {}
+
+    public static SqlStatementParameterCustomizer of(Type pojoType, SqlStatementParameterCustomizer customizer) {
+        return new SqlStatementParameterCustomizer() {
+            @Override
+            public void apply(SqlStatement<?> stmt, Object arg) throws SQLException {
+                customizer.apply(stmt, arg);
+            }
+
+            @Override
+            public void warm(ConfigRegistry config) {
+                Arguments arguments = config.get(Arguments.class);
+                config.get(PojoTypes.class)
+                        .findFor(pojoType)
+                        .map(Stream::of)
+                        .orElseGet(Stream::empty)
+                        .map(PojoProperties::getProperties)
+                        .map(Map::values)
+                        .flatMap(Collection::stream)
+                        .map(PojoProperty::getQualifiedType)
+                        .forEach(arguments::prepareFor);
+            }
+        };
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/SqlObjectInitData.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/SqlObjectInitData.java
@@ -119,6 +119,7 @@ public final class SqlObjectInitData {
             ExtensionMethod extensionMethod = new ExtensionMethod(extensionType, method);
             ConfigRegistry methodConfig = methodConfigurers.get(method).apply(instanceConfig.createCopy());
             Handler methodHandler = methodHandlers.get(method);
+            methodHandler.warm(methodConfig);
             return new InContextInvoker() {
                 @Override
                 public Object invoke(Object[] args) {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
@@ -26,6 +26,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.internal.IterableLike;
@@ -80,10 +81,16 @@ public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> 
                         .iterator();
             } else {
                 batchIntermediate = batch -> batch.executeAndReturnGeneratedKeys(columnNames)
-                        .mapTo(magic.elementType(batch.getContext()))
+                        .mapTo(magic.elementType(batch.getConfig()))
                         .iterator();
             }
         }
+    }
+
+    @Override
+    public void warm(ConfigRegistry config) {
+        super.warm(config);
+        magic.warm(config);
     }
 
     private Function<PreparedBatch, ResultIterator<?>> mapToBoolean(Function<PreparedBatch, ResultIterator<?>> modCounts) {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlQueryHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlQueryHandler.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.statement.internal;
 import java.lang.reflect.Method;
 
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.statement.Query;
@@ -32,6 +33,12 @@ public class SqlQueryHandler extends CustomizingStatementHandler<Query> {
     }
 
     @Override
+    public void warm(ConfigRegistry config) {
+        super.warm(config);
+        magic.warm(config);
+    }
+
+    @Override
     void configureReturner(Query q, SqlObjectStatementConfiguration cfg) {
         UseRowMapper useRowMapper = getMethod().getAnnotation(UseRowMapper.class);
         UseRowReducer useRowReducer = getMethod().getAnnotation(UseRowReducer.class);
@@ -42,7 +49,7 @@ public class SqlQueryHandler extends CustomizingStatementHandler<Query> {
 
         cfg.setReturner(() -> {
             StatementContext ctx = q.getContext();
-            QualifiedType<?> elementType = magic.elementType(ctx);
+            QualifiedType<?> elementType = magic.elementType(ctx.getConfig());
 
             if (useRowReducer != null) {
                 return magic.reducedResult(q.reduceRows(rowReducerFor(useRowReducer)), ctx);


### PR DESCRIPTION
This avoids needing to re-build argument preparers, collectors, and RowMapper / ColumnMappers on every method invocation for a pretty significant speed boost