### PR TITLE
Add support for jdbc databases in testcontainers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: build distribution
       env:
         JAVA_HOME: ${{ steps.build_jdk.outputs.path }}
-        JDBI_MAVEN_OPTS: "-DskipTests -Dbasepom.check.skip-all=true -Dbasepom.check.skip-enforcer=false -B -fae"
+        JDBI_MAVEN_OPTS: "-DskipTests -DskipITs -Dbasepom.check.skip-all=true -Dbasepom.check.skip-enforcer=false -B -fae"
       run: |
         ./mvnw --version
         echo $PATH

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,4 +1,4 @@
-name: Code style checks
+name: Run all container database tests
 
 on:
   push:
@@ -9,22 +9,27 @@ on:
     - master
 
 jobs:
-  style:
+  ci:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
 
     - uses: actions/setup-java@v3
+      id: build_jdk
       with:
         java-version: 17
         distribution: temurin
         cache: maven
 
-    - name: run code checkers
+    - name: build distribution
       env:
-        JDBI_MAVEN_OPTS: "-DskipITs -DskipTests -B -fae"
+        JDBI_MAVEN_OPTS: "-B -fn"
       run: |
-        ./mvnw --version
-        echo $PATH
-        make install
+        make install-fast
+
+    - name: run container tests
+      env:
+        JDBI_MAVEN_OPTS: "-B -fn"
+      run: |
+        make tests-container

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 SHELL = /bin/sh
 .SUFFIXES:
-.PHONY: help clean install install-nodocker install-fast docs tests tests-nodocker publish-docs deploy release
+.PHONY: help clean install install-nodocker install-fast docs tests tests-container tests-nodocker publish-docs deploy release
 
 # replace JDBI_MAVEN_OPTS with implicit MAVEN_OPTS, once 3.9.x or later has been released
 MAVEN = ./mvnw ${JDBI_MAVEN_OPTS}
@@ -42,6 +42,10 @@ tests: JDBI_MAVEN_OPTS += -Dbasepom.it.skip=false
 tests:
 	${MAVEN} surefire:test invoker:integration-test invoker:verify
 
+tests-container: JDBI_MAVEN_OPTS += -Dbasepom.test.skip=false
+tests-container:
+	${MAVEN} surefire:test -pl :jdbi3-testcontainers
+
 tests-nodocker: JDBI_MAVEN_OPTS += -Dno-docker
 tests-nodocker: tests
 
@@ -62,8 +66,9 @@ help:
 	@echo " * install-nodocker - same as 'install', but skip all tests that require a local docker installation"
 	@echo " * install-fast     - same as 'install', but skip test execution and code analysis (Checkstyle/PMD/Spotbugs)"
 	@echo " * docs             - build up-to-date documentation in docs/target/generated-docs/"
-	@echo " * tests            - run all unit and integration tests"
+	@echo " * tests            - run all unit and integration tests except really slow tests"
 	@echo " * tests-nodocker   - same as 'tests', but skip all tests that require a local docker installation"
+	@echo " * tests-container  - run the full multi-database container test suite"
 	@echo " *"
 	@echo " ***********************************************************************"
 	@echo " *"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
   - Support class-level (static) instance fields for JdbiExtension and its subclasses.
