### PR TITLE
Ensure that for non-class arguments, we check for possible supertype matches

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  - AbstractArgumentFactory also need to check for supertypes when the generic argument is not a class (fixes #2026)
+
 # 3.33.0
 
   - make `@Unmappable` work with FieldMapper fields and KotlinMapper properties

--- a/core/src/main/java/org/jdbi/v3/core/argument/AbstractArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/AbstractArgumentFactory.java
@@ -24,6 +24,7 @@ import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 
 import static org.jdbi.v3.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
+import static org.jdbi.v3.core.generic.GenericTypes.isSuperType;
 
 /**
  * An {@link ArgumentFactory} base class for arguments of type {@code T}. For values of type {@code T}, factories
@@ -71,7 +72,8 @@ public abstract class AbstractArgumentFactory<T> implements ArgumentFactory.Prep
             this.isInstance = (type, value) ->
                     argumentClass.isAssignableFrom(getErasedType(type)) || argumentClass.isInstance(value);
         } else {
-            this.isInstance = (type, value) -> argumentType.equals(type);
+            this.isInstance = (type, value) ->
+                argumentType.equals(type) || isSuperType(argumentType, type);
         }
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/generic/GenericTypes.java
@@ -174,12 +174,23 @@ public class GenericTypes {
     }
 
     /**
-     * Perform boxing conversion on a {@code Type}, if it is a primitive type.
-     * Otherwise return the input argument.
+     * Perform boxing conversion on a {@code Type}, if it is a primitive type. Otherwise return the input argument.
+     *
      * @param type the type to box
      * @return the boxed type, or the input type if it is not a primitive
      */
     public static Type box(Type type) {
         return GenericTypeReflector.box(type);
+    }
+
+    /**
+     * Tests whether a given type is a supertype of another type
+     *
+     * @param superType The supertype to check.
+     * @param subType   The subtype to check.
+     * @return True if supertype is a supertype of subtype.
+     */
+    public static boolean isSuperType(Type superType, Type subType) {
+        return GenericTypeReflector.isSuperType(superType, subType);
     }
 }


### PR DESCRIPTION
This fixes #2026

@stevenschlansker @qualidafial, please review. This seems to work but I want more eyeballs.

@peteruhnak