### PR TITLE
Append Maven project.artifactId to project.name in parens

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -23,7 +23,7 @@
 
     <artifactId>jdbi3-benchmark</artifactId>
 
-    <name>jdbi3 benchmarks</name>
+    <name>jdbi3 benchmarks (${project.artifactId})</name>
 
     <properties>
         <basepom.check.skip-checkstyle>true</basepom.check.skip-checkstyle>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>jdbi3-bom</artifactId>
     <packaging>pom</packaging>
 
-    <name>jdbi3 BOM</name>
+    <name>jdbi3 BOM (${project.artifactId})</name>
     <description>Jdbi is designed to provide convenient tabular data access in
         Java(tm). It uses the Java collections framework for query
         results, provides a convenient means of externalizing sql

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <artifactId>jdbi3-commons-text</artifactId>
 
-    <name>jdbi3 Apache Commons Text integration</name>
+    <name>jdbi3 ${project.artifactId} integration</name>
     <description>Provides features implemented with Apache Commons Text.</description>
 
     <licenses>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-core</artifactId>
-    <name>jdbi3 Core</name>
+    <name>jdbi3 Core (${project.artifactId})</name>
     <description>jdbi is designed to provide convenient tabular data access in
         Java(tm). It uses the Java collections framework for query
         results, provides a convenient means of externalizing sql

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-docs</artifactId>
-    <name>jdbi3 documentation</name>
+    <name>jdbi3 documentation (${project.artifactId})</name>
 
     <description>Build and deploy jdbi docs, written in AsciiDoc.</description>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-examples</artifactId>
-    <name>jdbi3 example code</name>
+    <name>jdbi3 example code (${project.artifactId})</name>
 
     <properties>
         <moduleName>org.jdbi.v3.examples</moduleName>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-freemarker</artifactId>
-    <name>jdbi3 Freemarker integration</name>
+    <name>jdbi3 Freemarker integration (${project.artifactId})</name>
     <description>jdbi-freemarker locates SQL statements in Freemarker files on the classpath</description>
 
     <licenses>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-generator</artifactId>
-    <name>jdbi3 Generator</name>
+    <name>jdbi3 Generator (${project.artifactId})</name>
     <description>jdbi Generator creates SqlObject implementations and simple value classes</description>
 
     <licenses>

--- a/gson2/pom.xml
+++ b/gson2/pom.xml
@@ -21,7 +21,7 @@
     </parent>
 
     <artifactId>jdbi3-gson2</artifactId>
-    <name>jdbi3 gson2</name>
+    <name>jdbi3 gson2 (${project.artifactId})</name>
     <description>Jdbi Gson 2 integration</description>
 
     <properties>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-guava</artifactId>
-    <name>jdbi3 Guava Integration</name>
+    <name>jdbi3 Guava Integration (${project.artifactId})</name>
 
     <properties>
         <moduleName>org.jdbi.v3.guava</moduleName>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-guice</artifactId>
-    <name>jdbi3 Guice Integration</name>
+    <name>jdbi3 Guice Integration (${project.artifactId})</name>
 
     <properties>
         <moduleName>org.jdbi.v3.guice</moduleName>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>jdbi3-build-parent</artifactId>
     <version>3.34.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>jdbi3 - internal - build parent</name>
+    <name>jdbi3 - internal - build parent (${project.artifactId})</name>
     <description>JDBI build related artifacts. Not for public consumption</description>
 
     <!-- do not remove URL and SCM, otherwise OSS refuses to accept the release -->

--- a/internal/policy/pom.xml
+++ b/internal/policy/pom.xml
@@ -26,6 +26,6 @@
     <groupId>org.jdbi.internal</groupId>
     <artifactId>jdbi3-policy</artifactId>
     <version>3.34.1-SNAPSHOT</version>
-    <name>jdbi3 - internal - policy</name>
+    <name>jdbi3 - internal - policy (${project.artifactId})</name>
     <description>Policy files for Jdbi build configuration</description>
 </project>

--- a/internal/pom.xml
+++ b/internal/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>jdbi3-internal-parent</artifactId>
     <version>3.34.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>jdbi3 - internal - parent</name>
+    <name>jdbi3 - internal - parent (${project.artifactId})</name>
 
     <modules>
         <module>policy</module>

--- a/jackson2/pom.xml
+++ b/jackson2/pom.xml
@@ -21,7 +21,7 @@
     </parent>
 
     <artifactId>jdbi3-jackson2</artifactId>
-    <name>jdbi3 jackson2</name>
+    <name>jdbi3 jackson2 (${project.artifactId})</name>
     <description>Jdbi Jackson 2 integration</description>
 
     <properties>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-jodatime2</artifactId>
-    <name>jdbi3 Joda-Time Integration</name>
+    <name>jdbi3 Joda-Time Integration (${project.artifactId})</name>
 
     <developers>
         <developer>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-jpa</artifactId>
