### PR TITLE
prefer setter annotations over getter annotations

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BeanPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BeanPropertiesFactory.java
@@ -172,7 +172,7 @@ public class BeanPropertiesFactory {
             @Override
             public <A extends Annotation> Optional<A> getAnnotation(Class<A> anno) {
                 return annoCache.computeIfAbsent(anno, x ->
-                    Stream.of(descriptor.getReadMethod(), descriptor.getWriteMethod())
+                    Stream.of(descriptor.getWriteMethod(), descriptor.getReadMethod())
                         .filter(Objects::nonNull)
                         .map(m -> m.getAnnotation(anno))
                         .filter(Objects::nonNull)

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperNestedTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperNestedTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jdbi.v3.core.mapper.reflect;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Something;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.jdbi.v3.core.mapper.Nested;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.jdbi.v3.core.junit5.H2DatabaseExtension.SOMETHING_INITIALIZER;
+
+public class BeanMapperNestedTest {
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(SOMETHING_INITIALIZER);
+
+    private Handle handle;
+
+    @BeforeEach
+    public void setUp() {
+        this.handle = h2Extension.getSharedHandle();
+        handle.registerRowMapper(BeanMapper.factory(NestedBean.class));
+        handle.registerRowMapper(BeanMapper.factory(NestedPrefixBean.class));
+        handle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
+    }
+
+    @Test
+    public void testNested() {
+        assertThat(handle
+            .createQuery("select id, name from something")
+            .mapTo(NestedBean.class)
+            .one())
+            .extracting("nested.id", "nested.name")
+            .containsExactly(1, "foo");
+    }
+
+    @Test
+    public void testNestedStrict() {
+        handle.getConfig(ReflectionMappers.class).setStrictMatching(true);
+
+        assertThat(handle
+            .createQuery("select id, name from something")
+            .mapTo(NestedBean.class)
+            .one())
+            .extracting("nested.id", "nested.name")
+            .containsExactly(1, "foo");
+
+        assertThatThrownBy(() -> handle
+            .createQuery("select id, name, 1 as other from something")
+            .mapTo(NestedBean.class)
+            .one())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("could not match properties for columns: [other]");
+    }
+
+    @Test
+    public void testNestedNotReturned() {
+        assertThat(handle
+            .createQuery("select 42 as testValue")
+            .mapTo(NestedBean.class)
+            .one())
+            .extracting("testValue", "nested")
+            .containsExactly(42, null);
+    }
+
+    @Test
+    public void testNestedPrefix() {
+        assertThat(handle
+            .createQuery("select id nested_id, name nested_name from something")
+            .mapTo(NestedPrefixBean.class)
+            .one())
+            .extracting("nested.id", "nested.name")
+            .containsExactly(1, "foo");
+    }
+
+    @Test
+    public void testNestedPrefixStrict() {
+        handle.getConfig(ReflectionMappers.class).setStrictMatching(true);
+
+        assertThat(handle
+            .createQuery("select id nested_id, name nested_name, integerValue from something")
+            .mapTo(NestedPrefixBean.class)
+            .one())
+            .extracting("nested.id", "nested.name", "integerValue")
+            .containsExactly(1, "foo", 5);
+
+        assertThatThrownBy(() -> handle
+            .createQuery("select id nested_id, name nested_name, 1 as other from something")
+            .mapTo(NestedPrefixBean.class)
+            .one())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("could not match properties for columns: [other]");
+
+        assertThatThrownBy(() -> handle
+            .createQuery("select id nested_id, name nested_name, 1 as nested_other from something")
+            .mapTo(NestedPrefixBean.class)
+            .one())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("could not match properties for columns: [nested_other]");
+    }
+
+    @Test
+    public void testNestedPrefixNotReturned() {
+        assertThat(handle
+            .createQuery("select 42 as integerValue")
+            .mapTo(NestedPrefixBean.class)
+            .one())
+            .extracting("integerValue", "nested")
+            .containsExactly(42, null);
+    }
+
+    public static class NestedBean {
+
+        private Integer testValue;
+        private Something nested;
+
+        public Integer getTestValue() {
+            return testValue;
+        }
+
+        public void setTestValue(Integer testValue) {
+            this.testValue = testValue;
+        }
+
+        public Something getNested() {
+            return nested;
+        }
+
+        @Nested
+        public void setNested(Something nested) {
+            this.nested = nested;
+        }
+    }
+
+    public static class NestedPrefixBean {
+
+        private Integer integerValue;
+        private Something nested;
+
+        public Integer getIntegerValue() {
+            return integerValue;
+        }
+
+        public void setIntegerValue(Integer integerValue) {
+            this.integerValue = integerValue;
+        }
+
+        public Something getNested() {
+            return nested;
+        }
+
+        @Nested("nested")
+        public void setNested(Something nested) {
+            this.nested = nested;
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperPropagateNullableTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperPropagateNullableTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jdbi.v3.core.mapper.reflect;
+
+import javax.annotation.Nullable;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.jdbi.v3.core.mapper.Nested;
+import org.jdbi.v3.core.mapper.PropagateNull;
+import org.jdbi.v3.core.mapper.reflect.ConstructorMapperTest.ClassPropagateNullThing;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.junit5.H2DatabaseExtension.SOMETHING_INITIALIZER;
+
+public class BeanMapperPropagateNullableTest {
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(SOMETHING_INITIALIZER);
+
+    private Handle handle;
+
+    @BeforeEach
+    public void setUp() {
+        this.handle = h2Extension.getSharedHandle();
+    }
+
+   @Test
+    public void propagateNull() {
+        assertThat(handle
+            .registerRowMapper(BeanMapper.factory(PropagateNullThing.class))
+            .select("SELECT null as testValue, 'foo' as s")
+            .mapTo(PropagateNullThing.class)
+            .one())
+            .isNull();
+    }
+
+    @Test
+    public void propagateNotNull() {
+        assertThat(handle
+            .registerRowMapper(BeanMapper.factory(PropagateNullThing.class))
+            .select("SELECT 42 as testValue, 'foo' as s")
+            .mapTo(PropagateNullThing.class)
+            .one())
+            .extracting("testValue", "s")
+            .containsExactly(42, "foo");
+    }
+
+    @Test
+    public void nestedPropagateNull() {
+        assertThat(handle
+            .registerRowMapper(BeanMapper.factory(NestedPropagateNullThing.class))
+            .select("SELECT 42 as integerValue, null as testValue, 'foo' as s")
+            .mapTo(NestedPropagateNullThing.class)
+            .one())
+            .extracting("integerValue", "nested")
+            .containsExactly(42, null);
+    }
+
+    @Test
+    public void nestedPropagateNotNull() {
+        assertThat(handle
+            .registerRowMapper(BeanMapper.factory(NestedPropagateNullThing.class))
+            .select("SELECT 42 as integerValue, 60 as testValue, 'foo' as s")
+            .mapTo(NestedPropagateNullThing.class)
+            .one())
+            .extracting("integerValue", "nested.testValue", "nested.s")
+            .containsExactly(42, 60, "foo");
+    }
+
+    @Test
+    public void classPropagateNull() {
+        assertThat(handle.select("select 42 as \"value\", null as fk")
+            .map(BeanMapper.of(ClassPropagateNullThing.class))
+            .one())
+            .isNull();
+    }
+
+    @Test
+    public void classPropagateNotNull() {
+        assertThat(handle.select("select 42 as \"value\", 'a' as fk")
+            .map(BeanMapper.of(ClassPropagateNullThing.class))
+            .one())
+            .extracting(cpnt -> cpnt.value)
+            .isEqualTo(42);
+    }
+
+    public static class NestedPropagateNullThing {
+
+        private Integer integerValue;
+        private PropagateNullThing nested;
+
+        public Integer getIntegerValue() {
+            return integerValue;
+        }
+
+        public void setIntegerValue(@Nullable Integer integerValue) {
+            this.integerValue = integerValue;
+        }
+
+        public PropagateNullThing getNested() {
+            return nested;
+        }
+
+        @Nested
+        public void setNested(PropagateNullThing nested) {
+            this.nested = nested;
+        }
+    }
+
+    public static class PropagateNullThing {
+
+        private int testValue;
+        private String s;
+
+        public int getTestValue() {
+            return testValue;
+        }
+
+        @PropagateNull
+        public void setTestValue(int testValue) {
+            this.testValue = testValue;
+        }
+
+        public String getS() {
+            return s;
+        }
+
+        public void setS(String s) {
+            this.s = s;
+        }
+    }
+}

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -1409,7 +1409,8 @@ public class User {
 ----
 
 The `@ColumnName` annotation can be placed on either the getter or setter
-method.
+method. Annotations on the setter are preferred if conflicting annotations
+exist.
 
 [NOTE]
 The `@ColumnName` annotation only applies while mapping SQL data into Java
@@ -4359,7 +4360,7 @@ supports Immutables.
 
 [WARNING]
 Freebuilder support is still experimental and may not support all Freebuilder
-implemented feaatures. We do support both JavaBean style getters and setters as
+implemented features. We do support both JavaBean style getters and setters as
 well as unprefixed getters and setters.
 
 Just tell us about your Freebuilder types by installing the plugin and


### PR DESCRIPTION
As all of the mappers deal with mapping data onto beans (which they use the setters for), they should also prefer the annotations found on the setter over the annotations on the getter.

This PR also splits the very unwieldy and confusing BeanMapperTest into three separate tests, one focusing on general bean mapper properties, one for the PropagateNullable tests and one for Nested tests.