### PR TITLE
Remove caffeine dependency from core

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
   - upgrade to geantyref 1.3.14
+  - removes the core dependency on the caffeine library. This now uses a simple LRU cache for sql parser and sql statements.
 
 # 3.36.0
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -65,11 +65,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
             <scope>provided</scope>

--- a/core/src/main/java/org/jdbi/v3/core/cache/JdbiCache.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/JdbiCache.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache;
+
+/**
+ * A generic cache implementation for JDBI internal use.
+ * <br/>
+ * All implementations of this interface must be threadsafe!
+ *
+ * @param <K> A key type for the cache.
+ * @param <V> A value type for the cache.
+ */
+public interface JdbiCache<K, V> {
+
+    /**
+     * Returns the cached value for a key.
+     *
+     * @param key The key value. Must not be null.
+     * @return The cached value or null if no value was cached.
+     */
+    V get(K key);
+
+    /**
+     * Returns a cached value for a key. If no value is cached, create a new value using the
+     * provided cache loader.
+     *
+     * @param key The key value. Must not be null.
+     * @param loader A {@link JdbiCacheLoader} implementation. May be called with the provided key value.
+     * @return The cached value or null if no value was cached.
+     */
+    V getWithLoader(K key, JdbiCacheLoader<K, V> loader);
+
+    /**
+     * Return implementation specific statistics for the cache object. This can be used to expose
+     * statistic information about the underlying implementation.
+     *
+     * @return An implementation specific object.
+     */
+    <T> T getStats();
+}

--- a/core/src/main/java/org/jdbi/v3/core/cache/JdbiCacheBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/JdbiCacheBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache;
+
+/**
+ * Builder class for {@link JdbiCache} implementations.
+ */
+public interface JdbiCacheBuilder {
+
+    /**
+     * Creates an cache instance from the values in the builder.
+     *
+     * @return A cache instance.
+     */
+    <K, V> JdbiCache<K, V> build();
+
+    /**
+     * Creates an cache instance from the values in the builder and a supplied cache loader.
+     *
+     * @param cacheLoader A {@link JdbiCacheLoader} instance that is used to create a new value if no value is currently stored in the cache.
+     */
+    <K, V> JdbiCache<K, V> buildWithLoader(JdbiCacheLoader<K, V> cacheLoader);
+
+    /**
+     * Sets an upper boundary to the cache size.
+     *
+     * @param maxSize Sets the maximum size of the cache. If the value is zero or negative, the cache is unbounded.
+     * @return The instance of the builder itself.
+     */
+    JdbiCacheBuilder maxSize(int maxSize);
+}

--- a/core/src/main/java/org/jdbi/v3/core/cache/JdbiCacheLoader.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/JdbiCacheLoader.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache;
+
+/**
+ * Creates a new value for a {@link JdbiCache}.
+ *
+ * @param <K> A key type for the cache.
+ * @param <V> A value type for the cache.
+ */
+@FunctionalInterface
+public interface JdbiCacheLoader<K, V> {
+
+    /**
+     * Create a new value for caching from a cache key.
+     *
+     * @param key The key that the value will be associated with. Never null.
+     * @return A value for the cache to store. May return null if no value could be created; the cache is expected to ignore null values and should call the
+     * loader again.
+     */
+    V create(K key);
+}

--- a/core/src/main/java/org/jdbi/v3/core/cache/JdbiCacheStats.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/JdbiCacheStats.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache;
+
+/**
+ * Simple statistics about a {@link JdbiCache} instance. The values in this object are a snapshot of
+ * the cache status. Calling any method multiple times should be cheap and constant time.
+ */
+public interface JdbiCacheStats {
+
+    /**
+     * Returns the current size of the cache.
+     * @return The current size of the cache.
+     */
+    int cacheSize();
+
+    /**
+     * Returns the maximum size of the cache.
+     * @return The maximum size of the cache.
+     */
+    int maxSize();
+}