+  - Add jdbi3-testing support for testcontainer based databases
 
 # 3.35.0
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -174,6 +174,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-testcontainers</artifactId>
+                <version>${dep.jdbi3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-vavr</artifactId>
                 <version>${dep.jdbi3.version}</version>
             </dependency>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -126,6 +126,10 @@
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testcontainers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>
         </dependency>
         <dependency>

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -136,8 +136,15 @@ jdbi3-core::
     The core Jdbi library. Required by all other components.
 jdbi3-sqlobject::
     SQL Object extension for declarative database access.
+
+
+===== Testing support
+
 jdbi3-testing::
     Testing framework support. Currently, only supports JUnit4 and JUnit5.
+
+jdbi3-testcontainers::
+    Support for arbitrary databases running in link:https://testcontainers.org/[Testcontainers^]. Currently, only suports JUnit 5.
 
 
 ===== External data types and libraries
@@ -4843,12 +4850,13 @@ The instances injected are the same instances as returned by link:{jdbidocs}/tes
 
 Currently supported databases:
 
-* link:https://www.postgresql.org/[Postgres] - link:{jdbidocs}/testing/junit5/JdbiPostgresExtension.html[JdbiPostgresExtension^], link:{jdbidocs}/testing/junit5/JdbiExternalPostgresExtension.html[JdbiExternalPostgresExtension^], link:{jdbidocs}/testing/junit5/JdbiOtjPostgresExtension.html[JdbiOtjPostgresExtension^]
-* link:https://www.h2database.com/[H2] - link:{jdbidocs}/testing/junit5/JdbiH2Extension.html[JdbiH2Extension^]
-* link:https://www.sqlite.org/[Sqlite] - link:{jdbidocs}/testing/junit5/JdbiSqliteExtension.html[JdbiSqliteExtension^]
+* link:https://www.postgresql.org/[Postgres^] - link:{jdbidocs}/testing/junit5/JdbiPostgresExtension.html[JdbiPostgresExtension^], link:{jdbidocs}/testing/junit5/JdbiExternalPostgresExtension.html[JdbiExternalPostgresExtension^], link:{jdbidocs}/testing/junit5/JdbiOtjPostgresExtension.html[JdbiOtjPostgresExtension^]
+* link:https://www.h2database.com/[H2^] - link:{jdbidocs}/testing/junit5/JdbiH2Extension.html[JdbiH2Extension^]
+* link:https://www.sqlite.org/[Sqlite^] - link:{jdbidocs}/testing/junit5/JdbiSqliteExtension.html[JdbiSqliteExtension^]
 * Generic JDBC database support - link:{jdbidocs}/testing/junit5/JdbiGenericExtension.html[JdbiGenericExtension^]. This is a minimal extension that can support any database that support JDBC. The driver for the database must be on the classpath. All database management (schema creation, DDL object management etc.) must be done by the calling code.
+* link:https://testcontainers.org/[Testcontainers^] - link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^]. See <<Using Testcontainers>> for detailed documentation.
 
-Support for other databases is wanted!
+Support for other databases wanted!
 
 The link:{jdbidocs}/testing/junit5/JdbiExtension.html[JdbiExtension^] provides a number of convenience methods:
 
@@ -4896,6 +4904,80 @@ Postgres is supported through multiple test classes:
 * link:{jdbidocs}/testing/junit5/JdbiExternalPostgresExtension.html[JdbiExternalPostgresExtension^] supports an external Postgres database and can run tests against any local or remote database.
 * link:{jdbidocs}/testing/junit5/JdbiOtjPostgresExtension.html[JdbiOtjPostgresExtension^] supports the link:https://github.com/opentable/otj-pg-embedded[OpenTable Java Embedded PostgreSQL component].
 
+
+=== Using Testcontainers
+
+The link:https://testcontainers.org[Testcontainers^] project provides a number of services as docker containers with a programmatic interface for JVM code. Jdbi supports JDBC type databases with the link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^]:
+
+[source,java, indent=0]
+----
+@Testcontainers
+class TestWithContainers {
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new YugabyteDBYSQLContainer("yugabytedb/yugabyte");
+
+    @RegisterExtension
+    JdbiExtension extension = JdbiTestcontainersExtension.instance(dbContainer);
+
+    // ... test code using the yugabyte engine
+}
+----
+
+The link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] has builtin support to isolate each test method in a test class. The container can be declared as a static class member which speeds up test execution significantly.
+
+There is builtin support for MySQL, MariaDB, TiDB, PostgreSQL, CockroachDB, YugabyteDB, ClickHouse, Oracle XE and Trino. It also supports the various compatible flavors (such as PostGIS for PostgreSQL).
+
+==== Providing custom database information
+
+The link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] creates a new database or schema (depending on the database engine) for each test. This speeds up test execution. In some cases (e.g. when using a not yet supported database engine or when using a custom docker image), it may be necessary to provide a custom instance of the link:{jdbidocs}/testing/junit5/tc/TestcontainersDatabaseInformation.html[TestcontainersDatabaseInformation^] class that describes how to manage a specific database engine.
+
+Here are examples for MySQL and PostgreSQL:
+
+[source,java, indent=0]
+----
+// MySQL has only databases, no schemata. The Jdbi extension creates a new database
+// for each test method.
+private static final TestcontainersDatabaseInformation MYSQL = TestcontainersDatabaseInformation.of(
+        "root",  // Testcontainers provides the 'root' superuser for MySQL instances.
+        null,    // do not override the generated catalog name
+        null,    // do not override the generated schema name (which is not used by MySQL)
+        // create a new database from the catalog name
+        (catalogName, schemaName) -> format("CREATE DATABASE %s", catalogName)
+);
+
+// PostgreSQL knows about schemata but needs to use the predefined "test" database.
+// The Jdbi extension creates a new schema for each test method
+private static final TestcontainersDatabaseInformation POSTGRES = TestcontainersDatabaseInformation.of(
+        null,   // Use the default user that testcontainers provides
+        "test", // override the generated catalog name with 'test'
+        null,   // do not override the generated schema name
+        // create a new schema from the schema name
+        (catalogName, schemaName) -> format("CREATE SCHEMA %s", schemaName)
+);
+----
+
+See the Javadoc for the link:{jdbidocs}/testing/junit5/tc/TestcontainersDatabaseInformation.html[TestcontainersDatabaseInformation^] class for further details.
+
+The link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] provides the link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html#instance(org.jdbi.v3.testing.junit5.tc.TestcontainersDatabaseInformation,org.testcontainers.containers.JdbcDatabaseContainer)[instance(TestcontainersDatabaseInformation, JdbcDatabaseContainer)^] method which uses a custom database information object:
+
+[source,java,indent=0]
+----
+@Testcontainers
+class TestWithCustomContainer {
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new PostgreSQLContainer<>(
+       DockerImageName.parse("custom-image").asCompatibleSubstituteFor("postgres"));
+
+
+    static final TestcontainersDatabaseInformation CUSTOM_DATABASE =
+       TestcontainersDatabaseInformation.of( ... custom setup ...);
+
+    @RegisterExtension
+    JdbiExtension extension = JdbiTestcontainersExtension.instance(CUSTOM_DATABASE, dbContainer);
+
+    // ... test code using the custom engine
+}
+----
 
 
 == Third-Party Integration

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -77,6 +77,8 @@
         <dep.freebuilder.version>2.7.0</dep.freebuilder.version>
         <dep.guava.version>30.1.1-jre</dep.guava.version>
         <dep.h2.version>2.1.214</dep.h2.version>
