### PR TITLE
BaseStatement: why do we need a helper method for close()?

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
@@ -52,15 +52,9 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This> {
         return ctx;
     }
 
-    public static void nullSafeCleanUp(BaseStatement<?> statement) {
-        if (statement != null) {
-            statement.getContext().close();
-        }
-    }
-
     protected final void cleanUpForException(SQLException e) {
         try {
-            nullSafeCleanUp(this);
+            close();
         } catch (CloseException ce) {
             e.addSuppressed(ce.getCause());
         } catch (Exception e1) {
@@ -99,7 +93,7 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This> {
 
     @Override
     public void close() {
-        nullSafeCleanUp(this);
+        getContext().close();
     }
 
     @FunctionalInterface

--- a/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
@@ -89,7 +89,7 @@ public class Batch extends BaseStatement<Batch> {
                 throw new UnableToExecuteStatementException(mungeBatchException(e), getContext());
             }
         } finally {
-            nullSafeCleanUp(this);
+            close();
         }
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -135,7 +135,7 @@ public class Call extends SqlStatement<Call> {
             }
             return resultComputer.apply(out);
         } finally {
-            nullSafeCleanUp(this);
+            close();
         }
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -122,7 +122,7 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
         try {
             return internalBatchExecute().updateCounts;
         } finally {
-            nullSafeCleanUp(this);
+            close();
         }
     }
 


### PR DESCRIPTION
This is a followup to #2123 - I don't understand why a public static helper method is preferable to simply using the existing close method.

Even if we choose to ditch Closeable, if there is any cleanup to do, the close method seems like the natural place.
I do not intend to start an edit war, but why is the current state preferable to the simpler place we were at before?