### PR TITLE
Allow FieldMapper to use inaccessible default constructors

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -201,9 +202,12 @@ public class FieldMapper<T> implements RowMapper<T> {
         return format("%s.%s", type.getSimpleName(), field.getName());
     }
 
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private T construct() {
         try {
-            return type.getDeclaredConstructor().newInstance();
+            Constructor<T> ctor = type.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            return ctor.newInstance();
         } catch (ReflectiveOperationException e) {
             throw new IllegalArgumentException(format("A type, %s, was mapped which was not instantiable", type.getName()), e);
         }

--- a/core/src/test/java/org/jdbi/v3/core/SamplePrivateBean.java
+++ b/core/src/test/java/org/jdbi/v3/core/SamplePrivateBean.java
@@ -23,9 +23,7 @@ public class SamplePrivateBean {
     BigDecimal privateBigDecimalField;
     ValueType valueTypeField;
 
-    private SamplePrivateBean() {
-
-    }
+    private SamplePrivateBean() {}
 
     public Long getLongField() {
         return longField;

--- a/core/src/test/java/org/jdbi/v3/core/SamplePrivateBean.java
+++ b/core/src/test/java/org/jdbi/v3/core/SamplePrivateBean.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jdbi.v3.core;
+
+import java.math.BigDecimal;
+
+public class SamplePrivateBean {
+    private Long longField;
+    protected String protectedStringField;
+    public int packagePrivateIntField;
+    BigDecimal privateBigDecimalField;
+    ValueType valueTypeField;
+
+    private SamplePrivateBean() {
+
+    }
+
+    public Long getLongField() {
+        return longField;
+    }
+
+    public void setLongField(Long longField) {
+        this.longField = longField;
+    }
+
+    public String getProtectedStringField() {
+        return protectedStringField;
+    }
+
+    protected void setProtectedStringField(String protectedStringField) {
+        this.protectedStringField = protectedStringField;
+    }
+
+    public int getPackagePrivateIntField() {
+        return packagePrivateIntField;
+    }
+
+    /* default */ void setPackagePrivateIntField(int packagePrivateIntField) {
+        this.packagePrivateIntField = packagePrivateIntField;
+    }
+
+    public BigDecimal getPrivateBigDecimalField() {
+        return privateBigDecimalField;
+    }
+
+    @SuppressWarnings("unused")
+    private void setPrivateBigDecimalField(BigDecimal privateBigDecimalField) {
+        this.privateBigDecimalField = privateBigDecimalField;
+    }
+
+    public ValueType getValueTypeField() {
+        return valueTypeField;
+    }
+
+    public void setValueTypeField(ValueType valueTypeField) {
+        this.valueTypeField = valueTypeField;
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperPrivateMockTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperPrivateMockTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper.reflect;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.HandleAccess;
+import org.jdbi.v3.core.SamplePrivateBean;
+import org.jdbi.v3.core.ValueType;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.mapper.ValueTypeMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.StatementContextAccess;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FieldMapperPrivateMockTest {
+
+    @Mock
+    ResultSet resultSet;
+
+    @Mock
+    ResultSetMetaData resultSetMetaData;
+
+    Handle handle;
+    StatementContext ctx;
+
+    RowMapper<SamplePrivateBean> mapper = FieldMapper.of(SamplePrivateBean.class);
+
+    @BeforeEach
+    public void setUpMocks() throws SQLException {
+        handle = HandleAccess.createHandle();
+        ctx = StatementContextAccess.createContext(handle);
+        when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+    }
+
+    private void mockColumns(String... columns) throws SQLException {
+        when(resultSetMetaData.getColumnCount()).thenReturn(columns.length);
+        for (int i = 0; i < columns.length; i++) {
+            when(resultSetMetaData.getColumnLabel(i + 1)).thenReturn(columns[i]);
+        }
+    }
+
+    @Test
+    public void shouldSetValueOnPrivateField() throws Exception {
+        mockColumns("longField");
+
+        Long aLongVal = 100L;
+        when(resultSet.getLong(1)).thenReturn(aLongVal);
+        when(resultSet.wasNull()).thenReturn(false);
+
+        SamplePrivateBean sampleBean = mapper.map(resultSet, ctx);
+
+        assertThat(sampleBean.getLongField()).isEqualTo(aLongVal);
+    }
+
+    @Test
+    public void shouldHandleEmptyResult() throws Exception {
+        mockColumns();
+
+        SamplePrivateBean sampleBean = mapper.map(resultSet, ctx);
+
+        assertThat(sampleBean).isNotNull();
+    }
+
+    @Test
+    public void shouldBeCaseInSensitiveOfColumnAndFieldNames() throws Exception {
+        mockColumns("LoNgfielD");
+
+        Long aLongVal = 100L;
+        when(resultSet.getLong(1)).thenReturn(aLongVal);
+        when(resultSet.wasNull()).thenReturn(false);
+
+        SamplePrivateBean sampleBean = mapper.map(resultSet, ctx);
+
+        assertThat(sampleBean.getLongField()).isEqualTo(aLongVal);
+
+    }
+
+    @Test
+    public void shouldHandleNullValue() throws Exception {
+        mockColumns("LoNgfielD");
+
+        when(resultSet.getLong(1)).thenReturn(0L);
+        when(resultSet.wasNull()).thenReturn(true);
+
+        SamplePrivateBean sampleBean = mapper.map(resultSet, ctx);
+
+        assertThat(sampleBean.getLongField()).isNull();
+    }
+
+    @Test
+    public void shouldThrowOnTotalMismatch() throws Exception {
+        mockColumns("somethingElseEntirely");
+        assertThatThrownBy(() -> mapper.map(resultSet, ctx)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void shouldSetValuesOnAllFieldAccessTypes() throws Exception {
+        mockColumns("longField", "protectedStringField", "packagePrivateIntField", "privateBigDecimalField");
+
+        Long aLongVal = 100L;
+        String aStringVal = "something";
+        int aIntVal = 1;
+        BigDecimal aBigDecimal = BigDecimal.TEN;
+        when(resultSet.getLong(1)).thenReturn(aLongVal);
+        when(resultSet.getString(2)).thenReturn(aStringVal);
+        when(resultSet.getInt(3)).thenReturn(aIntVal);
+        when(resultSet.getBigDecimal(4)).thenReturn(aBigDecimal);
+        when(resultSet.wasNull()).thenReturn(false);
+
+        SamplePrivateBean sampleBean = mapper.map(resultSet, ctx);
+
+        assertThat(sampleBean.getLongField()).isEqualTo(aLongVal);
+        assertThat(sampleBean.getPrivateBigDecimalField()).isEqualTo(aBigDecimal);
+        assertThat(sampleBean.getPackagePrivateIntField()).isEqualTo(aIntVal);
+        assertThat(sampleBean.getProtectedStringField()).isEqualTo(aStringVal);
+    }
+
+    @Test
+    public void shouldSetValuesInSuperClassFields() throws Exception {
+        mockColumns("longField", "blongField");
+
+        Long aLongVal = 100L;
+        Long bLongVal = 200L;
+
+        when(resultSet.getLong(1)).thenReturn(aLongVal);
+        when(resultSet.getLong(2)).thenReturn(bLongVal);
+        when(resultSet.wasNull()).thenReturn(false);
+
+        DerivedBean derivedBean = FieldMapper.of(DerivedBean.class).map(resultSet, ctx);
+
+        assertThat(derivedBean.getLongField()).isEqualTo(aLongVal);
+        assertThat(derivedBean.getBlongField()).isEqualTo(bLongVal);
+    }
+
+    @Test
+    public void shouldUseRegisteredMapperForUnknownPropertyType() throws Exception {
+        handle.registerColumnMapper(new ValueTypeMapper());
+
+        mockColumns("longField", "valueTypeField");
+
+        when(resultSet.getLong(1)).thenReturn(123L);
+        when(resultSet.getString(2)).thenReturn("foo");
+        when(resultSet.wasNull()).thenReturn(false);
+
+        SamplePrivateBean sampleBean = mapper.map(resultSet, ctx);
+
+        Long expected = 123L;
+        assertThat(sampleBean.getLongField()).isEqualTo(expected);
+        assertThat(sampleBean.getValueTypeField()).isEqualTo(ValueType.valueOf("foo"));
+    }
+
+    @Test
+    public void shouldThrowOnPropertyTypeWithoutRegisteredMapper() throws Exception {
+        mockColumns("longField", "valueTypeField");
+
+        when(resultSet.getLong(1)).thenReturn(123L);
+        when(resultSet.getObject(2)).thenReturn(new Object());
+        when(resultSet.wasNull()).thenReturn(false);
+
+        assertThatThrownBy(() -> mapper.map(resultSet, ctx)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    public void shouldNotThrowOnMismatchedColumns() throws Exception {
+        mockColumns("longField", "extraColumn");
+
+        Long expected = 666L;
+        when(resultSet.getLong(1)).thenReturn(expected);
+        when(resultSet.getString(2)).thenReturn("foo");
+
+        SamplePrivateBean sampleBean = mapper.map(resultSet, ctx);
+
+        assertThat(sampleBean.getLongField()).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldThrowOnMismatchedColumnsStrictMatch() throws Exception {
+        ctx.getConfig(ReflectionMappers.class).setStrictMatching(true);
+        mockColumns("longField", "misspelledField");
+        assertThatThrownBy(() -> mapper.map(resultSet, ctx)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperPrivateMockTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperPrivateMockTest.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleAccess;
 import org.jdbi.v3.core.SamplePrivateBean;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperPrivateMockTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperPrivateMockTest.java
@@ -13,6 +13,10 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleAccess;
 import org.jdbi.v3.core.SamplePrivateBean;
@@ -28,11 +32,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
-import java.math.BigDecimal;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;


### PR DESCRIPTION
Currently, the FieldMapper requires the default constructor be public in order to instantiate a new instance prior to setting the fields. The FieldMapper already allows private fields to be set via reflection, so it makes sense that it should work with private constructors as well. 

Making a constructor private provides the benefit of preventing its use outside of reflective mapping.