### PR TITLE
Remove Closeable from BaseStatement

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
@@ -89,7 +89,7 @@ public class Batch extends BaseStatement<Batch> {
                 throw new UnableToExecuteStatementException(mungeBatchException(e), getContext());
             }
         } finally {
-            close();
+            nullSafeCleanUp(this);
         }
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -94,8 +94,8 @@ public class Call extends SqlStatement<Call> {
     }
 
     /**
-     * Invoke the callable statement.  Note that the statement will be {@link #close()}d,
-     * so cursor-typed values may not work.
+     * Invoke the callable statement.  Note that the statement will be cleaned up, so cursor-typed values may not work.
+     *
      * @return the output parameters resulting from the invocation.
      */
     public OutParameters invoke() {
@@ -118,6 +118,8 @@ public class Call extends SqlStatement<Call> {
      */
     public <T> T invoke(Function<OutParameters, T> resultComputer) {
         try {
+            // it is ok to ignore the PreparedStatement returned here. internalExecute registers it to close with the context and the
+            // nullSafeCleanUp below will take care of it.
             internalExecute();
             OutParameters out = new OutParameters(getContext());
             for (OutParamArgument param : params) {
@@ -133,7 +135,7 @@ public class Call extends SqlStatement<Call> {
             }
             return resultComputer.apply(out);
         } finally {
-            close();
+            nullSafeCleanUp(this);
         }
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -122,7 +122,7 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
         try {
             return internalBatchExecute().updateCounts;
         } finally {
-            getContext().close();
+            PreparedBatch.nullSafeCleanUp(this);
         }
     }
 
@@ -206,11 +206,7 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
                 return batch.stmt;
             }, getContext());
         } catch (SQLException e) {
-            try {
-                close();
-            } catch (Exception e1) {
-                e.addSuppressed(e1);
-            }
+            cleanUpForException(e);
             throw new UnableToProduceResultException("Exception producing batch result", e, getContext());
         }
     }

--- a/core/src/main/java/org/jdbi/v3/core/statement/Query.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Query.java
@@ -51,11 +51,7 @@ public class Query extends SqlStatement<Query> implements ResultBearing {
         try {
             return producer.produce(this::internalExecute, getContext());
         } catch (SQLException e) {
-            try {
-                close();
-            } catch (Exception e1) {
-                e.addSuppressed(e1);
-            }
+            cleanUpForException(e);
             throw new UnableToProduceResultException(e, getContext());
         }
     }

--- a/core/src/main/java/org/jdbi/v3/core/statement/Update.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Update.java
@@ -68,11 +68,7 @@ public class Update extends SqlStatement<Update> {
         try {
             return producer.produce(this::internalExecute, getContext());
         } catch (SQLException e) {
-            try {
-                close();
-            } catch (Exception e1) {
-                e.addSuppressed(e1);
-            }
+            cleanUpForException(e);
             throw new UnableToProduceResultException("Could not produce statement result", e, getContext());
         }
     }


### PR DESCRIPTION
Interestingly enough, there are only very few changes required to make BaseStatement not implement Closable. And the places are few and all internal.

As we have never actually published that the various SqlStatement things are closable (and basically no one ever should have to deal with them directly anyway), it should be possible to make this change without causing too much scare amongst JDBI users. Or not?

Discussion wanted!

@hjohn would that change help your evaluation? I can follow your arguments and I am not actually sure why BaseStatement extends Closable. I don't think it is really needed. :-) 