### PR TITLE
Fix xml validation error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -721,7 +721,7 @@
                             <version>${project.version}</version>
                         </dependency>
                     </dependencies>
-                    <configuration combine.children="append">
+                    <configuration>
                         <includeFilterFile>policy/spotbugs-include.xml</includeFilterFile>
                         <excludeFilterFile>policy/spotbugs-exclude.xml</excludeFilterFile>
                     </configuration>


### PR DESCRIPTION
> cvc-complex-type.3.2.2: Attribute 'combine.children' is not allowed to appear in element 'configuration'.