### PR TITLE
Replace ConnectionCloser with Cleanable

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/ConnectionFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/ConnectionFactory.java
@@ -16,25 +16,40 @@ package org.jdbi.v3.core;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import org.jdbi.v3.core.statement.Cleanable;
+
 /**
  * Supplies {@link Connection} instances to a created {@link Handle} and allows
  * custom close handling.
  */
 @FunctionalInterface
 public interface ConnectionFactory {
+
     /**
-     * Open a connection.
-     * @return a Connection
+     * Opens a connection.
+     *
+     * @return A {@link Connection} object.
      * @throws SQLException if anything goes wrong
      */
     Connection openConnection() throws SQLException;
 
     /**
-     * Close a connection.
-     * @param conn the connection to close
+     * Closes a connection.
+     *
+     * @param conn A {@link Connection} object.
      * @throws SQLException if anything goes wrong
      */
     default void closeConnection(Connection conn) throws SQLException {
         conn.close();
+    }
+
+    /**
+     * Returns a {@link Cleanable} that will close the connection and release all necessary resources.
+     *
+     * @param conn A {@link Connection} object.
+     * @return A {@link Cleanable} instance. Calling the {@link Cleanable#close()} method will close the connection and release all resources.
+     */
+    default Cleanable getCleanableFor(Connection conn) {
+        return () -> this.closeConnection(conn);
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -29,6 +29,7 @@ import org.jdbi.v3.core.extension.NoSuchExtensionException;
 import org.jdbi.v3.core.result.ResultBearing;
 import org.jdbi.v3.core.statement.Batch;
 import org.jdbi.v3.core.statement.Call;
+import org.jdbi.v3.core.statement.Cleanable;
 import org.jdbi.v3.core.statement.MetaData;
 import org.jdbi.v3.core.statement.PreparedBatch;
 import org.jdbi.v3.core.statement.Query;
@@ -56,7 +57,7 @@ public class Handle implements Closeable, Configurable<Handle> {
     private static final Logger LOG = LoggerFactory.getLogger(Handle.class);
 
     private final Jdbi jdbi;
-    private final ConnectionCloser closer;
+    private final Cleanable closer;
     private final TransactionHandler transactions;
     private final Connection connection;
     private final boolean forceEndTransactions;
@@ -72,7 +73,7 @@ public class Handle implements Closeable, Configurable<Handle> {
 
     Handle(Jdbi jdbi,
            ConfigRegistry localConfig,
-           ConnectionCloser closer,
+           Cleanable closer,
            TransactionHandler transactions,
            StatementBuilder statementBuilder,
            Connection connection) throws SQLException {
@@ -189,7 +190,7 @@ public class Handle implements Closeable, Configurable<Handle> {
 
         try {
             if (connectionIsLive) {
-                closer.close(connection);
+                closer.close();
             }
 
             if (!suppressed.isEmpty()) {
@@ -761,10 +762,6 @@ public class Handle implements Closeable, Configurable<Handle> {
 
     void setExtensionMethodThreadLocal(ThreadLocal<ExtensionMethod> extensionMethodThreadLocal) {
         this.localExtensionMethod = requireNonNull(extensionMethodThreadLocal);
-    }
-
-    interface ConnectionCloser {
-        void close(Connection conn) throws SQLException;
     }
 
     private class TransactionResetter implements Closeable {

--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -324,7 +324,12 @@ public class Jdbi implements Configurable<Jdbi> {
             }
 
             StatementBuilder cache = statementBuilderFactory.get().createStatementBuilder(conn);
-            Handle h = new Handle(this, config.createCopy(), connectionFactory::closeConnection, transactionhandler.get(), cache, conn);
+            Handle h = new Handle(this,
+                config.createCopy(),
+                connectionFactory.getCleanableFor(conn), // don't use conn::close, the cleanup must be done by the connection factory!
+                transactionhandler.get(),
+                cache,
+                conn);
             for (JdbiPlugin p : plugins) {
                 h = p.customizeHandle(h);
             }

--- a/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
+++ b/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
@@ -34,7 +34,9 @@ public class HandleAccess {
     public static Handle createHandle() throws SQLException {
         Connection fakeConnection = Mockito.mock(Connection.class);
 
-        return new Handle(null, new ConfigRegistry(), Connection::close, new LocalTransactionHandler(),
+        Jdbi fakeJdbi = Mockito.mock(Jdbi.class);
+
+        return new Handle(fakeJdbi, new ConfigRegistry(), fakeConnection::close, new LocalTransactionHandler(),
                 new DefaultStatementBuilder(), fakeConnection);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/TestOnDemandMethodBehavior.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestOnDemandMethodBehavior.java
@@ -113,6 +113,9 @@ public class TestOnDemandMethodBehavior {
             .thenReturn(connection)
             .thenThrow(IllegalStateException.class);
 
+        when(connectionFactory.getCleanableFor(connection))
+            .thenReturn(() -> connection.close());
+
         onDemand.run(() -> assertThat(onDemand.getHandle().getConnection()).isSameAs(connection));
 
         verify(connectionFactory, times(1)).openConnection();
@@ -123,6 +126,9 @@ public class TestOnDemandMethodBehavior {
         when(connectionFactory.openConnection())
             .thenReturn(connection)
             .thenThrow(IllegalStateException.class);
+
+        when(connectionFactory.getCleanableFor(connection))
+            .thenReturn(() -> connection.close());
 
         onDemand.run(() -> assertThat(anotherOnDemand.getHandle().getConnection()).isSameAs(connection));
 


### PR DESCRIPTION
Remove a single-use interface that works just as well with a lambda.