### PR TITLE
Rename JdbiCache to ConfigCache

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectFieldArguments.java
@@ -25,8 +25,8 @@ import org.jdbi.v3.core.annotation.internal.JdbiAnnotations;
 import org.jdbi.v3.core.argument.internal.ObjectPropertyNamedArgumentFinder;
 import org.jdbi.v3.core.argument.internal.TypedValue;
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.config.JdbiCache;
-import org.jdbi.v3.core.config.JdbiCaches;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.qualifier.Qualifiers;
@@ -38,8 +38,8 @@ import org.jdbi.v3.core.statement.StatementContext;
  */
 @Deprecated
 public class ObjectFieldArguments extends ObjectPropertyNamedArgumentFinder {
-    private static final JdbiCache<Class<?>, Map<String, Function<Object, TypedValue>>> FIELD_CACHE =
-            JdbiCaches.declare((config, beanClazz) ->
+    private static final ConfigCache<Class<?>, Map<String, Function<Object, TypedValue>>> FIELD_CACHE =
+            ConfigCaches.declare((config, beanClazz) ->
                 Stream.of(beanClazz.getFields())
                     .filter(JdbiAnnotations::isBound)
                     .collect(Collectors.toMap(Field::getName, f -> {

--- a/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ObjectMethodArguments.java
@@ -28,8 +28,8 @@ import org.jdbi.v3.core.annotation.internal.JdbiAnnotations;
 import org.jdbi.v3.core.argument.internal.ObjectPropertyNamedArgumentFinder;
 import org.jdbi.v3.core.argument.internal.TypedValue;
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.config.JdbiCache;
-import org.jdbi.v3.core.config.JdbiCaches;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.qualifier.Qualifiers;
@@ -41,8 +41,8 @@ import org.jdbi.v3.core.statement.StatementContext;
  */
 @Deprecated
 public class ObjectMethodArguments extends ObjectPropertyNamedArgumentFinder {
-    private static final JdbiCache<Class<?>, Map<String, Function<Object, TypedValue>>> NULLARY_METHOD_CACHE =
-            JdbiCaches.declare(ObjectMethodArguments::load);
+    private static final ConfigCache<Class<?>, Map<String, Function<Object, TypedValue>>> NULLARY_METHOD_CACHE =
+            ConfigCaches.declare(ObjectMethodArguments::load);
     /**
      * @param prefix an optional prefix (we insert a '.' as a separator)
      * @param object the object to bind functions on

--- a/core/src/main/java/org/jdbi/v3/core/config/ConfigRegistry.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/ConfigRegistry.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.collector.JdbiCollectors;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.core.mapper.Mappers;
@@ -43,7 +44,7 @@ public final class ConfigRegistry {
      */
     public ConfigRegistry() {
         configFactories = new ConcurrentHashMap<>();
-        get(JdbiCaches.class);
+        get(ConfigCaches.class);
         get(SqlStatements.class);
         get(Arguments.class);
         get(RowMappers.class);

--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCache.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCache.java
@@ -11,17 +11,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.config;
+package org.jdbi.v3.core.config.internal;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.config.Configurable;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.meta.Beta;
 
 /**
  * Simple cache interface.
- * @see JdbiCaches
+ * @see ConfigCaches
  */
 @Beta
-public interface JdbiCache<K, V> {
+public interface ConfigCache<K, V> {
     V get(K key, ConfigRegistry config);
 
     default V get(K key, Configurable<?> configurable) {

--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
@@ -11,13 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.config;
+package org.jdbi.v3.core.config.internal;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.meta.Beta;
 
 /**
@@ -30,35 +32,35 @@ import org.jdbi.v3.meta.Beta;
  * <b>This makes it unsuitable as a general-purpose shared cache.</b>
  */
 @Beta
-public final class JdbiCaches implements JdbiConfig<JdbiCaches> {
-    private final Map<JdbiCache<?, ?>, Map<Object, Object>> caches = new ConcurrentHashMap<>();
+public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
+    private final Map<ConfigCache<?, ?>, Map<Object, Object>> caches = new ConcurrentHashMap<>();
 
     /**
      * Does not actually create a copy!!
      */
     @Override
-    public JdbiCaches createCopy() {
+    public ConfigCaches createCopy() {
         return this;
     }
 
-    public static <K, V> JdbiCache<K, V> declare(Function<K, V> computer) {
+    public static <K, V> ConfigCache<K, V> declare(Function<K, V> computer) {
         return declare(Function.identity(), computer);
     }
 
-    public static <K, V> JdbiCache<K, V> declare(Function<K, ?> keyNormalizer, Function<K, V> computer) {
+    public static <K, V> ConfigCache<K, V> declare(Function<K, ?> keyNormalizer, Function<K, V> computer) {
         return declare(keyNormalizer, (config, k) -> computer.apply(k));
     }
 
-    public static <K, V> JdbiCache<K, V> declare(BiFunction<ConfigRegistry, K, V> computer) {
+    public static <K, V> ConfigCache<K, V> declare(BiFunction<ConfigRegistry, K, V> computer) {
         return declare(Function.identity(), computer);
     }
 
-    public static <K, V> JdbiCache<K, V> declare(Function<K, ?> keyNormalizer, BiFunction<ConfigRegistry, K, V> computer) {
-        return new JdbiCache<K, V>() {
+    public static <K, V> ConfigCache<K, V> declare(Function<K, ?> keyNormalizer, BiFunction<ConfigRegistry, K, V> computer) {
+        return new ConfigCache<K, V>() {
             @SuppressWarnings("unchecked")
             @Override
             public V get(K key, ConfigRegistry config) {
-                return (V) config.get(JdbiCaches.class).caches
+                return (V) config.get(ConfigCaches.class).caches
                         .computeIfAbsent(this, x -> new ConcurrentHashMap<>())
                         .computeIfAbsent(keyNormalizer.apply(key), x -> computer.apply(config, key));
             }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/EnumMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/EnumMapper.java
@@ -21,8 +21,8 @@ import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import org.jdbi.v3.core.config.JdbiCache;
-import org.jdbi.v3.core.config.JdbiCaches;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.enums.DatabaseValue;
 import org.jdbi.v3.core.enums.EnumByName;
 import org.jdbi.v3.core.enums.EnumByOrdinal;
@@ -66,8 +66,8 @@ public abstract class EnumMapper<E extends Enum<E>> implements ColumnMapper<E> {
     }
 
     static class EnumByNameColumnMapper<E extends Enum<E>> implements ColumnMapper<E> {
-        private static final JdbiCache<Class<? extends Enum<?>>, JdbiCache<String, Enum<?>>> BY_NAME_CACHE =
-                JdbiCaches.declare(e -> JdbiCaches.declare(
+        private static final ConfigCache<Class<? extends Enum<?>>, ConfigCache<String, Enum<?>>> BY_NAME_CACHE =
+                ConfigCaches.declare(e -> ConfigCaches.declare(
                         name -> e.cast(getValueByName(e, name))));
         private final Class<E> enumClass;
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BeanPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BeanPropertiesFactory.java
@@ -37,8 +37,8 @@ import java.util.stream.Stream;
 
 import io.leangen.geantyref.GenericTypeReflector;
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.config.JdbiCache;
-import org.jdbi.v3.core.config.JdbiCaches;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.internal.exceptions.Sneaky;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
@@ -48,8 +48,8 @@ import org.jdbi.v3.core.qualifier.Qualifiers;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 
 public class BeanPropertiesFactory {
-    private static final JdbiCache<Type, PropertiesHolder<?>> PROPERTY_CACHE =
-            JdbiCaches.declare(PropertiesHolder::new);
+    private static final ConfigCache<Type, PropertiesHolder<?>> PROPERTY_CACHE =
+            ConfigCaches.declare(PropertiesHolder::new);
 
     private BeanPropertiesFactory() {}
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BuilderPojoPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BuilderPojoPropertiesFactory.java
@@ -15,12 +15,12 @@ package org.jdbi.v3.core.mapper.reflect.internal;
 
 import java.util.function.Supplier;
 
-import org.jdbi.v3.core.config.JdbiCache;
-import org.jdbi.v3.core.config.JdbiCaches;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 
 public interface BuilderPojoPropertiesFactory extends PojoPropertiesFactory {
-    JdbiCache<BuilderSpec<?, ?>, BuilderPojoProperties<?, ?>> BUILDER_CACHE =
-        JdbiCaches.declare(s -> s.type, BuilderPojoProperties::new);
+    ConfigCache<BuilderSpec<?, ?>, BuilderPojoProperties<?, ?>> BUILDER_CACHE =
+        ConfigCaches.declare(s -> s.type, BuilderPojoProperties::new);
 
     static <T, B> PojoPropertiesFactory builder(Class<T> defn, Supplier<B> builder) {
         return (t, config) -> BUILDER_CACHE.get(new BuilderSpec<>(t, config, defn, builder), config);

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ModifiablePojoPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ModifiablePojoPropertiesFactory.java
@@ -21,16 +21,16 @@ import java.lang.reflect.Type;
 import java.util.function.Supplier;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.config.JdbiCache;
-import org.jdbi.v3.core.config.JdbiCaches;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.qualifier.Qualifiers;
 
 public interface ModifiablePojoPropertiesFactory extends PojoPropertiesFactory {
-    JdbiCache<ModifiableSpec<?, ?>, ModifiablePojoProperties<?, ?>> MODIFIABLE_CACHE =
-            JdbiCaches.declare(s -> s.type, ModifiablePojoProperties::new);
+    ConfigCache<ModifiableSpec<?, ?>, ModifiablePojoProperties<?, ?>> MODIFIABLE_CACHE =
+            ConfigCaches.declare(s -> s.type, ModifiablePojoProperties::new);
 
     static <T, M extends T> PojoPropertiesFactory modifiable(Class<T> defn, Class<M> impl, Supplier<M> constructor) {
         return (t, config) -> MODIFIABLE_CACHE.get(new ModifiableSpec<>(t, config, defn, impl, constructor), config);

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/Qualifiers.java
@@ -23,19 +23,19 @@ import java.util.Set;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.config.JdbiCache;
-import org.jdbi.v3.core.config.JdbiCaches;
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.internal.CollectionCollectors;
 
 /**
  * Utility class for type qualifiers supported by Jdbi core.
  */
 public class Qualifiers implements JdbiConfig<Qualifiers> {
-    private static final JdbiCache<AnnotatedElement[], Set<Annotation>> QUALIFIER_CACHE = JdbiCaches.declare(
+    private static final ConfigCache<AnnotatedElement[], Set<Annotation>> QUALIFIER_CACHE = ConfigCaches.declare(
             elements -> elements.length == 1 ? elements[0] : new HashSet<>(Arrays.asList(elements)),
             (Function<AnnotatedElement[], Set<Annotation>>) Qualifiers::getQualifiers);
-    private static final JdbiCache<AnnotatedElement, QualifiedType<?>> QUALIFIED_TYPE_CACHE = JdbiCaches.declare(
+    private static final ConfigCache<AnnotatedElement, QualifiedType<?>> QUALIFIED_TYPE_CACHE = ConfigCaches.declare(
             type -> QualifiedType.of((Type) type).withAnnotations(getQualifiers(type)));
     private ConfigRegistry registry;
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/DescribedArgument.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/DescribedArgument.java
@@ -18,12 +18,12 @@ import java.sql.SQLException;
 import java.util.Objects;
 
 import org.jdbi.v3.core.argument.Argument;
-import org.jdbi.v3.core.config.JdbiCache;
-import org.jdbi.v3.core.config.JdbiCaches;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 
 class DescribedArgument implements Argument {
-    private static final JdbiCache<Class<?>, Boolean> ARG_CLASS_HAS_TOSTRING =
-            JdbiCaches.declare(type -> {
+    private static final ConfigCache<Class<?>, Boolean> ARG_CLASS_HAS_TOSTRING =
+            ConfigCaches.declare(type -> {
                 try {
                     return type.getMethod("toString")
                                .getDeclaringClass() != Object.class;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -35,8 +35,8 @@ import java.util.stream.Stream;
 
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.config.JdbiCache;
-import org.jdbi.v3.core.config.JdbiCaches;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.extension.ExtensionFactory;
 import org.jdbi.v3.core.extension.Extensions;
 import org.jdbi.v3.core.extension.HandleSupplier;
@@ -50,8 +50,8 @@ import org.jdbi.v3.sqlobject.internal.SqlObjectInitData.InContextInvoker;
  * Creates implementations for SqlObject interfaces.
  */
 public class SqlObjectFactory implements ExtensionFactory, OnDemandExtensions.Factory {
-    private final JdbiCache<Class<?>, SqlObjectInitData> sqlObjectCache =
-            JdbiCaches.declare(SqlObjectFactory::initDataFor);
+    private final ConfigCache<Class<?>, SqlObjectInitData> sqlObjectCache =
+            ConfigCaches.declare(SqlObjectFactory::initDataFor);
 
     SqlObjectFactory() {}
 


### PR DESCRIPTION
The generic named class "JdbiCache" is actually a very special cache class that is used to cache specific configuration information and configuration metadata. Rename the interface and its related config class to "ConfigCache" and "ConfigCaches".

This is user visible as the "JdbiCaches" element is technically part of the public API. However it is marked as @Beta so we could rename it.

"JdbiCache" is never used in a public API except on the methods of the "JdbiCaches" method.