### PR TITLE
Rewrite handle in cleanable style

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMethod.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMethod.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.extension;
 
 import java.lang.reflect.Method;
+import java.util.StringJoiner;
 
 import static java.util.Objects.requireNonNull;
 
@@ -51,5 +52,13 @@ public final class ExtensionMethod {
      */
     public Method getMethod() {
         return method;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ExtensionMethod.class.getSimpleName() + "[", "]")
+            .add("type=" + type)
+            .add("method=" + method)
+            .toString();
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/internal/exceptions/ThrowableSuppressor.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/exceptions/ThrowableSuppressor.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.internal.exceptions;
+
+import java.util.LinkedList;
+import java.util.function.Function;
+
+import org.jdbi.v3.core.internal.exceptions.Unchecked.CheckedRunnable;
+
+import static org.jdbi.v3.core.internal.exceptions.Sneaky.throwAnyway;
+
+/**
+ * Manage multi-exception chains by adding additional throwables as suppressed.
+ */
+public final class ThrowableSuppressor {
+
+    private final LinkedList<Throwable> throwables = new LinkedList<>();
+
+    /**
+     * Run a piece of code and record any thrown exception at the end of the exception chain.
+     *
+     * @param supplier     Code to execute.
+     * @param defaultValue Default value if the code throws an exception.
+     * @param <T>          The return value type.
+     * @return The output of the executed code or the default value in case of an exception.
+     */
+    public <T> T suppressAppend(CheckedSupplier<T> supplier, T defaultValue) {
+        try {
+            return supplier.get();
+        } catch (Throwable t) {
+            throwables.add(t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Run a piece of code and record any thrown exception at the end of the exception chain.
+     *
+     * @param runnable Code to execute.
+     */
+    public void suppressAppend(CheckedRunnable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable t) {
+            throwables.add(t);
+        }
+    }
+
+    /**
+     * Run a piece of code and record any thrown exception at the beginning of the exception chain.
+     *
+     * @param supplier     Code to execute.
+     * @param defaultValue Default value if the code throws an exception.
+     * @param <T>          The return value type.
+     * @return The output of the executed code or the default value in case of an exception.
+     */
+    public <T> T suppressPrepend(CheckedSupplier<T> supplier, T defaultValue) {
+        try {
+            return supplier.get();
+        } catch (Throwable t) {
+            throwables.addFirst(t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Run a piece of code and record any thrown exception at the beginning of the exception chain.
+     *
+     * @param runnable Code to execute.
+     */
+    public void suppressPrepend(CheckedRunnable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable t) {
+            throwables.addFirst(t);
+        }
+    }
+
+    /**
+     * Attach all recorded exceptions to another throwable as suppressed exceptions.
+     *
+     * @param throwable The throwable to attach to.
+     */
+    public void attachToThrowable(Throwable throwable) {
+        for (Throwable t : throwables) {
+            throwable.addSuppressed(t);
+        }
+        throwables.clear();
+    }
+
+    /**
+     * Attach all recorded exceptions to a new throwable and throw it.
+     *
+     * @param function Returns the throwable to attach to. Only called if there are any additional throwables present. The first one present is passed into the
+     *                 function and is intended as the cause for the exception chain.
+     */
+    public <T extends Throwable> void throwIfNecessary(Function<Throwable, T> function) throws T {
+        if (!throwables.isEmpty()) {
+            T result = function.apply(throwables.removeFirst());
+            attachToThrowable(result);
+            throw result;
+        }
+    }
+
+    /**
+     * If any throwables were recorded, use the first as the primary exception and attach all other suppressed exceptions to it.
+     */
+    public void throwIfNecessary() {
+        if (!throwables.isEmpty()) {
+            Throwable first = throwables.removeFirst();
+            attachToThrowable(first);
+            throw throwAnyway(first);
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
@@ -85,6 +85,16 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This> {
         getContext().close();
     }
 
+    @Override
+    public final boolean equals(Object o) {
+        return this == o;
+    }
+
+    @Override
+    public final int hashCode() {
+        return super.hashCode() * 11;
+    }
+
     @FunctionalInterface
     interface StatementCustomizerInvocation {
         void call(StatementCustomizer t) throws SQLException;

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementBuilder.java
@@ -76,9 +76,10 @@ public interface StatementBuilder {
     void close(Connection conn, String sql, Statement stmt) throws SQLException;
 
     /**
-     * Called when the handle this StatementBuilder is attached to is closed.
+     * Is called when the Handle, to which this StatementBuilder is attached to, is closed.
      *
-     * @param conn the connection to close.
+     * @param conn The connection which can be used to release resources. The Connection is managed by the
+     *             Handle and <b>must not</b> be closed by the StatementBuilder.
      */
     default void close(Connection conn) {}
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
@@ -49,7 +49,7 @@ public class TestPreparedBatch {
 
         final PreparedBatch batch = h.prepareBatch("insert into something (id, name) values (:id, :name)");
         assertThat(batch.execute()).isEmpty();
-        assertThat(batch.getContext().isClosed()).isTrue();
+        assertThat(batch.getContext().isClean()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Allow registration of cleanables, unwind the connection closing through a separate cleanable.