### PR TITLE
Slf4JSqlLogger: avoid NPE when used with Script

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Unreleased
   - *SPI change* `@Json String` database type mappers now use `@EncodedJson String` instead (#1953)
+  - Sql4JSqlLogger: fix NPE when using Script
 
 # 3.24.1
   - fix Bean property arguments type being erased on generic beans

--- a/core/src/main/java/org/jdbi/v3/core/statement/Slf4JSqlLogger.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Slf4JSqlLogger.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.statement;
 
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,9 @@ public class Slf4JSqlLogger implements SqlLogger {
     public void logException(StatementContext context, SQLException ex) {
         if (log.isErrorEnabled()) {
             log.error("Exception while executing '{}' with parameters '{}'",
-                    context.getParsedSql().getSql(),
+                    Optional.ofNullable(context.getParsedSql())
+                            .map(ParsedSql::getSql)
+                            .orElse("<not available>"),
                     context.getBinding(),
                     ex);
         }


### PR DESCRIPTION
Fixes #1961