### PR TITLE
Update to spotbugs 4.7

### DIFF
--- a/policy/pom.xml
+++ b/policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>basepom-oss</artifactId>
         <groupId>org.basepom</groupId>
-        <version>43</version>
+        <version>44</version>
         <relativePath />
     </parent>
 
@@ -27,4 +27,10 @@
     <version>3.28.1-SNAPSHOT</version>
     <name>jdbi3 Policy</name>
     <description>Policy files for Jdbi build configuration</description>
+
+    <properties>
+        <!-- remove after next basepom update -->
+        <dep.plugin.spotbugs.version>4.7.0.0</dep.plugin.spotbugs.version>
+        <dep.spotbugs.version>4.7.0</dep.spotbugs.version>
+    </properties>
 </project>

--- a/policy/src/main/resources/policy/spotbugs-exclude.xml
+++ b/policy/src/main/resources/policy/spotbugs-exclude.xml
@@ -29,4 +29,14 @@
     <Match>
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
     </Match>
+    <!-- new patterns in 4.7.0 that are very noisy -->
+    <Match>
+        <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION" />
+    </Match>
+    <Match>
+        <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE" />
+    </Match>
+    <Match>
+        <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION" />
+    </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,11 @@
         <dep.plugin.inline.version>1.0.1</dep.plugin.inline.version>
         <dep.plugin.ktlint.version>1.13.1</dep.plugin.ktlint.version>
         <dep.plugin.sortpom.version>2.8.0</dep.plugin.sortpom.version>
+        <!-- remove after next basepom update -->
+        <dep.plugin.spotbugs.version>4.7.0.0</dep.plugin.spotbugs.version>
         <dep.slf4j.version>1.7.32</dep.slf4j.version>
+        <!-- remove after next basepom update -->
+        <dep.spotbugs.version>4.7.0</dep.spotbugs.version>
         <dep.spring.version>5.3.14</dep.spring.version>
         <dep.vavr.version>0.9.3</dep.vavr.version>
         <jdbi.check.fail-detekt>${jdbi.check.fail-kotlin}</jdbi.check.fail-detekt>


### PR DESCRIPTION
Removes the warning about SecurityManager deprecation on JDK17.