### PR TITLE
Register boolean array types

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
   - new RollbackOnlyTransactionHandler rolls back everything for testing
   - upgrade caffeine dep to 3.0.1 for jdk16 (NOTE: jdk8 users will need to manage it back to 2.x)
   - add support for Moshi JSON mapping (#1809, thanks unoexperto!)
+  - Register more array types like `boolean` out of the box, #1802
 
 # 3.18.1
   - Comments like -- and // now recognized and discarded from SQL, thanks @rherrmann!

--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayTypes.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.array;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
@@ -35,6 +36,20 @@ public class SqlArrayTypes implements JdbiConfig<SqlArrayTypes> {
     public SqlArrayTypes() {
         argumentStrategy = SqlArrayArgumentStrategy.SQL_ARRAY;
 
+        register(boolean.class, "boolean");
+        register(Boolean.class, "boolean");
+        register(short.class, "smallint");
+        register(Short.class, "smallint");
+        register(int.class, "integer");
+        register(Integer.class, "integer");
+        register(long.class, "bigint");
+        register(Long.class, "bigint");
+        register(float.class, "float4");
+        register(Float.class, "float4");
+        register(double.class, "float8");
+        register(Double.class, "float8");
+        register(String.class, "varchar");
+        register(UUID.class, "uuid");
         register(new EnumSqlArrayTypeFactory());
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/h2/H2DatabasePlugin.java
+++ b/core/src/main/java/org/jdbi/v3/core/h2/H2DatabasePlugin.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.core.h2;
 
-import java.util.UUID;
-
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.array.SqlArrayArgumentStrategy;
 import org.jdbi.v3.core.spi.JdbiPlugin;
@@ -26,18 +24,5 @@ public class H2DatabasePlugin extends JdbiPlugin.Singleton {
     @Override
     public void customizeJdbi(Jdbi db) {
         db.setSqlArrayArgumentStrategy(SqlArrayArgumentStrategy.OBJECT_ARRAY);
-        db.registerArrayType(UUID.class, "uuid")
-            .registerArrayType(short.class, "smallint")
-            .registerArrayType(Short.class, "smallint")
-            .registerArrayType(int.class, "integer")
-            .registerArrayType(Integer.class, "integer")
-            .registerArrayType(long.class, "bigint")
-            .registerArrayType(Long.class, "bigint")
-            .registerArrayType(String.class, "varchar")
-            .registerArrayType(UUID.class, "uuid")
-            .registerArrayType(float.class, "float4")
-            .registerArrayType(Float.class, "float4")
-            .registerArrayType(double.class, "float8")
-            .registerArrayType(Double.class, "float8");
     }
 }

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
@@ -15,7 +15,6 @@ package org.jdbi.v3.postgres;
 
 import java.sql.Connection;
 import java.util.Map;
-import java.util.UUID;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -112,19 +111,6 @@ public class PostgresPlugin extends JdbiPlugin.Singleton {
         jdbi.registerArgument(new BitStringEnumSetArgumentFactory());
         jdbi.registerArgument(new BlobInputStreamArgumentFactory());
         jdbi.registerArgument(new ClobReaderArgumentFactory());
-
-        jdbi.registerArrayType(short.class, "smallint");
-        jdbi.registerArrayType(Short.class, "smallint");
-        jdbi.registerArrayType(int.class, "integer");
-        jdbi.registerArrayType(Integer.class, "integer");
-        jdbi.registerArrayType(long.class, "bigint");
-        jdbi.registerArrayType(Long.class, "bigint");
-        jdbi.registerArrayType(String.class, "varchar");
-        jdbi.registerArrayType(UUID.class, "uuid");
-        jdbi.registerArrayType(float.class, "float4");
-        jdbi.registerArrayType(Float.class, "float4");
-        jdbi.registerArrayType(double.class, "float8");
-        jdbi.registerArrayType(Double.class, "float8");
 
         // built-in PGobject types
         jdbi.registerArrayType(PGbox.class, "box");


### PR DESCRIPTION
Pull common array type configuration with SQL standard names up to base SqlArraytypes
They can always be overridden anyway

Fixes #1802