### PR TITLE
remove BaseStatement#addCleanable

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
@@ -62,17 +62,6 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This> {
         }
     }
 
-    /**
-     * Registers the given {@link Cleanable} to be executed when this statement is closed.
-     *
-     * @param cleanable the cleanable to register
-     * @return this
-     */
-    This addCleanable(Cleanable cleanable) {
-        getContext().addCleanable(cleanable);
-        return typedThis;
-    }
-
     void addCustomizers(final Collection<StatementCustomizer> customizers) {
         customizers.forEach(this::addCustomizer);
     }

--- a/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
@@ -65,7 +65,7 @@ public class Batch extends BaseStatement<Batch> {
             try {
                 stmt = getHandle().getStatementBuilder().create(getHandle().getConnection(), getContext());
 
-                addCleanable(stmt::close);
+                getContext().addCleanable(stmt::close);
                 getConfig(SqlStatements.class).customize(stmt);
             } catch (SQLException e) {
                 throw new UnableToCreateStatementException(e, getContext());

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -231,7 +231,7 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
                 Connection connection = getHandle().getConnection();
                 stmt = statementBuilder.create(connection, sql, ctx);
 
-                addCleanable(() -> statementBuilder.close(connection, sql, stmt));
+                getContext().addCleanable(() -> statementBuilder.close(connection, sql, stmt));
                 getConfig(SqlStatements.class).customize(stmt);
             } catch (SQLException e) {
                 throw new UnableToCreateStatementException(e, ctx);

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -125,7 +125,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
     }
 
     private This cleanupHandle(Consumer<Handle> action) {
-        addCleanable(() -> {
+        getContext().addCleanable(() -> {
             Handle handle = getHandle();
             if (handle != null) {
                 if (handle.isInTransaction()) {
@@ -1769,7 +1769,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
             stmt = createStatement(ctx, parsedSql);
             // The statement builder might (or might not) clean up the statement when called. E.g. the
             // caching statement builder relies on the statement *not* being closed.
-            addCleanable(() -> getHandle().getStatementBuilder().close(getHandle().getConnection(), this.sql, stmt));
+            getContext().addCleanable(() -> getHandle().getStatementBuilder().close(getHandle().getConnection(), this.sql, stmt));
             getConfig(SqlStatements.class).customize(stmt);
         } catch (SQLException e) {
             throw new UnableToCreateStatementException(e, ctx);


### PR DESCRIPTION
this is only a passthru for getContext().addCleanable() and provides no value. As this is an internal method, we can just remove it.

Use getContext().addCleanable() directly.