### PR TITLE
JdbiConfig: MethodHandle lookup cannot be public since it loads user code

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/config/ConfigRegistry.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/ConfigRegistry.java
@@ -83,7 +83,7 @@ public final class ConfigRegistry {
         return configFactories.computeIfAbsent(configClass, klass -> {
             final Exception notFound;
             try {
-                MethodHandle mh = MethodHandles.publicLookup().findConstructor(klass,
+                MethodHandle mh = MethodHandles.lookup().findConstructor(klass,
                         MethodType.methodType(void.class, ConfigRegistry.class))
                     .asType(MethodType.methodType(JdbiConfig.class, ConfigRegistry.class));
                 return Unchecked.function(registry -> (JdbiConfig<?>) mh.invokeExact(registry));
@@ -93,7 +93,7 @@ public final class ConfigRegistry {
                 throw new IllegalStateException("Unable to use constructor taking ConfigRegistry to create " + configClass, e);
             }
             try {
-                MethodHandle mh = MethodHandles.publicLookup().findConstructor(klass,
+                MethodHandle mh = MethodHandles.lookup().findConstructor(klass,
                         MethodType.methodType(void.class))
                     .asType(MethodType.methodType(JdbiConfig.class));
                 return Unchecked.function(registry -> {


### PR DESCRIPTION
this causes a LinkageError in multi-classloader environments:

```
Caused by: java.lang.LinkageError: loader constraint violation:
  when resolving method 'void org.jdbi.v3.core.argument.Arguments.<init>(org.jdbi.v3.core.config.ConfigRegistry)'
  the class loader 'bootstrap' of the current class, java/lang/Object, and the class loader
  com.paywholesail.components.testutil.IntegrationRuleClassLoader @7b222230 for the method's defining class,
  org/jdbi/v3/core/argument/Arguments, have different Class objects for the type org/jdbi/v3/core/config/ConfigRegistry
  used in the signature (java.lang.Object is in module java.base of loader 'bootstrap';
  org.jdbi.v3.core.argument.Arguments is in unnamed module of loader
  com.paywholesail.components.testutil.IntegrationRuleClassLoader @7b222230, parent loader 'platform')
```