### PR TITLE
Fix generated javadocs

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -55,6 +55,11 @@
         <dependencies>
             <dependency>
                 <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-commons-text</artifactId>
+                <version>${dep.jdbi3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-core</artifactId>
                 <version>${dep.jdbi3.version}</version>
             </dependency>
@@ -63,12 +68,6 @@
                 <artifactId>jdbi3-core</artifactId>
                 <version>${dep.jdbi3.version}</version>
                 <classifier>tests</classifier>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-commons-text</artifactId>
-                <version>${dep.jdbi3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>
@@ -83,11 +82,6 @@
             <dependency>
                 <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-gson2</artifactId>
-                <version>${dep.jdbi3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-moshi</artifactId>
                 <version>${dep.jdbi3.version}</version>
             </dependency>
             <dependency>
@@ -138,6 +132,16 @@
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-moshi</artifactId>
+                <version>${dep.jdbi3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-postgis</artifactId>
+                <version>${dep.jdbi3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-postgres</artifactId>
                 <version>${dep.jdbi3.version}</version>
             </dependency>
@@ -149,8 +153,15 @@
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-postgis</artifactId>
+                <artifactId>jdbi3-spring5</artifactId>
                 <version>${dep.jdbi3.version}</version>
+                <!--- it is always spring. always. -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-jcl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>
@@ -167,11 +178,6 @@
                 <artifactId>jdbi3-sqlobject</artifactId>
                 <version>${dep.jdbi3.version}</version>
                 <classifier>tests</classifier>
-            </dependency>
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-spring5</artifactId>
-                <version>${dep.jdbi3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -40,13 +40,17 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-core</artifactId>
-        </dependency>
+        <!-- needs to be the same list as the public module list in the
+             root POM, otherwise some classes will not be in the javadocs!
+        -->
+
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-commons-text</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
@@ -54,11 +58,19 @@
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-guice</artifactId>
+            <artifactId>jdbi3-generator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-gson2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-guice</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
@@ -78,11 +90,27 @@
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-postgres</artifactId>
+            <artifactId>jdbi3-kotlin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-kotlin-sqlobject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-moshi</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-postgis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-postgres</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-spring5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
@@ -96,20 +124,13 @@
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-stringtemplate4</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testing</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-vavr</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-kotlin</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-kotlin-sqlobject</artifactId>
         </dependency>
 
         <dependency>
@@ -166,12 +187,6 @@
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-testing</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,33 +38,38 @@
         <!-- integration tests will not find the bom dependency and fail -->
         <module>internal</module>
         <module>bom</module>
-        <module>examples</module>
-        <module>core</module>
-        <module>sqlobject</module>
-        <module>stringtemplate4</module>
+
+        <!-- alphabetical list of the documented (public) modules that we ship -->
         <module>commons-text</module>
-        <module>lombok</module>
+        <module>core</module>
         <module>freemarker</module>
+        <module>generator</module>
         <module>gson2</module>
-        <module>moshi</module>
-        <module>guice</module>
         <module>guava</module>
+        <module>guice</module>
         <module>jackson2</module>
         <module>jodatime2</module>
         <module>jpa</module>
         <module>json</module>
-        <module>postgres</module>
-        <module>postgis</module>
-        <module>spring5</module>
-        <module>docs</module>
-        <module>kotlin</module>
         <module>kotlin-sqlobject</module>
-        <module>noparameters</module>
-        <module>vavr</module>
+        <module>kotlin</module>
+        <module>moshi</module>
+        <module>postgis</module>
+        <module>postgres</module>
+        <module>spring5</module>
         <module>sqlite</module>
-        <module>generator</module>
-        <module>benchmark</module>
+        <module>sqlobject</module>
+        <module>stringtemplate4</module>
         <module>testing</module>
+        <module>vavr</module>
+
+        <!-- support pieces, examples, benchmark, tests etc. -->
+        <!-- none of those ship actual end-user code -->
+        <module>benchmark</module>
+        <module>docs</module>
+        <module>examples</module>
+        <module>lombok</module>
+        <module>noparameters</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
Turns out, we are not shipping a metric ton of javadocs that are supposed to be published. Fix that.