### PR TITLE
Alternate fix for Issue 2109

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgument.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayArgument.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.core.array;
 
+import java.lang.reflect.Array;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -31,7 +32,7 @@ class SqlArrayArgument<T> implements Argument {
 
         @SuppressWarnings("unchecked")
         Stream<T> stream = (Stream<T>) IterableLike.stream(newArray);
-        array = stream.map(arrayType::convertArrayElement).toArray();
+        array = stream.map(arrayType::convertArrayElement).toArray(n -> (Object[]) Array.newInstance(arrayType.getArrayElementClass(), n));
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayType.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayType.java
@@ -39,6 +39,16 @@ public interface SqlArrayType<T> {
     Object convertArrayElement(T element);
 
     /**
+     * Returns the element class that is used to create the backing array. By default, {@link Object} is used
+     * and the backing array is an {@code Object[]} array. Can be overridden if a more specific type is needed.
+     *
+     * @return A {@link Class} instance which is used with {@link java.lang.reflect.Array#newInstance(Class, int)}.
+     */
+    default Class<?> getArrayElementClass() {
+        return Object.class;
+    }
+
+    /**
      * Create a SqlArrayType from the given type and convert function.
      *
      * @param typeName the vendor sql type to use

--- a/postgres/src/main/java/org/jdbi/v3/postgres/internal/ByteaArrayType.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/internal/ByteaArrayType.java
@@ -14,7 +14,6 @@
 package org.jdbi.v3.postgres.internal;
 
 import org.jdbi.v3.core.array.SqlArrayType;
-import org.postgresql.util.PGbytea;
 
 public final class ByteaArrayType implements SqlArrayType<byte[]> {
 
@@ -24,7 +23,12 @@ public final class ByteaArrayType implements SqlArrayType<byte[]> {
     }
 
     @Override
+    public Class<?> getArrayElementClass() {
+        return byte[].class;
+    }
+
+    @Override
     public Object convertArrayElement(byte[] element) {
-        return PGbytea.toPGString(element);
+        return element;
     }
 }


### PR DESCRIPTION
Extend the SqlArrayType class to provide information for the element type of the backing array. Use a byte[] for bytea arrays, fall back to Object otherwise.

@pingw33n, could you check whether this works for you? Looking at the code, it now uses the binary data format. 

I did not want to add this to the 3.33.0 release b/c it requires a minor (default method) change to a public API.