### PR TITLE
Fix bad concurrent test in stringtemplate4

### DIFF
--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateLoading.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateLoading.java
@@ -18,16 +18,19 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.stringtemplate4.TestStringTemplateSqlLocator.Wombat;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -37,35 +40,81 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestStringTemplateLoading {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2()
+        .enableLeakChecker(false) // otherwise the test may run out of memory
+        .withInitializer(TestingInitializers.something())
+        .withPlugin(new SqlObjectPlugin());
 
-    private Handle handle;
+    private Handle singleThreadedHandle;
+    private Wombat shareableDao;
+    private ExecutorService pool;
+    private Jdbi jdbi;
+    private final AtomicInteger oid = new AtomicInteger();
 
     @BeforeEach
     public void setUp() {
-        handle = h2Extension.getSharedHandle();
+        pool = Executors.newFixedThreadPool(10);
+        jdbi = h2Extension.getJdbi();
+
+        singleThreadedHandle = h2Extension.getSharedHandle();
+        shareableDao = h2Extension.getJdbi().onDemand(Wombat.class);
     }
 
-    public void testBaz(int id) {
-        Wombat wombat = handle.attach(Wombat.class);
+    @AfterEach
+    public void tearDown() throws Exception {
+        pool.shutdown();
+        pool.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testSlowConcurrentLoading() {
+        doLoad(this::slowLoader);
+    }
+
+    @Test
+    public void testFastConcurrentLoading() {
+        doLoad(this::fastLoader);
+    }
+
+    private void doLoad(Runnable runnable) {
+        for (int i = 0; i < 20; i++) {
+            List<Future<?>> futures = IntStream
+                .range(1, 10)
+                .mapToObj(id -> pool.submit(runnable))
+                .collect(Collectors.toList());
+            futures.forEach(Unchecked.consumer(f -> f.get(5, TimeUnit.SECONDS)));
+        }
+    }
+
+    // The loader shares the handle across multiple threads. However a handle is
+    // a single-threaded object so any access must be synchronized to ensure that only
+    // one thread at a time accesses the handle.
+    private synchronized void slowLoader() {
+        int id = oid.getAndIncrement();
+
+        Wombat wombat = singleThreadedHandle.attach(Wombat.class);
         wombat.insert(new Something(id, "Doo" + id));
 
-        String name = handle.createQuery("select name from something where id = " + id)
-                            .mapTo(String.class)
-                            .one();
+        String name = singleThreadedHandle.createQuery("select name from something where id = " + id)
+            .mapTo(String.class)
+            .one();
 
         assertThat(name).isEqualTo("Doo" + id);
     }
 
-    @Test
-    public void testConcurrentLoading() throws InterruptedException {
-        ExecutorService pool = Executors.newFixedThreadPool(10);
-        List<Future<?>> futures = IntStream
-            .range(1, 10)
-            .mapToObj(id -> pool.submit(() -> testBaz(id)))
-            .collect(Collectors.toList());
-        pool.shutdown();
-        pool.awaitTermination(10, TimeUnit.SECONDS);
-        futures.forEach(Unchecked.consumer(f -> f.get(100, TimeUnit.MILLISECONDS)));
+    public void fastLoader() {
+        int id = oid.getAndIncrement();
+
+        // this is a global object and executing an operation on it
+        // creates a new handle behind the scenes. So it can be shared between threads.
+        shareableDao.insert(new Something(id, "Doo" + id));
+
+        jdbi.useHandle(handle -> {
+            String name = handle.createQuery("select name from something where id = " + id)
+                .mapTo(String.class)
+                .one();
+
+            assertThat(name).isEqualTo("Doo" + id);
+        });
     }
 }


### PR DESCRIPTION
This was hidden by the handle threadlocal and started popping up once they were removed.