### PR TITLE
Tighten Checkstyle ruleset

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/EnumArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/EnumArgumentFactory.java
@@ -73,10 +73,10 @@ class EnumArgumentFactory implements QualifiedArgumentFactory {
                                                                           E value,
                                                                           Function<E, A> transform,
                                                                           ConfigRegistry config) {
-            if (value == null) {
-                return Optional.of(new NullArgument(nullType));
-            }
+        if (value == null) {
+            return Optional.of(new NullArgument(nullType));
+        }
 
-            return config.get(Arguments.class).findFor(attributeType, transform.apply(value));
+        return config.get(Arguments.class).findFor(attributeType, transform.apply(value));
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/collector/OptionalCollectors.java
+++ b/core/src/main/java/org/jdbi/v3/core/collector/OptionalCollectors.java
@@ -32,76 +32,76 @@ public class OptionalCollectors {
     }
 
     /**
-   * Returns a {@code Collector} that accumulates 0 or 1 input elements into an {@code Optional<T>}.
-   * The returned collector will throw {@code IllegalStateException} whenever 2 or more elements
-   * are present in a stream. Null elements are mapped to {@code Optional.empty()}.
-   *
-   * @param <T> the collected type
-   * @return a {@code Collector} which collects 0 or 1 input elements into an {@code Optional<T>}.
-   */
-  public static <T> Collector<T, ?, Optional<T>> toOptional() {
-    return toOptional(Optional::empty, Optional::of);
-  }
+     * Returns a {@code Collector} that accumulates 0 or 1 input elements into an {@code Optional<T>}.
+     * The returned collector will throw {@code IllegalStateException} whenever 2 or more elements
+     * are present in a stream. Null elements are mapped to {@code Optional.empty()}.
+     *
+     * @param <T> the collected type
+     * @return a {@code Collector} which collects 0 or 1 input elements into an {@code Optional<T>}.
+     */
+    public static <T> Collector<T, ?, Optional<T>> toOptional() {
+        return toOptional(Optional::empty, Optional::of);
+    }
 
-  /**
-   * Returns a {@code Collector} that accumulates 0 or 1 input {@code Integer} elements into an
-   * {@code OptionalInt}. The returned collector will throw {@code IllegalStateException} whenever
-   * 2 or more elements are present in a stream. Null elements are mapped to
-   * {@code OptionalInt.empty()}.
-   *
-   * @return a {@code Collector} which collects 0 or 1 input {@code Integer} elements into an
-   * {@code OptionalInt}.
-   */
-  public static Collector<Integer, ?, OptionalInt> toOptionalInt() {
-    return toOptional(OptionalInt::empty, OptionalInt::of);
-  }
+    /**
+     * Returns a {@code Collector} that accumulates 0 or 1 input {@code Integer} elements into an
+     * {@code OptionalInt}. The returned collector will throw {@code IllegalStateException} whenever
+     * 2 or more elements are present in a stream. Null elements are mapped to
+     * {@code OptionalInt.empty()}.
+     *
+     * @return a {@code Collector} which collects 0 or 1 input {@code Integer} elements into an
+     * {@code OptionalInt}.
+     */
+    public static Collector<Integer, ?, OptionalInt> toOptionalInt() {
+        return toOptional(OptionalInt::empty, OptionalInt::of);
+    }
 
-  /**
-   * Returns a {@code Collector} that accumulates 0 or 1 input {@code Long} elements into an
-   * {@code OptionalLong}. The returned collector will throw {@code IllegalStateException} whenever
-   * 2 or more elements are present in a stream. Null elements are mapped to
-   * {@code OptionalLong.empty()}.
-   *
-   * @return a {@code Collector} which collects 0 or 1 input {@code Long} elements into an
-   * {@code OptionalLong}.
-   */
-  public static Collector<Long, ?, OptionalLong> toOptionalLong() {
-    return toOptional(OptionalLong::empty, OptionalLong::of);
-  }
+    /**
+     * Returns a {@code Collector} that accumulates 0 or 1 input {@code Long} elements into an
+     * {@code OptionalLong}. The returned collector will throw {@code IllegalStateException} whenever
+     * 2 or more elements are present in a stream. Null elements are mapped to
+     * {@code OptionalLong.empty()}.
+     *
+     * @return a {@code Collector} which collects 0 or 1 input {@code Long} elements into an
+     * {@code OptionalLong}.
+     */
+    public static Collector<Long, ?, OptionalLong> toOptionalLong() {
+        return toOptional(OptionalLong::empty, OptionalLong::of);
+    }
 
-  /**
-   * Returns a {@code Collector} that accumulates 0 or 1 input {@code Double} elements into an
-   * {@code OptionalDouble}. The returned collector will throw {@code IllegalStateException}
-   * whenever 2 or more elements are present in a stream. Null elements are mapped to
-   * {@code OptionalDouble.empty()}.
-   *
-   * @return a {@code Collector} which collects 0 or 1 input {@code Double} elements into an
-   * {@code OptionalDouble}.
-   */
-  public static Collector<Double, ?, OptionalDouble> toOptionalDouble() {
-    return toOptional(OptionalDouble::empty, OptionalDouble::of);
-  }
+    /**
+     * Returns a {@code Collector} that accumulates 0 or 1 input {@code Double} elements into an
+     * {@code OptionalDouble}. The returned collector will throw {@code IllegalStateException}
+     * whenever 2 or more elements are present in a stream. Null elements are mapped to
+     * {@code OptionalDouble.empty()}.
+     *
+     * @return a {@code Collector} which collects 0 or 1 input {@code Double} elements into an
+     * {@code OptionalDouble}.
+     */
+    public static Collector<Double, ?, OptionalDouble> toOptionalDouble() {
+        return toOptional(OptionalDouble::empty, OptionalDouble::of);
+    }
 
-  /**
-   * Returns a {@code Collector} that accumulates 0 or 1 input elements into an arbitrary
-   * optional-style container type. The returned collector will throw
-   * {@code IllegalStateException} whenever 2 or more elements are present in a stream. Null elements
-   * are mapped to an empty container.
-   *
-   * @param empty   Supplies an instance of the optional type with no value.
-   * @param factory Returns an instance of the optional type with the input parameter as the value.
-   * @param <T>     The optional element type.
-   * @param <O>     The optional type, which may incorporate the {@code T} generic parameter e.g.
-   *                {@code Optional<T>}.
-   * @return a {@code Collector} which collects 0 or 1 input elements into an arbitrary
-   * optional-style container type.
-   */
-  public static <T, O> Collector<T, ?, O> toOptional(Supplier<O> empty,
-                                                     Function<T, O> factory) {
-    return Collector.of(
-        () -> new OptionalBuilder<>(empty, factory),
-        OptionalBuilder::set,
-        OptionalBuilder::combine,
-        OptionalBuilder::build);
-  }
+    /**
+     * Returns a {@code Collector} that accumulates 0 or 1 input elements into an arbitrary
+     * optional-style container type. The returned collector will throw
+     * {@code IllegalStateException} whenever 2 or more elements are present in a stream. Null elements
+     * are mapped to an empty container.
+     *
+     * @param empty   Supplies an instance of the optional type with no value.
+     * @param factory Returns an instance of the optional type with the input parameter as the value.
+     * @param <T>     The optional element type.
+     * @param <O>     The optional type, which may incorporate the {@code T} generic parameter e.g.
+     *                {@code Optional<T>}.
+     * @return a {@code Collector} which collects 0 or 1 input elements into an arbitrary
+     * optional-style container type.
+     */
+    public static <T, O> Collector<T, ?, O> toOptional(Supplier<O> empty, Function<T, O> factory) {
+        return Collector.of(
+            () -> new OptionalBuilder<>(empty, factory),
+            OptionalBuilder::set,
+            OptionalBuilder::combine,
+            OptionalBuilder::build);
+    }
+
 }

