### PR TITLE
fix(generator): return latest supported SourceVersion instead of 8

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  - `jdbi3-generator` will now support any Java 8+ version without generating compile-time warnings (#2128)
   - AbstractArgumentFactory also need to check for supertypes when the generic argument is not a class (fixes #2026)
 
 # 3.33.0

--- a/generator/src/main/java/org/jdbi/v3/generator/GenerateSqlObjectProcessor.java
+++ b/generator/src/main/java/org/jdbi/v3/generator/GenerateSqlObjectProcessor.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -53,10 +52,21 @@ import org.jdbi.v3.sqlobject.internal.SqlObjectInitData;
 import org.jdbi.v3.sqlobject.internal.SqlObjectInitData.InContextInvoker;
 
 @SupportedAnnotationTypes("org.jdbi.v3.sqlobject.GenerateSqlObject")
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class GenerateSqlObjectProcessor extends AbstractProcessor {
     private static final Set<ElementKind> ACCEPTABLE = EnumSet.of(ElementKind.CLASS, ElementKind.INTERFACE);
     private long counter = 0;
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        // We should be able to output generated code for any supported releases >= 8.
+        // Considering the bytecode we output for the artifact (i.e. the processor, not the
+        //   generated code) is always Java 8 or newer as of writing, this will not be an issue.
+        //
+        // We return the latest supported version for javac instead of the lowest version we expect
+        //   to support, because javac will print warnings in that case.  This breaks -Werror builds
+        //   on versions higher than this is made to support (i.e. Java 9+ as of writing).
+        return SourceVersion.latestSupported();
+    }
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {


### PR DESCRIPTION
Fixes #2127.

We should be able to output generated code for any supported releases >= 8. Considering the bytecode we output for the artifact (i.e. the processor, not the generated code) is always Java 8 or newer as of writing, this will not be an issue.

We return the latest supported version for javac instead of the lowest version we expect to support, because javac will print warnings in that case. This breaks -Werror builds on versions higher than this is made to support (i.e. Java 9+ as of writing).

Legal note: this code is submitted under the applicable licence(s) (Apache 2.0, Jan 2004) with the ownership retained as Spotify AB.