### PR TITLE
Update otj-pg-embedded to 1.0.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,19 @@
 # Unreleased
 
-# 3.28.1
+# 3.29.0
+
+  This is a maintenance release. It bumps the minor because of a backwards incompatible change
+  in the `JdbiOtjPostgresExtension` due to a change in the upstream `otj-pg-embedded` component.
+
+  If you do not use this component, there are no significant changes over 3.28.0.
+
   - build now fully supports building with JDK 17
   - minor changes and cleanups (#2020, #2023)
   - always load kotlin plugin if using kotlin-sqlobject (#2023)
   - change BOM to resolve versions in the released bom version
+  - update to otj-pg-embedded 1.0.1 (0.13.x started to crash on MacOS Monterey). This is a backwards
+    incompatible change as the component changed the call signature of `getJdbcUrl`. This only
+    affects the JdbiOtjPostgresExtension
 
 # 3.28.0
   - Remove the antlr4-runtime dependency by inlining it into the core jar.

--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
             <dependency>
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-pg-embedded</artifactId>
-                <version>0.13.4</version>
+                <version>1.0.1</version>
             </dependency>
 
             <dependency>

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtension.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtension.java
@@ -75,7 +75,7 @@ public class JdbiOtjPostgresExtension extends JdbiExtension {
             throw new IllegalStateException("not within a Junit test!");
         }
 
-        return pg.getJdbcUrl("postgres", "postgres");
+        return pg.getJdbcUrl("postgres");
     }
 
     @Override


### PR DESCRIPTION
This fixes crashes on MacOS Monterey which prevented from
releasing. Ironically, it still built fine on the CI.

OT jumped the shark (well, the whale) and switched from a fully embedded
model to testcontainer which slows down the tests further.