### PR TITLE
Support static @RegisterExtension for JdbiExtension

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  - Support class-level (static) instance fields for JdbiExtension and its subclasses.
+
 # 3.35.0
 
   - Fix `JdbiFlywayMigration` to work with Flyway 9 (#2179, thanks @broccolai)

--- a/core/src/main/java/org/jdbi/v3/core/config/ConfiguringPlugin.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/ConfiguringPlugin.java
@@ -18,9 +18,9 @@ import java.util.function.Consumer;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 
-public class ConfiguringPlugin<C extends JdbiConfig<C>> implements JdbiPlugin {
-    private Class<C> configClass;
-    private Consumer<C> configurer;
+public final class ConfiguringPlugin<C extends JdbiConfig<C>> implements JdbiPlugin {
+    private final Class<C> configClass;
+    private final Consumer<C> configurer;
 
     private ConfiguringPlugin(Class<C> configClass, Consumer<C> configurer) {
         this.configClass = configClass;

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -4814,8 +4814,14 @@ public class Test {
 }
 ----
 
+The link:{jdbidocs}/testing/junit5/JdbiExtension.html[JdbiExtension^] and all its database specific subclasses can be registered as instance fields or as class-level (static) fields.
+
 [NOTE]
-link:{jdbidocs}/testing/junit5/JdbiExtension.html[JdbiExtension^] and all the database specific subclasses are intended to be registered as instance fields. Fields annotated with the link:https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/extension/RegisterExtension.html[@RegisterExtension^] that hold JdbiExtension instances should *not* be static! While this may work, the behavior is currently undefined and should be avoided.
+Registration as class-level (static) fields is *only supported in Jdbi version 3.35.1 and beyond*. For all releases before this, the behavior of the link:{jdbidocs}/testing/junit5/JdbiExtension.html[JdbiExtension^] instances is undefined.
+
+When registered as an instance field, each test will get a new Jdbi instance. The in-memory database specific subclasses (H2, SQLite or HsqlDB with the generic extension) will reset their content and provide a new instance.
+
+When registered as a static field, the extension will be initialized before all test methods are executed. All tests share the same extension instance and its associated fields. The in-memory database specfic subclasses will retain their contents across multiple tests.
 
 The javadoc page for link:{jdbidocs}/testing/junit5/JdbiExtension.html[JdbiExtension^] contains additional information on how to customize a programmatically registered instance.
 

--- a/testing/src/test/java/org/jdbi/v3/testing/junit5/TestJdbiExtensionScopes.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/junit5/TestJdbiExtensionScopes.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5;
+
+import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.core.statement.Update;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static java.lang.String.format;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class TestJdbiExtensionScopes {
+
+    @RegisterExtension
+    public static JdbiExtension perClassInstance = JdbiExtension.h2();
+
+    @RegisterExtension
+    public JdbiExtension perTestInstance = JdbiExtension.h2();
+
+    @Test
+    @Order(1)
+    public void testTableCreation() {
+        // create tables in a static (perClass) and a member (perTest) instance
+        assertThat(createTable(perClassInstance, "TABLE1")).isZero();
+        assertThat(existsTable(perClassInstance, "TABLE1")).isTrue();
+
+        // ensure that the tables exist
+        assertThat(createTable(perTestInstance, "TABLE1")).isZero();
+        assertThat(existsTable(perTestInstance, "TABLE1")).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    public void testTableExists() {
+        // perClassInstance is still the same as in testTableCreation, so the table is still here
+        assertThat(existsTable(perClassInstance, "TABLE1")).isTrue();
+        // perTestInstance got reset between tests, so the table is gone.
+        assertThat(existsTable(perTestInstance, "TABLE1")).isFalse();
+    }
+
+
+    static int createTable(JdbiExtension extension, String table) {
+        try (Update update = extension.getSharedHandle().createUpdate(format("CREATE TABLE public.%s (a INTEGER)", table))) {
+            return update.execute();
+        }
+    }
+
+    static boolean existsTable(JdbiExtension extension, String table) {
+        try (Query query = extension.getSharedHandle()
+            .createQuery(format("SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'PUBLIC' AND table_name = '%s')", table))) {
+            return query.mapTo(Boolean.class).one();
+        }
+    }
+}


### PR DESCRIPTION
This creates a single instance that is used for all tests in a test class.

There are situations where this is desireable to have the same test database for all tests. Support this by implementing the BeforeAll and AfterAll JUnit5 APIs.