### PR TITLE
noop cache implementation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
   - removes the core dependency on the caffeine library. This now uses a simple LRU cache for sql parser and sql statements.
   - adds pluggable cache implementation using caffeine. The old caching behavior can now be restored by using the
     `jdbi3-caffeine-cache` dependency and adding `jdbi.installPlugin(new CaffeineCachePlugin());`.
+  - adds pluggable no-op cache implementation for testing and debugging
 
 # 3.36.0
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -125,6 +125,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-noop-cache</artifactId>
+                <version>${dep.jdbi3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-postgis</artifactId>
                 <version>${dep.jdbi3.version}</version>
             </dependency>

--- a/cache/noop-cache/pom.xml
+++ b/cache/noop-cache/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jdbi</groupId>
+        <artifactId>jdbi3-parent</artifactId>
+        <version>3.36.1-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>jdbi3-noop-cache</artifactId>
+    <name>jdbi3 noop cache</name>
+    <description>no op cache implementation</description>
+
+    <properties>
+        <!-- run with -Dbasepom.it.skip=false to run tests using the noop cache plugin -->
+        <basepom.it.skip>true</basepom.it.skip>
+        <moduleName>org.jdbi.v3.cache.noop</moduleName>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cache/noop-cache/src/it/settings.xml
+++ b/cache/noop-cache/src/it/settings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+
+<settings>
+    <mirrors>
+        <mirror>
+            <id>local.central</id>
+            <url>@localRepositoryUrl@</url>
+            <mirrorOf>snapshots-repo</mirrorOf>
+        </mirror>
+    </mirrors>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>ignore</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>ignore</checksumPolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>ignore</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>ignore</checksumPolicy>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/cache/noop-cache/src/it/test-noop-cache/invoker.properties
+++ b/cache/noop-cache/src/it/test-noop-cache/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=clean surefire:test
+invoker.buildResult = success
+invoker.failureBehavior = fail-at-end

--- a/cache/noop-cache/src/it/test-noop-cache/pom.xml
+++ b/cache/noop-cache/src/it/test-noop-cache/pom.xml
@@ -1,0 +1,157 @@
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>jdbi3-parent</artifactId>
+        <groupId>org.jdbi</groupId>
+        <version>@project.version@</version>
+    </parent>
+
+    <artifactId>test-noop-cache</artifactId>
+
+    <properties>
+        <basepom.check.skip-all>true</basepom.check.skip-all>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-noop-cache</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- optionals, required for tests -->
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.inferred</groupId>
+            <artifactId>freebuilder</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- all the test dependencies as the -tests jar does not provide deps -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>de.softwareforge.testing</groupId>
+            <artifactId>pg-embedded</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <dependenciesToScan>
+                        <dependency>org.jdbi:jdbi3-core:*:*:tests</dependency>
+                    </dependenciesToScan>
+                    <systemProperties combine.children="append">
+                        <jdbi.test.cache-plugin>org.jdbi.v3.cache.noop.NoopCachePlugin</jdbi.test.cache-plugin>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/TestCollectionArguments.*</exclude>
+                                <exclude>**/TestBatchExceptionRewrite.*</exclude>
+                                <exclude>**/TestPreparedBatchGenerateKeysPostgres.*</exclude>
+                                <exclude>**/TestPreparedBatchPG.*</exclude>
+                                <exclude>**/TestScript.*</exclude>
+                                <exclude>**/ConstructorMapperPgTest.*</exclude>
+                                <exclude>**/TestArgumentBinder.*</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/cache/noop-cache/src/main/java/org/jdbi/v3/cache/noop/NoopCache.java
+++ b/cache/noop-cache/src/main/java/org/jdbi/v3/cache/noop/NoopCache.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.noop;
+
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
+import org.jdbi.v3.core.cache.JdbiCacheLoader;
+
+/**
+ * A no operation cache implementation.
+ *
+ * @param <K> The key type.
+ * @param <V> The value type.
+ */
+public final class NoopCache<K, V> implements JdbiCache<K, V> {
+
+    static final Object NOOP_CACHE_STATS = new Object();
+
+    private final JdbiCacheLoader<K, V> cacheLoader;
+
+    /**
+     * Returns a new {@link JdbiCacheBuilder} which can be used to construct the internal caches.
+     *
+     * @return A {@link JdbiCacheBuilder} instance.
+     */
+    public static JdbiCacheBuilder builder() {
+        return new NoopCacheBuilder();
+    }
+
+    NoopCache(JdbiCacheLoader<K, V> cacheLoader) {
+        this.cacheLoader = cacheLoader;
+    }
+
+    @Override
+    public V get(K key) {
+        if (cacheLoader != null) {
+            return cacheLoader.create(key);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public V getWithLoader(K key, JdbiCacheLoader<K, V> loader) {
+        return loader.create(key);
+    }
+
+    @Override
+    public Object getStats() {
+        return NOOP_CACHE_STATS;
+    }
+}

--- a/cache/noop-cache/src/main/java/org/jdbi/v3/cache/noop/NoopCacheBuilder.java
+++ b/cache/noop-cache/src/main/java/org/jdbi/v3/cache/noop/NoopCacheBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.noop;
+
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
+import org.jdbi.v3.core.cache.JdbiCacheLoader;
+
+/**
+ * Cache builder for the no op cache.
+ */
+public final class NoopCacheBuilder implements JdbiCacheBuilder {
+
+    NoopCacheBuilder() {}
+
+    @Override
+    public <K, V> JdbiCache<K, V> build() {
+        return new NoopCache<>(null);
+    }
+
+    @Override
+    public <K, V> JdbiCache<K, V> buildWithLoader(JdbiCacheLoader<K, V> cacheLoader) {
+        return new NoopCache<>(cacheLoader);
+    }
+
+    @Override
+    public JdbiCacheBuilder maxSize(int maxSize) {
+        return this;
+    }
+}

--- a/cache/noop-cache/src/main/java/org/jdbi/v3/cache/noop/NoopCachePlugin.java
+++ b/cache/noop-cache/src/main/java/org/jdbi/v3/cache/noop/NoopCachePlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.noop;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jdbi.v3.core.statement.ColonPrefixSqlParser;
+import org.jdbi.v3.core.statement.SqlStatements;
+
+/**
+ * Installing this plugin uses the no op (no caching) cache.
+ */
+public final class NoopCachePlugin implements JdbiPlugin {
+
+    @Override
+    public void customizeJdbi(Jdbi jdbi) {
+        final SqlStatements config = jdbi.getConfig(SqlStatements.class);
+
+        config.setTemplateCache(NoopCache.builder());
+        config.setSqlParser(new ColonPrefixSqlParser(NoopCache.builder()));
+    }
+}

--- a/cache/noop-cache/src/main/java/org/jdbi/v3/cache/noop/package-info.java
+++ b/cache/noop-cache/src/main/java/org/jdbi/v3/cache/noop/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * A non-caching cache implementation.
+ */
+package org.jdbi.v3.cache.noop;

--- a/cache/noop-cache/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
+++ b/cache/noop-cache/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
@@ -1,0 +1,1 @@
+org.jdbi.v3.cache.noop.NoopCachePlugin

--- a/cache/noop-cache/src/test/java/org/jdbi/v3/cache/noop/JdbiUsesNoopCacheTest.java
+++ b/cache/noop-cache/src/test/java/org/jdbi/v3/cache/noop/JdbiUsesNoopCacheTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.noop;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JdbiUsesNoopCacheTest {
+
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new NoopCachePlugin());
+
+    @Test
+    public void testUsingNoop() {
+
+        Jdbi jdbi = h2Extension.getJdbi();
+
+        SqlStatements sqlStatements = jdbi.getConfig(SqlStatements.class);
+        assertThat((Object) sqlStatements.cacheStats()).isSameAs(NoopCache.NOOP_CACHE_STATS);
+    }
+}

--- a/cache/noop-cache/src/test/java/org/jdbi/v3/cache/noop/NoopCacheTest.java
+++ b/cache/noop-cache/src/test/java/org/jdbi/v3/cache/noop/NoopCacheTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.noop;
+
+import java.util.UUID;
+
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.internal.JdbiCacheTest;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoopCacheTest extends JdbiCacheTest {
+
+    @BeforeEach
+    void beforeEach() {
+        this.builder = NoopCache.builder();
+    }
+
+    protected void doTestWithGlobalLoader(JdbiCache<String, String> cache) {
+        assertThat(cacheLoader.created()).isZero();
+
+        String key = UUID.randomUUID().toString();
+
+        // cache creation. creation event.
+        String value = cache.get(key);
+        assertThat(value).isEqualTo(cacheLoader.checkKey(key));
+        assertThat(cacheLoader.created()).isOne();
+
+        // no cache. another creation event
+        value = cache.get(key);
+        assertThat(value).isEqualTo(cacheLoader.checkKey(key));
+        assertThat(cacheLoader.created()).isEqualTo(2);
+
+        String key2 = UUID.randomUUID().toString();
+
+        // cache creation. next creation event.
+        String value2 = cache.get(key2);
+        assertThat(cacheLoader.created()).isEqualTo(3);
+        assertThat(value2).isEqualTo(cacheLoader.checkKey(key2));
+    }
+
+    protected void doTestWithLoader(JdbiCache<String, String> cache) {
+        assertThat(cacheLoader.created()).isZero();
+
+        String key = UUID.randomUUID().toString();
+
+        // cache creation. creation event.
+        String value = cache.getWithLoader(key, cacheLoader);
+        assertThat(value).isEqualTo(cacheLoader.checkKey(key));
+        assertThat(cacheLoader.created()).isOne();
+
+        // no cache. another creation event
+        value = cache.getWithLoader(key, cacheLoader);
+        assertThat(value).isEqualTo(cacheLoader.checkKey(key));
+        assertThat(cacheLoader.created()).isEqualTo(2);
+
+        String key2 = UUID.randomUUID().toString();
+
+        // cache creation. second creation event.
+        String value2 = cache.getWithLoader(key2, cacheLoader);
+        assertThat(cacheLoader.created()).isEqualTo(3);
+        assertThat(value2).isEqualTo(cacheLoader.checkKey(key2));
+    }
+}

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -30,6 +30,7 @@
 
     <modules>
         <module>caffeine-cache</module>
+        <module>noop-cache</module>
     </modules>
 
     <properties>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -106,6 +106,10 @@
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-noop-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-postgis</artifactId>
         </dependency>
         <dependency>

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -219,6 +219,9 @@ jdbi3-freemarker::
 
 jdbi3-caffeine-cache::
     Use the link:https://github.com/ben-manes/caffeine[Caffeine^] caching library for SQL template and parse caching.
+jdbi3-noop-cache::
+    Turn off SQL template and parse caching for testing and debugging.
+
 
 ===== Additional Language support
 
@@ -4781,6 +4784,7 @@ For applications than run a lot of different SQL operations, it is possible to u
 The following cache implementations are included:
 
 - `jdbi3-caffeine-cache` - using the link:https://github.com/ben-manes/caffeine[Caffeine^] cache library. This used to be the default cache up to version 3.36.0
+- `jdbi3-noop-cache`, - disables caching. This is useful for testing and debugging.
 
 A cache module can provide a plugin to enable it. Only one plugin can be in use at a time (last one installed wins):
 


### PR DESCRIPTION
Installing this cache module turns off caching for SQL statements and parsed SQL. This is useful for debugging and testing.