### PR TITLE
fix(testing/junit5): renable cleaning in flyway configuration

### DIFF
--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiFlywayMigration.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiFlywayMigration.java
@@ -127,6 +127,7 @@ public final class JdbiFlywayMigration implements JdbiExtensionInitializer {
             .dataSource(ds)
             .locations(paths.toArray(new String[0]))
             .schemas(schemas.toArray(new String[0]))
+            .cleanDisabled(!this.cleanAfter)
             .load();
 
         this.flyway.migrate();


### PR DESCRIPTION
In Flyway V9 they made the default value of `cleanDisabled` to `false`. This breaks jdbi's `JdbiFlywayMigration` because it's `cleanAfter` property is always true. Interestingly there is a setter that only allows making it true even though its default value is true.

Another solution to this PR is just setting `cleanDisabled` to always be true.