### PR TITLE
Settle reformatting wars

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -20,7 +20,7 @@
         <artifactId>basepom-oss</artifactId>
         <version>49</version>
         <!-- null out the relative path, otherwise maven complains that the referenced POM is not in the parent directory -->
-        <relativePath/>
+        <relativePath />
     </parent>
 
     <groupId>org.jdbi.internal</groupId>
@@ -604,6 +604,7 @@
                         <nrOfIndentSpace>4</nrOfIndentSpace>
                         <sortDependencies>scope</sortDependencies>
                         <sortProperties>true</sortProperties>
+                        <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
                         <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
                     </configuration>
                 </plugin>
@@ -772,7 +773,7 @@
                         <configuration>
                             <rules>
                                 <!-- Ensure consistency -->
-                                <dependencyConvergence/>
+                                <dependencyConvergence />
                                 <requireProperty>
                                     <property>moduleName</property>
                                     <message>This module must set a moduleName.</message>
@@ -830,7 +831,7 @@
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>
-                                                <ignore/>
+                                                <ignore />
                                             </action>
                                         </pluginExecution>
                                         <pluginExecution>
@@ -843,7 +844,7 @@
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>
-                                                <ignore/>
+                                                <ignore />
                                             </action>
                                         </pluginExecution>
                                     </pluginExecutions>


### PR DESCRIPTION
Make the sortpom plugin format the empty xml tags the same way that the release plugin does.