+        <!-- leave hikari-cp on 4.x for jdk8 compatibility! -->
+        <dep.hikari-cp.version>4.0.3</dep.hikari-cp.version>
         <dep.hsqldb.version>2.7.1</dep.hsqldb.version>
         <dep.immutables.version>2.8.8</dep.immutables.version>
         <dep.jackson2.version>2.10.5.20201202</dep.jackson2.version>
@@ -97,8 +99,9 @@
         <dep.plugin.ktlint.version>1.15.1</dep.plugin.ktlint.version>
         <dep.plugin.sortpom.version>3.2.0</dep.plugin.sortpom.version>
         <dep.postgresql.version>42.5.1</dep.postgresql.version>
-        <dep.slf4j.version>1.7.32</dep.slf4j.version>
+        <dep.slf4j.version>1.7.36</dep.slf4j.version>
         <dep.spring.version>5.3.20</dep.spring.version>
+        <dep.testcontainers.version>1.17.6</dep.testcontainers.version>
         <dep.vavr.version>0.9.3</dep.vavr.version>
         <jdbi.check.fail-detekt>${jdbi.check.fail-kotlin}</jdbi.check.fail-detekt>
         <jdbi.check.fail-kotlin>${basepom.check.fail-extended}</jdbi.check.fail-kotlin>
