### PR TITLE
Fix warm() calls for SqlStatementCustomizer

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
@@ -75,6 +75,11 @@ abstract class CustomizingStatementHandler<StatementType extends SqlStatement<St
             .collect(Collectors.toList());
     }
 
+    @Override
+    public void warm(ConfigRegistry config) {
+        statementCustomizers.forEach(s -> s.warm(config));
+    }
+
     // duplicate implementation in SqlObjectFactory
     private static Stream<Class<?>> superTypes(Class<?> type) {
         Class<?>[] interfaces = type.getInterfaces();

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseConfiguredDefaultParameterCustomizerFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/config/TestUseConfiguredDefaultParameterCustomizerFactory.java
@@ -59,7 +59,9 @@ public class TestUseConfiguredDefaultParameterCustomizerFactory {
         SomethingDao h = handle.attach(SomethingDao.class);
         h.findByNameAndIdNoBindAnnotation(1, "Joy");
 
-        assertThat(invocationCounter.get()).isEqualTo(2);
+        // factory is called twice for each parameters, once in
+        // warm() and once in apply()
+        assertThat(invocationCounter.get()).isEqualTo(4);
     }
 
     @Test


### PR DESCRIPTION
Fixes #2040. This needs some discussion as this increases the number of
calls to the #createForParameter of all ParameterCustomizerFactory
implementations.

This is because warm()'ing the SqlStatementCustomizers will call this in
addition to the regular #apply() calls from the BoundStatementCustomizer
in the CustomizingStatementHandler.