### PR TITLE
Add one-time init methods to row and column mappers

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/codec/Codec.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/Codec.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.codec;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.meta.Alpha;
 
@@ -31,15 +32,41 @@ public interface Codec<T> {
 
     /**
      * Returns a {@link ColumnMapper} that creates an attribute value from a database column.
+     * <p>
+     * Either this method or {@link #getColumnMapper(ConfigRegistry)} must be implemented.
      */
     default ColumnMapper<T> getColumnMapper() {
         throw new UnsupportedOperationException("getColumnMapper");
     }
 
     /**
+     * Returns a {@link ColumnMapper} that creates an attribute value from a database column.
+     * <p>
+     * This method is optional. If it is not implemented, the result of {@link #getColumnMapper()} is returned.
+     *
+     * @param configRegistry The {@link ConfigRegistry} that this argument belongs to.
+     */
+    default ColumnMapper<T> getColumnMapper(ConfigRegistry configRegistry) {
+        return getColumnMapper();
+    }
+
+    /**
      * Returns a {@link Function} that creates an {@link Argument} to map an attribute value onto the database column.
+     * <p>
+     * Either this method or {@link #getArgumentFunction(ConfigRegistry)} must be implemented.
      */
     default Function<T, Argument> getArgumentFunction() {
         throw new UnsupportedOperationException("getArgumentFunction");
+    }
+
+    /**
+     * Returns a {@link Function} that creates an {@link Argument} to map an attribute value onto the database column.
+     * <p>
+     * This method is optional. If it is not implemented, the result of {@link #getArgumentFunction()} is returned.
+     *
+     * @param configRegistry The {@link ConfigRegistry} that this argument belongs to.
+     */
+    default Function<T, Argument> getArgumentFunction(ConfigRegistry configRegistry) {
+        return getArgumentFunction();
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
@@ -78,7 +78,7 @@ public class CodecFactory implements QualifiedColumnMapperFactory, QualifiedArgu
 
     @Override
     public final Optional<Function<Object, Argument>> prepare(final QualifiedType<?> type, final ConfigRegistry config) {
-        return Optional.of(type).map(this::resolveType).map(key -> (Function<Object, Argument>) key.getArgumentFunction());
+        return Optional.of(type).map(this::resolveType).map(key -> (Function<Object, Argument>) key.getArgumentFunction(config));
     }
 
     @Override
@@ -93,7 +93,7 @@ public class CodecFactory implements QualifiedColumnMapperFactory, QualifiedArgu
 
     @Override
     public final Optional<ColumnMapper<?>> build(final QualifiedType<?> type, final ConfigRegistry config) {
-        return Optional.of(type).map(this::resolveType).map(Codec::getColumnMapper);
+        return Optional.of(type).map(this::resolveType).map(c -> c.getColumnMapper(config));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMapper.java
@@ -59,8 +59,10 @@ public interface ColumnMapper<T> {
     }
 
     /**
-     * Allows for one-time initialization of the column mapper instance. This method is called once
-     * when the column mapper is first used.
+     * Allows for initialization of the column mapper instance within a ConfigRegistry scope. This method is called once when the column mapper is first used from a
+     * ConfigRegistry.
+     * <p>
+     * Note that handles, statements, sql objects etc. all create copies of the registry, and this method will be called for every copy
      *
      * @param registry A reference to the {@link ConfigRegistry} that this instance belongs to.
      */

--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMapper.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.mapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**
@@ -56,4 +57,12 @@ public interface ColumnMapper<T> {
     default T map(ResultSet r, String columnLabel, StatementContext ctx) throws SQLException {
         return map(r, r.findColumn(columnLabel), ctx);
     }
+
+    /**
+     * Allows for one-time initialization of the column mapper instance. This method is called once
+     * when the column mapper is first used.
+     *
+     * @param registry A reference to the {@link ConfigRegistry} that this instance belongs to.
+     */
+    default void init(ConfigRegistry registry) {}
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
@@ -195,6 +195,8 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
                 .flatMap(factory -> JdbiOptionals.stream(factory.build(type, registry)))
                 .findFirst();
 
+        mapper.ifPresent(m -> m.init(registry));
+
         cache.put(type, mapper);
 
         return mapper;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.mapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**
@@ -60,4 +61,12 @@ public interface RowMapper<T> {
     default RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {
         return this;
     }
+
+    /**
+     * Allows for one-time initialization of the row mapper instance. This method is called once
+     * when the row mapper is first used.
+     *
+     * @param registry A reference to the {@link ConfigRegistry} that this instance belongs to.
+     */
+    default void init(ConfigRegistry registry) {}
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
@@ -63,8 +63,10 @@ public interface RowMapper<T> {
     }
 
     /**
-     * Allows for one-time initialization of the row mapper instance. This method is called once
-     * when the row mapper is first used.
+     * Allows for initialization of the row mapper instance within a ConfigRegistry scope. This method is called once when the row mapper is first used from a
+     * ConfigRegistry.
+     * <p>
+     * Note that handles, statements, sql objects etc. all create copies of the registry, and this method will be called for every copy
      *
      * @param registry A reference to the {@link ConfigRegistry} that this instance belongs to.
      */

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMappers.java
@@ -147,6 +147,8 @@ public class RowMappers implements JdbiConfig<RowMappers> {
                 .flatMap(factory -> JdbiOptionals.stream(factory.build(type, registry)))
                 .findFirst();
 
+        mapper.ifPresent(m -> m.init(registry));
+
         cache.put(type, mapper);
 
         return mapper;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestMapperInit.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestMapperInit.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jdbi.v3.core.mapper;
 
 import java.sql.ResultSet;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestMapperInit.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestMapperInit.java
@@ -113,7 +113,7 @@ public class TestMapperInit {
 
     @Test
     public void testRowMapper() {
-        final GenericType<Map.Entry<StringValue, Integer>> RESULT_TYPE = new GenericType<Entry<StringValue, Integer>>() {};
+        final GenericType<Map.Entry<StringValue, Integer>> resultType = new GenericType<Entry<StringValue, Integer>>() {};
 
         final StringValueMapper mapper = new StringValueMapper();
         // not yet initialized
@@ -122,7 +122,7 @@ public class TestMapperInit {
 
         Jdbi jdbi = rule.getJdbi();
         jdbi.registerColumnMapper(StringValue.class, mapper);
-        jdbi.registerRowMapper(RESULT_TYPE, new ResultMapper());
+        jdbi.registerRowMapper(resultType, new ResultMapper());
 
         // still not initialized, only at first retrieval
         assertEquals(0, mapper.getInitializedCount());
@@ -130,7 +130,7 @@ public class TestMapperInit {
 
         List<Map.Entry<StringValue, Integer>> values = jdbi.withHandle(h -> {
             List<Map.Entry<StringValue, Integer>> value = h.createQuery("SELECT * FROM column_mappers")
-                .mapTo(RESULT_TYPE)
+                .mapTo(resultType)
                 .list();
 
             // has been called once
@@ -140,7 +140,7 @@ public class TestMapperInit {
             assertEquals(value.size(), mapper.getMappedCount());
 
             value = h.createQuery("SELECT * FROM column_mappers")
-                .mapTo(RESULT_TYPE)
+                .mapTo(resultType)
                 .list();
 
             // has been called once
@@ -157,7 +157,7 @@ public class TestMapperInit {
         // redo with another handle
         values = jdbi.withHandle(h -> {
             List<Map.Entry<StringValue, Integer>> value = h.createQuery("SELECT * FROM column_mappers")
-                .mapTo(RESULT_TYPE)
+                .mapTo(resultType)
                 .list();
             // called again for the statement
             assertEquals(3, mapper.getInitializedCount());
@@ -168,7 +168,6 @@ public class TestMapperInit {
             return value;
         });
     }
-
 
     public static class StringValue {
 

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestMapperInit.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestMapperInit.java
@@ -1,0 +1,232 @@
+package org.jdbi.v3.core.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestMapperInit {
+
+    @Rule
+    public H2DatabaseRule rule = new H2DatabaseRule();
+
+    @Before
+    public void setUp() {
+        Handle handle = rule.getSharedHandle();
+
+        handle.execute("create table column_mappers (string_value varchar, long_value integer)");
+        handle.execute("insert into column_mappers (string_value, long_value) values (?, ?)", "foo", 1L);
+        handle.execute("insert into column_mappers (string_value, long_value) values (?, ?)", "bar", 2L);
+        handle.execute("insert into column_mappers (string_value, long_value) values (?, ?)", "baz", 3L);
+    }
+
+    @Test
+    public void testColumnMapper() {
+        final StringValueMapper mapper = new StringValueMapper();
+        // not yet initialized
+        assertEquals(0, mapper.getInitializedCount());
+        assertEquals(0, mapper.getMappedCount());
+
+        Jdbi jdbi = rule.getJdbi();
+        jdbi.registerColumnMapper(StringValue.class, mapper);
+
+        // still not initialized, only at first retrieval
+        assertEquals(0, mapper.getInitializedCount());
+        assertEquals(0, mapper.getMappedCount());
+
+        List<StringValue> values = jdbi.withHandle(h -> {
+            List<StringValue> value = h.createQuery("SELECT string_value FROM column_mappers")
+                .mapTo(StringValue.class)
+                .list();
+
+            // has been called once
+            assertEquals(1, mapper.getInitializedCount());
+
+            // has been called for every row (mapper gets reused)
+            assertEquals(value.size(), mapper.getMappedCount());
+
+            value = h.createQuery("SELECT string_value FROM column_mappers")
+                .mapTo(StringValue.class)
+                .list();
+
+            // has been called once
+            assertEquals(2, mapper.getInitializedCount());
+
+            // has been called for every row (mapper gets reused)
+            assertEquals(value.size() * 2, mapper.getMappedCount());
+            return value;
+        });
+
+        assertNotNull(values);
+        assertEquals(3, values.size());
+        assertTrue(values.contains(new StringValue("foo")));
+        assertTrue(values.contains(new StringValue("bar")));
+        assertTrue(values.contains(new StringValue("baz")));
+
+        // redo with another handle
+        values = jdbi.withHandle(h -> {
+            List<StringValue> value = h.createQuery("SELECT string_value FROM column_mappers")
+                .mapTo(StringValue.class)
+                .list();
+
+            // called again for the statement
+            assertEquals(3, mapper.getInitializedCount());
+
+            // has been called for every row again (mapper gets reused)
+            assertEquals(value.size() * 3, mapper.getMappedCount());
+
+            return value;
+        });
+    }
+
+    @Test
+    public void testRowMapper() {
+        final GenericType<Map.Entry<StringValue, Integer>> RESULT_TYPE = new GenericType<Entry<StringValue, Integer>>() {};
+
+        final StringValueMapper mapper = new StringValueMapper();
+        // not yet initialized
+        assertEquals(0, mapper.getInitializedCount());
+        assertEquals(0, mapper.getMappedCount());
+
+        Jdbi jdbi = rule.getJdbi();
+        jdbi.registerColumnMapper(StringValue.class, mapper);
+        jdbi.registerRowMapper(RESULT_TYPE, new ResultMapper());
+
+        // still not initialized, only at first retrieval
+        assertEquals(0, mapper.getInitializedCount());
+        assertEquals(0, mapper.getMappedCount());
+
+        List<Map.Entry<StringValue, Integer>> values = jdbi.withHandle(h -> {
+            List<Map.Entry<StringValue, Integer>> value = h.createQuery("SELECT * FROM column_mappers")
+                .mapTo(RESULT_TYPE)
+                .list();
+
+            // has been called once
+            assertEquals(1, mapper.getInitializedCount());
+
+            // has been called for every row (mapper gets reused)
+            assertEquals(value.size(), mapper.getMappedCount());
+
+            value = h.createQuery("SELECT * FROM column_mappers")
+                .mapTo(RESULT_TYPE)
+                .list();
+
+            // has been called once
+            assertEquals(2, mapper.getInitializedCount());
+
+            // has been called for every row (mapper gets reused)
+            assertEquals(value.size() * 2, mapper.getMappedCount());
+            return value;
+        });
+
+        assertNotNull(values);
+        assertEquals(3, values.size());
+
+        // redo with another handle
+        values = jdbi.withHandle(h -> {
+            List<Map.Entry<StringValue, Integer>> value = h.createQuery("SELECT * FROM column_mappers")
+                .mapTo(RESULT_TYPE)
+                .list();
+            // called again for the statement
+            assertEquals(3, mapper.getInitializedCount());
+
+            // has been called for every row again (mapper gets reused)
+            assertEquals(value.size() * 3, mapper.getMappedCount());
+
+            return value;
+        });
+    }
+
+
+    public static class StringValue {
+
+        private final String value;
+
+        public StringValue(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            StringValue that = (StringValue) o;
+            return Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
+    public static class StringValueMapper implements ColumnMapper<StringValue> {
+
+        private final AtomicInteger initializedCount = new AtomicInteger(0);
+        private final AtomicInteger mappedCount = new AtomicInteger(0);
+
+        int getInitializedCount() {
+            return initializedCount.get();
+        }
+
+        int getMappedCount() {
+            return mappedCount.get();
+        }
+
+        @Override
+        public StringValue map(ResultSet rs, int columnNumber, StatementContext ctx) throws SQLException {
+            mappedCount.incrementAndGet();
+            return new StringValue(rs.getString(columnNumber));
+        }
+
+        @Override
+        public void init(ConfigRegistry registry) {
+            initializedCount.incrementAndGet();
+        }
+    }
+
+    public static class ResultMapper implements RowMapper<Entry<StringValue, Integer>> {
+
+        private ColumnMapper<StringValue> stringValueMapper;
+
+        @Override
+        public Entry<StringValue, Integer> map(ResultSet rs, StatementContext ctx) throws SQLException {
+            return new SimpleImmutableEntry<StringValue, Integer>(
+                stringValueMapper.map(rs, 1, ctx),
+                rs.getInt(2)
+            );
+        }
+
+        @Override
+        public void init(ConfigRegistry registry) {
+            stringValueMapper = registry.get(ColumnMappers.class).findFor(StringValue.class).orElseGet(() -> fail("No mapper found!"));
+        }
+    }
+}


### PR DESCRIPTION
Allow creation-time initialization of row and column mappers. Also
make the config registry available to the factory methods on the
codec interface.