### PR TITLE
Batch ops should give access to modified row count

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/result/BatchResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/BatchResultBearing.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.result;
+
+import java.lang.reflect.Type;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.mapper.RowViewMapper;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+
+/**
+ * Extends the {@link ResultBearing} class to provide access to the per-batch row modification counts.
+ */
+public final class BatchResultBearing implements ResultBearing {
+
+    private final ResultBearing delegate;
+    private final Supplier<int[]> modifiedRowCountsSupplier;
+
+    public BatchResultBearing(ResultBearing delegate, Supplier<int[]> modifiedRowCountsSupplier) {
+        this.delegate = delegate;
+        this.modifiedRowCountsSupplier = modifiedRowCountsSupplier;
+    }
+
+    @Override
+    public <R> R scanResultSet(ResultSetScanner<R> mapper) {
+        return delegate.scanResultSet(mapper);
+    }
+
+    @Override
+    public <T> BatchResultIterable<T> mapTo(Class<T> type) {
+        return BatchResultIterable.of(delegate.mapTo(type), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public <T> BatchResultIterable<T> mapTo(GenericType<T> type) {
+        return BatchResultIterable.of(delegate.mapTo(type), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public BatchResultIterable<?> mapTo(Type type) {
+        return BatchResultIterable.of(delegate.mapTo(type), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public <T> BatchResultIterable<T> mapTo(QualifiedType<T> type) {
+        return BatchResultIterable.of(delegate.mapTo(type), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public <T> BatchResultIterable<T> mapToBean(Class<T> type) {
+        return BatchResultIterable.of(delegate.mapToBean(type), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public BatchResultIterable<Map<String, Object>> mapToMap() {
+        return BatchResultIterable.of(delegate.mapToMap(), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public <T> BatchResultIterable<Map<String, T>> mapToMap(Class<T> valueType) {
+        return BatchResultIterable.of(delegate.mapToMap(valueType), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public <T> BatchResultIterable<Map<String, T>> mapToMap(GenericType<T> valueType) {
+        return BatchResultIterable.of(delegate.mapToMap(valueType), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public <T> BatchResultIterable<T> map(ColumnMapper<T> mapper) {
+        return BatchResultIterable.of(delegate.map(mapper), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public <T> BatchResultIterable<T> map(RowMapper<T> mapper) {
+        return BatchResultIterable.of(delegate.map(mapper), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public <T> BatchResultIterable<T> map(RowViewMapper<T> mapper) {
+        return BatchResultIterable.of(delegate.map(mapper), modifiedRowCountsSupplier);
+    }
+
+    @Override
+    public <C, R> Stream<R> reduceRows(RowReducer<C, R> reducer) {
+        return delegate.reduceRows(reducer);
+    }
+
+    @Override
+    public <K, V> Stream<V> reduceRows(BiConsumer<Map<K, V>, RowView> accumulator) {
+        return delegate.reduceRows(accumulator);
+    }
+
+    @Override
+    public <U> U reduceRows(U seed, BiFunction<U, RowView, U> accumulator) {
+        return delegate.reduceRows(seed, accumulator);
+    }
+
+    @Override
+    public <U> U reduceResultSet(U seed, ResultSetAccumulator<U> accumulator) {
+        return delegate.reduceResultSet(seed, accumulator);
+    }
+
+    @Override
+    public <A, R> R collectRows(Collector<RowView, A, R> collector) {
+        return delegate.collectRows(collector);
+    }
+
+    @Override
+    public <R> R collectInto(Class<R> containerType) {
+        return delegate.collectInto(containerType);
+    }
+
+    @Override
+    public <R> R collectInto(GenericType<R> containerType) {
+        return delegate.collectInto(containerType);
+    }
+
+    @Override
+    public Object collectInto(Type containerType) {
+        return delegate.collectInto(containerType);
+    }
+
+    /**
+     * Returns the mod counts for the executed {@link org.jdbi.v3.core.statement.PreparedBatch}
+     * Note that some database drivers might return special values like {@link Statement#SUCCESS_NO_INFO}
+     * or {@link Statement#EXECUTE_FAILED}.
+     * <br>
+     * <b>Note that the result is only available after the statement was executed (eg. by calling map())</b>. Calling this method before execution
+     * will return an empty array.
+     *
+     * @return the number of modified rows per batch part for the executed {@link org.jdbi.v3.core.statement.PreparedBatch}.
+     */
+    public int[] modifiedRowCounts() {
+        return modifiedRowCountsSupplier.get();
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/result/BatchResultIterable.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/BatchResultIterable.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.result;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Extend the {@link ResultIterable} for batch operations.
+ * @param <T>
+ */
+public interface BatchResultIterable<T> extends ResultIterable<T> {
+
+    /**
+     * Split the results into per-batch sub-lists. Note that this may not be correct if any of the executed batches returned an error code.
+     *
+     * @return results in a {@link List} of {@link List}s.
+     */
+    List<List<T>> listPerBatch();
+
+    static <U> BatchResultIterable<U> of(ResultIterable<U> delegate, Supplier<int[]> modifiedRowCountsSupplier) {
+
+        return new BatchResultIterable<U>() {
+            @Override
+            public List<List<U>> listPerBatch() {
+                List<List<U>> results = new LinkedList<>();
+                try (ResultIterator<U> iterator = delegate.iterator()) {
+                    for (int modCount : modifiedRowCountsSupplier.get()) {
+                        if (modCount <= 0) {
+                            // error return (SUCCESS_NO_INFO or EXECUTE_FAILED) or empty.
+                            results.add(Collections.emptyList());
+                        } else {
+                            List<U> batchResult = new ArrayList<>(modCount);
+                            for (int i = 0; i < modCount; i++) {
+                                batchResult.add(iterator.next());
+                            }
+                            results.add(batchResult);
+                        }
+                    }
+                }
+                return results;
+            }
+
+            @Override
+            public ResultIterator<U> iterator() {
+                return delegate.iterator();
+            }
+        };
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatchGenerateKeysPostgres.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatchGenerateKeysPostgres.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.core.statement;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -21,6 +22,8 @@ import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.junit5.PgDatabaseExtension;
+import org.jdbi.v3.core.result.BatchResultBearing;
+import org.jdbi.v3.core.result.ResultIterator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -68,6 +71,87 @@ public class TestPreparedBatchGenerateKeysPostgres {
         assertThat(ids).hasSize(2);
         assertThat(ids).extracting(ic -> ic.id).containsExactly(1, 2);
         assertThat(ids).extracting(ic -> ic.createTime).doesNotContainNull();
+    }
+
+    @Test
+    public void testBatchResultBearing() {
+        try (Handle h = pgExtension.openHandle()) {
+
+            PreparedBatch batch1 = h.prepareBatch("insert into something (name) values (?) ");
+            batch1.add("Brian1");
+            batch1.add("Brian2");
+            batch1.add("Thom1");
+            batch1.add("Thom2");
+            List<IdCreateTime> ids = batch1.executeAndReturnGeneratedKeys("id", "create_time")
+                .map((r, ctx) -> new IdCreateTime(
+                    r.getInt("id"),
+                    r.getTimestamp("create_time")))
+                .list();
+
+            PreparedBatch batch2 = h.prepareBatch("update something set create_time = now() where name like :name returning id, name, create_time");
+
+            batch2.bind("name", "Brian%")
+                .add()
+                .bind("name", "Thom%")
+                .add()
+                .bind("name", "Nothing%")
+                .add();
+
+            List<List<IdCreateTime>> choppedList = batch2.executePreparedBatch("id", "create_time")
+                .map((r, ctx) -> new IdCreateTime(r.getInt("id"), r.getTimestamp("create_time")))
+                .listPerBatch();
+
+            assertThat(choppedList).hasSize(3);
+            assertThat(choppedList.get(0)).extracting(ic -> ic.id).containsExactly(1, 2);
+            assertThat(choppedList.get(0)).extracting(ic -> ic.createTime)
+                .allMatch(date -> ids.stream().map(idCreateTime -> idCreateTime.createTime).allMatch(date1 -> date1.before(date)));
+            assertThat(choppedList.get(1)).extracting(ic -> ic.id).containsExactly(3, 4);
+            assertThat(choppedList.get(1)).extracting(ic -> ic.createTime)
+                .allMatch(date -> ids.stream().map(idCreateTime -> idCreateTime.createTime).allMatch(date1 -> date1.before(date)));
+            assertThat(choppedList.get(2)).extracting(ic -> ic.id).isEmpty();
+            assertThat(choppedList.get(2)).extracting(ic -> ic.createTime).isEmpty();
+        }
+    }
+
+    @Test
+    public void testListModCount() {
+        try (Handle h = pgExtension.openHandle()) {
+            for (int i = 0; i < 5; i++) {
+                h.execute("INSERT INTO something (name) VALUES('Brian" + i + "')");
+                h.execute("INSERT INTO something (name) VALUES('Tom" + i + "')");
+                h.execute("INSERT INTO something (name) VALUES('Steven" + i + "')");
+            }
+
+            assertThat(h.createQuery("SELECT COUNT(1) FROM something").mapTo(Integer.class).first()).isEqualTo(15);
+
+            PreparedBatch batch = h.prepareBatch("update something set create_time = now() where name like :name");
+            batch.bind("name", "Brian%").add()
+                .bind("name", "Tom%").add()
+                .bind("name", "Steven%").add()
+                .bind("name", "Nothing%").add();
+
+            List<Integer> counts = new ArrayList<>();
+            try (ResultIterator<Integer> i = batch.executeAndGetModCount()) {
+                while (i.hasNext()) {
+                    counts.add(i.next());
+                }
+            }
+
+            assertThat(counts).containsExactly(5, 5, 5, 0);
+
+            PreparedBatch batch2 = h.prepareBatch("update something set create_time = now() where name like :name");
+            batch2.bind("name", "Brian%").add()
+                .bind("name", "Tom%").add()
+                .bind("name", "Steven%").add()
+                .bind("name", "Nothing%").add();
+
+            BatchResultBearing batchResultBearing = batch2.executePreparedBatch();
+            batchResultBearing.mapTo(Integer.class).list();
+
+            int[] batchCounts = batchResultBearing.modifiedRowCounts();
+            assertThat(batchCounts).containsExactly(5, 5, 5, 0);
+
+        }
     }
 
     private static class IdCreateTime {


### PR DESCRIPTION
Add `executePreparedBatch` to supersede `executeAndReturnGeneratedKeys`,
which allows access to the modified row count after execution. Also add
a convenience method to the iterable that allows splitting up the list
of results into per-batch sets.

Addresses the problems described in #2060

Based on a proposal by @doppelrittberger (Markus Ritter)