### PR TITLE
Cleanup StatementBuilder usage

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
@@ -63,8 +63,8 @@ public class Batch extends BaseStatement<Batch> {
         Statement stmt;
         try {
             try {
-                stmt = getHandle().getStatementBuilder().create(getHandle().getConnection(), getContext());
-                getContext().addCleanable(() -> getHandle().getStatementBuilder().close(getHandle().getConnection(), "<batch>", stmt));
+                stmt = createStatement();
+                getContext().addCleanable(() -> cleanupStatement(stmt));
                 getConfig(SqlStatements.class).customize(stmt);
             } catch (SQLException e) {
                 throw new UnableToCreateStatementException(e, getContext());
@@ -90,6 +90,14 @@ public class Batch extends BaseStatement<Batch> {
         } finally {
             close();
         }
+    }
+
+    Statement createStatement() throws SQLException {
+        return getHandle().getStatementBuilder().create(getHandle().getConnection(), getContext());
+    }
+
+    void cleanupStatement(final Statement statement) throws SQLException {
+        getHandle().getStatementBuilder().close(getHandle().getConnection(), "<batch>", statement);
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
@@ -64,8 +64,7 @@ public class Batch extends BaseStatement<Batch> {
         try {
             try {
                 stmt = getHandle().getStatementBuilder().create(getHandle().getConnection(), getContext());
-
-                getContext().addCleanable(stmt::close);
+                getContext().addCleanable(() -> getHandle().getStatementBuilder().close(getHandle().getConnection(), "<batch>", stmt));
                 getConfig(SqlStatements.class).customize(stmt);
             } catch (SQLException e) {
                 throw new UnableToCreateStatementException(e, getContext());

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -45,8 +45,8 @@ public class Call extends SqlStatement<Call> {
     }
 
     @Override
-    PreparedStatement createStatement(final StatementContext ctx, ParsedSql parsedSql) throws SQLException {
-        return getHandle().getStatementBuilder().createCall(getHandle().getConnection(), parsedSql.getSql(), ctx);
+    PreparedStatement createStatement(String parsedSql) throws SQLException {
+        return getHandle().getStatementBuilder().createCall(getHandle().getConnection(), parsedSql, getContext());
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/DefaultStatementBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/DefaultStatementBuilder.java
@@ -75,12 +75,6 @@ public class DefaultStatementBuilder implements StatementBuilder {
     }
 
     /**
-     * No need to do anything on connection close.
-     */
-    @Override
-    public void close(Connection conn) {}
-
-    /**
      * Called each time a Callable statement needs to be created
      *
      * @param conn the JDBC Connection the statement is being created for

--- a/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/PreparedBatch.java
@@ -14,7 +14,6 @@
 package org.jdbi.v3.core.statement;
 
 import java.lang.reflect.Type;
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -226,12 +225,9 @@ public class PreparedBatch extends SqlStatement<PreparedBatch> implements Result
 
         try {
             try {
-                StatementBuilder statementBuilder = getHandle().getStatementBuilder();
-                @SuppressWarnings("PMD.CloseResource")
-                Connection connection = getHandle().getConnection();
-                stmt = statementBuilder.create(connection, sql, ctx);
+                stmt = createStatement(sql);
 
-                getContext().addCleanable(() -> statementBuilder.close(connection, sql, stmt));
+                getContext().addCleanable(() -> cleanupStatement(stmt));
                 getConfig(SqlStatements.class).customize(stmt);
             } catch (SQLException e) {
                 throw new UnableToCreateStatementException(e, ctx);

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementBuilder.java
@@ -57,7 +57,7 @@ public interface StatementBuilder {
      *
      * @param conn the JDBC Connection the statement is being created for
      * @param sql the translated SQL which should be prepared
-     * @param ctx Statement context associated with the SqlStatement this is building for
+     * @param ctx Statement context associated with the SqlStatement
      *
      * @return a CallableStatement for the given arguments
      *
@@ -66,13 +66,12 @@ public interface StatementBuilder {
     CallableStatement createCall(Connection conn, String sql, StatementContext ctx) throws SQLException;
 
     /**
-     * Called to close an individual prepared statement created from this builder.
+     * Called to close an individual statement created from this builder.
      *
-     * @param conn the connection to close
-     * @param sql the translated SQL which was prepared
-     * @param stmt the statement
-     *
-     * @throws SQLException if anything goes wrong closing the statement
+     * @param conn the JDBC Connection that this statement was created for.
+     * @param sql  the translated SQL which was prepared.
+     * @param stmt the statement.
+     * @throws SQLException if anything goes wrong closing the statement.
      */
     void close(Connection conn, String sql, Statement stmt) throws SQLException;
 
@@ -81,5 +80,5 @@ public interface StatementBuilder {
      *
      * @param conn the connection to close.
      */
-    void close(Connection conn);
+    default void close(Connection conn) {}
 }


### PR DESCRIPTION
- Consistent calling of close for statements created by the builder
- Explicit close methods for PreparedStatement and regular Statement