### PR TITLE
CharSequence support for Sql statements

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -229,13 +229,20 @@ public class Handle implements Closeable, Configurable<Handle> {
      * @param args arguments to bind positionally
      * @return query object
      */
-    public Query select(String sql, Object... args) {
+    public Query select(CharSequence sql, Object... args) {
         Query query = this.createQuery(sql);
         int position = 0;
         for (Object arg : args) {
             query.bind(position++, arg);
         }
         return query;
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public Query select(String sql, Object... args) {
+        return select((CharSequence) sql, args);
     }
 
     /**
@@ -246,7 +253,7 @@ public class Handle implements Closeable, Configurable<Handle> {
      *
      * @return the number of rows affected
      */
-    public int execute(String sql, Object... args) {
+    public int execute(CharSequence sql, Object... args) {
         try (Update stmt = createUpdate(sql)) {
             int position = 0;
             for (Object arg : args) {
@@ -254,6 +261,13 @@ public class Handle implements Closeable, Configurable<Handle> {
             }
             return stmt.execute();
         }
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public int execute(String sql, Object... args) {
+        return execute((CharSequence) sql, args);
     }
 
     /**
@@ -272,8 +286,15 @@ public class Handle implements Closeable, Configurable<Handle> {
      * @param sql the batch SQL
      * @return a batch which can have "statements" added
      */
-    public PreparedBatch prepareBatch(String sql) {
+    public PreparedBatch prepareBatch(CharSequence sql) {
         return new PreparedBatch(this, sql);
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public PreparedBatch prepareBatch(String sql) {
+        return prepareBatch((CharSequence) sql);
     }
 
     /**
@@ -283,8 +304,15 @@ public class Handle implements Closeable, Configurable<Handle> {
      *
      * @return the Call
      */
-    public Call createCall(String sql) {
+    public Call createCall(CharSequence sql) {
         return new Call(this, sql);
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public Call createCall(String sql) {
+        return createCall((CharSequence) sql);
     }
 
     /**
@@ -293,8 +321,15 @@ public class Handle implements Closeable, Configurable<Handle> {
      * @param sql SQL that may return results
      * @return a Query builder
      */
-    public Query createQuery(String sql) {
+    public Query createQuery(CharSequence sql) {
         return new Query(this, sql);
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public Query createQuery(String sql) {
+        return createQuery((CharSequence) sql);
     }
 
     /**
@@ -304,8 +339,15 @@ public class Handle implements Closeable, Configurable<Handle> {
      *
      * @return the created Script
      */
-    public Script createScript(String sql) {
+    public Script createScript(CharSequence sql) {
         return new Script(this, sql);
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public Script createScript(String sql) {
+        return createScript((CharSequence) sql);
     }
 
     /**
@@ -315,8 +357,15 @@ public class Handle implements Closeable, Configurable<Handle> {
      *
      * @return the Update builder
      */
-    public Update createUpdate(String sql) {
+    public Update createUpdate(CharSequence sql) {
         return new Update(this, sql);
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public Update createUpdate(String sql) {
+        return createUpdate((CharSequence) sql);
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/Sql.java
+++ b/core/src/main/java/org/jdbi/v3/core/Sql.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * <p>
+ *   An immutable sql statement string created from multiple tokens
+ *   in order to write inline sql statements in an easy-to-read fashion
+ *   spread out over multiple lines of code.
+ * </p>
+ *
+ * <p>
+ *   The class implements {@link CharSequence} and thus can be used as a drop-in
+ *   alternative wherever API supports {@code CharSequence} rather than {@code String}.
+ * </p>
+ *
+ * Please note that the validity of the statement is never checked,
+ * and that {@code null} or empty inputs are permitted (no run-time exceptions).<br>
+ *
+ * The input of multiple tokens is formatted into a single String by
+ * removing leading and trailing whitespace and concatenating
+ * non-empty tokens by a single space character.
+ * Further, any trailing semicolons are removed from the resulting sql string.
+ *
+ * <p>Example:</p>
+ *
+ * <pre>
+ *     String tblName = "table";
+ *     Sql.of("SELECT COUNT(*)",
+ *            "FROM", tblName,
+ *            " WHERE cond1 = :cond1",
+ *            "   AND cond2 = :cond2");
+ * </pre>
+ *
+ * @author Markus Spann
+ */
+public final class Sql implements CharSequence {
+
+    /** The internal sql string. Cannot be null. */
+    private final String str;
+
+    private Sql(String sql) {
+        str = sql;
+    }
+
+    public static Sql of(CharSequence... tokens) {
+        return tokens == null ? new Sql("") : of(Arrays.asList(tokens));
+    }
+
+    public static Sql of(Collection<CharSequence> tokens) {
+        return tokens == null ? new Sql("") : new Sql(format(tokens));
+    }
+
+    /**
+     * Formats an sql statement from multiple tokens.<br>
+     * Leading and trailing whitespace is removed from each token and empty tokens ignored.<br>
+     * The tokens are joined using a single blank character to create the sql string.<br>
+     * Finally, any trailing semicolons are removed from the resulting sql.
+     *
+     * @param tokens collection of tokens
+     * @return formatted sql string
+     */
+    static String format(Collection<CharSequence> tokens) {
+        String sql = Objects.requireNonNull(tokens).stream()
+                .filter(Objects::nonNull)
+                .map(CharSequence::toString)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(" "));
+        while (sql.endsWith(";")) {
+            sql = sql.substring(0, sql.length() - 1);
+        }
+        return sql;
+    }
+
+    @Override
+    public int length() {
+        return str.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+        return str.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        return str.subSequence(start, end);
+    }
+
+    @Override
+    public int hashCode() {
+        return str.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        return str.equals(((Sql) obj).str);
+    }
+
+    @Override
+    public String toString() {
+        return str;
+    }
+
+}

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -31,8 +31,15 @@ import org.jdbi.v3.core.argument.Argument;
 public class Call extends SqlStatement<Call> {
     private final List<OutParamArgument> params = new ArrayList<>();
 
-    public Call(Handle handle, String sql) {
+    public Call(Handle handle, CharSequence sql) {
         super(handle, sql);
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public Call(Handle handle, String sql) {
+        super(handle, (CharSequence) sql);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -64,9 +64,16 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
     private final List<PreparedBinding> bindings = new ArrayList<>();
     final Map<PrepareKey, Function<String, Optional<Function<Object, Argument>>>> preparedFinders = new HashMap<>();
 
-    public PreparedBatch(Handle handle, String sql) {
+    public PreparedBatch(Handle handle, CharSequence sql) {
         super(handle, sql);
         getContext().setBinding(new PreparedBinding(getContext()));
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public PreparedBatch(Handle handle, String sql) {
+        super(handle, (CharSequence) sql);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/statement/Query.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Query.java
@@ -27,8 +27,15 @@ import org.jdbi.v3.core.result.UnableToProduceResultException;
  * Statement providing convenience result handling for SQL queries.
  */
 public class Query extends SqlStatement<Query> implements ResultBearing {
-    public Query(Handle handle, String sql) {
+    public Query(Handle handle, CharSequence sql) {
         super(handle, sql);
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public Query(Handle handle, String sql) {
+        super(handle, (CharSequence) sql);
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/Script.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Script.java
@@ -26,9 +26,16 @@ import org.jdbi.v3.core.internal.SqlScriptParser;
 public class Script extends SqlStatement<Script> {
     private final Handle handle;
 
-    public Script(Handle h, String sql) {
+    public Script(Handle h, CharSequence sql) {
         super(h, sql);
         this.handle = h;
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public Script(Handle handle, String sql) {
+        this(handle, (CharSequence) sql);
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -74,15 +74,15 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
     PreparedStatement stmt;
 
     SqlStatement(Handle handle,
-                 String sql) {
+                 CharSequence sql) {
         super(handle);
 
         this.handle = handle;
-        this.sql = sql;
+        this.sql = sql.toString();
 
         getContext()
             .setConnection(handle.getConnection())
-            .setRawSql(sql);
+            .setRawSql(this.sql);
     }
 
     protected Binding getBinding() {

--- a/core/src/main/java/org/jdbi/v3/core/statement/Update.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Update.java
@@ -28,8 +28,15 @@ import static org.jdbi.v3.core.result.ResultProducers.returningUpdateCount;
  * Used for INSERT, UPDATE, and DELETE statements
  */
 public class Update extends SqlStatement<Update> {
-    public Update(Handle handle, String sql) {
+    public Update(Handle handle, CharSequence sql) {
         super(handle, sql);
+    }
+
+    /**
+     * Deprecated delegate - please use {@code CharSequence} signature for future compatibility.
+     */
+    public Update(Handle handle, String sql) {
+        this(handle, (CharSequence) sql);
     }
 
     public void one() {

--- a/core/src/test/java/org/jdbi/v3/core/SqlTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/SqlTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class SqlTest {
+
+    @Test
+    void testEmptyInput() {
+        assertEquals("", Sql.of((CharSequence[]) null).toString());
+        assertEquals("", Sql.of((Collection<CharSequence>) null).toString());
+        assertEquals("", Sql.of(new CharSequence[0]).toString());
+        assertEquals("", Sql.of(new ArrayList<>()).toString());
+        assertEquals("", Sql.of().toString());
+    }
+
+    @Test
+    void testMultipleTokens() {
+        assertEquals("SELECT COUNT(*) FROM table WHERE cond1 = :cond1",
+                Sql.of("SELECT COUNT(*) FROM table ",
+                       " WHERE cond1 = :cond1; ").toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "\n", "\t", ";"})
+    @NullAndEmptySource
+    void testStrip(String str) {
+        Sql sql = Sql.of(str);
+        assertEquals("", sql.toString());
+    }
+
+    @Test
+    void testCharSequenceMethods() {
+        Sql sql1 = Sql.of("SELECT * FROM table");
+        assertEquals(19, sql1.length());
+        assertEquals('S', sql1.charAt(0));
+        assertEquals("SEL", sql1.subSequence(0, 3));
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        Sql sql1 = Sql.of("DROP TABLE table;");
+        Sql sql2 = Sql.of(sql1);
+        assertEquals(sql1.hashCode(), sql2.hashCode());
+        assertEquals(sql1, sql2);
+        assertNotNull(sql1);
+        assertNotEquals("", sql1);
+        assertNotEquals(sql1, Sql.of());
+    }
+
+}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/MapEntryMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/MapEntryMapperTest.java
@@ -99,7 +99,7 @@ public class MapEntryMapperTest {
                 .execute();
 
         // tag::joinRow[]
-        String sql = "select u.id u_id, u.name u_name, p.id p_id, p.phone p_phone "
+        CharSequence sql = "select u.id u_id, u.name u_name, p.id p_id, p.phone p_phone "
 
             + "from \"user\" u left join phone p on u.id = p.user_id";
         Map<User, Phone> map = h.createQuery(sql)
@@ -129,7 +129,7 @@ public class MapEntryMapperTest {
                 .add(30, 3, "555-0003")
                 .execute();
 
-        String sql = "select u.id u_id, u.name u_name, p.id p_id, p.phone p_phone "
+        CharSequence sql = "select u.id u_id, u.name u_name, p.id p_id, p.phone p_phone "
             + "from \"user\" u left join phone p on u.id = p.user_id";
         h2Extension.getJdbi()
                 .setMapKeyColumn("foo")

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -455,6 +455,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
This pull request enhances jdbi to allow `CharSequence` rather than `String` when passing sql statements to the library
e.g.
    `public Query(Handle handle, String sql)`
becomes
    `public Query(Handle handle, CharSequence sql)`

It also adds class `org.jdbi.v3.core.Sql` to write easy-to-read inline sql statements while Java multi-line strings (from Java 15) are not yet available.
