### PR TITLE
Add Codecs for easy type mapping to columns.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
   - upgrade caffeine dep to 3.0.1 for jdk16 (NOTE: jdk8 users will need to manage it back to 2.x)
   - add support for Moshi JSON mapping (#1809, thanks unoexperto!)
   - Register more array types like `boolean` out of the box, #1802
+  - add Codec (combination of ArgumentFactory and ColumnMapper) to provide one API for serialization/deserialization.
 
 # 3.18.1
   - Comments like -- and // now recognized and discarded from SQL, thanks @rherrmann!

--- a/core/src/main/java/org/jdbi/v3/core/codec/Codec.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/Codec.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.codec;
+
+import java.util.function.Function;
+
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+
+/**
+ * A Codec provides a convenient way for a bidirectional mapping of an attribute to a database column.
+ * <p>
+ * Groups a {@link ColumnMapper} and an {@link org.jdbi.v3.core.argument.Argument} mapping function for a given type.
+ */
+public interface Codec<T> {
+
+    /**
+     * Returns a {@link ColumnMapper<T>} that creates an attribute value from a database column.
+     */
+    default ColumnMapper<T> getColumnMapper() {
+        throw new UnsupportedOperationException("getColumnMapper");
+    }
+
+    /**
+     * Returns a {@link Function<T, Argument>} that creates an {@link Argument} to map an attribute value onto the database column.
+     */
+    default Function<T, Argument> getArgumentFunction() {
+        throw new UnsupportedOperationException("getArgumentFunction");
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/codec/Codec.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/Codec.java
@@ -26,14 +26,14 @@ import org.jdbi.v3.core.mapper.ColumnMapper;
 public interface Codec<T> {
 
     /**
-     * Returns a {@link ColumnMapper<T>} that creates an attribute value from a database column.
+     * Returns a {@link ColumnMapper} that creates an attribute value from a database column.
      */
     default ColumnMapper<T> getColumnMapper() {
         throw new UnsupportedOperationException("getColumnMapper");
     }
 
     /**
-     * Returns a {@link Function<T, Argument>} that creates an {@link Argument} to map an attribute value onto the database column.
+     * Returns a {@link Function} that creates an {@link Argument} to map an attribute value onto the database column.
      */
     default Function<T, Argument> getArgumentFunction() {
         throw new UnsupportedOperationException("getArgumentFunction");

--- a/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.core.codec;
 
-import static java.util.Objects.requireNonNull;
-
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,6 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -35,6 +34,8 @@ import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.QualifiedColumnMapperFactory;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.meta.Beta;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * CodecFactory provides column mappers and arguments for bidirectional mapping types to database columns.
@@ -98,8 +99,7 @@ public class CodecFactory implements QualifiedColumnMapperFactory, QualifiedArgu
 
         private final Map<QualifiedType<?>, Codec<?>> codecMap = new HashMap<>();
 
-        Builder() {
-        }
+        Builder() {}
 
         /**
          * Add a codec for a {@link QualifiedType}.

--- a/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.codec;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.argument.QualifiedArgumentFactory;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.QualifiedColumnMapperFactory;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+import org.jdbi.v3.meta.Beta;
+
+/**
+ * CodecFactory provides column mappers and arguments for bidirectional mapping types to database columns.
+ * <p>
+ * This class is immutable and thread safe.
+ */
+@ThreadSafe
+@Beta
+public class CodecFactory implements QualifiedColumnMapperFactory, QualifiedArgumentFactory.Preparable {
+
+    private final ConcurrentMap<QualifiedType<?>, Codec<?>> codecMap = new ConcurrentHashMap<>();
+
+    /**
+     * Returns a builder for fluent API.
+     *
+     * @return Builder for fluent API.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static CodecFactory forSingleCodec(QualifiedType<?> type, Codec<?> codec) {
+        return new CodecFactory(Collections.singletonMap(type, codec));
+    }
+
+    /**
+     * Create a new CodecFactory.
+     *
+     * @param codecMap
+     */
+    public CodecFactory(final Map<QualifiedType<?>, Codec<?>> codecMap) {
+        requireNonNull(codecMap, "codecMap is null");
+        this.codecMap.putAll(codecMap);
+    }
+
+    @Override
+    public Optional<Function<Object, Argument>> prepare(final QualifiedType<?> type, final ConfigRegistry config) {
+        return Optional.of(type).map(codecMap::get).map(key -> (Function<Object, Argument>) key.getArgumentFunction());
+    }
+
+    @Override
+    public Collection<QualifiedType<?>> prePreparedTypes() {
+        return codecMap.keySet();
+    }
+
+    @Override
+    public Optional<Argument> build(final QualifiedType<?> type, final Object value, final ConfigRegistry config) {
+        return prepare(type, config).map(f -> f.apply(value));
+    }
+
+    @Override
+    public Optional<ColumnMapper<?>> build(final QualifiedType<?> type, final ConfigRegistry config) {
+        return Optional.of(type).map(codecMap::get).map(Codec::getColumnMapper);
+    }
+
+    /**
+     * Fluent Builder for {@link CodecFactory}.
+     */
+    @NotThreadSafe
+    public static final class Builder {
+
+        private final Map<QualifiedType<?>, Codec<?>> codecMap = new HashMap<>();
+
+        Builder() {
+        }
+
+        /**
+         * Add a codec for a {@link QualifiedType}.
+         */
+        public Builder addCodec(final QualifiedType<?> type, final Codec<?> codec) {
+            requireNonNull(type, "type is null");
+            requireNonNull(codec, "codec is null");
+            codecMap.put(type, codec);
+
+            return this;
+        }
+
+        /**
+         * Add a codec for a {@link Type}.
+         */
+        public Builder addCodec(final Type type, final Codec<?> codec) {
+            requireNonNull(type, "type is null");
+            requireNonNull(codec, "codec is null");
+            codecMap.put(QualifiedType.of(type), codec);
+
+            return this;
+        }
+
+        /**
+         * Add a codec for a {@link GenericType}.
+         */
+        public Builder addCodec(final GenericType<?> type, final Codec<?> codec) {
+            requireNonNull(type, "type is null");
+            requireNonNull(codec, "codec is null");
+            codecMap.put(QualifiedType.of(type.getType()), codec);
+
+            return this;
+        }
+
+        public CodecFactory build() {
+            return new CodecFactory(codecMap);
+        }
+    }
+
+}

--- a/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Type;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.jdbi.v3.core.codec.CodecFactory;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.argument.QualifiedArgumentFactory;
@@ -25,6 +24,7 @@ import org.jdbi.v3.core.array.SqlArrayArgumentStrategy;
 import org.jdbi.v3.core.array.SqlArrayType;
 import org.jdbi.v3.core.array.SqlArrayTypeFactory;
 import org.jdbi.v3.core.array.SqlArrayTypes;
+import org.jdbi.v3.core.codec.CodecFactory;
 import org.jdbi.v3.core.collector.CollectorFactory;
 import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.extension.ExtensionFactory;
@@ -359,7 +359,6 @@ public interface Configurable<This> {
     default This registerRowMapper(RowMapperFactory factory) {
         return configure(RowMappers.class, c -> c.register(factory));
     }
-
 
     /**
      * Convenience method to register a {@link CodecFactory}.

--- a/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Type;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.jdbi.v3.core.codec.CodecFactory;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.argument.QualifiedArgumentFactory;
@@ -357,6 +358,19 @@ public interface Configurable<This> {
      */
     default This registerRowMapper(RowMapperFactory factory) {
         return configure(RowMappers.class, c -> c.register(factory));
+    }
+
+
+    /**
+     * Convenience method to register a {@link CodecFactory}.
+     *
+     * @param codecFactory codec factory
+     * @return this
+     */
+    @Beta
+    default This registerCodecFactory(CodecFactory codecFactory) {
+        registerColumnMapper(codecFactory);
+        return registerArgument(codecFactory);
     }
 }
 

--- a/core/src/test/java/org/jdbi/v3/core/codec/TestCodecFactoryH2.java
+++ b/core/src/test/java/org/jdbi/v3/core/codec/TestCodecFactoryH2.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.v3.core.codec;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -26,6 +24,8 @@ import org.jdbi.v3.core.rule.DatabaseRule;
 import org.jdbi.v3.core.rule.H2DatabaseRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestCodecFactoryH2 {
 

--- a/core/src/test/java/org/jdbi/v3/core/codec/TestCodecFactoryH2.java
+++ b/core/src/test/java/org/jdbi/v3/core/codec/TestCodecFactoryH2.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.codec;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+import org.jdbi.v3.core.rule.DatabaseRule;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestCodecFactoryH2 {
+
+    @Rule
+    public DatabaseRule dbRule = new H2DatabaseRule();
+
+    @Test
+    public void testCodecFactory() throws Exception {
+        QualifiedType<TestValue> testType = QualifiedType.of(TestValue.class);
+
+        Jdbi jdbi = dbRule.getJdbi();
+
+        jdbi.registerCodecFactory(CodecFactory.forSingleCodec(testType, new TestValueCodec()));
+
+        jdbi.useHandle(h -> {
+            h.execute("CREATE TABLE test (test VARCHAR PRIMARY KEY)");
+        });
+
+        TestValue value = new TestValue(12345);
+
+        int result = jdbi.withHandle(h -> h.createUpdate("INSERT INTO test (test) VALUES (:test)")
+            .bindByType("test", value, testType)
+            .execute());
+
+        assertEquals(1, result);
+
+        TestValue response = jdbi.withHandle(h -> h.createQuery("SELECT * from test")
+            .mapTo(testType).first());
+
+        assertEquals(value, response);
+    }
+
+    public static class TestValueCodec implements Codec<TestValue> {
+
+        @Override
+        public ColumnMapper<TestValue> getColumnMapper() {
+            return (r, idx, ctx) -> TestValue.create(r.getString(idx));
+        }
+
+        @Override
+        public Function<TestValue, Argument> getArgumentFunction() {
+            return value -> (pos, stmt, ctx) -> stmt.setString(pos, value.getValue());
+        }
+    }
+
+    public static class TestValue {
+
+        private final long value;
+
+        public static TestValue create(String value) {
+            return new TestValue(Long.parseLong(value, 8));
+        }
+
+        public TestValue(long value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return Long.toString(value, 8);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestValue testValue = (TestValue) o;
+            return value == testValue.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+}

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -1662,6 +1662,57 @@ fails, an exception is thrown.
 Jdbi can be enhanced to support arbitrary container types. See
 <<JdbiCollectors>> for more information.
 
+=== Codecs
+
+[NOTE]
+The Codec API is still unstable and may change.
+
+A codec is a replacement for registering an argument and a column mapper for a type. It is responsible for serializing a typed value into a database column and creating a type from a database column.
+
+Codecs are collected in a codec factory which can be registered with the registerCodecFactory convenience method.
+
+[source,java]
+----
+// register a single codec
+jdbi.registerCodecFactory(CodecFactory.forSingleCodec(type, codec));
+
+// register a few codecs
+jdbi.registerCodecFactory(CodecFactory.builder()
+  // register a codec by qualified type
+  .addCodec(QualifiedType.of(Foo.class), codec1)
+  // register a codec by direct java type
+  .addCodec(Foo.class, codec2)
+  // register a codec by generic type
+  .addCodec(new GenericType<Set<Foo>>() {}. codec3)
+  .build());
+
+// register many codecs
+Map<QualifiedType<?>, Codec<?>> codecs = ...
+jdbi.registerCodecFactory(new CodecFactory(codecs));
+----
+
+
+Codec example:
+
+[source,java,indent=0]
+----
+include::{exampledir}/Counter.java[tags=counterCodec]
+----
+
+JDBI core API:
+
+[source,java,indent=0]
+----
+include::{exampledir}/CodecExampleTest.java[tags=register;load;store]
+----
+
+SQL Object API uses the codecs transparently:
+
+[source,java,indent=0]
+----
+include::{exampledir}/CodecSqlObjectTest.java[tags=dao;register;load;store]
+----
+
 === Templating
 
 Binding query parameters, as described above, is excellent for sending a static set of parameters to the database engine.  Binding ensures that the parameterized query string (`... where foo = ?`) is transmitted to the database without allowing hostile parameter values to inject SQL.

--- a/docs/src/test/java/jdbi/doc/CodecExampleTest.java
+++ b/docs/src/test/java/jdbi/doc/CodecExampleTest.java
@@ -1,0 +1,85 @@
+package jdbi.doc;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import jdbi.doc.Counter.CounterCodec;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.codec.CodecFactory;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+import org.jdbi.v3.core.rule.DatabaseRule;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+
+public class CodecExampleTest {
+
+    @Rule
+    public DatabaseRule dbRule = new H2DatabaseRule();
+
+    public static final QualifiedType<Counter> COUNTER_TYPE = QualifiedType.of(Counter.class);
+
+    @Before
+    public void setUp() {
+        dbRule.getJdbi().useHandle(h -> {
+            h.execute("CREATE TABLE counters (id VARCHAR PRIMARY KEY, value INT)");
+        });
+    }
+
+    @Test
+    public void testCounter() {
+        Jdbi jdbi = dbRule.getJdbi();
+
+        // tag::register[]
+
+        // register the codec with JDBI
+        jdbi.registerCodecFactory(CodecFactory.forSingleCodec(COUNTER_TYPE, new CounterCodec()));
+
+        // end::register[]
+
+        Counter counter = new Counter();
+        for (int i = 0; i < ThreadLocalRandom.current().nextInt(1000); i++) {
+            counter.nextValue();
+        }
+
+        String counterId = UUID.randomUUID().toString();
+
+        // tag::store[]
+
+        // store object
+        int result = jdbi.withHandle(h -> h.createUpdate("INSERT INTO counters (id, value) VALUES (:id, :value)")
+            .bind("id", counterId)
+            .bindByType("value", counter, COUNTER_TYPE)
+            .execute());
+
+        // end::store[]
+
+        int nextValue = counter.nextValue();
+
+        // increment counter
+        counter.nextValue();
+        counter.nextValue();
+        counter.nextValue();
+
+        // tag::load[]
+
+        // load object
+        Counter restoredCounter = jdbi.withHandle(h -> h.createQuery("SELECT value from counters where id = :id")
+            .bind("id", counterId)
+            .mapTo(COUNTER_TYPE).first());
+
+        // end::load[]
+
+        assertNotSame(counter, restoredCounter);
+
+        int nextRestoredValue = restoredCounter.nextValue();
+
+        assertNotEquals(counter.nextValue(), nextRestoredValue);
+        assertEquals(nextValue, nextRestoredValue);
+    }
+}

--- a/docs/src/test/java/jdbi/doc/CodecSqlObjectTest.java
+++ b/docs/src/test/java/jdbi/doc/CodecSqlObjectTest.java
@@ -1,0 +1,98 @@
+package jdbi.doc;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import jdbi.doc.Counter.CounterCodec;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.codec.CodecFactory;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+import org.jdbi.v3.core.rule.DatabaseRule;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+
+public class CodecSqlObjectTest {
+
+    // tag::dao[]
+
+    // SQL object dao
+    public interface CounterDao {
+        @SqlUpdate("INSERT INTO counters (id, value) VALUES (:id, :value)")
+        int storeCounter(@Bind("id") String id, @Bind("value") Counter counter);
+
+        @SqlQuery("SELECT value from counters where id = :id")
+        Counter loadCounter(@Bind("id") String id);
+    }
+
+    // end::dao[]
+
+    @Rule
+    public DatabaseRule dbRule = new H2DatabaseRule().withPlugin(new SqlObjectPlugin());
+
+    public static final QualifiedType<Counter> COUNTER_TYPE = QualifiedType.of(Counter.class);
+
+    @Before
+    public void setUp() {
+        dbRule.getJdbi().useHandle(h -> {
+            h.execute("CREATE TABLE counters (id VARCHAR PRIMARY KEY, value INT)");
+        });
+    }
+
+    @Test
+    public void testCounter() {
+        Jdbi jdbi = dbRule.getJdbi();
+
+        // tag::register[]
+
+        // register the codec with JDBI
+        jdbi.registerCodecFactory(CodecFactory.forSingleCodec(COUNTER_TYPE, new CounterCodec()));
+
+        // end::register[]
+
+        Counter counter = new Counter();
+        for (int i = 0; i < ThreadLocalRandom.current().nextInt(1000); i++) {
+            counter.nextValue();
+        }
+
+        String counterId = UUID.randomUUID().toString();
+        // tag::store[]
+
+        // store object
+        int result = jdbi.withExtension(CounterDao.class, dao -> dao.storeCounter(counterId, counter));
+
+        // end::store[]
+
+        assertEquals(1, result);
+
+        int nextValue = counter.nextValue();
+
+        // increment counter
+        counter.nextValue();
+        counter.nextValue();
+        counter.nextValue();
+
+        // tag::load[]
+
+        // load object
+        Counter restoredCounter = jdbi.withExtension(CounterDao.class, dao -> dao.loadCounter(counterId));
+
+        // end::load[]
+
+        assertNotSame(counter, restoredCounter);
+
+        int nextRestoredValue = restoredCounter.nextValue();
+
+        assertNotEquals(counter.nextValue(), nextRestoredValue);
+        assertEquals(nextValue, nextRestoredValue);
+    }
+}

--- a/docs/src/test/java/jdbi/doc/Counter.java
+++ b/docs/src/test/java/jdbi/doc/Counter.java
@@ -1,0 +1,48 @@
+package jdbi.doc;
+
+import java.util.function.Function;
+
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.codec.Codec;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+
+/**
+ * A simple counter class.
+ */
+// tag::counterCodec[]
+public class Counter {
+
+    private int count = 0;
+
+    public Counter() {}
+
+    public int nextValue() {
+        return count++;
+    }
+
+    private Counter setValue(int value) {
+        this.count = value;
+        return this;
+    }
+
+    private int getValue() {
+        return count;
+    }
+
+    /**
+     * Codec to persist a counter to the database and restore it back.
+     */
+    public static class CounterCodec implements Codec<Counter> {
+
+        @Override
+        public ColumnMapper<Counter> getColumnMapper() {
+            return (r, idx, ctx) -> new Counter().setValue(r.getInt(idx));
+        }
+
+        @Override
+        public Function<Counter, Argument> getArgumentFunction() {
+            return counter -> (idx, stmt, ctx) -> stmt.setInt(idx, counter.getValue());
+        }
+    }
+}
+// end::counterCodec[]


### PR DESCRIPTION
A codec is a replacement for registering an argument and a column
mapper for a type. It is responsible for serializing a typed value
into a database column and creating a type from a database column.