### PR TITLE
Java language migration updates

### DIFF
--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/BeanBindingBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/BeanBindingBenchmark.java
@@ -190,7 +190,7 @@ public class BeanBindingBenchmark {
     public String randomString(int targetStringLength) {
         return random.ints('a', 'z')
             .limit(targetStringLength)
-            .mapToObj(c -> Character.valueOf((char) c))
+            .mapToObj(c -> (char) c)
             .reduce("", (buf, chr) -> buf + chr, (a, b) -> a + b);
     }
 

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/TestContent.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/TestContent.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.benchmark.sqlobject;
 
+import java.util.Objects;
 import java.util.StringJoiner;
 
 public final class TestContent {
@@ -46,10 +47,10 @@ public final class TestContent {
 
         final TestContent that = (TestContent) o;
 
-        if (name != null ? !name.equals(that.name) : that.name != null) {
+        if (!Objects.equals(name, that.name)) {
             return false;
         }
-        return description != null ? description.equals(that.description) : that.description == null;
+        return Objects.equals(description, that.description);
     }
 
     @Override

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/TestData.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/sqlobject/TestData.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.benchmark.sqlobject;
 
+import java.util.Objects;
 import java.util.StringJoiner;
 
 public final class TestData {
@@ -56,7 +57,7 @@ public final class TestData {
         if (id != testData.id) {
             return false;
         }
-        return content != null ? content.equals(testData.content) : testData.content == null;
+        return Objects.equals(content, testData.content);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/argument/EnumArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/EnumArgumentFactory.java
@@ -27,7 +27,7 @@ import org.jdbi.v3.core.qualifier.QualifiedType;
 
 class EnumArgumentFactory implements QualifiedArgumentFactory {
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public Optional<Argument> build(QualifiedType<?> givenType, Object value, ConfigRegistry config) {
         return ifEnum(givenType.getType())
             .flatMap(clazz -> makeEnumArgument((QualifiedType<Enum>) givenType, (Enum) value, config));

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectArgumentFactory.java
@@ -56,7 +56,7 @@ public class ObjectArgumentFactory implements ArgumentFactory.Preparable {
     @Override
     public Optional<Function<Object, Argument>> prepare(Type expectedType, ConfigRegistry config) {
         return Optional.of(expectedType)
-                .filter(t -> type.equals(t))
+                .filter(type::equals)
                 .map(t -> o -> ObjectArgument.of(o, sqlType));
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayType.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayType.java
@@ -46,6 +46,6 @@ public interface SqlArrayType<T> {
      * @return the created array type
      */
     static <T> SqlArrayType<T> of(String typeName, Function<T, ?> conversion) {
-        return new SqlArrayTypeImpl<T>(typeName, conversion);
+        return new SqlArrayTypeImpl<>(typeName, conversion);
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/enums/internal/EnumMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/enums/internal/EnumMapperFactory.java
@@ -29,7 +29,7 @@ public class EnumMapperFactory implements QualifiedColumnMapperFactory {
     public Optional<ColumnMapper<?>> build(QualifiedType<?> givenType, ConfigRegistry config) {
         return Optional.of(givenType.getType())
             .map(GenericTypes::getErasedType)
-            .filter(c -> Enum.class.isAssignableFrom(c))
+            .filter(Enum.class::isAssignableFrom)
             .map(clazz -> makeEnumArgument((QualifiedType<Enum>) givenType, (Class<Enum>) clazz, config));
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/enums/internal/EnumSqlArrayTypeFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/enums/internal/EnumSqlArrayTypeFactory.java
@@ -31,7 +31,7 @@ public class EnumSqlArrayTypeFactory implements SqlArrayTypeFactory {
     public Optional<SqlArrayType<?>> build(Type elementType, ConfigRegistry config) {
         return Optional.of(elementType)
             .map(GenericTypes::getErasedType)
-            .filter(c -> Enum.class.isAssignableFrom(c))
+            .filter(Enum.class::isAssignableFrom)
             .map(clazz -> makeSqlArrayType((Class<Enum>) clazz, config));
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
@@ -42,7 +42,7 @@ public class ClasspathBuilder {
     }
 
     // org.foo.Bar$Inner -> org/foo/Bar$Inner
-    public ClasspathBuilder appendFullyQualifiedClassName(@Nonnull Class clazz) {
+    public ClasspathBuilder appendFullyQualifiedClassName(@Nonnull Class<?> clazz) {
         return appendDotPath(clazz.getName());
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMapper.java
@@ -34,6 +34,7 @@ import static org.jdbi.v3.core.generic.GenericTypes.resolveType;
  * @param <K> entry key type
  * @param <V> entry value type
  */
+@SuppressWarnings("rawtypes")
 public class MapEntryMapper<K, V> implements RowMapper<Map.Entry<K, V>> {
     private static final TypeVariable<Class<Map.Entry>> KEY_PARAM;
     private static final TypeVariable<Class<Map.Entry>> VALUE_PARAM;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Field;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -168,7 +167,7 @@ public class FieldMapper<T> implements RowMapper<T> {
             return Optional.empty();
         }
 
-        Collections.sort(fields, Comparator.comparing(f -> f.propagateNull ? 1 : 0));
+        fields.sort(Comparator.comparing(f -> f.propagateNull ? 1 : 0));
 
         final Optional<String> nullMarkerColumn =
                 Optional.ofNullable(type.getAnnotation(PropagateNull.class))

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
@@ -140,7 +140,6 @@ public interface ResultBearing {
      * @param <T>  the bean type to map the result set rows to
      * @return a {@link ResultIterable} of the given type.
      */
-    @SuppressWarnings("deprecation")
     default <T> ResultIterable<T> mapToBean(Class<T> type) {
         return map(BeanMapper.of(type));
     }

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -186,7 +186,6 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      *
      * @return modified statement
      */
-    @SuppressWarnings("deprecation")
     public This bindBean(String prefix, Object bean) {
         return bindNamedArgumentFinder(
                 NamedArgumentFinderFactory.BEAN,
@@ -364,7 +363,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      */
     public This bindMap(Map<String, ?> map) {
         if (map != null) {
-            map.forEach((name, value) -> bind(name, value));
+            map.forEach(this::bind);
         }
         return typedThis;
     }

--- a/core/src/test/java/org/jdbi/v3/core/TestHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestHandle.java
@@ -170,9 +170,7 @@ public class TestHandle {
             assertThat(onRollback.get()).isTrue();
 
             onRollback.set(false);
-            h.useTransaction(inner -> {
-                inner.rollback();
-            });
+            h.useTransaction(Handle::rollback);
             assertThat(onRollback.get()).isFalse();
         }
     }

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestOptionalArgumentH2.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestOptionalArgumentH2.java
@@ -30,9 +30,8 @@ public class TestOptionalArgumentH2 {
 
     @BeforeEach
     public void createTable() {
-        h2Extension.getJdbi().useHandle(h -> {
-            h.execute("CREATE TABLE test (id BIGINT PRIMARY KEY, val TEXT)");
-        });
+        h2Extension.getJdbi().useHandle(h ->
+            h.execute("CREATE TABLE test (id BIGINT PRIMARY KEY, val TEXT)"));
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/codec/TestCodecFactoryH2.java
+++ b/core/src/test/java/org/jdbi/v3/core/codec/TestCodecFactoryH2.java
@@ -39,9 +39,8 @@ public class TestCodecFactoryH2 {
 
         jdbi.registerCodecFactory(CodecFactory.forSingleCodec(testType, new TestValueCodec()));
 
-        jdbi.useHandle(h -> {
-            h.execute("CREATE TABLE test (test VARCHAR PRIMARY KEY)");
-        });
+        jdbi.useHandle(h ->
+            h.execute("CREATE TABLE test (test VARCHAR PRIMARY KEY)"));
 
         TestValue value = new TestValue(12345);
 

--- a/core/src/test/java/org/jdbi/v3/core/collector/EnumSetCollectorFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/collector/EnumSetCollectorFactoryTest.java
@@ -30,7 +30,7 @@ public class EnumSetCollectorFactoryTest {
 
     @Test
     public void enumSet() {
-        GenericType genericType = new GenericType<EnumSet<Color>>() {};
+        GenericType<EnumSet<Color>> genericType = new GenericType<EnumSet<Color>>() {};
         Type containerType = genericType.getType();
         Class<?> erasedType = getErasedType(containerType);
         assertThat(factory.accepts(containerType)).isTrue();

--- a/core/src/test/java/org/jdbi/v3/core/config/ConfiguringPlugin.java
+++ b/core/src/test/java/org/jdbi/v3/core/config/ConfiguringPlugin.java
@@ -28,7 +28,7 @@ public class ConfiguringPlugin<C extends JdbiConfig<C>> implements JdbiPlugin {
     }
 
     public static <C extends JdbiConfig<C>> ConfiguringPlugin<C> of(Class<C> configClass, Consumer<C> configurer) {
-        return new ConfiguringPlugin<C>(configClass, configurer);
+        return new ConfiguringPlugin<>(configClass, configurer);
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
+++ b/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
@@ -40,12 +40,11 @@ public class TestH2SqlArrays {
     private static final String U_INSERT = "INSERT INTO uuids VALUES(:u)";
 
     @RegisterExtension
-    public static H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(h -> {
+    public static H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(h ->
         h.useTransaction(th -> {
             th.execute("DROP TABLE IF EXISTS uuids");
             th.execute("CREATE TABLE uuids (u UUID ARRAY)");
-        });
-    });
+    }));
 
     private final UUID[] testUuids = new UUID[]{
         UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()

--- a/core/src/test/java/org/jdbi/v3/core/interceptor/JdbiInterceptionChainHolderTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/interceptor/JdbiInterceptionChainHolderTest.java
@@ -33,9 +33,7 @@ public class JdbiInterceptionChainHolderTest {
     public void testDefault() {
         JdbiInterceptionChainHolder<Object, Object> holder = new JdbiInterceptionChainHolder<>();
 
-        UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, () -> {
-            holder.process(new Object());
-        });
+        UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, () -> holder.process(new Object()));
 
         assertEquals("object type 'Object' is not supported", e.getMessage());
     }
@@ -44,9 +42,7 @@ public class JdbiInterceptionChainHolderTest {
     public void testDefaultNull() {
         JdbiInterceptionChainHolder<Object, Object> holder = new JdbiInterceptionChainHolder<>();
 
-        UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, () -> {
-            holder.process(null);
-        });
+        UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, () -> holder.process(null));
 
         assertEquals("null value is not supported", e.getMessage());
     }

--- a/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
@@ -92,7 +92,7 @@ public class IterableLikeTest {
 
     @Test
     public void testListToIterator() {
-        final List<String> in = new ArrayList<String>(2);
+        final List<String> in = new ArrayList<>(2);
         in.add("1");
         in.add("2");
 
@@ -103,7 +103,7 @@ public class IterableLikeTest {
 
     @Test
     public void testSetToIterator() {
-        final Set<String> in = new HashSet<String>(2);
+        final Set<String> in = new HashSet<>(2);
         in.add("1");
         in.add("2");
 
@@ -114,15 +114,12 @@ public class IterableLikeTest {
 
     @Test
     public void testIterableToIterator() {
-        final Iterable<String> in = new Iterable<String>() {
-            @Override
-            public Iterator<String> iterator() {
-                final List<String> tmp = new ArrayList<String>();
-                tmp.add("1");
-                tmp.add("2");
+        final Iterable<String> in = () -> {
+            final List<String> tmp = new ArrayList<>();
+            tmp.add("1");
+            tmp.add("2");
 
-                return tmp.iterator();
-            }
+            return tmp.iterator();
         };
 
         final Object[] out = toArray(IterableLike.of(in));

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
@@ -96,13 +96,11 @@ public class TestEnums {
 
     @Test
     public void testGenericEnumBindBean() {
-        h2Extension.getSharedHandle().useTransaction(h -> {
-            assertThat(h.createQuery("select :e.val")
-                    .bindBean("e", new E<SomethingElse.Name>(SomethingElse.Name.brian))
-                    .mapTo(SomethingElse.Name.class)
-                    .one())
-                .isEqualTo(SomethingElse.Name.brian);
-        });
+        h2Extension.getSharedHandle().useTransaction(h -> assertThat(h.createQuery("select :e.val")
+                .bindBean("e", new E<>(SomethingElse.Name.brian))
+                .mapTo(SomethingElse.Name.class)
+                .one())
+            .isEqualTo(SomethingElse.Name.brian));
     }
 
     public static class E<T extends SomethingElse.Name> {

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestMapperInit.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestMapperInit.java
@@ -230,7 +230,7 @@ public class TestMapperInit {
 
         @Override
         public Entry<StringValue, Integer> map(ResultSet rs, StatementContext ctx) throws SQLException {
-            return new SimpleImmutableEntry<StringValue, Integer>(
+            return new SimpleImmutableEntry<>(
                 stringValueMapper.map(rs, 1, ctx),
                 rs.getInt(2)
             );

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestNVarchar.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestNVarchar.java
@@ -51,6 +51,7 @@ public class TestNVarchar {
             handle.execute("drop table nvarchars"));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void sqlStatementBindNVarchar() {
         h2Extension.getJdbi().useHandle(handle -> {

--- a/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
@@ -53,7 +53,7 @@ public class TestReducing {
     public void testReduceRowsWithSeed() {
         Map<Integer, SomethingWithLocations> result = h2Extension.getSharedHandle()
             .createQuery("SELECT something.id, name, location FROM something NATURAL JOIN something_location")
-            .reduceRows(new HashMap<Integer, SomethingWithLocations>(), (map, rr) -> {
+            .reduceRows(new HashMap<>(), (map, rr) -> {
                 map.computeIfAbsent(rr.getColumn("id", Integer.class),
                         id -> new SomethingWithLocations(rr.getRow(Something.class)))
                     .locations
@@ -107,7 +107,7 @@ public class TestReducing {
     public void testReduceResultSet() {
         Map<Integer, SomethingWithLocations> result = h2Extension.getSharedHandle()
             .createQuery("SELECT something.id, name, location FROM something NATURAL JOIN something_location")
-            .reduceResultSet(new HashMap<Integer, SomethingWithLocations>(), (map, rs, ctx) -> {
+            .reduceResultSet(new HashMap<>(), (map, rs, ctx) -> {
                 final String name = rs.getString("name");
                 map.computeIfAbsent(rs.getInt("id"),
                         id -> new SomethingWithLocations(new Something(id, name)))

--- a/docs/src/test/java/jdbi/doc/CodecExampleTest.java
+++ b/docs/src/test/java/jdbi/doc/CodecExampleTest.java
@@ -25,9 +25,8 @@ public class CodecExampleTest {
 
     @BeforeEach
     public void setUp() {
-        h2Extension.getJdbi().useHandle(h -> {
-            h.execute("CREATE TABLE counters (id VARCHAR PRIMARY KEY, \"value\" INT)");
-        });
+        h2Extension.getJdbi().useHandle(h ->
+            h.execute("CREATE TABLE counters (id VARCHAR PRIMARY KEY, \"value\" INT)"));
     }
 
     @Test

--- a/docs/src/test/java/jdbi/doc/CodecSqlObjectTest.java
+++ b/docs/src/test/java/jdbi/doc/CodecSqlObjectTest.java
@@ -44,9 +44,8 @@ public class CodecSqlObjectTest {
 
     @BeforeEach
     public void setUp() {
-        h2Extension.getJdbi().useHandle(h -> {
-            h.execute("CREATE TABLE counters (id VARCHAR PRIMARY KEY, \"value\" INT)");
-        });
+        h2Extension.getJdbi().useHandle(h ->
+            h.execute("CREATE TABLE counters (id VARCHAR PRIMARY KEY, \"value\" INT)"));
     }
 
     @Test

--- a/docs/src/test/java/jdbi/doc/TestInheritedValueH2.java
+++ b/docs/src/test/java/jdbi/doc/TestInheritedValueH2.java
@@ -78,9 +78,8 @@ public class TestInheritedValueH2 {
 
     @BeforeEach
     public void setUp() {
-        h2Extension.getJdbi().useHandle(h -> {
-            h.execute("CREATE TABLE data (id VARCHAR PRIMARY KEY, \"value\" VARCHAR)");
-        });
+        h2Extension.getJdbi().useHandle(h ->
+            h.execute("CREATE TABLE data (id VARCHAR PRIMARY KEY, \"value\" VARCHAR)"));
     }
 
     @Test
@@ -186,16 +185,12 @@ public class TestInheritedValueH2 {
 
         @Override
         public ColumnMapper<Value<String>> getColumnMapper() {
-            return (r, idx, ctx) -> {
-                return new StringValue(r.getString(idx));
-            };
+            return (r, idx, ctx) -> new StringValue(r.getString(idx));
         }
 
         @Override
         public Function<Value<String>, Argument> getArgumentFunction() {
-            return data -> (idx, stmt, ctx) -> {
-                stmt.setString(idx, data.getValue());
-            };
+            return data -> (idx, stmt, ctx) -> stmt.setString(idx, data.getValue());
         }
     }
 

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListNullPostgresTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListNullPostgresTest.java
@@ -74,7 +74,7 @@ public class BindListNullPostgresTest {
     public void testSomethingByIterableHandleNullWithEmptyList() {
         final SomethingByIterableHandleNull s = handle.attach(SomethingByIterableHandleNull.class);
 
-        final List<Something> out = s.get(new ArrayList<Object>());
+        final List<Something> out = s.get(new ArrayList<>());
 
         assertThat(out).isEmpty();
     }

--- a/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListTest.java
+++ b/freemarker/src/test/java/org/jdbi/v3/freemarker/BindListTest.java
@@ -163,12 +163,7 @@ public class BindListTest {
     public void testSomethingByIterableHandleDefaultWithIterable() {
         final SomethingByIterableHandleDefault s = handle.attach(SomethingByIterableHandleDefault.class);
 
-        final List<Something> out = s.get(new Iterable<Integer>() {
-            @Override
-            public Iterator<Integer> iterator() {
-                return Arrays.asList(1, 2).iterator();
-            }
-        });
+        final List<Something> out = s.get(() -> Arrays.asList(1, 2).iterator());
 
         assertThat(out).hasSameElementsAs(expectedSomethings);
     }

--- a/generator/src/test/java/org/jdbi/v3/generator/NonpublicSubclassTest.java
+++ b/generator/src/test/java/org/jdbi/v3/generator/NonpublicSubclassTest.java
@@ -20,8 +20,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.function.Predicate;
 
-import com.google.common.base.Predicate;
 import org.assertj.core.groups.Tuple;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
@@ -99,7 +99,7 @@ public class NonpublicSubclassTest {
         @GeneratorConfigurerMethod
         public boolean checkConfigurer(Predicate<GeneratorConfig> test) {
             final GeneratorConfig cfg = getHandle().getConfig(GeneratorConfig.class);
-            return test.apply(cfg);
+            return test.test(cfg);
         }
 
         // test both value-returning and void methods

--- a/guice/src/test/java/org/jdbi/v3/guice/TestMultipleConfigurationModules.java
+++ b/guice/src/test/java/org/jdbi/v3/guice/TestMultipleConfigurationModules.java
@@ -143,9 +143,7 @@ public class TestMultipleConfigurationModules {
     @Test
     public void testDefinitionModule() {
         Injector inj = GuiceTestSupport.createTestInjector(
-            binder -> {
-                binder.bind(DataSource.class).annotatedWith(Foo.class).toInstance(new JdbcDataSource());
-            },
+            binder -> binder.bind(DataSource.class).annotatedWith(Foo.class).toInstance(new JdbcDataSource()),
             new AbstractJdbiConfigurationModule() {
                 @Override
                 public void configureJdbi() {
@@ -199,9 +197,7 @@ public class TestMultipleConfigurationModules {
         };
 
         Injector inj = GuiceTestSupport.createTestInjector(
-            binder -> {
-                binder.bind(DataSource.class).annotatedWith(Foo.class).toInstance(new JdbcDataSource());
-            },
+            binder -> binder.bind(DataSource.class).annotatedWith(Foo.class).toInstance(new JdbcDataSource()),
             configModule
         );
 

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestLobStream.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestLobStream.java
@@ -42,9 +42,7 @@ public class TestLobStream {
 
     @RegisterExtension
     public static EmbeddedPgExtension pg = MultiDatabaseBuilder.instanceWithDefaults()
-        .withDatabasePreparer(ds -> {
-            Jdbi.create(ds).withHandle(h -> h.execute("CREATE TABLE lob (id int, lob oid)"));
-        }).build();
+        .withDatabasePreparer(ds -> Jdbi.create(ds).withHandle(h -> h.execute("CREATE TABLE lob (id int, lob oid)"))).build();
 
     @RegisterExtension
     public JdbiExtension pgExtension = JdbiExtension.postgres(pg).withPlugins(new SqlObjectPlugin(), new PostgresPlugin());

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
@@ -54,12 +54,10 @@ public class TestSqlArrays {
 
     @RegisterExtension
     public JdbiExtension pgExtension = JdbiExtension.postgres(pg).withPlugins(new SqlObjectPlugin(), new PostgresPlugin())
-        .withInitializer((ds, h) -> {
-            h.useTransaction(th -> {
-                th.execute("DROP TABLE IF EXISTS uuids");
-                th.execute("CREATE TABLE uuids (u UUID[], i INT[])");
-            });
-        });
+        .withInitializer((ds, h) -> h.useTransaction(th -> {
+            th.execute("DROP TABLE IF EXISTS uuids");
+            th.execute("CREATE TABLE uuids (u UUID[], i INT[])");
+        }));
 
     private Handle handle;
     private ArrayObject ao;

--- a/postgres/src/test/java/org/jdbi/v3/sqlobject/TestJsonOperator.java
+++ b/postgres/src/test/java/org/jdbi/v3/sqlobject/TestJsonOperator.java
@@ -37,9 +37,8 @@ public class TestJsonOperator {
 
     @RegisterExtension
     public JdbiExtension pgExtension = JdbiExtension.postgres(pg).withPlugins(new SqlObjectPlugin(), new PostgresPlugin())
-        .withInitializer((ds, h) -> {
-            h.execute("create table something (id serial primary key, value jsonb)");
-        });
+        .withInitializer((ds, h) ->
+            h.execute("create table something (id serial primary key, value jsonb)"));
 
     private KeyValueStore kvs;
 

--- a/spring5/src/test/java/org/jdbi/v3/spring5/TestJdbiFactoryBean.java
+++ b/spring5/src/test/java/org/jdbi/v3/spring5/TestJdbiFactoryBean.java
@@ -132,15 +132,13 @@ public class TestJdbiFactoryBean {
             final Handle h = JdbiUtil.getHandle(outer);
             h.execute("insert into something (id, name) values (7, 'ignored')");
 
-            assertThatExceptionOfType(ForceRollback.class).isThrownBy(() -> {
-                service.inRequiresNewReadUncommitted(inner -> {
-                    final Handle h1 = JdbiUtil.getHandle(inner);
-                    final int count = h1.createQuery("select count(*) from something").mapTo(Integer.class).one();
-                    assertThat(count).isEqualTo(1);
-                    h1.execute("insert into something (id, name) values (8, 'ignored again')");
-                    throw new ForceRollback();
-                });
-            });
+            assertThatExceptionOfType(ForceRollback.class).isThrownBy(() -> service.inRequiresNewReadUncommitted(inner -> {
+                final Handle h1 = JdbiUtil.getHandle(inner);
+                final int count = h1.createQuery("select count(*) from something").mapTo(Integer.class).one();
+                assertThat(count).isEqualTo(1);
+                h1.execute("insert into something (id, name) values (8, 'ignored again')");
+                throw new ForceRollback();
+            }));
 
             final int count = h.createQuery("select count(*) from something").mapTo(Integer.class).one();
             assertThat(count).isEqualTo(1);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/DefineNamedBindingsFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/DefineNamedBindingsFactory.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.sqlobject.customizer.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
+import org.jdbi.v3.core.statement.SqlStatement;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
 
@@ -27,6 +28,6 @@ public class DefineNamedBindingsFactory implements SqlStatementCustomizerFactory
 
     @Override
     public SqlStatementCustomizer createForType(Annotation annotation, Class<?> sqlObjectType) {
-        return s -> s.defineNamedBindings();
+        return SqlStatement::defineNamedBindings;
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlScriptsHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlScriptsHandler.java
@@ -26,7 +26,7 @@ public class SqlScriptsHandler extends CustomizingStatementHandler<Script> {
 
     @Override
     void configureReturner(Script stmt, SqlObjectStatementConfiguration cfg) {
-        cfg.setReturner(() -> stmt.execute());
+        cfg.setReturner(stmt::execute);
     }
 
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlUpdateHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlUpdateHandler.java
@@ -62,7 +62,7 @@ public class SqlUpdateHandler extends CustomizingStatementHandler<Update> {
                 return magic.mappedResult(iterable, update.getContext());
             };
         } else if (isNumeric(method.getReturnType())) {
-            this.returner = update -> update.execute();
+            this.returner = Update::execute;
             magic = null;
         } else if (isBoolean(method.getReturnType())) {
             this.returner = update -> update.execute() > 0;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/internal/TransactionDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/internal/TransactionDecorator.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.sqlobject.transaction.internal;
 
 import java.lang.reflect.Method;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.jdbi.v3.core.Handle;
@@ -29,7 +30,7 @@ public class TransactionDecorator implements HandlerDecorator {
     public Handler decorateHandler(Handler base, Class<?> sqlObjectType, Method method) {
         final Transaction txnAnnotation = Stream.of(method, sqlObjectType)
                 .map(ae -> ae.getAnnotation(Transaction.class))
-                .filter(txn -> txn != null)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElseThrow(() -> new TransactionException("No @Transaction annotation found"));
         final TransactionIsolationLevel isolation = txnAnnotation.value();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethods.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindMethods.java
@@ -99,7 +99,7 @@ public class TestBindMethods {
             .collect(Collectors.toList());
 
         assertThat(direct.size()).isEqualTo(2);
-        assertThat(direct.stream().filter(m -> m.isBridge())).hasSize(1);
+        assertThat(direct.stream().filter(Method::isBridge)).hasSize(1);
 
         // This version has multiple bridge methods!
         final List<Method> override = Arrays.stream(DatabaseLongValueWithOverride.class.getMethods())
@@ -107,7 +107,7 @@ public class TestBindMethods {
             .collect(Collectors.toList());
 
         assertThat(override.size()).isEqualTo(3);
-        assertThat(override.stream().filter(m -> m.isBridge())).hasSize(2);
+        assertThat(override.stream().filter(Method::isBridge)).hasSize(2);
 
         // Only one bridge method expected.
         final List<Method> implicit = Arrays.stream(DatabaseLongValue.class.getMethods())
@@ -115,7 +115,7 @@ public class TestBindMethods {
             .collect(Collectors.toList());
 
         assertThat(implicit.size()).isEqualTo(2);
-        assertThat(implicit.stream().filter(m -> m.isBridge())).hasSize(1);
+        assertThat(implicit.stream().filter(Method::isBridge)).hasSize(1);
     }
 
     public interface PairRowDAO {
@@ -171,14 +171,14 @@ public class TestBindMethods {
     public static final class DatabaseLongValue extends DatabaseNumberValue<Long> {
 
         DatabaseLongValue(final long value) {
-            super(Long.valueOf(value));
+            super(value);
         }
     }
 
     public static final class DatabaseLongValueWithOverride extends DatabaseNumberValue<Long> {
 
         DatabaseLongValueWithOverride(final long value) {
-            super(Long.valueOf(value));
+            super(value);
         }
 
         @Override
@@ -198,7 +198,7 @@ public class TestBindMethods {
 
         @Override
         public Long getColumnValue() {
-            return Long.valueOf(this.value);
+            return this.value;
         }
     }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestCollectorFactory.java
@@ -13,13 +13,13 @@
  */
 package org.jdbi.v3.sqlobject;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.SortedSet;
+import java.util.stream.Collectors;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
-import org.jdbi.v3.guava.GuavaCollectors;
 import org.jdbi.v3.guava.GuavaPlugin;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.guava.api.Assertions.assertThat;
 
 public class TestCollectorFactory {
 
@@ -47,7 +46,7 @@ public class TestCollectorFactory {
         Optional<String> rs = h.createQuery("select name from something where id = :id")
             .bind("id", 1)
             .mapTo(String.class)
-            .collect(GuavaCollectors.toOptional());
+            .findFirst();
 
         assertThat(rs).contains("Coda");
     }
@@ -60,9 +59,9 @@ public class TestCollectorFactory {
         Optional<String> rs = h.createQuery("select name from something where id = :id")
                 .bind("id", 2)
                 .mapTo(String.class)
-                .collect(GuavaCollectors.toOptional());
+                .findFirst();
 
-        assertThat(rs).isAbsent();
+        assertThat(rs).isEmpty();
     }
 
     @Test
@@ -72,9 +71,9 @@ public class TestCollectorFactory {
         h.execute("insert into something (id, name) values (1, 'Coda')");
         h.execute("insert into something (id, name) values (2, 'Brian')");
 
-        ImmutableList<String> rs = h.createQuery("select name from something order by id")
+        List<String> rs = h.createQuery("select name from something order by id")
                 .mapTo(String.class)
-                .collect(ImmutableList.toImmutableList());
+                .collect(Collectors.toList());
 
         assertThat(rs).containsExactly("Coda", "Brian");
     }
@@ -85,7 +84,7 @@ public class TestCollectorFactory {
         dao.insert(new Something(1, "Coda"));
         dao.insert(new Something(2, "Brian"));
 
-        ImmutableList<String> rs = dao.findAll();
+        List<String> rs = dao.findAll();
         assertThat(rs).containsExactly("Coda", "Brian");
     }
 
@@ -117,7 +116,7 @@ public class TestCollectorFactory {
 
     public interface Dao extends Base<String> {
         @SqlQuery("select name from something order by id")
-        ImmutableList<String> findAll();
+        List<String> findAll();
 
         @SqlQuery("select name from something order by id")
         SortedSet<String> findAllAsSet();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefaultMethods.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestDefaultMethods.java
@@ -83,7 +83,7 @@ public class TestDefaultMethods {
 
     @Test
     public void testHandleHasExtensionMethodSet() throws Exception {
-        h2Extension.getJdbi().useExtension(StatementContextExtensionMethodDao.class, dao -> dao.check());
+        h2Extension.getJdbi().useExtension(StatementContextExtensionMethodDao.class, StatementContextExtensionMethodDao::check);
     }
 
     private interface StatementContextExtensionMethodDao extends SqlObject {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredMappersWork.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisteredMappersWork.java
@@ -126,10 +126,9 @@ public class TestRegisteredMappersWork {
         bdb.insertBean(lima);
 
         assertThat(bdb.findByNameDefaultMethod("lima"))
-                .hasValueSatisfying(bean -> {
+                .hasValueSatisfying(bean ->
                     assertThat(bean).extracting(Bean::getName, Bean::getColor)
-                            .contains(lima.getName(), lima.getColor());
-                });
+                        .contains(lima.getName(), lima.getColor()));
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactional.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactional.java
@@ -143,9 +143,7 @@ public class TestTransactional {
     public void testNestedTransactionCallbacks() {
         AtomicBoolean result = new AtomicBoolean();
         CommitCallbackDao dao = jdbi.onDemand(CommitCallbackDao.class);
-        jdbi.useTransaction(txn -> {
-            dao.txnCommitSet(() -> result.set(true));
-        });
+        jdbi.useTransaction(txn -> dao.txnCommitSet(() -> result.set(true)));
         assertThat(result.get()).isTrue();
     }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/internal/TestTimestamped.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/internal/TestTimestamped.java
@@ -22,6 +22,7 @@ import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -261,7 +262,7 @@ public class TestTimestamped {
             if (!firstName.equals(person.firstName)) {
                 return false;
             }
-            return lastName != null ? lastName.equals(person.lastName) : person.lastName == null;
+            return Objects.equals(lastName, person.lastName);
         }
 
         @Override

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullPostgresTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullPostgresTest.java
@@ -73,7 +73,7 @@ public class BindListNullPostgresTest {
     public void testSomethingByIterableHandleNullWithEmptyList() {
         final SomethingByIterableHandleNull s = handle.attach(SomethingByIterableHandleNull.class);
 
-        final List<Something> out = s.get(new ArrayList<Object>());
+        final List<Something> out = s.get(new ArrayList<>());
 
         assertThat(out).isEmpty();
     }

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListNullTest.java
@@ -78,7 +78,7 @@ public class BindListNullTest {
     public void testSomethingByIterableHandleNullWithEmptyList() {
         final SomethingByIterableHandleNull s = handle.attach(SomethingByIterableHandleNull.class);
 
-        final List<Something> out = s.get(new ArrayList<Object>());
+        final List<Something> out = s.get(new ArrayList<>());
 
         assertThat(out).isEmpty();
     }

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -160,12 +160,7 @@ public class BindListTest {
     public void testSomethingByIterableHandleDefaultWithIterable() {
         final SomethingByIterableHandleDefault s = handle.attach(SomethingByIterableHandleDefault.class);
 
-        final List<Something> out = s.get(new Iterable<Integer>() {
-            @Override
-            public Iterator<Integer> iterator() {
-                return Arrays.asList(1, 2).iterator();
-            }
-        });
+        final List<Something> out = s.get(() -> Arrays.asList(1, 2).iterator());
 
         assertThat(out).hasSameElementsAs(expectedSomethings);
     }

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExtension.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExtension.java
@@ -379,7 +379,7 @@ public abstract class JdbiExtension implements BeforeEachCallback, AfterEachCall
         }
 
         static <C extends JdbiConfig<C>> ConfiguringPlugin<C> of(Class<C> configClass, Consumer<C> configurer) {
-            return new ConfiguringPlugin<C>(configClass, configurer);
+            return new ConfiguringPlugin<>(configClass, configurer);
         }
 
         @Override

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtension.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtension.java
@@ -127,9 +127,7 @@ public class JdbiOtjPostgresExtension extends JdbiExtension {
     private EmbeddedPostgres createEmbeddedPostgres() throws IOException {
 
         final EmbeddedPostgres.Builder builder = EmbeddedPostgres.builder();
-        this.builderCustomizers.forEach((c) -> {
-            c.accept(builder);
-        });
+        this.builderCustomizers.forEach(c -> c.accept(builder));
 
         return builder.start();
     }


### PR DESCRIPTION
This pull request contains a number of Java language migration updates.
All changes are non-functional. They aim to improve code quality and make use of new Java language features.

- use Java functional primitives (instead of Guava's)
- use statement lambdas, use method references where possible
- avoid unnecessary boxing
- use Objects.equals
- use diamond operator without explicit type where permitted
- fix raw usage of parametrized classes

Tests are green.