### PR TITLE
Map `long` and `Long` arguments to `BIGINT`

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/BoxedArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/BoxedArgumentFactory.java
@@ -23,7 +23,7 @@ class BoxedArgumentFactory extends DelegatingArgumentFactory {
         register(Character.class, Types.CHAR, new ToStringBinder<>(PreparedStatement::setString));
         register(Short.class, Types.SMALLINT, PreparedStatement::setShort);
         register(Integer.class, Types.INTEGER, PreparedStatement::setInt);
-        register(Long.class, Types.INTEGER, PreparedStatement::setLong);
+        register(Long.class, Types.BIGINT, PreparedStatement::setLong);
         register(Float.class, Types.FLOAT, PreparedStatement::setFloat);
         register(Double.class, Types.DOUBLE, PreparedStatement::setDouble);
     }

--- a/core/src/main/java/org/jdbi/v3/core/argument/PrimitivesArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/PrimitivesArgumentFactory.java
@@ -28,7 +28,7 @@ class PrimitivesArgumentFactory extends DelegatingArgumentFactory {
         register(char.class, Types.CHAR, new ToStringBinder<>(PreparedStatement::setString));
         register(short.class, Types.SMALLINT, PreparedStatement::setShort);
         register(int.class, Types.INTEGER, PreparedStatement::setInt);
-        register(long.class, Types.INTEGER, PreparedStatement::setLong);
+        register(long.class, Types.BIGINT, PreparedStatement::setLong);
         register(float.class, Types.FLOAT, PreparedStatement::setFloat);
         register(double.class, Types.DOUBLE, PreparedStatement::setDouble);
     }

--- a/core/src/test/java/org/jdbi/v3/core/argument/PrimitivesArgumentFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/PrimitivesArgumentFactoryTest.java
@@ -51,5 +51,9 @@ public class PrimitivesArgumentFactoryTest {
         assertThat(handle.createQuery("select :foo").bindByType("foo", null, Integer.class).mapTo(Integer.class).one())
             .describedAs("binding a null to a boxed type is fine")
             .isNull();
+
+        assertThat(handle.createQuery("select :foo").bindByType("foo", null, Long.class).mapTo(Long.class).one())
+            .describedAs("binding a null to a boxed type is fine")
+            .isNull();
     }
 }


### PR DESCRIPTION
The SQL type `INTEGER` often (always?) maps to integer types which are only 32 bits (4 bytes) long while `BIGINT` maps to integer types which are 64 bits (8 bytes) long.

Considering this, mapping the Java types `long` and `Long` to the SQL type `BIGINT` instead of `INTEGER` seems to make more sense.

This is also consistent with the handling of `OptionalLong` in Jdbi:
https://github.com/jdbi/jdbi/blob/ee22bb85a6971737181a4b231cce4dbd55de8734/core/src/main/java/org/jdbi/v3/core/argument/OptionalArgumentFactory.java#L38-L44

FWIW, this is motivated by a bug we discovered in CockroachDB when sending `NULL` values in a prepared statement which were sent as `NULL::INT4` by Jdbi 3.20.1 instead of `NULL::INT8` for a column declared as `INT8`:
https://github.com/cockroachdb/cockroach/issues/67605