### PR TITLE
Add Maven profile 'fast'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 SHELL = /bin/sh
 .SUFFIXES:
-.PHONY: help clean install install-nodocker docs tests tests-nodocker publish-docs deploy release
+.PHONY: help clean install install-nodocker install-fast docs tests tests-nodocker publish-docs deploy release
 
 # replace JDBI_MAVEN_OPTS with implicit MAVEN_OPTS, once 3.9.x or later has been released
 MAVEN = ./mvnw ${JDBI_MAVEN_OPTS}
@@ -30,6 +30,9 @@ install:
 
 install-nodocker: JDBI_MAVEN_OPTS += -Dno-docker
 install-nodocker: install
+
+install-fast: JDBI_MAVEN_OPTS += -Pfast
+install-fast: install
 
 docs: JDBI_MAVEN_OPTS += -Dbasepom.check.skip-all=true -Dbasepom.javadoc.skip=false -DskipTests=true
 docs: install
@@ -57,6 +60,7 @@ help:
 	@echo " * clean            - clean local build tree"
 	@echo " * install          - builds and installs the current version in the local repository"
 	@echo " * install-nodocker - same as 'install', but skip all tests that require a local docker installation"
+	@echo " * install-fast     - same as 'install', but skip test execution and code analysis (Checkstyle/PMD/Spotbugs)
 	@echo " * docs             - build up-to-date documentation in docs/target/generated-docs/"
 	@echo " * tests            - run all unit and integration tests"
 	@echo " * tests-nodocker   - same as 'tests', but skip all tests that require a local docker installation"

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -1057,5 +1057,15 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <!-- Profile to skip time-consuming steps. -->
+            <id>fast</id>
+            <properties>
+                <basepom.check.skip-all>true</basepom.check.skip-all>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+
     </profiles>
 </project>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -64,7 +64,7 @@
         <dep.freebuilder.version>2.7.0</dep.freebuilder.version>
         <dep.guava.version>30.1.1-jre</dep.guava.version>
         <dep.h2.version>2.1.212</dep.h2.version>
-        <dep.hsqldb.version>2.6.0</dep.hsqldb.version>
+        <dep.hsqldb.version>2.7.1</dep.hsqldb.version>
         <dep.immutables.version>2.8.8</dep.immutables.version>
         <dep.jackson2.version>2.10.5.20201202</dep.jackson2.version>
         <dep.jdbi-policy.version>3.34.1-SNAPSHOT</dep.jdbi-policy.version>


### PR DESCRIPTION
This PR adds Maven profile 'fast' to the internal build parent POM.
The profile is intended to build the project while skipping all time-consuming steps such as test execution, pmd, checkstyle, javadoc, etc. It is of course not active by default.