### PR TITLE
Adding Lifecycle listeners to StatementContext and Handle

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/HandleListener.java
+++ b/core/src/main/java/org/jdbi/v3/core/HandleListener.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+/**
+ * Allows listening to events on the {@link Handle} lifecycle.
+ * <br>
+ * {@link HandleListener} objects are stored in a collection class. To ensure correct operation, they should implement {@link Object#equals} and
+ * {@link Object#hashCode()} to allow correct addition and deletion from the collection.
+ */
+public interface HandleListener {
+
+    /**
+     * A handle was created.
+     *
+     * @param handle The {@link Handle} object.
+     */
+    default void handleCreated(Handle handle) {}
+
+    /**
+     * A handle was closed. This method is only called once, even if the handle is closed multiple times.
+     *
+     * @param handle The {@link Handle} object.
+     */
+    default void handleClosed(Handle handle) {}
+}

--- a/core/src/main/java/org/jdbi/v3/core/Handles.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handles.java
@@ -13,18 +13,26 @@
  */
 package org.jdbi.v3.core;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
 import org.jdbi.v3.core.config.JdbiConfig;
 
 /**
  * Configuration class for handles.
  */
 public class Handles implements JdbiConfig<Handles> {
+
     private boolean forceEndTransactions = true;
+
+    private final Set<HandleListener> handleListeners = new CopyOnWriteArraySet<>();
 
     public Handles() {}
 
     private Handles(Handles that) {
         this.forceEndTransactions = that.forceEndTransactions;
+        this.handleListeners.addAll(that.handleListeners);
     }
 
     /**
@@ -52,6 +60,40 @@ public class Handles implements JdbiConfig<Handles> {
      */
     public void setForceEndTransactions(boolean forceEndTransactions) {
         this.forceEndTransactions = forceEndTransactions;
+    }
+
+    /**
+     * Add a {@link HandleListener} which is called for specific events. Adding a listener will add
+     * it to all Handles that are subsequently created (this call does not affect existing handles).
+     *
+     * @param handleListener A {@link HandleListener} object.
+     *
+     * @return The Handles object itself.
+     */
+    public Handles addListener(final HandleListener handleListener) {
+        this.handleListeners.add(handleListener);
+        return this;
+    }
+
+    /**
+     * Remove a {@link HandleListener}. Removing a listener will only affect Handles that are subsequently created, not existing handles.
+     *
+     * @param handleListener A {@link HandleListener} object.
+     *
+     * @return The Handles object itself.
+     */
+    public Handles removeListener(final HandleListener handleListener) {
+        this.handleListeners.remove(handleListener);
+        return this;
+    }
+
+    /**
+     * Returns the collection of {@link HandleListener} objects. This set is immutable.
+     *
+     * @return A set of {@link HandleListener} objects. The set is never null, can be empty and is immutable.
+     */
+    public Set<HandleListener> getListeners() {
+        return Collections.unmodifiableSet(handleListeners);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -324,12 +324,14 @@ public class Jdbi implements Configurable<Jdbi> {
             }
 
             StatementBuilder cache = statementBuilderFactory.get().createStatementBuilder(conn);
-            Handle h = new Handle(this,
+
+            Handle h = Handle.createHandle(this,
                 config.createCopy(),
                 connectionFactory.getCleanableFor(conn), // don't use conn::close, the cleanup must be done by the connection factory!
                 transactionhandler.get(),
                 cache,
                 conn);
+
             for (JdbiPlugin p : plugins) {
                 h = p.customizeHandle(h);
             }

--- a/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
@@ -31,7 +31,7 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This> {
 
     BaseStatement(Handle handle) {
         this.handle = handle;
-        this.ctx = new StatementContext(handle.getConfig().createCopy(), handle.getExtensionMethod());
+        this.ctx = StatementContext.create(handle.getConfig().createCopy(), handle.getExtensionMethod());
     }
 
     public final Handle getHandle() {

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -47,6 +47,8 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     private boolean allowUnusedBindings;
     private final Collection<StatementCustomizer> customizers = new CopyOnWriteArrayList<>();
 
+    private final Collection<StatementContextListener> contextListeners = new CopyOnWriteArrayList<>();
+
     public SqlStatements() {
         attributes = Collections.synchronizedMap(new HashMap<>());
         templateEngine = new DefinedAttributeTemplateEngine();
@@ -64,6 +66,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
         this.queryTimeout = that.queryTimeout;
         this.allowUnusedBindings = that.allowUnusedBindings;
         this.customizers.addAll(that.customizers);
+        this.contextListeners.addAll(that.contextListeners);
         this.templateCache = that.templateCache;
     }
 
@@ -120,6 +123,11 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      */
     public SqlStatements addCustomizer(final StatementCustomizer customizer) {
         this.customizers.add(customizer);
+        return this;
+    }
+
+    public SqlStatements addContextListener(final StatementContextListener listener) {
+        this.contextListeners.add(listener);
         return this;
     }
 
@@ -265,6 +273,10 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
 
     Collection<StatementCustomizer> getCustomizers() {
         return customizers;
+    }
+
+    Collection<StatementContextListener> getContextListeners() {
+        return contextListeners;
     }
 
     String preparedRender(String template, StatementContext ctx) {

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementContextListener.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementContextListener.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import org.jdbi.v3.meta.Beta;
+
+/**
+ * Listener interface for the {@link StatementContext}. Each method will be called when specific events with the context happen.
+ */
+@Beta
+public interface StatementContextListener {
+
+    /**
+     * A new {@link StatementContext} is created.
+     *
+     * @param statementContext The {@link StatementContext} object that was created. Never null.
+     */
+    default void contextCreated(StatementContext statementContext) {}
+
+    /**
+     * A {@link StatementContext} object was cleaned. Implementers should be aware that the
+     * {@link StatementContext#close()} method can be called multiple times as Statements can be reused.
+     *
+     * @param statementContext The {@link StatementContext} object that was cleaned. Never null.
+     */
+    default void contextCleaned(StatementContext statementContext) {}
+
+    /**
+     * A {@link Cleanable} object was added to this context for cleanup when the context is cleaned.
+     *
+     * @param statementContext The {@link StatementContext}. Never null.
+     * @param cleanable        The {@link Cleanable} object that should be closed when the context is closed. Never null.
+     */
+    default void cleanableAdded(StatementContext statementContext, Cleanable cleanable) {}
+
+    /**
+     * A {@link Cleanable} object was removed from the context.
+     *
+     * @param statementContext The {@link StatementContext}. Never null.
+     * @param cleanable        The {@link Cleanable} object that was removed from the context.
+     */
+    default void cleanableRemoved(StatementContext statementContext, Cleanable cleanable) {}
+}

--- a/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
+++ b/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
@@ -24,19 +24,19 @@ import org.mockito.Mockito;
 /**
  * Utilities for testing jdbi internal classes.
  */
-public class HandleAccess {
+public final class HandleAccess {
+
     private HandleAccess() {}
+
     /**
-     * Create a handle with a fake connection,
-     * useful for tests that do not actually hit
-     * a database.
+     * Create a handle with a fake connection, useful for tests that do not actually hit a database.
      */
     public static Handle createHandle() throws SQLException {
         Connection fakeConnection = Mockito.mock(Connection.class);
 
         Jdbi fakeJdbi = Mockito.mock(Jdbi.class);
 
-        return new Handle(fakeJdbi, new ConfigRegistry(), fakeConnection::close, new LocalTransactionHandler(),
+        return Handle.createHandle(fakeJdbi, new ConfigRegistry(), fakeConnection::close, new LocalTransactionHandler(),
                 new DefaultStatementBuilder(), fakeConnection);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/StatementContextAccess.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/StatementContextAccess.java
@@ -15,16 +15,20 @@ package org.jdbi.v3.core.statement;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.internal.UtilityClassException;
 
-public class StatementContextAccess {
-    private StatementContextAccess() {}
+public final class StatementContextAccess {
+
+    private StatementContextAccess() {
+        throw new UtilityClassException();
+    }
 
     public static StatementContext createContext() {
-        return new StatementContext();
+        return StatementContext.create(new ConfigRegistry(), null);
     }
 
     public static StatementContext createContext(ConfigRegistry config) {
-        return new StatementContext(config);
+        return StatementContext.create(config, null);
     }
 
     /**
@@ -32,6 +36,6 @@ public class StatementContextAccess {
      * with the given handle.
      */
     public static StatementContext createContext(Handle handle) {
-        return new StatementContext(handle.getConfig());
+        return StatementContext.create(handle.getConfig(), null);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestDefinedAttributeTemplateEngine.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestDefinedAttributeTemplateEngine.java
@@ -32,7 +32,7 @@ public class TestDefinedAttributeTemplateEngine {
     @BeforeEach
     public void setUp() {
         templateEngine = new DefinedAttributeTemplateEngine();
-        ctx = new StatementContext();
+        ctx = StatementContextAccess.createContext();
     }
 
     private String render(String sql) {


### PR DESCRIPTION
Adding two new listeners to register events that happen on the StatementContext and the Handle. This enables adding leak checking code to the testing framework.

This will also be useful for other use cases (e.g. logging, resource tracking)