### PR TITLE
PrepareBatch for every attempt in SqlBatchHandler

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
@@ -13,6 +13,19 @@
  */
 package org.jdbi.v3.sqlobject.statement.internal;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.HandleSupplier;
@@ -31,20 +44,6 @@ import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> {
     private final SqlBatch sqlBatch;
@@ -198,8 +197,7 @@ public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> 
                 // execute a single chunk and buffer
                 List<Object[]> currArgs = new ArrayList<>();
                 for (int i = 0; i < chunkSize && batchArgs.hasNext(); i++) {
-                    Object[] batchArg = batchArgs.next();
-                    currArgs.add(Arrays.copyOf(batchArg, batchArg.length));
+                    currArgs.add(batchArgs.next());
                 }
                 Supplier<PreparedBatch> preparedBatchSupplier = () -> createPreparedBatch(handle, sql, currArgs);
                 return executeBatch(handle, preparedBatchSupplier);
@@ -316,7 +314,6 @@ public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> 
                     + " did you mean @SqlQuery?", null, null);
         }
 
-        final Object[] sharedArg = new Object[args.length];
         return new Iterator<Object[]>() {
             @Override
             public boolean hasNext() {
@@ -330,6 +327,7 @@ public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> 
 
             @Override
             public Object[] next() {
+                final Object[] sharedArg = new Object[args.length];
                 for (int i = 0; i < extras.size(); i++) {
                     sharedArg[i] = extras.get(i).next();
                 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
@@ -13,16 +13,6 @@
  */
 package org.jdbi.v3.sqlobject.statement.internal;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.Type;
-import java.util.*;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.HandleSupplier;
@@ -41,6 +31,20 @@ import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> {
     private final SqlBatch sqlBatch;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
@@ -327,11 +327,11 @@ public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> 
 
             @Override
             public Object[] next() {
-                final Object[] sharedArg = new Object[args.length];
+                final Object[] argsArray = new Object[args.length];
                 for (int i = 0; i < extras.size(); i++) {
-                    sharedArg[i] = extras.get(i).next();
+                    argsArray[i] = extras.get(i).next();
                 }
-                return sharedArg;
+                return argsArray;
             }
         };
     }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
@@ -13,6 +13,11 @@
  */
 package org.jdbi.v3.sqlobject;
 
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
@@ -32,12 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
 import static java.util.Collections.emptySet;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -193,8 +194,8 @@ public class TestBatching {
         Jdbi jdbi = h2Extension.getJdbi();
         jdbi.setTransactionHandler(new SerializableTransactionRunner());
 
-        jdbi.useHandle(handle -> {
-            Handle spyHandle = spy(handle);
+        jdbi.useHandle(jdbiHandle -> {
+            Handle spyHandle = spy(jdbiHandle);
             given(spyHandle.commit()).willAnswer(invocation -> {
                 throw new SQLException("Test exception", "40001");
             }).willCallRealMethod();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
@@ -33,17 +33,15 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.spy;
 
 public class TestBatching {
 


### PR DESCRIPTION
Fixes #1967 . When SQLBatchHandler is used in conjuction with SerializableTransactionRunner (retry on failure), subsequent retry has the binding for PreparedBatch cleared. Therefore, make a copy of the binding arguments before executing and this ensures the binding's are not cleared.

