### PR TITLE
Use compiled regex for replacing snake case column names

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/SnakeCaseColumnNameMatcher.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/SnakeCaseColumnNameMatcher.java
@@ -13,12 +13,16 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
+import java.util.regex.Pattern;
+
 /**
  * Matches snake case column names to java camel case names, ignoring case.
  * <p>
  * Example: column names {@code first_name} or {@code FIRST_NAME} would match java name {@code firstName}.
  */
 public class SnakeCaseColumnNameMatcher implements ColumnNameMatcher {
+    private static final Pattern REPLACE_PATTERN = Pattern.compile("_");
+
     @Override
     public boolean columnNameMatches(String columnName, String javaName) {
         return removeUnderscores(columnName).equalsIgnoreCase(removeUnderscores(javaName));
@@ -31,7 +35,7 @@ public class SnakeCaseColumnNameMatcher implements ColumnNameMatcher {
     }
 
     private String removeUnderscores(String string) {
-        return string.replace("_", "");
+        return REPLACE_PATTERN.matcher(string).replaceAll("");
     }
 
     @Override


### PR DESCRIPTION
First of all, thanks for the library.

The idea of this PR comes from analyzing an internal system with JFR/JMC. I can see that the `Pattern` object that results from `removeUnderscores` seems to be created frequently. Below is a 5 minute sample of the system:
![image](https://user-images.githubusercontent.com/2695819/137394971-e5cf924d-2b10-4e94-926e-f2cadcc43967.png)


This should reduce the `Pattern` object creation, reducing the overall impact in GC.