@@ -132,6 +135,15 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${dep.testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>io.leangen.geantyref</groupId>
                 <artifactId>geantyref</artifactId>
@@ -465,6 +477,19 @@
             </dependency>
 
             <dependency>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP</artifactId>
+                <version>${dep.hikari-cp.version}</version>
+                <exclusions>
+                    <!-- excluded because it asks for 2.0.0 -->
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>${dep.spotbugs.version}</version>
@@ -562,6 +587,8 @@
                         <links>
                             <link>https://google.github.io/guice/api-docs/4.0/javadoc/</link>
                             <link>https://javaee.github.io/javaee-spec/javadocs/</link>
+                            <link>https://junit.org/junit5/docs/${dep.junit5.version}/api/</link>
+                            <link>https://javadoc.io/doc/org.testcontainers/jdbc/${dep.testcontainers.version}/</link>
                         </links>
                         <nodeprecated>false</nodeprecated>
                         <author>false</author>
@@ -1083,6 +1110,7 @@
             <properties>
                 <basepom.check.skip-all>true</basepom.check.skip-all>
                 <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
             </properties>
         </profile>
 

--- a/internal/policy/src/main/resources/policy/pmd.xml
+++ b/internal/policy/src/main/resources/policy/pmd.xml
@@ -109,6 +109,7 @@
 
     <rule ref="category/java/multithreading.xml">
         <exclude name="AvoidUsingVolatile"/>
+        <exclude name="DoNotUseThreads"/>
         <exclude name="UseConcurrentHashMap"/>
     </rule>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>sqlite</module>
         <module>sqlobject</module>
         <module>stringtemplate4</module>
+        <module>testcontainers</module>
         <module>testing</module>
         <module>vavr</module>
 

--- a/postgis/pom.xml
+++ b/postgis/pom.xml
@@ -52,8 +52,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -76,8 +76,32 @@
         </dependency>
 
         <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jdbi</groupId>
+        <artifactId>jdbi3-parent</artifactId>
+        <version>3.35.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jdbi3-testcontainers</artifactId>
+
+    <name>jdbi3 testcontainers</name>
+    <description>Support for the testcontainers.org project for testing databases.</description>
+
+    <properties>
+        <!-- all tests run docker containers. Run them one by one... -->
+        <basepom.test.fork-count>1</basepom.test.fork-count>
+        <!-- tests are slow, so run tests only if explictly asked for -->
+        <basepom.test.skip>true</basepom.test.skip>
+        <!-- docker tests run long -->
+        <basepom.test.timeout>600</basepom.test.timeout>
+        <dep.clickhouse.version>0.3.2</dep.clickhouse.version>
+        <dep.mysql.version>8.0.31</dep.mysql.version>
+        <dep.oracle-xe.version>19.14.0.0</dep.oracle-xe.version>
+        <dep.trino.version>403</dep.trino.version>
+        <dep.yugabyte.version>42.3.4</dep.yugabyte.version>
+        <moduleName>org.jdbi.v3.testcontainers</moduleName>
+    </properties>
+
+    <!-- we need tons of additional JDBC drivers in this one module. So we keep them all here. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>${dep.mysql.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ojdbc8</artifactId>
+                <version>${dep.oracle-xe.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.clickhouse</groupId>
+                <artifactId>clickhouse-jdbc</artifactId>
+                <version>${dep.clickhouse.version}</version>
+                <exclusions>
+                    <!-- sigh. Java is hard -->
+                    <exclusion>
+                        <groupId>com.clickhouse</groupId>
+                        <artifactId>clickhouse-grpc-client</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.yugabyte</groupId>
+                <artifactId>jdbc-yugabytedb</artifactId>
+                <version>${dep.yugabyte.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-jdbc</artifactId>
+                <version>${dep.trino.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testing</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+        </dependency>
+
+        <!-- test deps -->
+
+        <!-- JDBC drivers -->
+
+        <dependency>
+            <groupId>com.clickhouse</groupId>
+            <artifactId>clickhouse-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.yugabyte</groupId>
+            <artifactId>jdbc-yugabytedb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- containers -->
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>tidb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>trino</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>oracle-xe</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cockroachdb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>clickhouse</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>yugabytedb</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/EmbeddedUtil.java
+++ b/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/EmbeddedUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jdbi.v3.testing.junit5.tc;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+final class EmbeddedUtil {
+
+    private static final String LOWERCASE;
+
+    static {
+        LOWERCASE = sequence('a', 26);
+    }
+
+    private EmbeddedUtil() {
+        throw new AssertionError("EmbeddedUtil can not be instantiated");
+    }
+
+    static String randomLowercase(int length) {
+        return randomString(LOWERCASE, length);
+    }
+
+    private static String sequence(char start, int count) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            sb.append((char) (start + i));
+        }
+        return sb.toString();
+    }
+
+    private static String randomString(String alphabet, int length) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            int random = ThreadLocalRandom.current().nextInt(alphabet.length());
+            sb.append(alphabet.charAt(random));
+        }
+        return sb.toString();
+    }
+}

--- a/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/JdbiTestcontainersExtension.java
+++ b/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/JdbiTestcontainersExtension.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.jdbi.v3.meta.Beta;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import static java.lang.String.format;
+
+/**
+ * Support <a href="https://testcontainers.org/">Testcontainer JDBC containers</a> as database for Jdbi tests.
+ */
+@Beta
+public final class JdbiTestcontainersExtension extends JdbiExtension {
+
+    private final JdbcDatabaseContainer<?> jdbcDatabaseContainer;
+    private final TestcontainersDatabaseInformation databaseInformation;
+    private final TestcontainersDatabaseInformationSupplier instanceProvider;
+
+    private volatile HikariDataSource masterDatasource = null;
+    private volatile HikariConfig masterConfig = null;
+    private volatile HikariDataSource schemaDatasource = null;
+
+    /**
+     * Create a new {@link JdbiExtension} that uses the supplied {@link JdbcDatabaseContainer} as database. This must be a supported
+     * container instance.
+     *
+     * @param jdbcDatabaseContainer A supported {@link JdbcDatabaseContainer} instance.
+     * @return An initialized {@link JdbiExtension} instance that uses the database container.
+     * @throws IllegalArgumentException If the provided container class is not supported.
+     */
+    public static JdbiExtension instance(JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
+        TestcontainersDatabaseInformation databaseInformation = TestcontainersDatabaseInformation.forTestcontainerClass(jdbcDatabaseContainer.getClass());
+
+        if (databaseInformation == null) {
+            throw new IllegalArgumentException(format("Container class '%s' is unknown!", jdbcDatabaseContainer.getClass().getName()));
+        }
+
+        return new JdbiTestcontainersExtension(databaseInformation, jdbcDatabaseContainer);
+    }
+
+    /**
+     * Create a new {@link JdbiExtension} that uses the supplied {@link JdbcDatabaseContainer} as database.
+     *
+     * @param databaseInformation A {@link TestcontainersDatabaseInformation} instance that describes how to create new test-isolation databases or schemata.
+     * @param jdbcDatabaseContainer A {@link JdbcDatabaseContainer} instance.
+     * @return An initialized {@link JdbiExtension} instance that uses the database container.
+     */
+    public static JdbiExtension instance(TestcontainersDatabaseInformation databaseInformation, JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
+        return new JdbiTestcontainersExtension(databaseInformation, jdbcDatabaseContainer);
+    }
+
+    private JdbiTestcontainersExtension(TestcontainersDatabaseInformation databaseInformation, JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
+        this.jdbcDatabaseContainer = jdbcDatabaseContainer;
+        this.databaseInformation = databaseInformation;
+        this.instanceProvider = new TestcontainersDatabaseInformationSupplier(databaseInformation);
+    }
+
+    @Override
+    public String getUrl() {
+        return jdbcDatabaseContainer.getJdbcUrl();
+    }
+
+    @Override
+    protected DataSource createDataSource() {
+
+        if (masterDatasource == null || masterConfig == null) {
+            throw new IllegalArgumentException("Extension was not started!");
+        }
+
+        TestcontainersDatabaseInformation databaseInformation = instanceProvider.get();
+
+        HikariConfig schemaConfig = new HikariConfig();
+        masterConfig.copyStateTo(schemaConfig);
+
+        databaseInformation.getCatalog().ifPresent(schemaConfig::setCatalog);
+        databaseInformation.getSchema().ifPresent(schemaConfig::setSchema);
+        schemaConfig.setPoolName(format("jdbi-test-pool (%s)", databaseInformation));
+
+        try (HikariDataSource ds = schemaDatasource) {
+            this.schemaDatasource = new HikariDataSource(schemaConfig);
+        }
+
+        return schemaDatasource;
+    }
+
+    @Override
+    protected void startExtension() throws Exception {
+
+        if (masterDatasource != null || masterConfig != null) {
+            throw new IllegalArgumentException("Extension was already started!");
+        }
+
+        masterConfig = new HikariConfig();
+        masterConfig.setJdbcUrl(jdbcDatabaseContainer.getJdbcUrl());
+        masterConfig.setUsername(databaseInformation.getUser().orElse(jdbcDatabaseContainer.getUsername()));
+        masterConfig.setPassword(jdbcDatabaseContainer.getPassword());
+        masterConfig.setDriverClassName(jdbcDatabaseContainer.getDriverClassName());
+        masterConfig.setPoolName(format("jdbi-template-pool (%s)", databaseInformation));
+
+        databaseInformation.getCatalog().ifPresent(masterConfig::setCatalog);
+        databaseInformation.getSchema().ifPresent(masterConfig::setSchema);
+
+        this.masterDatasource = new HikariDataSource(masterConfig);
+
+        this.instanceProvider.start(masterDatasource);
+
+        super.startExtension();
+    }
+
+    @Override
+    protected void stopExtension() throws Exception {
+
+        if (masterDatasource == null || masterConfig == null) {
+            throw new IllegalArgumentException("Extension was not started!");
+        }
+
+        try (HikariDataSource masterDs = masterDatasource;
+            HikariDataSource schemaDs = schemaDatasource;
+            TestcontainersDatabaseInformationSupplier ip = instanceProvider) {
+            super.stopExtension();
+        }
+    }
+}

--- a/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/TestcontainersDatabaseInformation.java
+++ b/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/TestcontainersDatabaseInformation.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.function.BiFunction;
+
+import org.jdbi.v3.meta.Beta;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import static java.lang.String.format;
+
+/**
+ * Describes the parameters needed to create a new test-specific database or schema to isolate a test. Testcontainers supports many different databases and the
+ * Jdbi specific extension requires parameterization.
+ * <br>
+ * Custom TestcontainersDatabaseInformation instances can be created e.g. for a specific local setup or a customer docker image.
+ */
+@Beta
+public final class TestcontainersDatabaseInformation {
+
+    // Clickhouse driver uses schema for database selection...
+    private static final TestcontainersDatabaseInformation CLICKHOUSE =
+        of(null, null, null, (catalogName, schemaName) -> format("CREATE DATABASE %s Engine = Memory", schemaName));
+
+    private static final TestcontainersDatabaseInformation MYSQL =
+        of("root", null, null, (catalogName, schemaName) -> format("CREATE DATABASE %s", catalogName));
+
+    // Oracle is ... special. This works with the gvenzl images; YMMV.
+    private static final TestcontainersDatabaseInformation ORACLE_XE =
+        ofScript("system", null, null, (catalogName, schemaName) -> {
+            List<String> script = new ArrayList<>();
+            script.add(format("CREATE USER %s IDENTIFIED BY %s QUOTA UNLIMITED ON USERS", schemaName, schemaName));
+            script.add(format("GRANT CREATE session TO %s", schemaName));
+            script.add(format("GRANT CREATE table TO %s", schemaName));
+            script.add(format("GRANT CREATE view TO %s", schemaName));
+            script.add(format("GRANT CREATE any trigger TO %s", schemaName));
+            script.add(format("GRANT CREATE any procedure TO %s", schemaName));
+            script.add(format("GRANT CREATE sequence TO %s", schemaName));
+            script.add(format("GRANT CREATE synonym TO %s", schemaName));
+            return script;
+        });
+
+    private static final TestcontainersDatabaseInformation POSTGRES =
+        of(null, "test", null, (catalogName, schemaName) -> format("CREATE SCHEMA %s", schemaName));
+
+    private static final TestcontainersDatabaseInformation TRINO =
+        of(null, "memory", null, (catalogName, schemaName) -> format("CREATE SCHEMA %s", schemaName));
+
+    private static final Map<String, TestcontainersDatabaseInformation> KNOWN_CONTAINERS;
+
+    static {
+        Map<String, TestcontainersDatabaseInformation> knownContainers = new HashMap<>();
+        // mysql crowd
+        knownContainers.put("org.testcontainers.containers.MySQLContainer", TestcontainersDatabaseInformation.MYSQL);
+        knownContainers.put("org.testcontainers.containers.MariaDBContainer", TestcontainersDatabaseInformation.MYSQL);
+        knownContainers.put("org.testcontainers.tidb.TiDBContainer", TestcontainersDatabaseInformation.MYSQL);
+
+        // postgres crowd
+        knownContainers.put("org.testcontainers.containers.PostgreSQLContainer", TestcontainersDatabaseInformation.POSTGRES);
+        knownContainers.put("org.testcontainers.containers.CockroachContainer", TestcontainersDatabaseInformation.POSTGRES);
+        knownContainers.put("org.testcontainers.containers.YugabyteDBYSQLContainer", TestcontainersDatabaseInformation.POSTGRES);
+
+        // odd ones
+        knownContainers.put("org.testcontainers.containers.ClickHouseContainer", TestcontainersDatabaseInformation.CLICKHOUSE);
+        knownContainers.put("org.testcontainers.containers.OracleContainer", TestcontainersDatabaseInformation.ORACLE_XE);
+        knownContainers.put("org.testcontainers.containers.TrinoContainer", TestcontainersDatabaseInformation.TRINO);
+
+        KNOWN_CONTAINERS = knownContainers;
+    }
+
+    /**
+     * Returns a {@link TestcontainersDatabaseInformation} instance for a given container instance class.
+     *
+     * @param containerClazz A {@link JdbcDatabaseContainer} class object. Must not be null.
+     * @return A {@link TestcontainersDatabaseInformation} instance describing how to use the database with the {@link JdbiTestcontainersExtension} or null if
+     * the container class is unknown.
+     */
+    public static TestcontainersDatabaseInformation forTestcontainerClass(Class<? extends JdbcDatabaseContainer> containerClazz) {
+        return KNOWN_CONTAINERS.get(containerClazz.getName());
+    }
+
+    private final String user;
+    private final String catalog;
+    private final String schema;
+    private final BiFunction<String, String, List<String>> createStatement;
+
+    /**
+     * Creates a new database information instance that describes a database.
+     *
+     * @param user            Specify a user that can create a new schema or database. If this parameter is null, the testcontainer specific default user is
+     *                        used.
+     * @param catalog         Specify a catalog that should be used. This is for databases that do not support creating a new catalog or require a fixed catalog
+     *                        for schema creation (e.g. Trino). If null, use a random catalog identifier.
+     * @param schema          Specify a schema that should be used. This is for databases that do not support schemas but create a new database for each test.
+     *                        If null, use a random schema identifier.
+     * @param createStatement Provides the statement to create a new database or schema for test isolation. It gets the selected catalog and schema name als
+     *                        parameters and returns a valid SQL statement.
+     * @return A {@link TestcontainersDatabaseInformation} object.
+     */
+    public static TestcontainersDatabaseInformation of(String user, String catalog, String schema, BiFunction<String, String, String> createStatement) {
+        return new TestcontainersDatabaseInformation(user, catalog, schema, wrapperFor(createStatement));
+    }
+
+    /**
+     * Creates a new database information instance that describes a database. This method is used for databases that require more than one statement to create a
+     * new schema or database.
+     *
+     * @param user            Specify a user that can create a new schema or database. If this parameter is null, the testcontainer specific default user is
+     *                        used.
+     * @param catalog         Specify a catalog that should be used. This is for databases that do not support creating a new catalog or require a fixed catalog
+     *                        for schema creation (e.g. Trino). If null, use a random catalog identifier.
+     * @param schema          Specify a schema that should be used. This is for databases that do not support schemas but create a new database for each test.
+     *                        If null, use a random schema identifier.
+     * @param createStatement Provides the statement to create a new database or schema for test isolation. It gets the selected catalog and schema name als
+     *                        parameters and returns a list of one or more valid SQL statements.
+     * @return A {@link TestcontainersDatabaseInformation} object.
+     */
+    public static TestcontainersDatabaseInformation ofScript(String user, String catalog, String schema,
+        BiFunction<String, String, List<String>> createStatement) {
+        return new TestcontainersDatabaseInformation(user, catalog, schema, createStatement);
+    }
+
+    private TestcontainersDatabaseInformation(String user, String catalog, String schema, BiFunction<String, String, List<String>> createStatement) {
+        this.user = user;
+        this.catalog = catalog;
+        this.schema = schema;
+        this.createStatement = createStatement;
+    }
+
+    Optional<String> getUser() {
+        return Optional.ofNullable(user);
+    }
+
+    Optional<String> getCatalog() {
+        return Optional.ofNullable(catalog);
+    }
+
+    Optional<String> getSchema() {
+        return Optional.ofNullable(schema);
+    }
+
+    TestcontainersDatabaseInformation forCatalogAndSchema(String catalog, String schema) {
+        return new TestcontainersDatabaseInformation(user, catalog, schema, createStatement);
+    }
+
+    List<String> getCreationScript() {
+        return this.createStatement.apply(
+            getCatalog().orElseThrow(() -> new IllegalArgumentException("no catalog name present!")),
+            getSchema().orElseThrow(() -> new IllegalArgumentException("no schema name present!")));
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(".", "", "")
+            .add(getCatalog().orElse("*"))
+            .add(getSchema().orElse("*"))
+            .toString();
+    }
+
+    private static BiFunction<String, String, List<String>> wrapperFor(BiFunction<String, String, String> createFunction) {
+        return (catalogName, schemaName) -> Collections.singletonList(createFunction.apply(catalogName, schemaName));
+    }
+}

--- a/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/TestcontainersDatabaseInformationSupplier.java
+++ b/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/TestcontainersDatabaseInformationSupplier.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jdbi.v3.testing.junit5.tc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+final class TestcontainersDatabaseInformationSupplier implements Supplier<TestcontainersDatabaseInformation>, AutoCloseable, Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestcontainersDatabaseInformationSupplier.class);
+
+    private final TestcontainersDatabaseInformation templateDatabaseInformation;
+    private final ExecutorService executor;
+    private final SynchronousQueue<TestcontainersDatabaseInformation> nextSchema = new SynchronousQueue<>();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    private volatile DataSource dataSource = null;
+
+    TestcontainersDatabaseInformationSupplier(TestcontainersDatabaseInformation templateDatabaseInformation) {
+        this.templateDatabaseInformation = templateDatabaseInformation;
+
+        this.executor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread t = new Thread(runnable, "database-schema-creator");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    void start(DataSource dataSource) {
+        this.dataSource = dataSource;
+        this.executor.submit(this);
+    }
+
+    @Override
+    public void close() {
+        if (!this.closed.getAndSet(true)) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Override
+    public void run() {
+        while (!closed.get()) {
+            try {
+                final String dbName = EmbeddedUtil.randomLowercase(12);
+                final String schemaName = EmbeddedUtil.randomLowercase(12);
+
+                final TestcontainersDatabaseInformation databaseInformation = templateDatabaseInformation.forCatalogAndSchema(
+                    templateDatabaseInformation.getCatalog().orElse(dbName),
+                    templateDatabaseInformation.getSchema().orElse(schemaName));
+
+                executeStatements(databaseInformation.getCreationScript());
+
+                nextSchema.put(databaseInformation);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break; // while
+            } catch (SQLException e) {
+                LOG.error("SQL Exception caught:", e);
+                break;
+
+            } catch (Throwable t) {
+                LOG.error("Could not create database:", t);
+            }
+        }
+        closed.set(true);
+    }
+
+    @Override
+    public TestcontainersDatabaseInformation get() {
+
+        while (true) {
+            if (closed.get()) {
+                throw new IllegalStateException("Already closed!");
+            }
+            try {
+                TestcontainersDatabaseInformation schema = nextSchema.poll(100, TimeUnit.MILLISECONDS);
+                if (schema != null) {
+                    return schema;
+                }
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    private void executeStatements(final List<String> statements) throws SQLException {
+        try (Connection c = dataSource.getConnection()) {
+            for (String statement : statements) {
+                try (Statement stmt = c.createStatement()) {
+                    stmt.executeUpdate(statement);
+                }
+            }
+        }
+    }
+}

--- a/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/package-info.java
+++ b/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Jdbi test support for <a href="https://testcontainers.org/">Testcontainer based JDBC containers</a>. Any
+ * database that is supported can be used as a test database in <a href="https://junit.org/junit5/">JUnit 5</a> tests.
+ */
+package org.jdbi.v3.testing.junit5.tc;

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/AbstractJdbiTestcontainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/AbstractJdbiTestcontainersExtensionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import java.util.List;
+
+import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+abstract class AbstractJdbiTestcontainersExtensionTest {
+
+    abstract JdbcDatabaseContainer<?> getDbContainer();
+
+    protected String getTableCreateStatement() {
+        return "CREATE TABLE users (id INTEGER, name VARCHAR(255))";
+    }
+
+    @RegisterExtension
+    JdbiExtension extension = JdbiTestcontainersExtension.instance(getDbContainer())
+        .withInitializer((ds, handle) -> {
+            handle.execute(getTableCreateStatement());
+            handle.execute("INSERT INTO users VALUES (1, 'Alice')");
+            handle.execute("INSERT INTO users VALUES (2, 'Bob')");
+        });
+
+    @Test
+    void testOne() {
+        runTest();
+    }
+
+    @Test
+    void testTwo() {
+        runTest();
+    }
+
+    @Test
+    void testThree() {
+        runTest();
+    }
+
+    private void runTest() {
+        List<String> userNames = extension.getJdbi().withHandle(h -> {
+            try (Query query = h.createQuery("SELECT name FROM users ORDER BY id")) {
+                return query.mapTo(String.class).list();
+            }
+        });
+
+        assertThat(userNames).hasSize(2);
+        assertThat(userNames).containsExactly("Alice", "Bob");
+    }
+}

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/ClickhouseJdbiTestContainerExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/ClickhouseJdbiTestContainerExtensionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class ClickhouseJdbiTestContainerExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new ClickHouseContainer("clickhouse/clickhouse-server:latest");
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+
+    @Override
+    protected String getTableCreateStatement() {
+        // I'm different!
+        return super.getTableCreateStatement() + " Engine = Memory";
+    }
+}

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/CockroachJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/CockroachJdbiTestContainersExtensionTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class CockroachJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new CockroachContainer("cockroachdb/cockroach:latest");
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+}

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/MySQLJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/MySQLJdbiTestContainersExtensionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class MySQLJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new MySQLContainer<>("mysql");
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+}

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/OracleXeJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/OracleXeJdbiTestContainersExtensionTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class OracleXeJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new OracleContainer("gvenzl/oracle-xe:slim-faststart");
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+}

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/PostGisJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/PostGisJdbiTestContainersExtensionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class PostGisJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new PostgreSQLContainer<>(
+        DockerImageName.parse("postgis/postgis:13-3.3-alpine").asCompatibleSubstituteFor("postgres"));
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+}

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TiDBJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TiDBJdbiTestContainersExtensionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.tidb.TiDBContainer;
+
+@Testcontainers
+class TiDBJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new TiDBContainer("pingcap/tidb");
+
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+}

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TimescaleJdbiTestContainerExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TimescaleJdbiTestContainerExtensionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public class TimescaleJdbiTestContainerExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new PostgreSQLContainer<>(
+        DockerImageName.parse("timescale/timescaledb:latest-pg13").asCompatibleSubstituteFor("postgres"));
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+}

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TrinoJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TrinoJdbiTestContainersExtensionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.TrinoContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class TrinoJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new TrinoContainer("trinodb/trino");
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        // we still love you, trino. But you are a mess.
+        Thread.sleep(5_000);
+    }
+}

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/YugabyteJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/YugabyteJdbiTestContainersExtensionTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.YugabyteDBYSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class YugabyteJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new YugabyteDBYSQLContainer("yugabytedb/yugabyte");
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+}


### PR DESCRIPTION
Let's face it: The Jdbi developers are PostgreSQL fanboys. Our tests run on PostgreSQL, we have three flavors of PostgreSQL testing and in general, if we have to grab a non-in-memory database, we use ... PostgreSQL. The only exception so far is ... Oracle of all things.

This PR adds full support to all databases that are provided by the testcontainers.org project and offers similar convenience (running multiple test methods on the same database instance) as the Postgres based test framework offers.

It supports (and runs test for!) MySQL, MariaDB, TiDB, PostgreSQL (with sub-flavors such as PostGIS and TimescaleDB), CockroachDB, YugabyteDB, ClickHouse, Oracle XE, and TrinoDB out of the box and any other testcontainer supported database can easily be configured and used. 