### PR TITLE
Update Travis CI badge URL from `travis-ci.org` to `travis-ci.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Jdbi Logo](docs/src/adoc/images/logo.svg)
 
-[![Build Status](https://travis-ci.org/jdbi/jdbi.svg?branch=master)](https://travis-ci.org/jdbi/jdbi)
+[![Build Status](https://api.travis-ci.com/jdbi/jdbi.svg?branch=master)](https://travis-ci.com/github/jdbi/jdbi)
 
 The Jdbi library provides convenient, idiomatic access to relational databases
 in Java.


### PR DESCRIPTION
The old badge image URL redirects to `api.travis-ci.com`, so I've used that instead.
The old badge URL redirects to `/github/jdbi/jdbi`, instead of just `/jdbi/jdbi`, so I've used the former instead.