### PR TITLE
Update spring framework to 5.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dep.slf4j.version>1.7.32</dep.slf4j.version>
         <!-- remove after next basepom update -->
         <dep.spotbugs.version>4.7.0</dep.spotbugs.version>
-        <dep.spring.version>5.3.18</dep.spring.version>
+        <dep.spring.version>5.3.20</dep.spring.version>
         <dep.vavr.version>0.9.3</dep.vavr.version>
         <jdbi.check.fail-detekt>${jdbi.check.fail-kotlin}</jdbi.check.fail-detekt>
         <jdbi.check.fail-kotlin>${basepom.check.fail-extended}</jdbi.check.fail-kotlin>


### PR DESCRIPTION
New and exciting vulnerabilities have been found in spring framework
and so we now require "latest and greatest" to keep up with these
issues.