### PR TITLE
Use instance configured ConfigRegistry correctly

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -93,10 +93,8 @@ public class SqlObjectFactory implements ExtensionFactory, OnDemandExtensions.Fa
      */
     @Override
     public <E> E attach(Class<E> extensionType, HandleSupplier handle) {
-        ConfigRegistry instanceConfig = handle.getConfig().createCopy();
-
-        SqlObjectInitData data = sqlObjectCache.get(extensionType, handle.getConfig());
-        data.configureInstance(instanceConfig);
+        final SqlObjectInitData data = sqlObjectCache.get(extensionType, handle.getConfig());
+        final ConfigRegistry instanceConfig = data.configureInstance(handle.getConfig().createCopy());
 
         if (data.isConcrete()) {
             return data.instantiate(extensionType, handle, instanceConfig);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/SqlObjectInitData.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/SqlObjectInitData.java
@@ -112,8 +112,8 @@ public final class SqlObjectInitData {
         }
     }
 
-    public void configureInstance(ConfigRegistry config) {
-        instanceConfigurer.apply(config);
+    public ConfigRegistry configureInstance(ConfigRegistry config) {
+        return instanceConfigurer.apply(config);
     }
 
     public void forEachMethodHandler(BiConsumer<Method, Handler> action) {


### PR DESCRIPTION
There is a minor correctness issue if a caller would register an
instance configurer that does not return itself but e.g. a modified
copy of the registry. This was actually found by error prone.