### PR TITLE
Add Database metadata access through the handle

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -24,8 +24,10 @@ import org.jdbi.v3.core.config.Configurable;
 import org.jdbi.v3.core.extension.ExtensionMethod;
 import org.jdbi.v3.core.extension.Extensions;
 import org.jdbi.v3.core.extension.NoSuchExtensionException;
+import org.jdbi.v3.core.result.ResultBearing;
 import org.jdbi.v3.core.statement.Batch;
 import org.jdbi.v3.core.statement.Call;
+import org.jdbi.v3.core.statement.MetaData;
 import org.jdbi.v3.core.statement.PreparedBatch;
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.core.statement.Script;
@@ -290,6 +292,39 @@ public class Handle implements Closeable, Configurable<Handle> {
      */
     public Update createUpdate(String sql) {
         return new Update(this, sql);
+    }
+
+    /**
+     * Access database metadata that returns a {@link java.sql.ResultSet}. All methods of {@link org.jdbi.v3.core.result.ResultBearing} can be used to format
+     * and map the returned results.
+     *
+     * <pre>
+     *     List&lt;String&gt; catalogs = h.queryMetadata(DatabaseMetaData::getCatalogs)
+     *                                      .mapTo(String.class)
+     *                                      .list();
+     * </pre>
+     * <p>
+     * returns the list of catalogs from the current database.
+     *
+     * @param metadataFunction Maps the provided {@link java.sql.DatabaseMetaData} object onto a {@link java.sql.ResultSet} object.
+     * @return The metadata builder.
+     */
+    public ResultBearing queryMetadata(MetaData.MetaDataResultSetProvider metadataFunction) {
+        return new MetaData(this, metadataFunction);
+    }
+
+    /**
+     * Access all database metadata that returns simple values.
+     *
+     * <pre>
+     *     boolean supportsTransactions = handle.queryMetadata(DatabaseMetaData::supportsTransactions);
+     * </pre>
+     *
+     * @param metadataFunction Maps the provided {@link java.sql.DatabaseMetaData} object to a response object.
+     * @return The response object.
+     */
+    public <T> T queryMetadata(MetaData.MetaDataValueProvider<T> metadataFunction) {
+        return new MetaData(this, metadataFunction).execute();
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/MetaData.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/MetaData.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.result.ResultBearing;
+import org.jdbi.v3.core.result.ResultSetScanner;
+
+/**
+ * Access to Database Metadata.
+ */
+public final class MetaData extends BaseStatement<MetaData> implements ResultBearing {
+
+    private final Handle handle;
+    private final MetaDataValueProvider<?> metaDataFunction;
+
+    public MetaData(Handle handle, MetaDataValueProvider<?> metaDataFunction) {
+        super(handle);
+        this.handle = handle;
+        this.metaDataFunction = metaDataFunction;
+    }
+
+    @Override
+    public <R> R scanResultSet(ResultSetScanner<R> mapper) {
+        return ResultBearing.of(getResultSetSupplier(), getContext())
+            .scanResultSet(mapper);
+    }
+
+    public <R> R execute() {
+        try {
+            Connection connection = handle.getConnection();
+            return (R) metaDataFunction.provideValue(connection.getMetaData());
+        } catch (SQLException e) {
+            throw new UnableToRetrieveMetaDataException(e, getContext());
+        }
+    }
+
+    private Supplier<ResultSet> getResultSetSupplier() {
+        return () -> {
+            ResultSet rs = execute();
+            getContext().addCleanable(rs::close);
+            return rs;
+        };
+    }
+
+    @FunctionalInterface
+    public interface MetaDataValueProvider<T> {
+
+        T provideValue(DatabaseMetaData databaseMetaData) throws SQLException;
+    }
+
+    @FunctionalInterface
+    public interface MetaDataResultSetProvider extends MetaDataValueProvider<ResultSet> {
+
+        @Override
+        ResultSet provideValue(DatabaseMetaData databaseMetaData) throws SQLException;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/statement/UnableToRetrieveMetaDataException.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/UnableToRetrieveMetaDataException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+/**
+ * Thrown when {@code Jdbi} couldn't retrieve metadata from the connection.
+ */
+public class UnableToRetrieveMetaDataException extends StatementException {
+
+    private static final long serialVersionUID = 1L;
+
+    UnableToRetrieveMetaDataException(Exception cause, StatementContext ctx) {
+        super(cause, ctx);
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestSqlMetaData.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestSqlMetaData.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import java.sql.DatabaseMetaData;
+import java.util.List;
+import java.util.Locale;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.rule.H2DatabaseRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSqlMetaData {
+
+    @Rule
+    public H2DatabaseRule dbRule = new H2DatabaseRule().withSomething();
+
+    private Handle h;
+
+    @Before
+    public void setUp() {
+        h = dbRule.openHandle();
+    }
+
+    @After
+    public void doTearDown() {
+        if (h != null) {
+            h.close();
+        }
+    }
+
+    @Test
+    public void testQueryCatalogs() {
+
+        List<String> catalogNames = h.queryMetadata(DatabaseMetaData::getCatalogs)
+            .mapTo(String.class)
+            .list();
+
+        assertThat(catalogNames).hasSize(1);
+        String catalog = catalogNames.iterator().next().toLowerCase(Locale.ROOT);
+
+        String dbConnectionString = dbRule.getConnectionString().toLowerCase(Locale.ROOT);
+
+        assertThat(dbConnectionString).endsWith(catalog);
+
+    }
+
+    @Test
+    public void testSimple() {
+        String url = h.queryMetadata(DatabaseMetaData::getURL);
+        String dbConnectionString = dbRule.getConnectionString().toLowerCase(Locale.ROOT);
+
+        assertThat(dbConnectionString).isEqualTo(url);
+    }
+
+    @Test
+    public void testTransactions() {
+        boolean supportsTransactions = h.queryMetadata(DatabaseMetaData::supportsTransactions);
+
+        assertThat(supportsTransactions).isTrue();
+    }
+}

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2593,6 +2593,30 @@ With serializable isolation, one of the two transactions is forced to abort and
 retry. On the second go around, it calculates 10 + 20 + 30 = 60. Adding to 30
 from the other, we get 30 + 60 = 90 and the assertion succeeds.
 
+=== Metadata
+
+Jdbi allows access to the Database Metadata through `queryMetadata` methods on the link:{jdbidocs}/core/Handle.html[Handle^].
+
+Simple values can be queried directly using a method reference:
+
+[source, java]
+----
+String url = h.queryMetadata(DatabaseMetaData::getURL);
+boolean supportsTransactions = h.queryMetadata(DatabaseMetaData::supportsTransactions);
+----
+
+Many methods on the link:{jdkdocs}/java/sql/DatabaseMetaData.html[DatabaseMetaData^] return a link:{jdkdocs}/java/sql/ResultSet.html[ResultSet^]. These can be used with the `queryMetadata` method that returns a <<ResultBearing>>.
+
+All JDBI <<Row Mappers>> and <<Column Mappers>> are available to map these results:
+
+[source, java]
+----
+List<String> catalogNames = h.queryMetadata(DatabaseMetaData::getCatalogs)
+            .mapTo(String.class)
+            .list();
+----
+
+
 == Configuration
 
 `Jdbi` aims to be useful out of the box with minimal configuration.  Sometimes


### PR DESCRIPTION
Allows accessing any method in the Database metadata either through a ResultBearing or simple values.