-    <name>jdbi3 JPA Integration</name>
+    <name>jdbi3 JPA Integration (${project.artifactId})</name>
 
     <developers>
         <developer>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -21,7 +21,7 @@
     </parent>
 
     <artifactId>jdbi3-json</artifactId>
-    <name>jdbi3 json</name>
+    <name>jdbi3 json (${project.artifactId})</name>
     <description>Jdbi Json column support</description>
 
     <properties>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-kotlin-sqlobject</artifactId>
-    <name>jdbi3 SqlObject Kotlin plugin</name>
+    <name>jdbi3 ${project.artifactId} plugin</name>
 
     <developers>
         <developer>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-kotlin</artifactId>
-    <name>jdbi3 Kotlin plugin</name>
+    <name>jdbi3 Kotlin plugin (${project.artifactId})</name>
 
     <developers>
         <developer>

--- a/lombok/pom.xml
+++ b/lombok/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-lombok</artifactId>
-    <name>jdbi3 lombok</name>
+    <name>jdbi3 lombok (${project.artifactId})</name>
 
     <properties>
         <basepom.deploy.skip>true</basepom.deploy.skip>

--- a/moshi/pom.xml
+++ b/moshi/pom.xml
@@ -21,7 +21,7 @@
     </parent>
 
     <artifactId>jdbi3-moshi</artifactId>
-    <name>jdbi3 moshi</name>
+    <name>jdbi3 moshi (${project.artifactId})</name>
     <description>Jdbi Moshi integration</description>
 
     <properties>

--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-noparameters</artifactId>
-    <name>jdbi3 noparameters tests</name>
+    <name>jdbi3 noparameters tests (${project.artifactId})</name>
 
     <description>Unit tests for scenarios where javac compiles without -parameters flag</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>jdbi3-parent</artifactId>
     <version>3.34.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>jdbi3 Parent</name>
+    <name>jdbi3 Parent (${project.artifactId})</name>
     <description>Jdbi is designed to provide convenient tabular data access in
     Java(tm). It uses the Java collections framework for query
     results, provides a convenient means of externalizing sql

--- a/postgis/pom.xml
+++ b/postgis/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-postgis</artifactId>
-    <name>jdbi3 PostGIS</name>
+    <name>jdbi3 PostGIS (${project.artifactId})</name>
     <description>jdbi PostgreSQL PostGIS support</description>
 
     <licenses>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-postgres</artifactId>
-    <name>jdbi3 Postgres</name>
+    <name>jdbi3 Postgres (${project.artifactId})</name>
     <description>jdbi PostgreSQL specific features</description>
 
     <licenses>

--- a/spring5/pom.xml
+++ b/spring5/pom.xml
@@ -21,7 +21,7 @@
     </parent>
 
     <artifactId>jdbi3-spring5</artifactId>
-    <name>jdbi3 Spring 5</name>
+    <name>jdbi3 Spring 5 (${project.artifactId})</name>
     <description>jdbi Spring 4/5 forward compatibility testing</description>
 
     <properties>

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -21,7 +21,7 @@
     </parent>
 
     <artifactId>jdbi3-sqlite</artifactId>
-    <name>jdbi3 sqlite</name>
+    <name>jdbi3 sqlite (${project.artifactId})</name>
     <description>Jdbi sqlite support</description>
 
     <licenses>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-sqlobject</artifactId>
-    <name>jdbi3 SqlObject</name>
+    <name>jdbi3 SqlObject (${project.artifactId})</name>
     <description>jdbi SqlObject transforms simple annotated interfaces into
         full-featured DAO implementations.</description>
 

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-stringtemplate4</artifactId>
-    <name>jdbi3 String Template 4 integration</name>
+    <name>jdbi3 ${project.artifactId} integration</name>
     <description>jdbi-stringtemplate4 locates SQL statements in StringTemplate 4 files on the classpath</description>
 
     <licenses>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>jdbi3-testing</artifactId>
-    <name>jdbi3 Test Helpers</name>
+    <name>jdbi3 Test Helpers (${project.artifactId})</name>
     <description>Utilities for testing Jdbi</description>
 
     <licenses>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -21,7 +21,7 @@
     </parent>
 
     <artifactId>jdbi3-vavr</artifactId>
-    <name>jdbi3 Vavr Integration</name>
+    <name>jdbi3 Vavr Integration (${project.artifactId})</name>
 
     <description>Vavr is a functional programming library for the JVM.
         It is greatly inspired by scala and brings persistent,


### PR DESCRIPTION
to show directory name of module in Maven builds
e.g. "Building jdbi3 BOM..." becomes "Building jdbi3 BOM (jdbi3-bom)..."
This way it becomes more obvious which subdirectory to cd into to fix the build of a failing module etc.


