### PR TITLE
Fix issue #1971

### DIFF
--- a/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/RegisterKotlinMappers.kt
+++ b/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/RegisterKotlinMappers.kt
@@ -17,5 +17,5 @@ import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation
 
 @Retention(AnnotationRetention.RUNTIME)
 @ConfiguringAnnotation(RegisterKotlinMappersImpl::class)
-@Target(AnnotationTarget.TYPE, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 annotation class RegisterKotlinMappers(vararg val value: RegisterKotlinMapper)


### PR DESCRIPTION
This change is aimed to fix the issue https://github.com/jdbi/jdbi/issues/1971

`AnnotationTarget.CLASS` includes interfaces, while `AnnotationTarget.TYPE` does not.

Added a test that would fail if the RegisterKotlinMappers for Dao interfaces will break.