### PR TITLE
Backport #2179 for Junit4

### DIFF
--- a/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
@@ -154,6 +154,7 @@ public abstract class JdbiRule extends ExternalResource {
                 .dataSource(getDataSource())
                 .locations(migration.paths.toArray(new String[0]))
                 .schemas(migration.schemas.toArray(new String[0]))
+                .cleanDisabled(!migration.cleanAfter)
                 .load();
             flyway.migrate();
         }

--- a/testing/src/main/java/org/jdbi/v3/testing/Migration.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/Migration.java
@@ -76,6 +76,15 @@ public class Migration {
     }
 
     /**
+     * Controls whether to drop all objects in the configured schemas after running the tests using Flyway.
+     */
+    @SuppressWarnings("HiddenField")
+    public Migration cleanAfter(boolean cleanAfter) {
+        this.cleanAfter = cleanAfter;
+        return this;
+    }
+
+    /**
      * Create new Migration.
      */
     public static Migration before() {


### PR DESCRIPTION
Flyway changed the default value of cleanDisabled to false in V9.

Set the value explicitly from cleanAfter. Also add a setter that allows other values than "true" and "more true".

Fixes #2197