### PR TITLE
Skip parsing parameters in single-line comments

### DIFF
--- a/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/ColonStatementLexer.g4
+++ b/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/ColonStatementLexer.g4
@@ -27,7 +27,7 @@ fragment NAME: JAVA_LETTER | [0-9] | '.' | '?.';
 /* Lovingly lifted from https://github.com/antlr/grammars-v4/blob/master/java/JavaLexer.g4 */
 fragment JAVA_LETTER : [a-zA-Z$_] | ~[\u0000-\u007F\uD800-\uDBFF] | [\uD800-\uDBFF] [\uDC00-\uDFFF];
 
-COMMENT: '/*' .*? '*/';
+COMMENT: '/*' .*? '*/' | '--' ~('\r' | '\n')* | '//' ~('\r' | '\n')*;
 QUOTED_TEXT: QUOTE (ESCAPE_QUOTE | ~'\'')* QUOTE;
 DOUBLE_QUOTED_TEXT: DOUBLE_QUOTE (~'"')+ DOUBLE_QUOTE;
 ESCAPED_TEXT : ESCAPE . ;

--- a/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/DefineStatementLexer.g4
+++ b/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/DefineStatementLexer.g4
@@ -24,7 +24,7 @@ fragment NAME: JAVA_LETTER | [0-9];
 /* Lovingly lifted from https://github.com/antlr/grammars-v4/blob/master/java/JavaLexer.g4 */
 fragment JAVA_LETTER : [a-zA-Z$_] | ~[\u0000-\u007F\uD800-\uDBFF] | [\uD800-\uDBFF] [\uDC00-\uDFFF];
 
-COMMENT: '/*' .*? '*/';
+COMMENT: '/*' .*? '*/' | '--' ~('\r' | '\n')* | '//' ~('\r' | '\n')*;
 QUOTED_TEXT: QUOTE (ESCAPE_QUOTE | ~'\'')* QUOTE;
 DOUBLE_QUOTED_TEXT: DOUBLE_QUOTE (~'"')+ DOUBLE_QUOTE;
 ESCAPED_TEXT : ESCAPE . ;

--- a/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/HashStatementLexer.g4
+++ b/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/HashStatementLexer.g4
@@ -26,7 +26,7 @@ fragment NAME: JAVA_LETTER | [0-9] | '.' | '?.';
 /* Lovingly lifted from https://github.com/antlr/grammars-v4/blob/master/java/JavaLexer.g4 */
 fragment JAVA_LETTER : [a-zA-Z$_] | ~[\u0000-\u007F\uD800-\uDBFF] | [\uD800-\uDBFF] [\uDC00-\uDFFF];
 
-COMMENT: '/*' .*? '*/';
+COMMENT: '/*' .*? '*/' | '--' ~('\r' | '\n')* | '//' ~('\r' | '\n')*;
 QUOTED_TEXT: QUOTE (ESCAPE_QUOTE | ~'\'')* QUOTE;
 DOUBLE_QUOTED_TEXT: DOUBLE_QUOTE (~'"')+ DOUBLE_QUOTE;
 ESCAPED_TEXT : ESCAPE . ;

--- a/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/SqlScriptLexer.g4
+++ b/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/SqlScriptLexer.g4
@@ -15,9 +15,9 @@
 lexer grammar SqlScriptLexer;
 
 COMMENT
-    : '--' ~('\n'|'\r')* |
-      '//' ~('\n'|'\r')* |
-      {_input.LA(2) != '>'}? '#' ~('\n'|'\r')* // Exception for Postgres #> and #>> JSON operators
+    : '--' ~('\r' | '\n')* |
+      '//' ~('\r' | '\n')* |
+      {_input.LA(2) != '>'}? '#' ~('\r' | '\n')* // Exception for Postgres #> and #>> JSON operators
      { skip(); }
     ;
 
@@ -30,7 +30,7 @@ NEWLINES
     ;
 
 fragment NEWLINE
-    : ('\n'|'\r')
+    : ('\r' | '\n')
     ;
 
 QUOTED_TEXT

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestColonPrefixSqlParser.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestColonPrefixSqlParser.java
@@ -53,6 +53,13 @@ public class TestColonPrefixSqlParser {
     }
 
     @Test
+    public void testCommentCharsInQuotes() {
+        String sql = "select '-- // /* */'";
+        assertThat(parser.parse(sql, ctx))
+            .isEqualTo(ParsedSql.builder().append(sql).build());
+    }
+
+    @Test
     public void testEscapedColon() {
         assertThat(parser.parse("select \\:foo", ctx))
             .isEqualTo(ParsedSql.builder().append("select :foo").build());
@@ -128,6 +135,12 @@ public class TestColonPrefixSqlParser {
                 .append("select column# from thetable where id = ")
                 .appendNamedParameter("id")
                 .build());
+    }
+
+    @Test
+    public void testParameterInCommentOkay() {
+        String sql = "select /* :skip */\n-- :skip\n// :skip\n:param";
+        assertThat(parser.parse(sql, ctx).getParameters().getParameterNames()).containsExactly("param");
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestDefinedAttributeTemplateEngine.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestDefinedAttributeTemplateEngine.java
@@ -79,6 +79,19 @@ public class TestDefinedAttributeTemplateEngine {
     }
 
     @Test
+    public void testIgnoreAngleBracketsInComments() {
+        Map<String, Object> attributes = ImmutableMap.of("foo", "bar");
+        String rendered = render("select /* <skip> */\n-- <skip>\n// <skip>\n<foo>", attributes);
+        assertThat(rendered).isEqualTo("select /* <skip> */\n-- <skip>\n// <skip>\nbar");
+    }
+
+    @Test
+    public void testIgnoreCommentsInAngleBrackets() {
+        String rendered = render("select <this--is//skipped/*>");
+        assertThat(rendered).isEqualTo("select <this--is//skipped/*>");
+    }
+
+    @Test
     public void testCommentQuote() {
         String sql = "select 1 /* ' \" <foo> */";
         assertThat(render(sql)).isEqualTo(sql);

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestHashPrefixSqlParser.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestHashPrefixSqlParser.java
@@ -59,6 +59,19 @@ public class TestHashPrefixSqlParser {
     }
 
     @Test
+    public void testCommentCharsInQuotes() {
+        String sql = "select '-- // /* */'";
+        assertThat(parser.parse(sql, ctx))
+            .isEqualTo(ParsedSql.builder().append(sql).build());
+    }
+
+    @Test
+    public void testParameterInCommentOkay() {
+        String sql = "select /* #skip */\n-- #skip\n// #skip\n:#param";
+        assertThat(parser.parse(sql, ctx).getParameters().getParameterNames()).containsExactly("param");
+    }
+
+    @Test
     public void testBacktickOkay() {
         ParsedSql parsed = parser.parse("select * from `v$session", ctx);
         assertThat(parsed.getSql()).isEqualTo("select * from `v$session");


### PR DESCRIPTION
Extend the lexer grammars used to parse statements for colon
parameters, hash parameters, and attribute definitions to
recognize single-line comments starting with `--` and `//`.
As a result, placeholders within comments will remain
untouched when pre-processing statements.

https://github.com/jdbi/jdbi/issues/1712