--- a/core/src/main/java/org/jdbi/v3/core/internal/AnnotationFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/AnnotationFactory.java
@@ -39,16 +39,16 @@ public class AnnotationFactory {
     }
     public static <T extends Annotation> T create(Class<T> annotationType, Map<String, ?> values) {
         Arrays.stream(annotationType.getDeclaredMethods())
-            .filter(m -> m.getDefaultValue() == null)
-            .filter(m -> !values.containsKey(m.getName()))
-            .findAny()
-            .ifPresent(m -> {
-                throw new IllegalArgumentException(String.format(
-                        "Cannot synthesize annotation @%s from %s.class because it has attribute '%s' without a default or specified value",
-                        annotationType.getSimpleName(),
-                        annotationType.getName(),
-                        m.getName()));
-        });
+                .filter(m -> m.getDefaultValue() == null)
+                .filter(m -> !values.containsKey(m.getName()))
+                .findAny()
+                .ifPresent(m -> {
+                    throw new IllegalArgumentException(String.format(
+                            "Cannot synthesize annotation @%s from %s.class because it has attribute '%s' without a default or specified value",
+                            annotationType.getSimpleName(),
+                            annotationType.getName(),
+                            m.getName()));
+                });
 
         Class<?>[] interfaces = {annotationType};
         InvocationHandler invocationHandler = getInvocationHandler(annotationType, values);
@@ -130,13 +130,12 @@ public class AnnotationFactory {
             Object valueA = invoker.apply(a);
             Object valueB = invoker.apply(b);
             if (valueA != null
-             && valueB != null
-             && valueA.getClass().isArray()
-             && valueA.getClass().equals(valueB.getClass())
-             && Boolean.FALSE.equals(Unchecked.supplier(() ->
-                    MethodHandles.publicLookup()
-                        .findStatic(Arrays.class, "equals", MethodType.methodType(boolean.class, valueA.getClass(), valueB.getClass()))
-                        .invoke(a, b)).get())) {
+                    && valueB != null
+                    && valueA.getClass().isArray()
+                    && valueA.getClass().equals(valueB.getClass())
+                    && Boolean.FALSE.equals(Unchecked.supplier(() -> MethodHandles.publicLookup()
+                            .findStatic(Arrays.class, "equals", MethodType.methodType(boolean.class, valueA.getClass(), valueB.getClass()))
+                            .invoke(a, b)).get())) {
                 return false;
             }
             if (!Objects.equals(valueA, valueB)) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/JoinRowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/JoinRowMapper.java
@@ -37,8 +37,7 @@ public class JoinRowMapper implements RowMapper<JoinRow> {
     }
 
     @Override
-    public JoinRow map(ResultSet r, StatementContext ctx)
-    throws SQLException {
+    public JoinRow map(ResultSet r, StatementContext ctx) throws SQLException {
         return specialize(r, ctx).map(r, ctx);
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/Nested.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/Nested.java
@@ -27,10 +27,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({PARAMETER, FIELD, METHOD})
 public @interface Nested {
-  /**
-   * The column name prefix for all members of the nested object. If unset,
-   * no column name prefix is applied.
-   * @return the column name prefix
-   */
-  String value() default "";
+    /**
+     * The column name prefix for all members of the nested object. If unset,
+     * no column name prefix is applied.
+     * @return the column name prefix
+     */
+    String value() default "";
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/SnakeCaseColumnNameMatcher.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/SnakeCaseColumnNameMatcher.java
@@ -26,7 +26,7 @@ public class SnakeCaseColumnNameMatcher extends AbstractSeparatorCharColumnNameM
         super('_');
     }
 
-   @Override
+    @Override
     public String toString() {
         return getClass().getSimpleName();
     }

--- a/core/src/main/java/org/jdbi/v3/core/result/RowReducer.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/RowReducer.java
@@ -24,31 +24,32 @@ import java.util.stream.Stream;
  * @see ResultBearing#reduceRows(RowReducer)
  */
 public interface RowReducer<C, R> {
-  /**
-   * Returns a new, empty result container.
-   *
-   * @return a new result container.
-   */
-  C container();
+    /**
+     * Returns a new, empty result container.
+     *
+     * @return a new result container.
+     */
+    C container();
 
-  /**
-   * Accumulate data from the current row into the result container. Do not attempt
-   * to accumulate the {@link RowView} itself into the result container--it is only
-   * valid within the {@link RowReducer#accumulate(Object, RowView) accumulate()}
-   * method invocation. Instead, extract mapped types from the RowView by calling
-   * {@code RowView.getRow()} or {@code RowView.getColumn()} and store those values
-   * in the container.
-   *
-   * @param container the result container
-   * @param rowView row view over the current result set row.
-   */
-  void accumulate(C container, RowView rowView);
+    /**
+     * Accumulate data from the current row into the result container. Do not attempt
+     * to accumulate the {@link RowView} itself into the result container--it is only
+     * valid within the {@link RowReducer#accumulate(Object, RowView) accumulate()}
+     * method invocation. Instead, extract mapped types from the RowView by calling
+     * {@code RowView.getRow()} or {@code RowView.getColumn()} and store those values
+     * in the container.
+     *
+     * @param container the result container
+     * @param rowView row view over the current result set row.
+     */
+    void accumulate(C container, RowView rowView);
 
-  /**
-   * Returns a stream of result elements from the result container.
-   *
-   * @param container the result container
-   * @return stream of result elements.
-   */
-  Stream<R> stream(C container);
+    /**
+     * Returns a stream of result elements from the result container.
+     *
+     * @param container the result container
+     * @return stream of result elements.
+     */
+    Stream<R> stream(C container);
+
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -182,7 +182,7 @@ public class Call extends SqlStatement<Call> {
                     case Types.BIGINT:
                         return stmt.getLong(position);
                     case Types.TIMESTAMP:
-                        case Types.TIME:
+                    case Types.TIME:
                         return stmt.getTimestamp(position);
                     case Types.DATE:
                         return stmt.getDate(position);

--- a/core/src/main/java/org/jdbi/v3/core/statement/DefinedAttributeTemplateEngine.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/DefinedAttributeTemplateEngine.java
@@ -56,29 +56,29 @@ public class DefinedAttributeTemplateEngine implements TemplateEngine.Parsing {
         Token t = lexer.nextToken();
         while (t.getType() != EOF) {
             switch (t.getType()) {
-            case COMMENT:
-            case LITERAL:
-            case QUOTED_TEXT:
-            case DOUBLE_QUOTED_TEXT:
-                buf.append(t.getText());
-                break;
-            case DEFINE:
-                pushBuf.run();
-                String text = t.getText();
-                String key = text.substring(1, text.length() - 1);
-                preparation.add((ctx, b) -> {
-                    Object value = ctx.getAttribute(key);
-                    if (value == null) {
-                        throw new UnableToCreateStatementException("Undefined attribute for token '" + text + "'", ctx);
-                    }
-                    b.append(value);
-                });
-                break;
-            case ESCAPED_TEXT:
-                buf.append(t.getText().substring(1));
-                break;
-            default:
-                break;
+                case COMMENT:
+                case LITERAL:
+                case QUOTED_TEXT:
+                case DOUBLE_QUOTED_TEXT:
+                    buf.append(t.getText());
+                    break;
+                case DEFINE:
+                    pushBuf.run();
+                    String text = t.getText();
+                    String key = text.substring(1, text.length() - 1);
+                    preparation.add((ctx, b) -> {
+                        Object value = ctx.getAttribute(key);
+                        if (value == null) {
+                            throw new UnableToCreateStatementException("Undefined attribute for token '" + text + "'", ctx);
+                        }
+                        b.append(value);
+                    });
+                    break;
+                case ESCAPED_TEXT:
+                    buf.append(t.getText().substring(1));
+                    break;
+                default:
+                    break;
             }
             t = lexer.nextToken();
         }

--- a/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
@@ -124,7 +124,7 @@ public class OutParameters {
         if (obj == null) {
             if (!map.containsKey(name)) {
                 throw new IllegalArgumentException(format("Parameter '%s' does not exist", name));
-           }
+            }
 
             return null;
         }
@@ -141,7 +141,7 @@ public class OutParameters {
         if (obj == null) {
             if (!map.containsKey(pos)) {
                 throw new IllegalArgumentException(format("Parameter at %d does not exist", pos));
-           }
+            }
 
             return null;
         }

--- a/core/src/test/java/org/jdbi/v3/core/TestHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestHandle.java
@@ -205,14 +205,14 @@ public class TestHandle {
     public void testAllNestedOpsSameHandle() {
         Jdbi jdbi = h2Extension.getJdbi();
         jdbi.useHandle(handle1 ->
-                jdbi.useTransaction(handle2 ->
-                        jdbi.withHandle(handle3 ->
-                                jdbi.inTransaction(handle4 -> {
-                                assertThat(handle1).isSameAs(handle2);
-                                assertThat(handle1).isSameAs(handle3);
-                                assertThat(handle1).isSameAs(handle4);
-                                return null;
-                            }))));
+            jdbi.useTransaction(handle2 ->
+                jdbi.withHandle(handle3 ->
+                    jdbi.inTransaction(handle4 -> {
+                        assertThat(handle1).isSameAs(handle2);
+                        assertThat(handle1).isSameAs(handle3);
+                        assertThat(handle1).isSameAs(handle4);
+                        return null;
+                    }))));
     }
 
     static class BoomHandler extends LocalTransactionHandler {

--- a/core/src/test/java/org/jdbi/v3/core/collector/OptionalCollectorsTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/collector/OptionalCollectorsTest.java
@@ -26,95 +26,96 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class OptionalCollectorsTest {
-  @Test
-  public void toOptional() {
-    Collector<String, ?, Optional<String>> collector = OptionalCollectors.toOptional();
+    @Test
+    public void toOptional() {
+        Collector<String, ?, Optional<String>> collector = OptionalCollectors.toOptional();
 
-    assertThat(Stream.<String>empty().collect(collector)).isEmpty();
+        assertThat(Stream.<String>empty().collect(collector)).isEmpty();
 
-    assertThat(Stream.of((String) null).collect(collector)).isEmpty();
-    assertThat(Stream.of("foo").collect(collector)).hasValue("foo");
+        assertThat(Stream.of((String) null).collect(collector)).isEmpty();
+        assertThat(Stream.of("foo").collect(collector)).hasValue("foo");
 
-    assertThatThrownBy(
-        () -> Stream.of("foo", "bar").collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: ['foo', 'bar', ...]");
-    assertThatThrownBy(
-        () -> Stream.of("foo", null).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: ['foo', null, ...]");
-    assertThatThrownBy(
-        () -> Stream.of(null, "bar").collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: [null, 'bar', ...]");
-  }
+        assertThatThrownBy(
+                () -> Stream.of("foo", "bar").collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: ['foo', 'bar', ...]");
+        assertThatThrownBy(
+                () -> Stream.of("foo", null).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: ['foo', null, ...]");
+        assertThatThrownBy(
+                () -> Stream.of(null, "bar").collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: [null, 'bar', ...]");
+    }
 
-  @Test
-  public void toOptionalInt() {
-    Collector<Integer, ?, OptionalInt> collector = OptionalCollectors.toOptionalInt();
+    @Test
+    public void toOptionalInt() {
+        Collector<Integer, ?, OptionalInt> collector = OptionalCollectors.toOptionalInt();
 
-    assertThat(Stream.<Integer>empty().collect(collector)).isEmpty();
+        assertThat(Stream.<Integer>empty().collect(collector)).isEmpty();
 
-    assertThat(Stream.of((Integer) null).collect(collector)).isEmpty();
-    assertThat(Stream.of(1).collect(collector)).hasValue(1);
+        assertThat(Stream.of((Integer) null).collect(collector)).isEmpty();
+        assertThat(Stream.of(1).collect(collector)).hasValue(1);
 
-    assertThatThrownBy(
-        () -> Stream.of(1, 2).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: ['1', '2', ...]");
-    assertThatThrownBy(
-        () -> Stream.of(1, null).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: ['1', null, ...]");
-    assertThatThrownBy(
-        () -> Stream.of(null, 2).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: [null, '2', ...]");
-  }
+        assertThatThrownBy(
+                () -> Stream.of(1, 2).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: ['1', '2', ...]");
+        assertThatThrownBy(
+                () -> Stream.of(1, null).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: ['1', null, ...]");
+        assertThatThrownBy(
+                () -> Stream.of(null, 2).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: [null, '2', ...]");
+    }
 
-  @Test
-  public void toOptionalLong() {
-    Collector<Long, ?, OptionalLong> collector = OptionalCollectors.toOptionalLong();
+    @Test
+    public void toOptionalLong() {
+        Collector<Long, ?, OptionalLong> collector = OptionalCollectors.toOptionalLong();
 
-    assertThat(Stream.<Long>empty().collect(collector)).isEmpty();
+        assertThat(Stream.<Long>empty().collect(collector)).isEmpty();
 
-    assertThat(Stream.of((Long) null).collect(collector)).isEmpty();
-    assertThat(Stream.of(1L).collect(collector)).hasValue(1L);
+        assertThat(Stream.of((Long) null).collect(collector)).isEmpty();
+        assertThat(Stream.of(1L).collect(collector)).hasValue(1L);
 
-    assertThatThrownBy(
-        () -> Stream.of(1L, 2L).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: ['1', '2', ...]");
-    assertThatThrownBy(
-        () -> Stream.of(1L, null).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: ['1', null, ...]");
-    assertThatThrownBy(
-        () -> Stream.of(null, 2L).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: [null, '2', ...]");
-  }
+        assertThatThrownBy(
+                () -> Stream.of(1L, 2L).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: ['1', '2', ...]");
+        assertThatThrownBy(
+                () -> Stream.of(1L, null).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: ['1', null, ...]");
+        assertThatThrownBy(
+                () -> Stream.of(null, 2L).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: [null, '2', ...]");
+    }
 
-  @Test
-  public void toOptionalDouble() {
-    Collector<Double, ?, OptionalDouble> collector = OptionalCollectors.toOptionalDouble();
+    @Test
+    public void toOptionalDouble() {
+        Collector<Double, ?, OptionalDouble> collector = OptionalCollectors.toOptionalDouble();
 
-    assertThat(Stream.<Double>empty().collect(collector)).isEmpty();
+        assertThat(Stream.<Double>empty().collect(collector)).isEmpty();
 
-    assertThat(Stream.of((Double) null).collect(collector)).isEmpty();
-    assertThat(Stream.of(1.5d).collect(collector)).hasValue(1.5d);
+        assertThat(Stream.of((Double) null).collect(collector)).isEmpty();
+        assertThat(Stream.of(1.5d).collect(collector)).hasValue(1.5d);
 
-    assertThatThrownBy(
-        () -> Stream.of(1.5d, 2.25d).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: ['1.5', '2.25', ...]");
-    assertThatThrownBy(
-        () -> Stream.of(1.5d, null).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: ['1.5', null, ...]");
-    assertThatThrownBy(
-        () -> Stream.of(null, 2.25d).collect(collector))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Multiple values for optional: [null, '2.25', ...]");
-  }
+        assertThatThrownBy(
+                () -> Stream.of(1.5d, 2.25d).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: ['1.5', '2.25', ...]");
+        assertThatThrownBy(
+                () -> Stream.of(1.5d, null).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: ['1.5', null, ...]");
+        assertThatThrownBy(
+                () -> Stream.of(null, 2.25d).collect(collector))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("Multiple values for optional: [null, '2.25', ...]");
+    }
+
 }

--- a/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
+++ b/core/src/test/java/org/jdbi/v3/core/h2/TestH2SqlArrays.java
@@ -44,7 +44,7 @@ public class TestH2SqlArrays {
         h.useTransaction(th -> {
             th.execute("DROP TABLE IF EXISTS uuids");
             th.execute("CREATE TABLE uuids (u UUID ARRAY)");
-    }));
+        }));
 
     private final UUID[] testUuids = new UUID[]{
         UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()

--- a/core/src/test/java/org/jdbi/v3/core/internal/AnnotationFactoryTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/AnnotationFactoryTest.java
@@ -83,8 +83,7 @@ public class AnnotationFactoryTest {
             .isNotEqualTo(getAnno(Baz.class, "createWithExplicitProperties"));
     }
 
-    private <A extends Annotation> void checkImplementation(Class<A> annoType, String annotatedMethod, A synthetic, String expectedToString)
-    throws NoSuchMethodException {
+    private <A extends Annotation> void checkImplementation(Class<A> annoType, String annotatedMethod, A synthetic, String expectedToString) throws NoSuchMethodException {
         A real = getAnno(annoType, annotatedMethod);
 
         assertThat(real).describedAs("real equals synthetic").isEqualTo(synthetic);

--- a/core/src/test/java/org/jdbi/v3/core/junit5/H2DatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/v3/core/junit5/H2DatabaseExtension.java
@@ -37,10 +37,10 @@ public final class H2DatabaseExtension implements DatabaseExtension<H2DatabaseEx
         h -> h.execute("create table something (id identity primary key, name varchar(50), integerValue integer, intValue integer)");
 
     public static final DatabaseInitializer USERS_INITIALIZER = h -> {
-            h.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR)");
-            h.execute("INSERT INTO users VALUES (1, 'Alice')");
-            h.execute("INSERT INTO users VALUES (2, 'Bob')");
-        };
+        h.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR)");
+        h.execute("INSERT INTO users VALUES (1, 'Alice')");
+        h.execute("INSERT INTO users VALUES (2, 'Bob')");
+    };
 
     private final String uri = "jdbc:h2:mem:" + UUID.randomUUID();
     private final Set<JdbiPlugin> plugins = new LinkedHashSet<>();

--- a/core/src/test/java/org/jdbi/v3/core/mapper/AbstractPropagateNullTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/AbstractPropagateNullTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractPropagateNullTest {
             testBean = mapFunction.apply(handle.select("select NULL as beanID"))
                 .one();
 
-        assertThat(testBean).isNotNull()
+            assertThat(testBean).isNotNull()
                 .extracting(TestBean::getNestedBean).isNull();
         }
     }
@@ -99,7 +99,7 @@ public abstract class AbstractPropagateNullTest {
 
             testBean = mapFunction.apply(handle.select("select NULL as bean_id")).one();
 
-        assertThat(testBean).isNotNull()
+            assertThat(testBean).isNotNull()
                 .extracting(TestBean::getNestedBean).isNull();
         }
     }
@@ -138,7 +138,7 @@ public abstract class AbstractPropagateNullTest {
             testBean = mapFunction.apply(handle.select("select 'fourty-two' as nestedid, NULL as nestedfk"))
                 .one();
 
-        assertThat(testBean).isNotNull()
+            assertThat(testBean).isNotNull()
                 .extracting(TestBean::getNestedBean).isNull();
         }
     }
@@ -160,7 +160,7 @@ public abstract class AbstractPropagateNullTest {
             testBean = mapFunction.apply(handle.select("select 'fourty-two' as beanID, NULL as beanFK"))
                 .one();
 
-        assertThat(testBean).isNotNull()
+            assertThat(testBean).isNotNull()
                 .extracting(TestBean::getNestedBean).isNull();
         }
     }

--- a/core/src/test/java/org/jdbi/v3/core/mapper/FreeBuildersTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/FreeBuildersTest.java
@@ -101,15 +101,15 @@ public class FreeBuildersTest {
 
         assertThat(
             h.createUpdate("insert into unnested_free_builders(test) values (:test)")
-            .bindPojo(unnestedFreeBuilder)
-            .execute())
-        .isOne();
+                .bindPojo(unnestedFreeBuilder)
+                .execute())
+                    .isOne();
 
         assertThat(
             h.createQuery("select * from unnested_free_builders")
-            .mapTo(UnnestedFreeBuilder.class)
-            .one())
-        .isEqualTo(unnestedFreeBuilder);
+                .mapTo(UnnestedFreeBuilder.class)
+                .one())
+                    .isEqualTo(unnestedFreeBuilder);
     }
 
     public interface BaseValue<T> {

--- a/core/src/test/java/org/jdbi/v3/core/mapper/RowViewMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/RowViewMapperTest.java
@@ -35,7 +35,7 @@ public class RowViewMapperTest {
     @Test
     public void testRowViewMap() {
         Handle h = h2Extension.getSharedHandle();
-        final Map<Integer, String> expected = new HashMap<>();
+        Map<Integer, String> expected = new HashMap<>();
         expected.put(1, "SFO");
         expected.put(2, "OAK");
         expected.put(3, "YYZ");

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperPropagateNullableTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperPropagateNullableTest.java
@@ -40,7 +40,7 @@ public class BeanMapperPropagateNullableTest {
         this.handle = h2Extension.getSharedHandle();
     }
 
-   @Test
+    @Test
     public void propagateNull() {
         assertThat(handle
             .registerRowMapper(BeanMapper.factory(PropagateNullThing.class))

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
@@ -155,9 +155,9 @@ public class ConstructorMapperTest {
     @Test
     public void testConstructorProperties() {
         final ConstructorPropertiesBean cpi = handle
-                .createQuery("SELECT * FROM bean")
-                .mapTo(ConstructorPropertiesBean.class)
-                .one();
+            .createQuery("SELECT * FROM bean")
+            .mapTo(ConstructorPropertiesBean.class)
+            .one();
         assertThat(cpi.s).isEqualTo("3");
         assertThat(cpi.i).isEqualTo(2);
     }
@@ -181,12 +181,12 @@ public class ConstructorMapperTest {
     @Test
     public void nestedParameters() {
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(NestedBean.class))
-            .select("select s, i from bean")
-            .mapTo(NestedBean.class)
-            .one())
-            .extracting("nested.s", "nested.i")
-            .containsExactly("3", 2);
+                .registerRowMapper(ConstructorMapper.factory(NestedBean.class))
+                .select("select s, i from bean")
+                .mapTo(NestedBean.class)
+                .one())
+                        .extracting("nested.s", "nested.i")
+                        .containsExactly("3", 2);
     }
 
     @Test
@@ -195,19 +195,19 @@ public class ConstructorMapperTest {
         handle.registerRowMapper(ConstructorMapper.factory(NestedBean.class));
 
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(NestedBean.class))
-            .select("select s, i from bean")
-            .mapTo(NestedBean.class)
-            .one())
-            .extracting("nested.s", "nested.i")
-            .containsExactly("3", 2);
+                .registerRowMapper(ConstructorMapper.factory(NestedBean.class))
+                .select("select s, i from bean")
+                .mapTo(NestedBean.class)
+                .one())
+                        .extracting("nested.s", "nested.i")
+                        .containsExactly("3", 2);
 
         assertThatThrownBy(() -> handle
-            .createQuery("select s, i, 1 as other from bean")
-            .mapTo(NestedBean.class)
-            .one())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("could not match parameters for columns: [other]");
+                .createQuery("select s, i, 1 as other from bean")
+                .mapTo(NestedBean.class)
+                .one())
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("could not match parameters for columns: [other]");
     }
 
     static class NestedBean {
@@ -246,7 +246,7 @@ public class ConstructorMapperTest {
     @Test
     public void nonNullableColumnOfNestedObjectAbsent() {
         assertThatThrownBy(() -> selectOne("select 'a' a, s from bean", NullableNestedBean.class))
-            .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     static class NullableNestedBean {
@@ -254,7 +254,7 @@ public class ConstructorMapperTest {
         private final NullableParameterBean nested;
 
         NullableNestedBean(String a,
-                           @Nullable @Nested NullableParameterBean nested) {
+                @Nullable @Nested NullableParameterBean nested) {
             this.a = a;
             this.nested = nested;
         }
@@ -263,10 +263,10 @@ public class ConstructorMapperTest {
     @Test
     public void nestedPrefixParameters() {
         NestedPrefixBean result = handle
-            .registerRowMapper(ConstructorMapper.factory(NestedPrefixBean.class))
-            .select("select i nested_i, s nested_s from bean")
-            .mapTo(NestedPrefixBean.class)
-            .one();
+                .registerRowMapper(ConstructorMapper.factory(NestedPrefixBean.class))
+                .select("select i nested_i, s nested_s from bean")
+                .mapTo(NestedPrefixBean.class)
+                .one();
         assertThat(result.nested.s).isEqualTo("3");
         assertThat(result.nested.i).isEqualTo(2);
     }
@@ -277,25 +277,25 @@ public class ConstructorMapperTest {
         handle.registerRowMapper(ConstructorMapper.factory(NestedPrefixBean.class));
 
         assertThat(handle
-            .createQuery("select i nested_i, s nested_s from bean")
-            .mapTo(NestedPrefixBean.class)
-            .one())
-            .extracting("nested.s", "nested.i")
-            .containsExactly("3", 2);
+                .createQuery("select i nested_i, s nested_s from bean")
+                .mapTo(NestedPrefixBean.class)
+                .one())
+                        .extracting("nested.s", "nested.i")
+                        .containsExactly("3", 2);
 
         assertThatThrownBy(() -> handle
-            .createQuery("select i nested_i, s nested_s, 1 as other from bean")
-            .mapTo(NestedPrefixBean.class)
-            .one())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("could not match parameters for columns: [other]");
+                .createQuery("select i nested_i, s nested_s, 1 as other from bean")
+                .mapTo(NestedPrefixBean.class)
+                .one())
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("could not match parameters for columns: [other]");
 
         assertThatThrownBy(() -> handle
-            .createQuery("select i nested_i, s nested_s, 1 as nested_other from bean")
-            .mapTo(NestedPrefixBean.class)
-            .one())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("could not match parameters for columns: [nested_other]");
+                .createQuery("select i nested_i, s nested_s, 1 as nested_other from bean")
+                .mapTo(NestedPrefixBean.class)
+                .one())
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("could not match parameters for columns: [nested_other]");
     }
 
     static class NestedPrefixBean {
@@ -309,61 +309,60 @@ public class ConstructorMapperTest {
     @Test
     public void propagateNull() {
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(PropagateNullThing.class))
-            .select("SELECT null as testValue, 'foo' as s")
-            .mapTo(PropagateNullThing.class)
-            .one())
-            .isNull();
+                .registerRowMapper(ConstructorMapper.factory(PropagateNullThing.class))
+                .select("SELECT null as testValue, 'foo' as s")
+                .mapTo(PropagateNullThing.class)
+                .one())
+                        .isNull();
     }
 
     @Test
     public void propagateNotNull() {
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(PropagateNullThing.class))
-            .select("SELECT 42 as testValue, 'foo' as s")
-            .mapTo(PropagateNullThing.class)
-            .one())
-            .extracting("testValue", "s")
-            .containsExactly(42, "foo");
+                .registerRowMapper(ConstructorMapper.factory(PropagateNullThing.class))
+                .select("SELECT 42 as testValue, 'foo' as s")
+                .mapTo(PropagateNullThing.class)
+                .one())
+                        .extracting("testValue", "s")
+                        .containsExactly(42, "foo");
     }
 
     @Test
     public void nestedPropagateNull() {
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(NestedPropagateNullThing.class))
-            .select("SELECT 42 as integerValue, null as testValue, 'foo' as s")
-            .mapTo(NestedPropagateNullThing.class)
-            .one())
-            .extracting("integerValue", "nested")
-            .containsExactly(42, null);
+                .registerRowMapper(ConstructorMapper.factory(NestedPropagateNullThing.class))
+                .select("SELECT 42 as integerValue, null as testValue, 'foo' as s")
+                .mapTo(NestedPropagateNullThing.class)
+                .one())
+                        .extracting("integerValue", "nested")
+                        .containsExactly(42, null);
     }
 
     @Test
     public void nestedPropagateNotNull() {
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(NestedPropagateNullThing.class))
-            .select("SELECT 42 as integerValue, 60 as testValue, 'foo' as s")
-            .mapTo(NestedPropagateNullThing.class)
-            .one())
-            .extracting("integerValue", "nested.testValue", "nested.s")
-            .containsExactly(42, 60, "foo");
+                .registerRowMapper(ConstructorMapper.factory(NestedPropagateNullThing.class))
+                .select("SELECT 42 as integerValue, 60 as testValue, 'foo' as s")
+                .mapTo(NestedPropagateNullThing.class)
+                .one())
+                        .extracting("integerValue", "nested.testValue", "nested.s")
+                        .containsExactly(42, 60, "foo");
     }
 
     @Test
     public void classPropagateNull() {
-            assertThat(handle.select("select 42 as \"value\", null as fk")
-                    .map(ConstructorMapper.of(ClassPropagateNullThing.class))
-                    .one())
-                .isNull();
+        assertThat(handle.select("select 42 as \"value\", null as fk")
+                .map(ConstructorMapper.of(ClassPropagateNullThing.class))
+                .one()).isNull();
     }
 
     @Test
     public void classPropagateNotNull() {
-            assertThat(handle.select("select 42 as \"value\", 'a' as fk")
-                    .map(ConstructorMapper.of(ClassPropagateNullThing.class))
-                    .one())
-                .extracting(cpnt -> cpnt.value)
-                .isEqualTo(42);
+        assertThat(handle.select("select 42 as \"value\", 'a' as fk")
+                .map(ConstructorMapper.of(ClassPropagateNullThing.class))
+                .one())
+                        .extracting(cpnt -> cpnt.value)
+                        .isEqualTo(42);
     }
 
     static class NestedPropagateNullThing {
@@ -412,6 +411,7 @@ public class ConstructorMapperTest {
         public int getValue() {
             return value;
         }
+
         public void setValue(int value) {
             this.value = value;
         }
@@ -452,8 +452,8 @@ public class ConstructorMapperTest {
     @Test
     public void multipleFactoryMethods() {
         assertThatThrownBy(() -> ConstructorMapper.factory(MultipleStaticFactoryMethodsBean.class))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageMatching("class .* may have at most one constructor or static factory method annotated @JdbiConstructor");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("class .* may have at most one constructor or static factory method annotated @JdbiConstructor");
     }
 
     @SuppressWarnings("unused")

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestEscapedCharacters.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestEscapedCharacters.java
@@ -46,6 +46,6 @@ public class TestEscapedCharacters {
     @Test
     public void testEscapedSql() {
         assertThat(parseString("insert into foo (xyz) values (:bar\\:\\:some_strange_type)"))
-        .isEqualTo("insert into foo (xyz) values (?::some_strange_type)");
+            .isEqualTo("insert into foo (xyz) values (?::some_strange_type)");
     }
 }

--- a/docs/src/test/java/jdbi/doc/ArgumentsTest.java
+++ b/docs/src/test/java/jdbi/doc/ArgumentsTest.java
@@ -62,8 +62,7 @@ public class ArgumentsTest {
         }
 
         @Override
-        public void apply(int position, PreparedStatement statement, StatementContext ctx)
-        throws SQLException {
+        public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException {
             statement.setString(position, uuid.toString()); // <1>
         }
     }

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaMappers.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaMappers.java
@@ -70,9 +70,7 @@ public class TestGuavaMappers {
 
     @Test
     public void testIntegerImmutableList() {
-        Integer[] testInts = new Integer[]{
-                5, 4, -6, 1, 9, Integer.MAX_VALUE, Integer.MIN_VALUE
-        };
+        Integer[] testInts = new Integer[] {5, 4, -6, 1, 9, Integer.MAX_VALUE, Integer.MIN_VALUE};
 
         h.execute("INSERT INTO arrays (i) VALUES(?)", (Object) testInts);
         ImmutableList<Integer> list = h.createQuery("SELECT i FROM arrays")

--- a/internal/policy/src/main/resources/policy/checkstyle.xml
+++ b/internal/policy/src/main/resources/policy/checkstyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 ~   Licensed under the Apache License, Version 2.0 (the "License");
 ~   you may not use this file except in compliance with the License.
@@ -12,15 +12,20 @@
 ~   See the License for the specific language governing permissions and
 ~   limitations under the License.
 -->
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
     <property name="fileExtensions" value="java,properties,xml"/>
+    <property name="tabWidth" value="4"/>
 
-    <module name="SuppressWarningsFilter" />
+    <module name="FileTabCharacter"/>
 
     <module name="NewlineAtEndOfFile">
         <property name="lineSeparator" value="lf"/>
     </module>
+
+    <module name="SuppressWarningsFilter"/>
 
     <module name="RegexpMultiline">
         <property name="format" value="(?s:(\r\n|\r).*)"/>
@@ -37,12 +42,13 @@
 
     <module name="TreeWalker">
         <module name="ArrayTypeStyle"/>
+        <module name="AvoidNestedBlocks"/>
         <module name="AvoidStarImport"/>
         <module name="ConstantName"/>
         <!--<module name="DeclarationOrder"/>-->
         <module name="EmptyCatchBlock">
             <!-- this value is a message to readers that also serves to "disable" the check, we don't expect this literal text in a comment inside the catch... -->
-            <property name="commentFormat" value="please always name the exception correctly and write a comment if necessary"/>
+            <property name="commentFormat" value="Please always name the exception correctly and write a comment if necessary."/>
             <property name="exceptionVariableName" value="expected|ignored?"/>
         </module>
         <module name="EmptyForInitializerPad"/>
@@ -64,8 +70,13 @@
             <property name="sortStaticImportsAlphabetically" value="true"/>
         </module>
         <!--<module name="InnerAssignment"/>-->
+        <module name="Indentation"/>
         <module name="InnerTypeLast"/>
         <module name="InterfaceIsType"/>
+        <module name="JavadocStyle">
+            <property name="checkFirstSentence" value="false"/>
+            <property name="checkHtml" value="false"/>
+        </module>
         <module name="LeftCurly"/>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
@@ -100,13 +111,15 @@
         <module name="StringLiteralEquality"/>
         <module name="SuperClone"/>
         <module name="SuperFinalize"/>
-        <module name="SuppressWarningsHolder" />
+        <module name="SuppressWarningsHolder"/>
         <module name="TodoComment"/>
         <module name="TypecastParenPad"/>
         <module name="TypeName"/>
         <module name="UnusedImports"/>
         <module name="UpperEll"/>
-        <module name="VariableDeclarationUsageDistance"/>
+        <module name="VariableDeclarationUsageDistance">
+            <property name="allowedDistance" value="10"/>
+        </module>
         <!--<module name="VisibilityModifier"/>-->
         <module name="WhitespaceAfter"/>
         <module name="WhitespaceAround">
@@ -118,26 +131,14 @@
         </module>
 
         <module name="RegexpSinglelineJava">
-            <property name="format" value="^ *\t"/>
-            <property name="message" value="Line contains leading tabs (instead of spaces)."/>
-            <property name="ignoreComments" value="true"/>
-        </module>
-        <module name="RegexpSinglelineJava">
-            <property name="format" value="@(org\.junit\.)?Test\s*\(\s*expected\s*="/>
-            <property name="message" value="Use AssertJ's assertThatThrownBy instead of @Test.expected"/>
-        </module>
-        <module name="RegexpSinglelineJava">
             <property name="format" value="\s+$"/>
             <property name="message" value="Line has trailing whitespace."/>
         </module>
         <module name="RegexpSinglelineJava">
-            <property name="format" value="^ {6}\S"/>
-            <property name="message" value="Indent of 6 spaces is suspicious. We indent with multiples of 4."/>
-        </module>
-        <module name="RegexpSinglelineJava">
-            <property name="format" value="\S {2,}\S"/>
-            <property name="message" value="Multiple consecutive space characters found."/>
+            <property name="format" value="\S\s{2,}\S"/>
+            <property name="message" value="Line has multiple consecutive whitespace characters."/>
             <property name="ignoreComments" value="true"/>
         </module>
+
     </module>
 </module>

--- a/postgres/src/main/java/org/jdbi/v3/postgres/internal/BitStringEnumSetColumnMapper.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/internal/BitStringEnumSetColumnMapper.java
@@ -47,12 +47,12 @@ public class BitStringEnumSetColumnMapper<E extends Enum<E>> implements ColumnMa
             .filter(i -> {
                 char bit = bits.charAt(i);
                 switch (bit) {
-                case '1':
-                    return true;
-                case '0':
-                    return false;
-                default:
-                    throw new IllegalArgumentException("bit string \"" + bits + "\" contains non-bit character " + bit);
+                    case '1':
+                        return true;
+                    case '0':
+                        return false;
+                    default:
+                        throw new IllegalArgumentException("bit string \"" + bits + "\" contains non-bit character " + bit);
                 }
             })
             .mapToObj(i -> enumConstants[i])

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestDuration.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestDuration.java
@@ -66,13 +66,12 @@ public class TestDuration {
     @Test
     public void testReadsViaFluentAPI() {
         List<Duration> periods = handle.createQuery("select foo from intervals where id = 1 or id = 2 order by id")
-                .mapTo(Duration.class)
-                .list();
+            .mapTo(Duration.class)
+            .list();
 
         assertThat(periods).isEqualTo(ImmutableList.of(
-                Duration.ofDays(1).plusHours(15),
-                Duration.ofDays(40).plusMinutes(22)
-       ));
+            Duration.ofDays(1).plusHours(15),
+            Duration.ofDays(40).plusMinutes(22)));
     }
 
     @Test

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestHStore.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestHStore.java
@@ -73,21 +73,20 @@ public class TestHStore {
     @Test
     public void testReadsViaFluentAPI() {
         List<Map<String, String>> initialCaps = handle.createQuery("select caps from campaigns order by id")
-                .mapTo(STRING_MAP)
-                .list();
+            .mapTo(STRING_MAP)
+            .list();
         assertThat(initialCaps).isEqualTo(ImmutableList.of(
-                ImmutableMap.of("yearly", "10000", "monthly", "5000", "daily", "200"),
-                ImmutableMap.of("yearly", "1000", "monthly", "200", "daily", "20")
-       ));
+            ImmutableMap.of("yearly", "10000", "monthly", "5000", "daily", "200"),
+            ImmutableMap.of("yearly", "1000", "monthly", "200", "daily", "20")));
     }
 
     @Test
     public void testHandlesEmptyMap() {
         handle.execute("insert into campaigns(id, caps) values (?,?)", 4, ImmutableMap.of());
         Map<String, String> newCaps = handle.createQuery("select caps from campaigns where id=?")
-                .bind(0, 4)
-                .mapTo(STRING_MAP)
-                .one();
+            .bind(0, 4)
+            .mapTo(STRING_MAP)
+            .one();
         assertThat(newCaps).isEmpty();
     }
 

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestQualifiedHStore.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestQualifiedHStore.java
@@ -74,12 +74,11 @@ public class TestQualifiedHStore {
     @Test
     public void testReadsViaFluentAPI() {
         List<Map<String, String>> initialCaps = handle.createQuery("select caps from campaigns order by id")
-                .mapTo(QualifiedType.of(STRING_MAP).with(HStore.class))
-                .list();
+            .mapTo(QualifiedType.of(STRING_MAP).with(HStore.class))
+            .list();
         assertThat(initialCaps).isEqualTo(ImmutableList.of(
-                ImmutableMap.of("yearly", "10000", "monthly", "5000", "daily", "200"),
-                ImmutableMap.of("yearly", "1000", "monthly", "200", "daily", "20")
-       ));
+            ImmutableMap.of("yearly", "10000", "monthly", "5000", "daily", "200"),
+            ImmutableMap.of("yearly", "1000", "monthly", "200", "daily", "20")));
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBridgeException.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBridgeException.java
@@ -40,8 +40,7 @@ public class TestBridgeException {
             for (int i = 0; i < 2; i++) {
                 dao.insert(arg);
             }
-        })
-        .isInstanceOf(UnableToExecuteStatementException.class);
+        }).isInstanceOf(UnableToExecuteStatementException.class);
     }
 
     public interface ExceptionalBridge<T> extends SqlObject {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactional.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestTransactional.java
@@ -112,10 +112,10 @@ public class TestTransactional {
             inTransaction.set(false);
             return null;
         }))
-                .isInstanceOf(UnableToManipulateTransactionIsolationLevelException.class)
-                .hasCauseInstanceOf(SQLException.class)
-                .extracting(ex -> ex.getCause().getMessage())
-                .isEqualTo("PostgreSQL would not let you set the transaction isolation here");
+            .isInstanceOf(UnableToManipulateTransactionIsolationLevelException.class)
+            .hasCauseInstanceOf(SQLException.class)
+            .extracting(ex -> ex.getCause().getMessage())
+            .isEqualTo("PostgreSQL would not let you set the transaction isolation here");
     }
 
     @Test

--- a/testing/src/test/java/org/jdbi/v3/testing/JdbiRuleTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/JdbiRuleTest.java
@@ -28,19 +28,19 @@ public class JdbiRuleTest {
     @Test
     public void migrateWithFlywayDefaultLocation() throws Throwable {
         JdbiRule rule = JdbiRule.embeddedPostgres()
-                .withMigration(Migration.before().withDefaultPath());
+            .withMigration(Migration.before().withDefaultPath());
 
         Statement statement =
             new Statement() {
-              @Override
-              public void evaluate() {
-                assertThat(
+                @Override
+                public void evaluate() {
+                    assertThat(
                         rule.getHandle()
                             .select("select value from standard_migration_location")
                             .mapTo(String.class)
                             .one())
-                    .isEqualTo("inserted in migration script in the default location");
-              }
+                                .isEqualTo("inserted in migration script in the default location");
+                }
             };
 
         rule.apply(statement, Description.EMPTY).evaluate();
@@ -49,19 +49,19 @@ public class JdbiRuleTest {
     @Test
     public void migrateWithFlywayCustomLocation() throws Throwable {
         JdbiRule rule = JdbiRule.embeddedPostgres()
-                .withMigration(Migration.before().withPath("custom/migration/location"));
+            .withMigration(Migration.before().withPath("custom/migration/location"));
 
         Statement statement =
             new Statement() {
-              @Override
-              public void evaluate() {
-                assertThat(
+                @Override
+                public void evaluate() {
+                    assertThat(
                         rule.getHandle()
                             .select("select value from custom_migration_location")
                             .mapTo(String.class)
                             .one())
-                    .isEqualTo("inserted in migration script in a custom location");
-              }
+                                .isEqualTo("inserted in migration script in a custom location");
+                }
             };
 
         rule.apply(statement, Description.EMPTY).evaluate();
@@ -71,21 +71,21 @@ public class JdbiRuleTest {
     public void migrateWithMultipleFlywayCustomLocations() throws Throwable {
         JdbiRule rule =
             JdbiRule.embeddedPostgres().withMigration(Migration.before()
-                    .withPaths("custom/migration/location", "custom/migration/otherlocation"));
+                .withPaths("custom/migration/location", "custom/migration/otherlocation"));
 
         Statement statement =
             new Statement() {
-              @Override
-              public void evaluate() {
-                assertThat(
+                @Override
+                public void evaluate() {
+                    assertThat(
                         rule.getHandle()
                             .select("select value from custom_migration_location")
                             .mapTo(String.class)
                             .list())
-                    .containsOnly(
-                        "inserted in migration script in a custom location",
-                        "inserted in migration script in another custom location");
-              }
+                                .containsOnly(
+                                    "inserted in migration script in a custom location",
+                                    "inserted in migration script in another custom location");
+                }
             };
 
         rule.apply(statement, Description.EMPTY).evaluate();
@@ -97,10 +97,10 @@ public class JdbiRuleTest {
         DataSource dataSource = JdbcConnectionPool.create("jdbc:h2:mem:" + UUID.randomUUID(), "", "");
 
         JdbiRule rule = new JdbiRule() {
-          @Override
-          protected DataSource createDataSource() {
-            return dataSource;
-          }
+            @Override
+            protected DataSource createDataSource() {
+                return dataSource;
+            }
         };
 
         assertThat(rule.createDataSource()).isEqualTo(dataSource);

--- a/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiGenericExtensionTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiGenericExtensionTest.java
@@ -37,10 +37,10 @@ public class JdbiGenericExtensionTest {
     @Test
     public void testApacheDerby() {
         List<String> userNames = derbyExtension.getJdbi().withHandle(h -> {
-                    try (Query query = h.createQuery("SELECT name FROM users ORDER BY id")) {
-                        return query.mapTo(String.class).list();
-                    }
-                });
+            try (Query query = h.createQuery("SELECT name FROM users ORDER BY id")) {
+                return query.mapTo(String.class).list();
+            }
+        });
 
         assertThat(userNames).hasSize(2);
         assertThat(userNames).containsExactly("Alice", "Bob");

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrCollectors.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrCollectors.java
@@ -24,15 +24,15 @@ public class VavrCollectors {
         throw new UtilityClassException();
     }
 
-  /**
-   * Returns a {@code Collector} that accumulates 0 or 1 input elements into an {@code Option<T>}.
-   * The returned collector will throw {@code IllegalStateException} whenever 2 or more elements
-   * are present in a stream. Null elements are mapped to {@code Option.none()}.
-   *
-   * @param <T> the collected type
-   * @return a {@code Collector} which collects 0 or 1 input elements into an {@code Option<T>}.
-   */
-  public static <T> Collector<T, ?, Option<T>> toOption() {
-    return OptionalCollectors.toOptional(Option::none, Option::of);
-  }
+    /**
+     * Returns a {@code Collector} that accumulates 0 or 1 input elements into an {@code Option<T>}.
+     * The returned collector will throw {@code IllegalStateException} whenever 2 or more elements
+     * are present in a stream. Null elements are mapped to {@code Option.none()}.
+     *
+     * @param <T> the collected type
+     * @return a {@code Collector} which collects 0 or 1 input elements into an {@code Option<T>}.
+     */
+    public static <T> Collector<T, ?, Option<T>> toOption() {
+        return OptionalCollectors.toOptional(Option::none, Option::of);
+    }
 }

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrMapCollectorWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrMapCollectorWithDB.java
@@ -137,23 +137,21 @@ public class TestVavrMapCollectorWithDB {
         Handle h = h2Extension.getSharedHandle();
         h.execute("create table \"user\" (id int, name varchar)");
         h.prepareBatch("insert into \"user\" (id, name) values (?, ?)")
-                .add(1, "alice")
-                .add(2, "bob")
-                .add(3, "alice")
-                .execute();
+            .add(1, "alice")
+            .add(2, "bob")
+            .add(3, "alice")
+            .execute();
 
         Multimap<String, User> usersByName = h.createQuery("select * from \"user\"")
-                .setMapKeyColumn("name")
-                .registerRowMapper(ConstructorMapper.factory(User.class))
-                .collectInto(new GenericType<Multimap<String, User>>() {});
+            .setMapKeyColumn("name")
+            .registerRowMapper(ConstructorMapper.factory(User.class))
+            .collectInto(new GenericType<Multimap<String, User>>() {});
 
         assertThat(usersByName.apply("alice")).hasSize(2).containsExactly(
-                new User(1, "alice"),
-                new User(3, "alice")
-       );
+            new User(1, "alice"),
+            new User(3, "alice"));
         assertThat(usersByName.apply("bob")).hasSize(1).containsExactly(
-                new User(2, "bob")
-       );
+            new User(2, "bob"));
     }
 
     public static class User {


### PR DESCRIPTION
- Add rule Indentation (check correct indentation in sources) making rule RegexpSinglelineJava 'Indent of 6 spaces is suspicious' redundant
- Add rule FileTabCharacter (disallow tab chars in sources) making rule RegexpSinglelineJava 'Line contains leading tabs' redundant
- Remove RegexpSinglelineJava rule that checks for JUnit 4 usage "@Test.expected"

Btw, rule RegexpSinglelineJava 'Multiple consecutive space characters' raises false positives in string contents such as `String str = "x  x";`. Kind of hard to fix by way of regex only. There are however currently no cases, so no real issue.