### PR TITLE
Make legacy bindings configurable.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+# Unreleased
+  - Install PostgresPlugin without unqualified HStore bindings (#1875)
+  - Update Kotlin to 1.5.0
+  - Update Caffeine dependency to 3.0.2
+  - Add missing jdbi3-spring5 to the JDBI bom
+
 # 3.20.0
   - Promote Postgres LOB APIs to stable.
   - Promote JSON, Jackson, and Gson APIs to stable.

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -4565,6 +4565,18 @@ public interface AccountDao {
 }
 ----
 
+[NOTE]
+The default variant to install the plugin adds unqualified mappings of raw `Map` types from and to the `hstore` Postgres data type. There are situations where this interferes with other mappings of maps. It is recommended to always use the variant with the `@HStore` qualified type.
+
+To avoid binding the unqualified Argument and ColumnMapper bindings, install the plugin using the static factory method:
+
+[source,java,indent=0]
+----
+Jdbi jdbi = Jdbi.create("jdbc:postgresql://host:port/database")
+                .installPlugin(PostgresPlugin.noUnqualifiedHstoreBindings());
+----
+
+
 [reftext="PostgreSQL-GetGeneratedKeys"]
 ==== @GetGeneratedKeys
 

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
@@ -100,11 +100,20 @@ public class PostgresPlugin extends JdbiPlugin.Singleton {
 
     private final boolean installLegacy;
 
+    /**
+     * Do not install the legacy (unqualified) bindings for {@link HStoreArgumentFactory} and {@link HStoreColumnMapper}. When
+     * using the plugin returned by this factory method, any lookup for HStore specific arguments and column mappers must be qualified
+     * with the {@link HStore} annotation.
+     */
+    public static PostgresPlugin noUnqualifiedHstoreBindings() {
+        return new PostgresPlugin(false);
+    }
+
     public PostgresPlugin() {
         this(true);
     }
 
-    public PostgresPlugin(boolean installLegacy) {
+    protected PostgresPlugin(boolean installLegacy) {
         this.installLegacy = installLegacy;
     }
 

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
@@ -97,6 +97,17 @@ import org.postgresql.util.PGmoney;
  * interval (and consequently, a column-mapped Period) of <em>-2 years, -10 months</em>, and -1 days.
  */
 public class PostgresPlugin extends JdbiPlugin.Singleton {
+
+    private final boolean installLegacy;
+
+    public PostgresPlugin() {
+        this(true);
+    }
+
+    public PostgresPlugin(boolean installLegacy) {
+        this.installLegacy = installLegacy;
+    }
+
     @Override
     public void customizeJdbi(Jdbi jdbi) {
         jdbi.registerArgument(new TypedEnumArgumentFactory());
@@ -133,9 +144,11 @@ public class PostgresPlugin extends JdbiPlugin.Singleton {
         jdbi.registerColumnMapper(new BlobInputStreamColumnMapperFactory());
         jdbi.registerColumnMapper(new ClobReaderColumnMapperFactory());
 
-        // legacy unqualified HSTORE
-        jdbi.registerArgument((ArgumentFactory) new HStoreArgumentFactory()::build);
-        jdbi.registerColumnMapper(new GenericType<Map<String, String>>() {}, new HStoreColumnMapper());
+        if (installLegacy) {
+            // legacy unqualified HSTORE
+            jdbi.registerArgument((ArgumentFactory) new HStoreArgumentFactory()::build);
+            jdbi.registerColumnMapper(new GenericType<Map<String, String>>() {}, new HStoreColumnMapper());
+        }
 
         // optional integration
         if (JdbiClassUtils.isPresent("org.jdbi.v3.json.JsonConfig")) {


### PR DESCRIPTION
The postgres plugin binds some hstore related things unqualified for legacy reasons.
This interferes with custom bindings. This change makes the legacy bindings configurable.

By default they are still enabled (backwards compatible).