### PR TITLE
Fix issue 2065

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  - Fix exception in Handle#close() when underlying connection is closed (#2065)
+
 # 3.31.0
 
   - Support binding parameters of type CharSequence (#2057, thanks @sman-81)

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -148,14 +148,14 @@ public class Handle implements Closeable, Configurable<Handle> {
             return;
         }
 
-        boolean connectionIsLive = false;
+        boolean connectionIsLive;
 
         try {
             connectionIsLive = !connection.isClosed();
         } catch (SQLException e) {
             // if the connection state can not be determined, assume that the
-            // connection is closed
-            suppressed.add(e);
+            // connection is closed and ignore the exception
+            connectionIsLive = false;
         }
 
         boolean wasInTransaction = false;

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -148,8 +148,19 @@ public class Handle implements Closeable, Configurable<Handle> {
             return;
         }
 
+        boolean connectionIsLive = false;
+
+        try {
+            connectionIsLive = !connection.isClosed();
+        } catch (SQLException e) {
+            // if the connection state can not be determined, assume that the
+            // connection is closed
+            suppressed.add(e);
+        }
+
         boolean wasInTransaction = false;
-        if (forceEndTransactions && localConfig.get().get(Handles.class).isForceEndTransactions()) {
+
+        if (connectionIsLive && forceEndTransactions && localConfig.get().get(Handles.class).isForceEndTransactions()) {
             try {
                 wasInTransaction = isInTransaction();
             } catch (Exception e) {
@@ -168,14 +179,18 @@ public class Handle implements Closeable, Configurable<Handle> {
             }
         }
 
-        try {
-            statementBuilder.close(getConnection());
-        } catch (Exception e) {
-            suppressed.add(e);
+        if (connectionIsLive) {
+            try {
+                statementBuilder.close(getConnection());
+            } catch (Exception e) {
+                suppressed.add(e);
+            }
         }
 
         try {
-            closer.close(connection);
+            if (connectionIsLive) {
+                closer.close(connection);
+            }
 
             if (!suppressed.isEmpty()) {
                 final Throwable original = suppressed.remove(0);

--- a/core/src/test/java/org/jdbi/v3/core/TestHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestHandle.java
@@ -175,6 +175,22 @@ public class TestHandle {
         }
     }
 
+    @Test
+    public void testIssue2065() throws Exception {
+        Handle h = h2Extension.openHandle();
+
+        h.begin();
+        h.execute("insert into something (id, name) values (1, 'Brian')");
+        String value = h.createQuery("select name from something where id = 1").mapToBean(Something.class).one().getName();
+        h.commit();
+
+        // close connection between commit and handle close - this may be done by the connection pool or timeout or sth else
+        h.getConnection().close();
+
+        h.close();
+        assertThat(value).isEqualTo("Brian");
+    }
+
     static class BoomHandler extends LocalTransactionHandler {
         boolean failTest;
         boolean failRollback;


### PR DESCRIPTION
Check connection status in handle.close()

Ensure that the handle will tolerate a closed connection when close()
is called. If the database connection gets closed between the last
operation finishing successfully and the handle being closed, checking
the autocommit status will cause an exception to be thrown that is
user-visible but not actionable. Check the connection state before
executing any operation on the database connection.

Fixes #2065