--- a/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCache.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCache.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache.internal;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheLoader;
+
+final class DefaultJdbiCache<K, V> implements JdbiCache<K, V> {
+
+    private final ConcurrentMap<K, DoubleLinkedList.Node<K, V>> cache;
+
+    @GuardedBy("expungeQueue")
+    private final DoubleLinkedList<K, V> expungeQueue;
+
+    private final JdbiCacheLoader<K, DoubleLinkedList.Node<K, V>> cacheLoader;
+
+    private final int maxSize;
+
+    DefaultJdbiCache(DefaultJdbiCacheBuilder builder, JdbiCacheLoader<K, V> cacheLoader) {
+        this.cache = new ConcurrentHashMap<>();
+        this.expungeQueue = new DoubleLinkedList<>();
+        this.cacheLoader = wrapLoader(cacheLoader);
+
+        this.maxSize = builder.getMaxSize();
+    }
+
+    @Override
+    public V get(K key) {
+        try {
+            DoubleLinkedList.Node<K, V> node = cache.computeIfAbsent(key, cacheLoader::create);
+            refresh(node);
+            return node.value;
+        } finally {
+            expunge();
+        }
+    }
+
+    @Override
+    public V getWithLoader(K key, JdbiCacheLoader<K, V> loader) {
+        try {
+            DoubleLinkedList.Node<K, V> node = cache.computeIfAbsent(key, wrapLoader(loader)::create);
+            refresh(node);
+            return node.value;
+        } finally {
+            expunge();
+        }
+    }
+
+    @Override
+    public DefaultJdbiCacheStats getStats() {
+        synchronized (expungeQueue) {
+            return new DefaultJdbiCacheStats(expungeQueue.size, maxSize);
+        }
+    }
+
+    private JdbiCacheLoader<K, DoubleLinkedList.Node<K, V>> wrapLoader(JdbiCacheLoader<K, V> delegate) {
+
+        if (delegate == null) {
+            return k -> DoubleLinkedList.createNode(k, null);
+        }
+
+        return key -> {
+            V value = delegate.create(key);
+            DoubleLinkedList.Node<K, V> node = DoubleLinkedList.createNode(key, value);
+            if (maxSize > 0) {
+                synchronized (expungeQueue) {
+                    expungeQueue.addHead(node);
+                }
+            }
+            return node;
+        };
+    }
+
+    private void refresh(DoubleLinkedList.Node<K, V> node) {
+        if (maxSize > 0) {
+            synchronized (expungeQueue) {
+                DoubleLinkedList.Node<K, V> cacheNode = expungeQueue.removeNode(node);
+                // this can happen if the node that should be refreshed has been
+                // expunged between the call to computeIfAbsent and refresh (which is not
+                // done under the lock) above, so by the time the node gets passed here
+                // it is no longer in the list.
+                if (cacheNode != null) {
+                    expungeQueue.addHead(cacheNode);
+                }
+            }
+        }
+    }
+
+    private void expunge() {
+        synchronized (expungeQueue) {
+            if (maxSize <= 0 || expungeQueue.size <= maxSize) {
+                // unbounded or not yet full
+                return;
+            }
+
+            while (expungeQueue.size > maxSize) {
+                DoubleLinkedList.Node<K, V> node = expungeQueue.removeTail();
+                if (node != null) {
+                    cache.remove(node.key);
+                } else {
+                    // expunge queue is empty. This should never happen.
+                    // Reset the cache as well.
+                    cache.clear();
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache.internal;
+
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
+import org.jdbi.v3.core.cache.JdbiCacheLoader;
+
+/**
+ * Builder for the default Jdbi cache implementation.
+ */
+public final class DefaultJdbiCacheBuilder implements JdbiCacheBuilder {
+
+    private int maxSize = -1;
+
+    /**
+     * Returns a new Builder.
+     * @return A new builder instance for a {@link DefaultJdbiCache} instance.
+     */
+    public static DefaultJdbiCacheBuilder builder() {
+        return new DefaultJdbiCacheBuilder();
+    }
+
+    private DefaultJdbiCacheBuilder() {}
+
+    @Override
+    public <K, V> JdbiCache<K, V> build() {
+        return new DefaultJdbiCache<>(this, null);
+    }
+
+    @Override
+    public <K, V> JdbiCache<K, V> buildWithLoader(JdbiCacheLoader<K, V> loader) {
+        return new DefaultJdbiCache<>(this, loader);
+    }
+
+    @Override
+    public DefaultJdbiCacheBuilder maxSize(int maxSize) {
+        this.maxSize = maxSize;
+        return this;
+    }
+
+    int getMaxSize() {
+        return maxSize;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheStats.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheStats.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache.internal;
+
+/**
+ * Simple statistics for an {@link DefaultJdbiCache} instance. The values in this object are a snapshot of
+ * the cache status. Calling any method multiple times is cheap and constant time.
+ */
+public final class DefaultJdbiCacheStats {
+
+    private final int cacheSize;
+    private final int maxSize;
+
+    DefaultJdbiCacheStats(int cacheSize, int maxSize) {
+        this.cacheSize = cacheSize;
+        this.maxSize = maxSize;
+    }
+
+    /**
+     * Returns the current size of the cache.
+     *
+     * @return The current size of the cache.
+     */
+    public int cacheSize() {
+        return cacheSize;
+    }
+
+    /**
+     * Returns the maximum size of the cache.
+     *
+     * @return The maximum size of the cache.
+     */
+    public int maxSize() {
+        return maxSize;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/cache/internal/DoubleLinkedList.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/internal/DoubleLinkedList.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache.internal;
+
+final class DoubleLinkedList<K, V> {
+
+    // rootNode double times as start (rootNode.right) and end (rootNode.left).
+    // rootNode right <-> left <node> right <-> left <node> right <-> rootNode left
+
+    final Node<K, V> rootNode;
+    int size = 0;
+
+    DoubleLinkedList() {
+        this.rootNode = createNode(null, null);
+        rootNode.right = rootNode;
+        rootNode.left = rootNode;
+    }
+
+    void addHead(Node<K, V> node) {
+        if (node == null) {
+            return;
+        }
+
+        if (node.left != null || node.right != null) {
+            throw new IllegalStateException("Can not add node twice!");
+        }
+
+        // slot in at the beginning
+        node.left = rootNode;
+        node.right = rootNode.right;
+        node.left.right = node;
+        node.right.left = node;
+
+        size++;
+    }
+
+    Node<K, V> removeTail() {
+        return removeNode(rootNode.left);
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    Node<K, V> removeNode(Node<K, V> node) {
+        // check that the node is valid. The marker node can not be removed.
+        // if any of the pointers is null, the node is not actually part of the
+        // list.
+        if (node == rootNode || node.left == null || node.right == null) {
+            return null;
+        }
+
+        // unhook from the left side.
+        node.left.right = node.right;
+
+        // unhook the right side
+        node.right.left = node.left;
+
+        // clean out the node, don't want to leak pointers
+        node.left = null;
+        node.right = null;
+
+        size--;
+        return node;
+    }
+
+    static <K, V> Node<K, V> createNode(K key, V value) {
+        return new Node<>(key, value);
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    public String toString() {
+        StringBuilder sb = new StringBuilder("[");
+        Node<K, V> node = rootNode.right;
+        while (node != rootNode) {
+            sb.append(node.key).append(" = ").append(node.value);
+
+            if (node.right != null) {
+                sb.append(", ");
+            }
+            node = node.right;
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    static final class Node<K, V> {
+
+        Node<K, V> left = null;
+        Node<K, V> right = null;
+
+        final K key;
+        final V value;
+
+        private Node(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/cache/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Pluggable cache interface for Jdbi internal caches.
+ */
+package org.jdbi.v3.core.cache;

--- a/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ColonPrefixSqlParser.java
@@ -13,9 +13,9 @@
  */
 package org.jdbi.v3.core.statement;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.Token;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
 import org.jdbi.v3.core.internal.lexer.ColonStatementLexer;
 import org.jdbi.v3.core.statement.internal.ErrorListener;
 import org.jdbi.v3.meta.Beta;
@@ -41,8 +41,8 @@ public class ColonPrefixSqlParser extends CachingSqlParser {
     public ColonPrefixSqlParser() {}
 
     @Beta
-    public ColonPrefixSqlParser(Caffeine<Object, Object> cache) {
-        super(cache);
+    public ColonPrefixSqlParser(JdbiCacheBuilder cacheBuilder) {
+        super(cacheBuilder);
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/HashPrefixSqlParser.java
@@ -13,9 +13,9 @@
  */
 package org.jdbi.v3.core.statement;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.Token;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
 import org.jdbi.v3.core.internal.lexer.HashStatementLexer;
 import org.jdbi.v3.core.statement.internal.ErrorListener;
 import org.jdbi.v3.meta.Beta;
@@ -38,8 +38,8 @@ public class HashPrefixSqlParser extends CachingSqlParser {
     public HashPrefixSqlParser() {}
 
     @Beta
-    public HashPrefixSqlParser(final Caffeine<Object, Object> cache) {
-        super(cache);
+    public HashPrefixSqlParser(JdbiCacheBuilder cacheBuilder) {
+        super(cacheBuilder);
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache.internal;
+
+import java.util.UUID;
+
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
+import org.jdbi.v3.core.cache.internal.JdbiCacheTest.TestingCacheLoader;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultJdbiCacheTest {
+
+    private final JdbiCacheBuilder builder = DefaultJdbiCacheBuilder.builder();
+
+    private final TestingCacheLoader cacheLoader = new TestingCacheLoader();
+
+    @Test
+    void testUntouchedCacheExpunge() {
+        int keyCount = 0;
+
+        int size = 10;
+        JdbiCache<String, String> cache = builder.maxSize(size).buildWithLoader(cacheLoader);
+
+        // tests specific DefaultJdbiCache LRU behavior. Skip for all other cache types.
+        Assumptions.assumeTrue(cache instanceof DefaultJdbiCache);
+
+        DefaultJdbiCacheStats stats = cache.getStats();
+        assertThat(stats.maxSize()).isEqualTo(size);
+
+        String[] keys = new String[size * 2];
+
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = keyCount++ + "K_" + UUID.randomUUID();
+            cache.get(keys[i]);
+        }
+
+        assertThat(cacheLoader.created()).isEqualTo(size * 2);
+
+        stats = cache.getStats();
+        assertThat(stats.cacheSize()).isEqualTo(stats.maxSize());
+
+        // test LRU behavior. Change this part if the algorithm changes
+
+        // last elements are still in the cache, b/c were not touched.
+        for (int i = keys.length - 1; i >= size; i--) {
+            assertThat(cacheLoader.created()).isEqualTo(size * 2);
+            cache.get(keys[i]);
+            // no additional cache hit
+            assertThat(cacheLoader.created()).isEqualTo(size * 2);
+        }
+
+        // first were expunged
+        for (int i = 0; i < size; i++) {
+            int creations = cacheLoader.created();
+            cache.get(keys[i]);
+            // additional creation hit
+            assertThat(creations + 1).isEqualTo(cacheLoader.created());
+        }
+    }
+
+    @Test
+    void testLruCacheExpunge() {
+        int keyCount = 0;
+
+        int size = 10;
+        JdbiCache<String, String> cache = builder.maxSize(size).buildWithLoader(cacheLoader);
+
+        // tests specific DefaultJdbiCache LRU behavior. Skip for all other cache types.
+        Assumptions.assumeTrue(cache instanceof DefaultJdbiCache);
+
+        DefaultJdbiCacheStats stats = cache.getStats();
+        assertThat(stats.maxSize()).isEqualTo(size);
+
+        String[] keys = new String[size * 2];
+
+        // add 20 keys to a 10 size cache
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = keyCount++ + "K_" + UUID.randomUUID();
+            cache.get(keys[i]);
+
+            // refresh keys 0 - 4 constantly so they don't drop.
+            int cacheSize = Math.min(i + 1, size / 2);
+            for (int j = 0; j < cacheSize; j++) {
+                // does not cause an additional creation event (cache hit)
+                int creations = cacheLoader.created();
+                cache.get(keys[j]);
+                assertThat(cacheLoader.created()).isEqualTo(creations);
+            }
+        }
+
+        assertThat(cacheLoader.created()).isEqualTo(size * 2);
+
+        // cache now holds 0..4 and 15..19
+
+        stats = cache.getStats();
+        assertThat(stats.cacheSize()).isEqualTo(stats.maxSize());
+
+        // test LRU behavior. Change this part if the algorithm changes
+
+        for (int i = 0; i < size / 2; i++) {
+            // test that 0..4 come from cache, don't cause creation events
+            assertThat(cacheLoader.created()).isEqualTo(size * 2);
+            cache.get(keys[i]);
+            // no additional cache hit
+            assertThat(cacheLoader.created()).isEqualTo(size * 2);
+
+            // test that 19..15 come from cache, don't cause creation events
+            int upperKey = keys.length - 1 - i;
+            cache.get(keys[upperKey]);
+            // no additional cache hit
+            assertThat(cacheLoader.created()).isEqualTo(size * 2);
+
+        }
+
+        // 5..14 cause creation events and evict 0..4 and 15..19
+        for (int i = size / 2; i < (size * 3) / 2; i++) {
+            int creations = cacheLoader.created();
+            cache.get(keys[i]);
+            // creation hit
+            assertThat(creations + 1).isEqualTo(cacheLoader.created());
+        }
+
+        // cache now holds 5..14
+
+        // testing for 0..5 and 15..19 now causes all creation events
+        for (int i = 0; i < size / 2; i++) {
+            int creations = cacheLoader.created();
+            cache.get(keys[i]);
+            // creation hit
+            assertThat(creations + 1).isEqualTo(cacheLoader.created());
+
+            int upperKey = keys.length - 1 - i;
+            cache.get(keys[upperKey]);
+            // creation hit
+            assertThat(creations + 2).isEqualTo(cacheLoader.created());
+        }
+
+    }
+
+    static void refresh(int max, JdbiCache<String, String> cache, String[] keys) {
+        for (int i = 0; i < max; i++) {
+            cache.get(keys[i]);
+        }
+    }
+
+}

--- a/core/src/test/java/org/jdbi/v3/core/cache/internal/JdbiCacheTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/cache/internal/JdbiCacheTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
+import org.jdbi.v3.core.cache.JdbiCacheLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JdbiCacheTest {
+
+    protected JdbiCacheBuilder builder;
+
+    protected TestingCacheLoader cacheLoader = new TestingCacheLoader();
+
+    @BeforeEach
+    void beforeEach() {
+        this.builder = DefaultJdbiCacheBuilder.builder();
+    }
+
+    @Test
+    void testWithGlobalLoader() {
+        doTestWithGlobalLoader(builder.buildWithLoader(cacheLoader));
+    }
+
+    @Test
+    void testWithDirectLoader() {
+        doTestWithLoader(builder.build());
+    }
+
+    protected void doTestWithGlobalLoader(JdbiCache<String, String> cache) {
+        assertThat(cacheLoader.created()).isZero();
+
+        String key = UUID.randomUUID().toString();
+
+        // cache creation. creation event.
+        String value = cache.get(key);
+        assertThat(value).isEqualTo(cacheLoader.checkKey(key));
+        assertThat(cacheLoader.created()).isOne();
+
+        // cache hit. Same value, no creation event.
+        value = cache.get(key);
+        assertThat(value).isEqualTo(cacheLoader.checkKey(key));
+        assertThat(cacheLoader.created()).isOne();
+
+        String key2 = UUID.randomUUID().toString();
+
+        // cache creation. second creation event.
+        String value2 = cache.get(key2);
+        assertThat(cacheLoader.created()).isEqualTo(2);
+        assertThat(value2).isEqualTo(cacheLoader.checkKey(key2));
+    }
+
+    protected void doTestWithLoader(JdbiCache<String, String> cache) {
+        assertThat(cacheLoader.created()).isZero();
+
+        String key = UUID.randomUUID().toString();
+
+        // cache creation. creation event.
+        String value = cache.getWithLoader(key, cacheLoader);
+        assertThat(value).isEqualTo(cacheLoader.checkKey(key));
+        assertThat(cacheLoader.created()).isOne();
+
+        // cache hit. Same value, no creation event.
+        value = cache.getWithLoader(key, cacheLoader);
+        assertThat(value).isEqualTo(cacheLoader.checkKey(key));
+        assertThat(cacheLoader.created()).isOne();
+
+        String key2 = UUID.randomUUID().toString();
+
+        // cache creation. second creation event.
+        String value2 = cache.getWithLoader(key2, cacheLoader);
+        assertThat(cacheLoader.created()).isEqualTo(2);
+        assertThat(value2).isEqualTo(cacheLoader.checkKey(key2));
+    }
+
+    public static final class TestingCacheLoader implements JdbiCacheLoader<String, String> {
+
+        private final Map<String, String> values = new HashMap<>();
+        private int creations = 0;
+
+        @Override
+        public String create(String key) {
+            String value = creations++ + "V_" + UUID.randomUUID();
+            values.put(key, value);
+            return value;
+        }
+
+        public int created() {
+            return creations;
+        }
+
+        public String checkKey(String key) {
+            return values.get(key);
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/cache/internal/TestDoubleLinkedList.java
+++ b/core/src/test/java/org/jdbi/v3/core/cache/internal/TestDoubleLinkedList.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.cache.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestDoubleLinkedList {
+
+    @Test
+    public void testEmptyList() {
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+
+        assertThat(list.size).isZero();
+        assertThat(list.rootNode.right).isSameAs(list.rootNode);
+        assertThat(list.rootNode.left).isSameAs(list.rootNode);
+    }
+
+    @Test
+    public void testRemoveEmptyTail() {
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+
+        DoubleLinkedList.Node<String, String> node = list.removeTail();
+
+        assertThat(node).isNull();
+
+        assertThat(list.size).isZero();
+        assertThat(list.rootNode.right).isSameAs(list.rootNode);
+        assertThat(list.rootNode.left).isSameAs(list.rootNode);
+    }
+
+    @Test
+    public void testRemoveRemovedNode() {
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+
+        // add node
+        DoubleLinkedList.Node<String, String> node = DoubleLinkedList.createNode("foo", "bar");
+        list.addHead(node);
+        assertThat(node.left).isNotNull();
+        assertThat(node.right).isNotNull();
+
+        // remove node from list, ensure it is really removed
+        DoubleLinkedList.Node<String, String> removedNode = list.removeTail();
+        assertThat(removedNode).isSameAs(node);
+        assertThat(removedNode.left).isNull();
+        assertThat(removedNode.right).isNull();
+
+        // double remove is ok (but null)
+        removedNode = list.removeNode(removedNode);
+        assertThat(removedNode).isNull();
+    }
+
+    @Test
+    public void testRemoveRootNode() {
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+
+        DoubleLinkedList.Node<String, String> node = DoubleLinkedList.createNode("foo", "bar");
+        list.addHead(node);
+
+        assertThat(list.size).isOne();
+        assertThat(list.rootNode.right).isSameAs(node);
+        assertThat(list.rootNode.left).isSameAs(node);
+
+        assertThat(node.left).isSameAs(list.rootNode);
+        assertThat(node.right).isSameAs(list.rootNode);
+
+        // can't remove the root node.
+        DoubleLinkedList.Node<String, String> removedNode = list.removeNode(node.left);
+        assertThat(removedNode).isNull();
+
+        assertThat(list.size).isOne();
+        assertThat(list.rootNode.right).isSameAs(node);
+        assertThat(list.rootNode.left).isSameAs(node);
+    }
+
+    @Test
+    public void testAddNode() {
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+
+        DoubleLinkedList.Node<String, String> node = DoubleLinkedList.createNode("foo", "bar");
+
+        list.addHead(node);
+
+        assertThat(list.size).isOne();
+        assertThat(list.rootNode.right).isSameAs(node);
+        assertThat(list.rootNode.left).isSameAs(node);
+    }
+
+    @Test
+    public void testAddNodeTwice() {
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+
+        DoubleLinkedList.Node<String, String> node = DoubleLinkedList.createNode("foo", "bar");
+
+        list.addHead(node);
+
+        assertThatThrownBy(() -> list.addHead(node))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Can not add node twice!");
+
+        DoubleLinkedList.Node<String, String> node2 = DoubleLinkedList.createNode("foo", "bar");
+
+        // try to be smart.
+        list.addHead(node2);
+
+        assertThatThrownBy(() -> list.addHead(node))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Can not add node twice!");
+    }
+
+    @Test
+    public void testAddRemove() {
+
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+        DoubleLinkedList.Node<String, String> node = DoubleLinkedList.createNode("foo", "bar");
+
+        list.addHead(node);
+
+        assertThat(list.size).isOne();
+        assertThat(list.rootNode.right).isSameAs(node);
+        assertThat(list.rootNode.left).isSameAs(node);
+
+        list.removeNode(node);
+        assertThat(node.left).isNull();
+        assertThat(node.right).isNull();
+
+        assertThat(list.size).isZero();
+        assertThat(list.rootNode.right).isSameAs(list.rootNode);
+        assertThat(list.rootNode.left).isSameAs(list.rootNode);
+    }
+
+    @Test
+    public void testAddRemoveTail() {
+
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+        DoubleLinkedList.Node<String, String> node = DoubleLinkedList.createNode("foo", "bar");
+
+        list.addHead(node);
+
+        assertThat(list.size).isOne();
+        assertThat(list.rootNode.right).isSameAs(node);
+        assertThat(list.rootNode.left).isSameAs(node);
+
+        list.removeTail();
+        assertThat(node.left).isNull();
+        assertThat(node.right).isNull();
+
+        assertThat(list.size).isZero();
+        assertThat(list.rootNode.right).isSameAs(list.rootNode);
+        assertThat(list.rootNode.left).isSameAs(list.rootNode);
+    }
+
+    @Test
+    public void testAddTwiceRemoveTail() {
+
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+        DoubleLinkedList.Node<String, String> node1 = DoubleLinkedList.createNode("foo", "bar");
+        DoubleLinkedList.Node<String, String> node2 = DoubleLinkedList.createNode("foo", "bar");
+
+        list.addHead(node1);
+        list.addHead(node2);
+
+        assertThat(list.size).isEqualTo(2);
+        assertThat(list.rootNode.right).isSameAs(node2);
+        assertThat(list.rootNode.left).isSameAs(node1);
+
+        // remove tail node
+        list.removeNode(node1);
+        assertThat(node1.left).isNull();
+        assertThat(node1.right).isNull();
+
+        assertThat(list.size).isOne();
+        assertThat(list.rootNode.right).isSameAs(node2);
+        assertThat(list.rootNode.left).isSameAs(node2);
+    }
+
+    @Test
+    public void testAddTwiceRemoveHead() {
+
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+        DoubleLinkedList.Node<String, String> node1 = DoubleLinkedList.createNode("foo", "bar");
+        DoubleLinkedList.Node<String, String> node2 = DoubleLinkedList.createNode("foo", "bar");
+
+        list.addHead(node1);
+        list.addHead(node2);
+
+        assertThat(list.size).isEqualTo(2);
+        assertThat(list.rootNode.right).isSameAs(node2);
+        assertThat(list.rootNode.left).isSameAs(node1);
+
+        // remove tail node
+        list.removeNode(node2);
+        assertThat(node2.left).isNull();
+        assertThat(node2.right).isNull();
+
+        assertThat(list.size).isOne();
+        assertThat(list.rootNode.right).isSameAs(node1);
+        assertThat(list.rootNode.left).isSameAs(node1);
+    }
+
+    @Test
+    public void testAddThreeRemoveMiddle() {
+
+        DoubleLinkedList<String, String> list = new DoubleLinkedList<>();
+        DoubleLinkedList.Node<String, String> node1 = DoubleLinkedList.createNode("foo", "bar");
+        DoubleLinkedList.Node<String, String> node2 = DoubleLinkedList.createNode("foo", "bar");
+        DoubleLinkedList.Node<String, String> node3 = DoubleLinkedList.createNode("foo", "bar");
+
+        list.addHead(node1);
+        list.addHead(node2);
+        list.addHead(node3);
+
+        assertThat(list.size).isEqualTo(3);
+        assertThat(list.rootNode.right).isSameAs(node3);
+        assertThat(list.rootNode.left).isSameAs(node1);
+
+        // remove middle node
+        list.removeNode(node2);
+        assertThat(node2.left).isNull();
+        assertThat(node2.right).isNull();
+
+        assertThat(list.size).isEqualTo(2);
+        assertThat(list.rootNode.right).isSameAs(node3);
+        assertThat(list.rootNode.left).isSameAs(node1);
+    }
+
+}

--- a/core/src/test/java/org/jdbi/v3/core/junit5/DatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/v3/core/junit5/DatabaseExtension.java
@@ -43,6 +43,16 @@ public interface DatabaseExtension<T extends DatabaseExtension<T>> {
         return withPlugin(ConfiguringPlugin.of(configClass, configurer));
     }
 
+    default void installTestPlugins(Jdbi jdbi) throws Exception {
+        // cache plugin tests
+        String cachePluginName = System.getProperty("jdbi.test.cache-plugin");
+        if (cachePluginName != null) {
+            Class<? extends JdbiPlugin> cachePluginClass = (Class<? extends JdbiPlugin>) Class.forName(cachePluginName);
+            JdbiPlugin cachePlugin = cachePluginClass.getConstructor().newInstance();
+            jdbi.installPlugin(cachePlugin);
+        }
+    }
+
     @FunctionalInterface
     interface DatabaseInitializer {
         void initialize(Handle handle);

--- a/core/src/test/java/org/jdbi/v3/core/junit5/H2DatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/v3/core/junit5/H2DatabaseExtension.java
@@ -121,6 +121,8 @@ public final class H2DatabaseExtension implements DatabaseExtension<H2DatabaseEx
         }
         jdbi = Jdbi.create(uri);
 
+        installTestPlugins(jdbi);
+
         if (enableLeakchecker) {
             jdbi.getConfig(Handles.class).addListener(leakChecker);
             jdbi.getConfig(SqlStatements.class).addContextListener(leakChecker);

--- a/core/src/test/java/org/jdbi/v3/core/junit5/PgDatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/v3/core/junit5/PgDatabaseExtension.java
@@ -114,6 +114,8 @@ public final class PgDatabaseExtension implements DatabaseExtension<PgDatabaseEx
 
         jdbi = Jdbi.create(info.asDataSource());
 
+        installTestPlugins(jdbi);
+
         if (enableLeakchecker) {
             jdbi.getConfig(Handles.class).addListener(leakChecker);
             jdbi.getConfig(SqlStatements.class).addContextListener(leakChecker);

--- a/core/src/test/java/org/jdbi/v3/core/junit5/SqliteDatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/v3/core/junit5/SqliteDatabaseExtension.java
@@ -114,6 +114,8 @@ public final class SqliteDatabaseExtension implements DatabaseExtension<SqliteDa
         }
         jdbi = Jdbi.create(uri);
 
+        installTestPlugins(jdbi);
+
         if (enableLeakchecker) {
             jdbi.getConfig(Handles.class).addListener(leakChecker);
             jdbi.getConfig(SqlStatements.class).addContextListener(leakChecker);

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -96,7 +96,7 @@ Already using Jdbi v2? See <<Upgrading from v2 to v3>>
 
 Jdbi is licensed under the commercial friendly link:https://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0^] license.
 
-The core Jdbi module which offers programmatic access uses only link:https://slf4j.org/[slf4j^], link:https://github.com/ben-manes/caffeine[caffeine^] and link:https://github.com/leangen/geantyref[geantryref^] as hard dependencies.
+The core Jdbi module which offers programmatic access uses only link:https://slf4j.org/[slf4j^] and link:https://github.com/leangen/geantyref[geantryref^] as hard dependencies.
 
 All Jdbi modules are available through link:https://search.maven.org[Maven Central^]. Jdbi also offers a BOM (Bill of materials) module for easy dependency management.
 
@@ -4762,6 +4762,20 @@ public interface AccountDao extends CrudDao<Account, UUID> {
 <1> Method annotations are not inherited on override, so we must duplicate
     those we want to keep.
 
+== Statement caching
+
+Jdbi caches statement information in multiple places:
+
+- preparsed SQL where placeholders have been replaced.
+- rendered statement templates if the template engine supports it.
+
+Caching can dramatically speed up the execution of statements. By default, Jdbi uses a simple LRU in-memory cache with 1,000 entries. This cache is sufficient for most use cases.
+
+For applications than run a lot of different SQL operations, it is possible to use different cache implementations. Jdbi provides link:{jdbidocs}/core/cache/package-summary.html[a cache SPI^] for this.
+
+[TIP]
+If the underlying cache library exposes per-cache statistics, these can be accessed through the link:{jdbidocs}//core/statement/SqlStatements.html#cacheStats()[SqlStatements#cacheStats()^] and link:https://{jdbidocs}/core/statement/CachingSqlParser.html#cacheStats()[CachingSqlParser#cacheStats()] methods.
+
 
 == Testing
 
@@ -6453,7 +6467,7 @@ Jdbi jdbi = Jdbi.create("jdbc:sqlite:database")
 
 === StringTemplate 4
 
-This module allows you to plug in the StringTemplate 4 templating engine, in
+This module allows you to plug in the link:https://www.stringtemplate.org/[StringTemplate 4^] templating engine, in
 place of the standard Jdbi templating engine.
 
 To use module plugin, add a Maven dependency:
@@ -6466,8 +6480,7 @@ To use module plugin, add a Maven dependency:
 </dependency>
 ----
 
-To use StringTemplate format in SQL statements, set the template engine
-to `StringTemplateEngine`.
+To use StringTemplate format in SQL statements, set the template engine to link:{jdbidocs}/stringtemplate4/StringTemplateEngine.html[StringTemplateEngine^].
 
 Defined attributes are provided to the StringTemplate engine to render the SQL:
 
@@ -6487,12 +6500,15 @@ List<Account> accounts = handle
     .list();
 ----
 
-[WARNING]
 Since StringTemplate by default uses the `<` character to mark ST expressions,
-you might need to escape some SQL: `String datePredSql = "<if(datePredicate)> <dateColumn> \\< :dateFilter <endif>"`
+you might need to escape some SQL:
 
-Alternatively, SQL templates can be loaded from StringTemplate group files on
-the classpath:
+[source, java]
+----
+String datePredicateSql = "<if(datePredicate)> <dateColumn> \\< :dateFilter <endif>";
+----
+
+Alternatively, SQL templates can be loaded from StringTemplate group files on  the classpath:
 
 [source,stringtemplate]
 .com/foo/AccountDao.sql.stg
@@ -7472,10 +7488,10 @@ order of decorations is important, use the `@DecoratorOrder` annotation. If no o
 is declared, type decorators apply first, then method decorators, but the order is
 not further specified.
 
-For example, suppose a method were annotated both with `@Cached` and
-`@Transaction` (just go with it..). We would probably want the `@Cached`
-annotation to go first, so that transactions are not created unnecessarily when
-the cache already contains the entry.
+For example, if a method were annotated both with a custom `@Cached` and
+`@Transaction` annotation, then  `@DecoratorOrder` can be used to ensure that the `@Cached`
+annotation is evaluated first to avoid that transactions are not created unnecessarily when
+the result may already be cached.
 
 [source,java]
 ----
@@ -7561,7 +7577,7 @@ implementation to render templates into SQL. Template engines take a SQL
 template string and the `StatementContext` as input, and produce a parseable
 SQL string as output.
 
-Out of the box, Jdbi is configured to use `DefinedAttributeTemplateEngine`,
+Out of the box, Jdbi is configured to use link:{jdbidocs}/core/statement/DefinedAttributeTemplateEngine.html[DefinedAttributeTemplateEngine^],
 which replaces angle-bracked tokens like `<name>` in your SQL statements with
 the string value of the named attribute:
 
@@ -7596,9 +7612,12 @@ jdbi.setTemplateEngine(templateEngine);
 ----
 
 [TIP]
-Jdbi also provides `StringTemplateEngine`,
-which renders templates using the StringTemplate library. See
-<<StringTemplate 4>>.
+Jdbi also provides link:{jdbidocs}/stringtemplate4/StringTemplateEngine.html[StringTemplateEngine^],
+which renders templates using the link:https://www.stringtemplate.org/[StringTemplate library^]. See <<StringTemplate 4>>.
+
+Template engines interact with the SQL template caching. A template engine may implement the link:{jdbidocs}/core/statement/TemplateEngine.html#parse(java.lang.String,org.jdbi.v3.core.config.ConfigRegistry)[TemplateEngine#parse()^] methods to create an intermediary representation of a template that can be used to render a template faster. The output of this method will be cached. Depending on the implementation, defined attributes may be resolved at parse time and not at render time.
+
+The most commonly used template engines (link:{jdbidocs}/core/statement/DefinedAttributeTemplateEngine.html[DefinedAttributeTemplateEngine^] and link:{jdbidocs}/stringtemplate4/StringTemplateEngine.html[StringTemplateEngine^] do *not* support caching).
 
 
 === SqlParser


### PR DESCRIPTION
- factor out the direct dependency on caffeine
- introduce a generic cache interface in core/cache

- implementation with caffeine, installing the module restores the old behavior
- implementation with Guava cache
- no op implementation for testing

PR looks larger than it actually is, changes are in core/src, everything else is either required housekeeping or new code