### PR TITLE
inline plugin experiment

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,10 +44,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -71,6 +67,12 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -138,6 +140,23 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>inline-maven-plugin</artifactId>
+                    <version>0.1</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>inline</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.antlr</groupId>
@@ -151,8 +170,23 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>inline-maven-plugin</artifactId>
+                <configuration>
+                    <prefix>org.jdbi.relocated</prefix>
+                    <inlineDependencies>
+                        <inlineDependency>
+                            <groupId>org.antlr</groupId>
+                            <artifactId>antlr4-runtime</artifactId>
+                            <hideClasses>true</hideClasses>
+                        </inlineDependency>
+                    </inlineDependencies>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>jdk8</id>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -145,7 +145,7 @@
                 <plugin>
                     <groupId>org.basepom.maven</groupId>
                     <artifactId>inline-maven-plugin</artifactId>
-                    <version>0.1</version>
+                    <version>0.3</version>
                     <executions>
                         <execution>
                             <phase>package</phase>
@@ -175,11 +175,12 @@
                 <artifactId>inline-maven-plugin</artifactId>
                 <configuration>
                     <prefix>org.jdbi.relocated</prefix>
+                    <requireOptional>false</requireOptional>
+                    <requireProvided>false</requireProvided>
+                    <hideClasses>true</hideClasses>
                     <inlineDependencies>
                         <inlineDependency>
-                            <groupId>org.antlr</groupId>
-                            <artifactId>antlr4-runtime</artifactId>
-                            <hideClasses>true</hideClasses>
+                            <artifact>org.antlr:antlr4-runtime</artifact>
                         </inlineDependency>
                     </inlineDependencies>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dep.junit5.version>5.8.2</dep.junit5.version>
         <dep.kotlin.version>1.6.10</dep.kotlin.version>
         <dep.mockito.version>4.2.0</dep.mockito.version>
-        <dep.pg-embedded.version>4.1</dep.pg-embedded.version>
+        <dep.pg-embedded.version>4.2-SNAPSHOT</dep.pg-embedded.version>
         <dep.plugin.detekt.version>1.19.0</dep.plugin.detekt.version>
         <dep.plugin.flatten.version>1.2.2</dep.plugin.flatten.version>
         <dep.plugin.ktlint.version>1.11.2</dep.plugin.ktlint.version>


### PR DESCRIPTION
This is a highly experimental build that inlines the antlr4-runtime into the jdbi3-core plugin. 

The build passes all the tests but might need a bit more baking before we could mainline this. If you want to try it out, check out this branch, build locally and then build your service / application etc. using the -SNAPSHOT jars. Please report any errors etc. here. 

See https://github.com/basepom/inline-maven-plugin for more information about the inline plugin.