### PR TITLE
caffeine cache plugin using caffeine cache

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
   - upgrade to geantyref 1.3.14
   - removes the core dependency on the caffeine library. This now uses a simple LRU cache for sql parser and sql statements.
+  - adds pluggable cache implementation using caffeine. The old caching behavior can now be restored by using the
+    `jdbi3-caffeine-cache` dependency and adding `jdbi.installPlugin(new CaffeineCachePlugin());`.
 
 # 3.36.0
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -43,6 +43,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-caffeine-cache</artifactId>
+                <version>${dep.jdbi3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-core</artifactId>
                 <version>${dep.jdbi3.version}</version>
             </dependency>

--- a/cache/caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jdbi</groupId>
+        <artifactId>jdbi3-parent</artifactId>
+        <version>3.36.1-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>jdbi3-caffeine-cache</artifactId>
+    <name>jdbi3 caffeine cache</name>
+    <description>Cache implementation with the caffeine cache library</description>
+
+    <properties>
+        <!-- run with -Dbasepom.it.skip=false to run tests using the caffeine cache plugin -->
+        <basepom.it.skip>true</basepom.it.skip>
+        <moduleName>org.jdbi.v3.caffeine</moduleName>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/cache/caffeine-cache/src/it/settings.xml
+++ b/cache/caffeine-cache/src/it/settings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+
+<settings>
+    <mirrors>
+        <mirror>
+            <id>local.central</id>
+            <url>@localRepositoryUrl@</url>
+            <mirrorOf>snapshots-repo</mirrorOf>
+        </mirror>
+    </mirrors>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>ignore</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>ignore</checksumPolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>ignore</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>ignore</checksumPolicy>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/cache/caffeine-cache/src/it/test-caffeine-cache/invoker.properties
+++ b/cache/caffeine-cache/src/it/test-caffeine-cache/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=clean surefire:test
+invoker.buildResult = success
+invoker.failureBehavior = fail-at-end

--- a/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
@@ -1,0 +1,157 @@
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>jdbi3-parent</artifactId>
+        <groupId>org.jdbi</groupId>
+        <version>@project.version@</version>
+    </parent>
+
+    <artifactId>test-caffeine-cache</artifactId>
+
+    <properties>
+        <basepom.check.skip-all>true</basepom.check.skip-all>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-caffeine-cache</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- optionals, required for tests -->
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.inferred</groupId>
+            <artifactId>freebuilder</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- all the test dependencies as the -tests jar does not provide deps -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>de.softwareforge.testing</groupId>
+            <artifactId>pg-embedded</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <dependenciesToScan>
+                        <dependency>org.jdbi:jdbi3-core:*:*:tests</dependency>
+                    </dependenciesToScan>
+                    <systemProperties combine.children="append">
+                        <jdbi.test.cache-plugin>org.jdbi.v3.cache.caffeine.CaffeineCachePlugin</jdbi.test.cache-plugin>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/TestCollectionArguments.*</exclude>
+                                <exclude>**/TestBatchExceptionRewrite.*</exclude>
+                                <exclude>**/TestPreparedBatchGenerateKeysPostgres.*</exclude>
+                                <exclude>**/TestPreparedBatchPG.*</exclude>
+                                <exclude>**/TestScript.*</exclude>
+                                <exclude>**/ConstructorMapperPgTest.*</exclude>
+                                <exclude>**/TestArgumentBinder.*</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCache.java
+++ b/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCache.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.caffeine;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheLoader;
+
+/**
+ * Cache implementation using the caffeine cache library.
+ *
+ * @param <K> The key type.
+ * @param <V> The value type.
+ */
+public final class CaffeineCache<K, V> implements JdbiCache<K, V> {
+
+    private final Cache<K, V> cache;
+
+    CaffeineCache(Caffeine<Object, Object> caffeine) {
+        this.cache = caffeine.build();
+    }
+
+    @Override
+    public V get(K key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V getWithLoader(K key, JdbiCacheLoader<K, V> loader) {
+        return cache.get(key, loader::create);
+    }
+
+    @Override
+    public CacheStats getStats() {
+        return cache.stats();
+    }
+}

--- a/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCacheBuilder.java
+++ b/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCacheBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.caffeine;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
+import org.jdbi.v3.core.cache.JdbiCacheLoader;
+
+/**
+ * Cache builder using the caffeine caching library.
+ */
+public final class CaffeineCacheBuilder implements JdbiCacheBuilder {
+
+    private final Caffeine<Object, Object> caffeine;
+
+    /**
+     * Returns a new {@link JdbiCacheBuilder} which can be used to construct the internal caches.
+     *
+     * @return A {@link JdbiCacheBuilder} instance.
+     */
+    public static JdbiCacheBuilder instance() {
+        return new CaffeineCacheBuilder();
+    }
+
+    /**
+     * Wraps an existing {@link Caffeine} object for Jdbi internal use.
+     *
+     * @param caffeine A {@link Caffeine} object.
+     */
+    public CaffeineCacheBuilder(Caffeine<Object, Object> caffeine) {
+        this.caffeine = caffeine;
+    }
+
+    CaffeineCacheBuilder() {
+        this.caffeine = Caffeine.newBuilder().recordStats();
+    }
+
+    @Override
+    public <K, V> JdbiCache<K, V> build() {
+        return new CaffeineCache<>(caffeine);
+    }
+
+    @Override
+    public <K, V> JdbiCache<K, V> buildWithLoader(JdbiCacheLoader<K, V> cacheLoader) {
+        return new CaffeineLoadingCache<>(caffeine, cacheLoader);
+    }
+
+    @Override
+    public JdbiCacheBuilder maxSize(int maxSize) {
+        caffeine.maximumSize(maxSize);
+        return this;
+    }
+}

--- a/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCachePlugin.java
+++ b/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCachePlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.caffeine;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jdbi.v3.core.statement.ColonPrefixSqlParser;
+import org.jdbi.v3.core.statement.SqlStatements;
+
+import static org.jdbi.v3.core.statement.CachingSqlParser.PARSED_SQL_CACHE_SIZE;
+import static org.jdbi.v3.core.statement.SqlStatements.SQL_TEMPLATE_CACHE_SIZE;
+
+/**
+ * Installing this plugin restores the up-to 3.36.0 behavior of using the Caffeine cache library for SQL statements and the colon prefix parser.
+ */
+public final class CaffeineCachePlugin implements JdbiPlugin {
+
+    @Override
+    public void customizeJdbi(Jdbi jdbi) {
+        final SqlStatements config = jdbi.getConfig(SqlStatements.class);
+
+        config.setTemplateCache(CaffeineCacheBuilder.instance().maxSize(SQL_TEMPLATE_CACHE_SIZE));
+        config.setSqlParser(new ColonPrefixSqlParser(CaffeineCacheBuilder.instance().maxSize(PARSED_SQL_CACHE_SIZE)));
+    }
+}

--- a/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineLoadingCache.java
+++ b/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineLoadingCache.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.caffeine;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheLoader;
+
+/**
+ * Cache implementation using the caffeine cache library.
+ *
+ * @param <K> The key type.
+ * @param <V> The value type.
+ */
+public final class CaffeineLoadingCache<K, V> implements JdbiCache<K, V> {
+
+    private final LoadingCache<K, V> loadingCache;
+
+    CaffeineLoadingCache(Caffeine<Object, Object> caffeine, JdbiCacheLoader<K, V> cacheLoader) {
+
+        this.loadingCache = caffeine.build(cacheLoader::create);
+    }
+
+    @Override
+    public V get(K key) {
+        return loadingCache.get(key);
+    }
+
+    @Override
+    public V getWithLoader(K key, JdbiCacheLoader<K, V> loader) {
+        return loadingCache.get(key, loader::create);
+    }
+
+    @Override
+    public CacheStats getStats() {
+        return loadingCache.stats();
+    }
+}

--- a/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/package-info.java
+++ b/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Cache implementation using the Caffeine cache library.
+ */
+package org.jdbi.v3.cache.caffeine;

--- a/cache/caffeine-cache/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
+++ b/cache/caffeine-cache/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
@@ -1,0 +1,1 @@
+org.jdbi.v3.cache.caffeine.CaffeineCachePlugin

--- a/cache/caffeine-cache/src/test/java/org/jdbi/v3/cache/caffeine/CaffeineCacheTest.java
+++ b/cache/caffeine-cache/src/test/java/org/jdbi/v3/cache/caffeine/CaffeineCacheTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.caffeine;
+
+import java.time.Duration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.jdbi.v3.core.cache.internal.JdbiCacheTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CaffeineCacheTest extends JdbiCacheTest {
+
+    @BeforeEach
+    void beforeEach() {
+        this.builder = CaffeineCacheBuilder.instance();
+    }
+
+    @Test
+    void testCaffeineWithGlobalLoader() {
+        Caffeine<Object, Object> caffeine = Caffeine.newBuilder().expireAfterAccess(Duration.ofSeconds(5)).initialCapacity(10);
+        doTestWithGlobalLoader(new CaffeineCacheBuilder(caffeine).buildWithLoader(cacheLoader));
+    }
+
+    @Test
+    void testCaffeineWithDirectLoader() {
+        Caffeine<Object, Object> caffeine = Caffeine.newBuilder().expireAfterAccess(Duration.ofSeconds(5)).initialCapacity(10);
+        doTestWithLoader(new CaffeineCacheBuilder(caffeine).build());
+    }
+}

--- a/cache/caffeine-cache/src/test/java/org/jdbi/v3/cache/caffeine/JdbiUsesCaffeineCacheTest.java
+++ b/cache/caffeine-cache/src/test/java/org/jdbi/v3/cache/caffeine/JdbiUsesCaffeineCacheTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.caffeine;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JdbiUsesCaffeineCacheTest {
+
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new CaffeineCachePlugin());
+
+    @Test
+    public void testUsingCaffeine() {
+
+        Jdbi jdbi = h2Extension.getJdbi();
+
+        SqlStatements sqlStatements = jdbi.getConfig(SqlStatements.class);
+        assertThat((Object) sqlStatements.cacheStats()).isInstanceOf(CacheStats.class);
+    }
+}

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jdbi</groupId>
+        <artifactId>jdbi3-parent</artifactId>
+        <version>3.36.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.jdbi.internal</groupId>
+    <artifactId>jdbi3-internal-cache-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>jdbi3 - internal - cache</name>
+    <description>This is a Jdbi internal module and not part of the public API.</description>
+
+    <modules>
+        <module>caffeine-cache</module>
+    </modules>
+
+    <properties>
+        <basepom.deploy.skip>true</basepom.deploy.skip>
+        <basepom.install.skip>true</basepom.install.skip>
+    </properties>
+</project>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -46,6 +46,10 @@
 
         <dependency>
             <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-caffeine-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-commons-text</artifactId>
         </dependency>
         <dependency>

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -215,6 +215,11 @@ jdbi3-freemarker::
     Use link:https://freemarker.apache.org/[Apache Freemarker^] to render SQL statements.
 
 
+===== Cache support
+
+jdbi3-caffeine-cache::
+    Use the link:https://github.com/ben-manes/caffeine[Caffeine^] caching library for SQL template and parse caching.
+
 ===== Additional Language support
 
 Jdbi can be used from any language and technology running on the JVM that can use Java code (Kotlin, Scala, Clojure, JRuby etc).
@@ -4772,6 +4777,41 @@ Jdbi caches statement information in multiple places:
 Caching can dramatically speed up the execution of statements. By default, Jdbi uses a simple LRU in-memory cache with 1,000 entries. This cache is sufficient for most use cases.
 
 For applications than run a lot of different SQL operations, it is possible to use different cache implementations. Jdbi provides link:{jdbidocs}/core/cache/package-summary.html[a cache SPI^] for this.
+
+The following cache implementations are included:
+
+- `jdbi3-caffeine-cache` - using the link:https://github.com/ben-manes/caffeine[Caffeine^] cache library. This used to be the default cache up to version 3.36.0
+
+A cache module can provide a plugin to enable it. Only one plugin can be in use at a time (last one installed wins):
+
+[source,java]
+----
+    // use the caffeine cache library
+    jdbi.installPlugin(new CaffeineCachePlugin());
+----
+
+=== Using custom cache instances
+
+The default cache instances are installed when the Jdbi object is created. When using a cache plugin, the implementation is changed but only very few aspects of the cache can be modified.
+
+Full customization is possible by creating the cache outside Jdbi and then use a cache builder adapter:
+
+[source,java]
+----
+    // create a custom Caffeine cache
+    JdbiCacheBuilder customCacheBuilder = new CaffeineCacheBuilder(
+        Caffeine.newBuilder()
+            .maximumSize(100_000)
+            .expireAfterWrite(10, TimeUnit.MINUTES)
+            .recordStats());
+
+    SqlStatements config = jdbi.getConfig(SqlStatements.class);
+    config.setTemplateCache(customCacheBuilder));
+    config.setSqlParser(new ColonPrefixSqlParser(customCacheBuilder));
+----
+
+When setting the caches explicitly, no cache plugin needs to be installed.
+
 
 [TIP]
 If the underlying cache library exposes per-cache statistics, these can be accessed through the link:{jdbidocs}//core/statement/SqlStatements.html#cacheStats()[SqlStatements#cacheStats()^] and link:https://{jdbidocs}/core/statement/CachingSqlParser.html#cacheStats()[CachingSqlParser#cacheStats()] methods.

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -60,6 +60,7 @@
     <properties>
         <basepom.at-end.deploy>true</basepom.at-end.deploy>
         <basepom.check.fail-all>true</basepom.check.fail-all>
+        <basepom.it.timeout>600</basepom.it.timeout>
         <basepom.release.profiles>basepom.oss-release,jdbi-release</basepom.release.profiles>
         <basepom.release.tag-name-format>v@{project.version}</basepom.release.tag-name-format>
         <basepom.test.fork-count>4</basepom.test.fork-count>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
         <module>internal</module>
         <module>bom</module>
 
+        <module>cache</module>
+
         <!-- alphabetical list of the documented (public) modules that we ship -->
         <module>commons-text</module>
         <module>core</module>


### PR DESCRIPTION
Using caffeine for the internal caches. Installing the caffeine module replaces the internal caches with a caffeine implementation.