### PR TITLE
Json: rework inner @Json String binding to be @EncodedJson String

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
 # Unreleased
+  - *SPI change* `@Json String` database type mappers now use `@EncodedJson String` instead (#1953)
 
 # 3.24.1
   - fix Bean property arguments type being erased on generic beans

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -4249,19 +4249,20 @@ jdbi.getConfig(MoshiConfig.class).setMoshi(myMoshi);
 
 ==== Operation
 
-Any bound object qualified as link:{jdbidocs}/json/Json.html[@Json^] — except `String` —
+Any bound object qualified as link:{jdbidocs}/json/Json.html[@Json^]
 will be converted by the link:{jdbidocs}/json/JsonConfig.html[registered^]
-link:{jdbidocs}/json/JsonMapper.html[JsonMapper^] and _requalified_ as `@Json String`.
-A correspondingly qualified `ArgumentFactory` will then be called to store the JSON data,
+link:{jdbidocs}/json/JsonMapper.html[JsonMapper^] and _requalified_ as
+link:{jdbidocs}/json/EncodedJson.html[@EncodedJson^] `String`.
+A corresponding `@EncodedJson ArgumentFactory` will then be called to store the JSON data,
 allowing special JSON handling for your database to be implemented.
 If none are found, a factory for plain `String` will be used instead, to handle the JSON as plaintext.
 
 Mapping works just the same way, but in reverse: an output type qualified as `@Json T` will be fetched from a
-`@Json String` or `String` ColumnMapper, and then passed through the `JsonMapper`.
+`@EncodedJson String` or `String` ColumnMapper, and then passed through the `JsonMapper`.
 
 [TIP]
 Our PostgresPlugin provides qualified factories that will
-bind/map the `@Json String` to/from `json` or `jsonb`-typed columns.
+bind/map the `@EncodedJson String` to/from `json` or `jsonb`-typed columns.
 
 ==== Usage
 

--- a/jackson2/src/test/java/org/jdbi/v3/jackson2/TestJackson2Plugin.java
+++ b/jackson2/src/test/java/org/jdbi/v3/jackson2/TestJackson2Plugin.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.jackson2;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -27,6 +28,7 @@ import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
 import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
 import org.immutables.value.Value;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.immutables.JdbiImmutables;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.json.AbstractJsonMapperTest;
@@ -216,4 +218,14 @@ public class TestJackson2Plugin extends AbstractJsonMapperTest {
     }
 
     private interface ExtendingDao extends GenericContainingDao<A> {}
+
+    @Test
+    public void jsonbSet() {
+        assertThat(
+                h.createQuery("select jsonb_set('{}', '{val}', :val)")
+                    .bindByType("val", "testing", QualifiedType.of(String.class).with(Json.class))
+                    .mapTo(QualifiedType.of(new GenericType<Map<String, String>>() {}).with(Json.class))
+                    .one())
+            .isEqualTo(Collections.singletonMap("val", "testing"));
+    }
 }

--- a/json/src/main/java/org/jdbi/v3/json/EncodedJson.java
+++ b/json/src/main/java/org/jdbi/v3/json/EncodedJson.java
@@ -21,9 +21,9 @@ import java.lang.annotation.Target;
 import org.jdbi.v3.core.qualifier.Qualifier;
 
 /**
- * Type qualifying annotation for converting Java types to {@code json} data type.
+ * Type qualifying annotation for pre-encoded {@code json} data.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
 @Qualifier
-public @interface Json {}
+public @interface EncodedJson {}

--- a/json/src/main/java/org/jdbi/v3/json/internal/JsonColumnMapperFactory.java
+++ b/json/src/main/java/org/jdbi/v3/json/internal/JsonColumnMapperFactory.java
@@ -23,6 +23,7 @@ import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.result.UnableToProduceResultException;
+import org.jdbi.v3.json.EncodedJson;
 import org.jdbi.v3.json.Json;
 import org.jdbi.v3.json.JsonConfig;
 import org.jdbi.v3.json.JsonMapper;
@@ -39,13 +40,10 @@ public class JsonColumnMapperFactory implements ColumnMapperFactory {
 
     @Override
     public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
-        if (String.class.equals(type)) {
-            return Optional.empty();
-        }
         ColumnMappers cm = config.get(ColumnMappers.class);
         // look for specialized json support first, revert to simple String mapping if absent
         ColumnMapper<String> jsonStringMapper = JdbiOptionals.findFirstPresent(
-                () -> cm.findFor(QualifiedType.of(String.class).with(Json.class)),
+                () -> cm.findFor(QualifiedType.of(String.class).with(EncodedJson.class)),
                 () -> cm.findFor(String.class))
                 .orElseThrow(() -> new UnableToProduceResultException(JSON_NOT_RETRIEVABLE));
 

--- a/postgres/src/main/java/org/jdbi/v3/postgres/JsonArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/JsonArgumentFactory.java
@@ -18,9 +18,9 @@ import java.sql.Types;
 import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.json.Json;
+import org.jdbi.v3.json.EncodedJson;
 
-@Json
+@EncodedJson
 class JsonArgumentFactory extends AbstractArgumentFactory<String> {
     JsonArgumentFactory() {
         super(Types.OTHER);


### PR DESCRIPTION
This allows you to actually bind a @Json String which users intuitively expect to be able to do.
Fixes #1953