### PR TITLE
Update a ton of libraries

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -29,7 +29,7 @@
         <basepom.check.skip-checkstyle>true</basepom.check.skip-checkstyle>
         <basepom.check.skip-pmd>true</basepom.check.skip-pmd>
         <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
-        <jmh.version>1.25</jmh.version>
+        <jmh.version>1.32</jmh.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <moduleName>org.jdbi.v3.benchmark</moduleName>
         <uberjar.name>benchmarks</uberjar.name>

--- a/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 
+import org.assertj.core.api.Assertions;
 import org.immutables.value.Value;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -57,6 +58,8 @@ public class ImmutablesTest {
         jdbi = dbRule.getJdbi();
         h = dbRule.getSharedHandle();
         h.execute("create table immutables (t int, x varchar)");
+
+        Assertions.setExtractBareNamePropertyMethods(true);
     }
 
     // tag::example[]

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -51,7 +51,6 @@
         <dependency>
             <groupId>com.squareup</groupId>
             <artifactId>javapoet</artifactId>
-            <version>1.9.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,10 @@
     <packaging>pom</packaging>
     <name>jdbi3 Parent</name>
     <description>Jdbi is designed to provide convenient tabular data access in
-        Java(tm). It uses the Java collections framework for query
-        results, provides a convenient means of externalizing sql
-        statements, and provides named parameter support for any database
-        being used.</description>
+    Java(tm). It uses the Java collections framework for query
+    results, provides a convenient means of externalizing sql
+    statements, and provides named parameter support for any database
+    being used.</description>
     <url>http://jdbi.org/</url>
 
     <licenses>
@@ -83,20 +83,21 @@
         <basepom.test.reuse-vm>true</basepom.test.reuse-vm>
         <basepom.test.timeout>240</basepom.test.timeout>
 
-        <dep.antlr.version>4.9</dep.antlr.version>
-        <dep.caffeine.version>3.0.2</dep.caffeine.version>
+        <dep.antlr.version>4.9.2</dep.antlr.version>
+        <dep.caffeine.version>3.0.3</dep.caffeine.version>
         <!-- required until https://github.com/checkstyle/checkstyle/issues/10355 is resolved -->
         <dep.checkstyle.version>8.43</dep.checkstyle.version>
         <dep.dokka.version>1.4.32</dep.dokka.version>
-        <dep.freebuilder.version>2.6.1</dep.freebuilder.version>
-        <dep.immutables.version>2.7.1</dep.immutables.version>
-        <dep.jackson2.version>2.10.1</dep.jackson2.version>
-        <dep.jetbrainsAnnotations.version>13.0</dep.jetbrainsAnnotations.version>
-        <dep.kotlin.version>1.5.0</dep.kotlin.version>
+        <dep.freebuilder.version>2.7.0</dep.freebuilder.version>
+        <dep.hsqldb.version>2.6.0</dep.hsqldb.version>
+        <dep.immutables.version>2.8.8</dep.immutables.version>
+        <dep.jackson2.version>2.10.5</dep.jackson2.version>
+        <dep.jetbrainsAnnotations.version>21.0.1</dep.jetbrainsAnnotations.version>
+        <dep.kotlin.version>1.5.21</dep.kotlin.version>
         <dep.plugin.flatten.version>1.2.2</dep.plugin.flatten.version>
-
         <dep.plugin.sortpom.version>2.8.0</dep.plugin.sortpom.version>
-        <dep.slf4j.version>1.7.25</dep.slf4j.version>
+        <dep.slf4j.version>1.7.30</dep.slf4j.version>
+        <dep.spring.version>5.3.8</dep.spring.version>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <project.build.targetJdk>8</project.build.targetJdk>
     </properties>
