### PR TITLE
Fix resource leaks in script and sqlobject

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/Script.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Script.java
@@ -44,11 +44,10 @@ public class Script extends SqlStatement<Script> {
      */
     public int[] execute() {
         final List<String> statements = getStatements();
-        Batch b = getHandle().createBatch();
-        getContext().addCleanable(b::close);
-
-        statements.forEach(b::add);
-        return b.execute();
+        try (Batch b = getHandle().createBatch()) {
+            statements.forEach(b::add);
+            return b.execute();
+        }
     }
 
     /**

--- a/core/src/test/java/org/jdbi/v3/core/junit5/H2DatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/v3/core/junit5/H2DatabaseExtension.java
@@ -34,6 +34,12 @@ public final class H2DatabaseExtension implements DatabaseExtension<H2DatabaseEx
     public static final DatabaseInitializer SOMETHING_INITIALIZER =
         h -> h.execute("create table something (id identity primary key, name varchar(50), integerValue integer, intValue integer)");
 
+    public static final DatabaseInitializer USERS_INITIALIZER = h -> {
+            h.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR)");
+            h.execute("INSERT INTO users VALUES (1, 'Alice')");
+            h.execute("INSERT INTO users VALUES (2, 'Bob')");
+        };
+
     private final String uri = "jdbc:h2:mem:" + UUID.randomUUID();
     private final Set<JdbiPlugin> plugins = new LinkedHashSet<>();
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/LeakTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/LeakTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Many tests that try to provoke leaks and see whether the various checkers find them and various cleanup strategies catch them.
+ */
+
+public class LeakTest {
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withInitializer(H2DatabaseExtension.USERS_INITIALIZER);
+
+    private Handle handle;
+
+    @BeforeEach
+    public void setUp() {
+        this.handle = h2Extension.getSharedHandle();
+    }
+
+    @Test
+    public void testScript() {
+        int[] results = handle.createScript("INSERT INTO users (id, name) VALUES(3, 'Charlie');"
+                + "UPDATE users SET name='Bobby Tables' WHERE id=2;")
+            .execute();
+
+        assertThat(results).containsExactly(1, 1);
+    }
+
+    @Test
+    public void testScriptAsSeparateStatements() {
+        handle.createScript("INSERT INTO users (id, name) VALUES(3, 'Charlie');"
+                + "UPDATE users SET name='Bobby Tables' WHERE id=2;")
+            .executeAsSeparateStatements();
+    }
+
+    @Test
+    public void testScriptTwr() {
+        try (Script script = handle.createScript("INSERT INTO users (id, name) VALUES(3, 'Charlie');"
+            + "UPDATE users SET name='Bobby Tables' WHERE id=2;")) {
+            int[] results = script.execute();
+            assertThat(results).containsExactly(1, 1);
+        }
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
@@ -185,6 +185,10 @@ abstract class CustomizingStatementHandler<StatementType extends SqlStatement<St
         final Handle h = hs.getHandle();
         final String locatedSql = locateSql(h);
         final StatementType stmt = createStatement(h, locatedSql);
+
+        // clean the statement when the handle closes
+        stmt.attachToHandleForCleanup();
+
         final SqlObjectStatementConfiguration cfg = stmt.getConfig(SqlObjectStatementConfiguration.class);
         cfg.setArgs(args);
         configureReturner(stmt, cfg);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/AttachedHandleLeakTest.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/AttachedHandleLeakTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.jdbi.v3.core.mapper.RowMappers;
+import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
+import org.jdbi.v3.core.result.ResultIterator;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * An extension object that is attached to a handle can return iterators or streams. This class tests various ways on how this may leak resources.
+ */
+public class AttachedHandleLeakTest {
+
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2()
+        .withPlugin(new SqlObjectPlugin())
+        .withInitializer(TestingInitializers.usersWithData())
+        .withConfig(RowMappers.class, r -> r.register(User.class, ConstructorMapper.of(User.class)));
+
+    private UserDao dao;
+
+    @BeforeEach
+    public void setUp() {
+        this.dao = h2Extension.getSharedHandle().attach(UserDao.class);
+    }
+
+    @Test
+    public void testLeakDoNothing() {
+        for (int i = 0; i < 1000; i++) {
+            Iterator<User> it = dao.getIterableUsers();
+            assertThat(it.next()).extracting("id").isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void testLeakCallClean() throws Exception {
+        for (int i = 0; i < 1000; i++) {
+            Iterator<User> it = dao.getIterableUsers();
+            assertThat(it.next()).extracting("id").isEqualTo(1);
+            dao.getHandle().clean();
+        }
+    }
+
+    @Test
+    public void testLeakTwr() {
+        for (int i = 0; i < 1000; i++) {
+            try (ResultIterator<User> it = dao.getIterableUsers()) {
+                assertThat(it.next()).extracting("id").isEqualTo(1);
+            }
+        }
+    }
+
+    @Test
+    public void testLeakStreamDoNothing() {
+        for (int i = 0; i < 1000; i++) {
+            Stream<User> stream = dao.getStreamingUsers();
+            assertThat(stream.findFirst()).containsInstanceOf(User.class);
+        }
+    }
+
+    @Test
+    public void testLeakStreamCallClean() throws Exception {
+        for (int i = 0; i < 1000; i++) {
+            Stream<User> stream = dao.getStreamingUsers();
+            assertThat(stream.findFirst()).containsInstanceOf(User.class);
+            dao.getHandle().clean();
+        }
+    }
+
+    @Test
+    public void testLeakStreamTwr() {
+        for (int i = 0; i < 1000; i++) {
+            try (Stream<User> stream = dao.getStreamingUsers()) {
+                assertThat(stream.findFirst()).containsInstanceOf(User.class);
+            }
+        }
+    }
+
+    @Test
+    @Disabled("no support for iterator yet - #2169")
+    public void testLeakConsumer() {
+        for (int i = 0; i < 1000; i++) {
+            dao.getIterableUsers(it -> assertThat(it.next()).extracting("id").isEqualTo(1));
+        }
+    }
+
+    @Test
+    @Disabled("no support for iterator yet - #2169")
+    public void testLeakStreamConsumer() {
+        for (int i = 0; i < 1000; i++) {
+            dao.getStreamableUsers(stream -> assertThat(stream.findFirst()).containsInstanceOf(User.class));
+        }
+    }
+
+    public static class User {
+
+        private final int id;
+        private final String name;
+
+        public User(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            User user = (User) o;
+            return id == user.id && Objects.equals(name, user.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    public interface UserDao extends SqlObject {
+
+        @SqlQuery("SELECT * from users order by id")
+        ResultIterator<User> getIterableUsers();
+
+        @SqlQuery("SELECT * from users order by id")
+        Stream<User> getStreamingUsers();
+
+        @SqlQuery("SELECT * from users order by id")
+        void getIterableUsers(Consumer<ResultIterator<User>> consumer);
+
+        @SqlQuery("SELECT * from users order by id")
+        void getStreamableUsers(Consumer<Stream<User>> consumer);
+    }
+}

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/internal/TestingInitializers.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/internal/TestingInitializers.java
@@ -27,4 +27,16 @@ public final class TestingInitializers {
     public static JdbiExtensionInitializer something() {
         return (ds, h) -> h.execute("create table something (id identity primary key, name varchar(50), integerValue integer, intValue integer)");
     }
+
+    public static JdbiExtensionInitializer users() {
+        return (ds, h) -> h.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR)");
+    }
+
+    public static JdbiExtensionInitializer usersWithData() {
+        return (ds, h) -> {
+            users().initialize(ds, h);
+            h.execute("INSERT INTO users VALUES (1, 'Alice')");
+            h.execute("INSERT INTO users VALUES (2, 'Bob')");
+        };
+    }
 }


### PR DESCRIPTION
    - close the internal batch statement inside the script statement
    - attach all generated statements to the handle. They will be cleaned when the handle is cleaned up