### PR TITLE
Fix resource leaks

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -435,7 +435,9 @@ public class Handle implements Closeable, Configurable<Handle> {
      * @return The response object.
      */
     public <T> T queryMetadata(MetaData.MetaDataValueProvider<T> metadataFunction) {
-        return new MetaData(this, metadataFunction).execute();
+        try (MetaData metadata = new MetaData(this, metadataFunction)) {
+            return metadata.execute();
+        }
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/Script.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Script.java
@@ -45,6 +45,8 @@ public class Script extends SqlStatement<Script> {
     public int[] execute() {
         final List<String> statements = getStatements();
         Batch b = getHandle().createBatch();
+        getContext().addCleanable(b::close);
+
         statements.forEach(b::add);
         return b.execute();
     }


### PR DESCRIPTION
- Metadata must be closed, otherwise it will leak StatementContext objects.
- ensure that a Script, when closed, releases its wrapped Batch.