### PR TITLE
Remove antlr4-runtime dependency

### DIFF
--- a/.github/workflows/versions-check.yml
+++ b/.github/workflows/versions-check.yml
@@ -9,30 +9,6 @@ on:
     - master
 
 jobs:
-  antlr:
-    name: Test antlr runtime versions
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        test-version: [ 4.9, 4.9.1, 4.9.2, 4.9.3 ]
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-java@v2
-      id: setup_jdk
-      name: Setup JDK
-      with:
-        java-version: 17
-        distribution: temurin
-        cache: maven
-
-    - name: Build
-      run: |
-          ./mvnw -B -DskipTests -Dbasepom.check.skip-all=true clean install
-          ./mvnw -B -Ddep.antlr.version=${{ matrix.test-version }} -DargLine= surefire:test
-
   guava:
     name: Test Guava versions
     runs-on: ubuntu-latest

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
 # Unreleased
+  - Remove the antlr4-runtime dependency by inlining it into the core jar.
 
 # 3.27.2
   - Fix NPE in SqlLogger#logAfterExecution when query string is not available (#2000), thanks @tmichel!

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -151,6 +151,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>inline-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>inline</goal>
+                        </goals>
+                        <configuration>
+                            <prefix>org.jdbi.v3.core.inlined</prefix>
+                            <inlineDependencies>
+                                <inlineDependency>
+                                    <artifact>org.antlr:antlr4-runtime</artifact>
+                                </inlineDependency>
+                            </inlineDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <basepom.test.reuse-vm>true</basepom.test.reuse-vm>
         <basepom.test.timeout>240</basepom.test.timeout>
 
-        <dep.antlr.version>4.9.2</dep.antlr.version>
+        <dep.antlr.version>4.9.3</dep.antlr.version>
         <dep.caffeine.version>3.0.3</dep.caffeine.version>
         <dep.dokka.version>1.6.0</dep.dokka.version>
         <dep.freebuilder.version>2.7.0</dep.freebuilder.version>
@@ -102,6 +102,7 @@
         <dep.pg-embedded.version>4.1</dep.pg-embedded.version>
         <dep.plugin.detekt.version>1.19.0</dep.plugin.detekt.version>
         <dep.plugin.flatten.version>1.2.2</dep.plugin.flatten.version>
+        <dep.plugin.inline.version>1.0.1</dep.plugin.inline.version>
         <dep.plugin.ktlint.version>1.11.2</dep.plugin.ktlint.version>
         <dep.plugin.scm-publish.version>3.1.0</dep.plugin.scm-publish.version>
         <dep.plugin.sortpom.version>2.8.0</dep.plugin.sortpom.version>
@@ -790,6 +791,16 @@
                             <distributionManagement>remove</distributionManagement>
                             <repositories>remove</repositories>
                         </pomElements>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>inline-maven-plugin</artifactId>
+                    <version>${dep.plugin.inline.version}</version>
+
+                    <configuration>
+                        <prefix>org.jdbi.v3.inlined</prefix>
+                        <hideClasses>true</hideClasses>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Inline the dependency into the core jar. This removes the long
standing problem that jdbi creates version conflicts when used in
projects that also use antlr4 and that use a different runtime
version. Unfortunately antlr insists on a strong relationship between
the generated classes for the grammar and the runtime.

Inlining this dependency makes allows JDBI users to choose their antlr
version arbitrarily as JDBI will use its private version.