### PR TITLE
Do not require docker to build the code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <!-- remove after next basepom update -->
         <dep.spotbugs.version>4.7.0</dep.spotbugs.version>
         <dep.spring.version>5.3.20</dep.spring.version>
+        <dep.testcontainer.version>1.16.3</dep.testcontainer.version>
         <dep.vavr.version>0.9.3</dep.vavr.version>
         <jdbi.check.fail-detekt>${jdbi.check.fail-kotlin}</jdbi.check.fail-detekt>
         <jdbi.check.fail-kotlin>${basepom.check.fail-extended}</jdbi.check.fail-kotlin>
@@ -584,6 +585,14 @@
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${dep.junit5.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${dep.testcontainer.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -90,6 +90,12 @@
             <artifactId>flyway-core</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/testing/src/test/java/org/jdbi/v3/testing/JdbiRulePostgresTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/JdbiRulePostgresTest.java
@@ -13,14 +13,23 @@
  */
 package org.jdbi.v3.testing;
 
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 public class JdbiRulePostgresTest {
+
     @Rule
     public JdbiRule postgres = JdbiRule.embeddedPostgres();
+
+    @BeforeClass
+    public static void checkDocker() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+    }
 
     @Test
     public void isAlive() {

--- a/testing/src/test/java/org/jdbi/v3/testing/JdbiRuleTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/JdbiRuleTest.java
@@ -18,13 +18,22 @@ import java.util.UUID;
 import javax.sql.DataSource;
 
 import org.h2.jdbcx.JdbcConnectionPool;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.testcontainers.DockerClientFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 public class JdbiRuleTest {
+
+    @BeforeClass
+    public static void checkDocker() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+    }
+
     @Test
     public void migrateWithFlywayDefaultLocation() throws Throwable {
         JdbiRule rule = JdbiRule.embeddedPostgres()

--- a/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtendWithTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtendWithTest.java
@@ -15,13 +15,21 @@ package org.jdbi.v3.testing.junit5;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.DockerClientFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(JdbiOtjPostgresExtension.class)
 public class JdbiOtjPostgresExtendWithTest {
+
+    @BeforeAll
+    public static void checkDocker() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+    }
 
     @Test
     public void testJdbiIsAlive(Jdbi jdbi) {

--- a/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtensionTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtensionTest.java
@@ -13,15 +13,23 @@
  */
 package org.jdbi.v3.testing.junit5;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.DockerClientFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class JdbiOtjPostgresExtensionTest {
 
     @RegisterExtension
     public JdbiOtjPostgresExtension postgres = JdbiExtension.otjEmbeddedPostgres();
+
+    @BeforeAll
+    public static void checkDocker() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+    }
 
     @Test
     public void testIsAlive() {


### PR DESCRIPTION
The OTJ Postgres Plugin has switched to testcontainers which in turn
requires a local docker environment to build the code base.

Add a check for docker availability for all OTJ related tests.