### PR TITLE
Update to basepom-40

### DIFF
--- a/policy/pom.xml
+++ b/policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>basepom-oss</artifactId>
         <groupId>org.basepom</groupId>
-        <version>36</version>
+        <version>40</version>
         <relativePath />
     </parent>
 

--- a/policy/src/main/resources/policy/spotbugs-exclude.xml
+++ b/policy/src/main/resources/policy/spotbugs-exclude.xml
@@ -21,4 +21,8 @@
     <Match>
         <Package name="~.*\.generated" />
     </Match>
+    <!-- spotbugs 4.3.0 made this very aggressive and less useful -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>basepom-oss</artifactId>
         <groupId>org.basepom</groupId>
-        <version>39</version>
+        <version>40</version>
     </parent>
 
     <groupId>org.jdbi</groupId>
@@ -85,6 +85,8 @@
 
         <dep.antlr.version>4.9</dep.antlr.version>
         <dep.caffeine.version>3.0.2</dep.caffeine.version>
+        <!-- required until https://github.com/checkstyle/checkstyle/issues/10355 is resolved -->
+        <dep.checkstyle.version>8.43</dep.checkstyle.version>
         <dep.dokka.version>1.4.32</dep.dokka.version>
         <dep.freebuilder.version>2.6.1</dep.freebuilder.version>
         <dep.immutables.version>2.7.1</dep.immutables.version>


### PR DESCRIPTION
- needs to downgrade checkstyle to 8.43 b/c checkstyle/checkstyle #10355
- turns off agressive EI_EXPOSE_REP and EI_EXPOSE_REP2 rules in
  spotbugs 4.3.0