@@ -181,12 +182,6 @@
                 <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-spring5</artifactId>
                 <version>${project.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>commons-logging</artifactId>
-                        <groupId>commons-logging</groupId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>
@@ -228,8 +223,15 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>21.0</version>
+                <version>30.1.1-jre</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>checker-qual</artifactId>
+                        <groupId>org.checkerframework</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
+
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
@@ -239,12 +241,17 @@
                         <artifactId>error_prone_annotations</artifactId>
                         <groupId>com.google.errorprone</groupId>
                     </exclusion>
+                    <exclusion>
+                        <artifactId>checker-qual</artifactId>
+                        <groupId>org.checkerframework</groupId>
+                    </exclusion>
                 </exclusions>
             </dependency>
+
             <dependency>
                 <groupId>io.vavr</groupId>
                 <artifactId>vavr</artifactId>
-                <version>0.9.1</version>
+                <version>0.9.3</version>
             </dependency>
 
             <dependency>
@@ -267,13 +274,19 @@
 
             <dependency>
                 <groupId>org.springframework</groupId>
-                <artifactId>spring-jdbc</artifactId>
+                <artifactId>spring-core</artifactId>
                 <version>${dep.spring.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-beans</artifactId>
+                <version>${dep.spring.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-jdbc</artifactId>
                 <version>${dep.spring.version}</version>
             </dependency>
 
@@ -298,19 +311,19 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.5</version>
+                <version>2.8.7</version>
             </dependency>
 
             <dependency>
                 <groupId>com.squareup.moshi</groupId>
                 <artifactId>moshi</artifactId>
-                <version>1.11.0</version>
+                <version>1.12.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-core</artifactId>
-                <version>7.7.2</version>
+                <version>7.11.0</version>
             </dependency>
 
             <dependency>
@@ -322,19 +335,25 @@
             <dependency>
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
-                <version>2.3.2</version>
+                <version>${dep.hsqldb.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.2.8</version>
+                <version>42.2.22</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>checker-qual</artifactId>
+                        <groupId>org.checkerframework</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-pg-embedded</artifactId>
-                <version>0.13.1</version>
+                <version>0.13.4</version>
             </dependency>
 
             <dependency>
@@ -351,25 +370,31 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.1</version>
+                <version>4.13.2</version>
             </dependency>
 
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.23.0</version>
+                <version>3.11.2</version>
             </dependency>
 
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.12.2</version>
+                <version>3.20.2</version>
             </dependency>
 
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-guava</artifactId>
-                <version>3.2.1</version>
+                <version>3.4.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup</groupId>
+                <artifactId>javapoet</artifactId>
+                <version>1.13.0</version>
             </dependency>
 
             <dependency>
@@ -381,6 +406,12 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
+                <version>${dep.kotlin.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
                 <version>${dep.kotlin.version}</version>
             </dependency>
 
@@ -405,38 +436,38 @@
             <dependency>
                 <groupId>com.nhaarman</groupId>
                 <artifactId>mockito-kotlin</artifactId>
-                <version>1.3.0</version>
+                <version>1.6.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.6</version>
+                <version>1.9</version>
             </dependency>
 
             <!-- commons-text 1.6 wants 3.8.1, but otj-pg-embedded 0.13.0 wants 3.7 -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.8.1</version>
+                <version>3.12.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.xerial</groupId>
                 <artifactId>sqlite-jdbc</artifactId>
-                <version>3.8.11.2</version>
+                <version>3.36.0.1</version>
             </dependency>
 
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>ST4</artifactId>
-                <version>4.1</version>
+                <version>4.3.1</version>
             </dependency>
 
             <dependency>
                 <groupId>javax.annotation</groupId>
                 <artifactId>javax.annotation-api</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.2</version>
             </dependency>
 
             <dependency>
@@ -448,13 +479,13 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.9.3</version>
+                <version>2.9.9</version>
             </dependency>
 
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.28</version>
+                <version>2.3.31</version>
             </dependency>
 
             <dependency>
@@ -778,6 +809,17 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <!-- last JDK 8 compatible versions -->
+                <dep.caffeine.version>2.9.2</dep.caffeine.version>
+                <dep.hsqldb.version>2.5.2</dep.hsqldb.version>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/spring5/pom.xml
+++ b/spring5/pom.xml
@@ -26,7 +26,6 @@
     <url>http://jdbi.org/</url>
 
     <properties>
-        <dep.spring.version>5.3.5</dep.spring.version>
         <moduleName>org.jdbi.v3.spring5</moduleName>
     </properties>
 
@@ -38,7 +37,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>${dep.spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/src/build/ci-test.sh
+++ b/src/build/ci-test.sh
@@ -19,7 +19,7 @@ if [ "$JDK_VERSION" = "8" ]; then
         PATH=${OLD_PATH}
         JAVA_HOME=${OLD_JAVA_HOME}
         export JAVA_HOME PATH
-        exec mvn -Ddep.caffeine.version=2.8.0 -DargLine= surefire:test
+        exec mvn -DargLine= surefire:test
     fi
 fi
 


### PR DESCRIPTION
dependencies:

spring5 to 5.3.8
guava to 30.1.1-jre
antlr runtime to 4.9.2
caffeine to 3.0.3
freebuilder to 2.7.0
immutables to 2.8.8
jackson2 to 2.10.5 (latest 2.10)
jetbrains annotations to 21.0.1
kotlin to 1.5.20
slf4j to 1.7.30
moshi to 1.12.0
gson to 2.8.7
vavr to 0.9.3 (latest 0.9.x)

exclude checkerframework-qual as a dependency everywhere (only contains annotations)

tools:

dokka to 1.4.32
junit to 4.13.2
mockito to 3.11.2
assert4j-core to 3.20.2
assert4j-guava to 3.4.0
postgres driver to 4.2.22
hsqldb to 2.6.0
otj-pg-embedded to 0.13.4
flyway to 7.11
javapoet to 1.13.0
jmh to 1.32