### PR TITLE
Add null safety to PostGISCodec

### DIFF
--- a/postgis/src/main/java/org/jdbi/v3/postgis/PostgisCodec.java
+++ b/postgis/src/main/java/org/jdbi/v3/postgis/PostgisCodec.java
@@ -76,6 +76,9 @@ final class PostgisCodec implements Codec<Geometry> {
     }
 
     private static byte[] hexStringToByteArray(String s) {
+        if (s == null) {
+            return null;
+        }
         int len = s.length();
         byte[] data = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {

--- a/postgis/src/test/java/org/jdbi/v3/postgis/PostgisPluginTest.java
+++ b/postgis/src/test/java/org/jdbi/v3/postgis/PostgisPluginTest.java
@@ -102,6 +102,26 @@ final class PostgisPluginTest {
         assertThat(record.getPolygon()).isEqualTo(result.getPolygon());
     }
 
+    @Test
+    void postgisNullSafetyTest() {
+        PostgisRecord record = new PostgisRecord();
+        record.setId(2);
+
+        handle.createUpdate(
+                "INSERT INTO record (id, point, linestring, polygon) VALUES (:id, :point, :lineString, :polygon)")
+            .bindBean(record)
+            .execute();
+
+        PostgisRecord result = handle
+            .createQuery("SELECT * FROM record ORDER BY id")
+            .mapToBean(PostgisRecord.class)
+            .first();
+
+        assertThat(record.getPoint()).isNull();
+        assertThat(record.getLineString()).isNull();
+        assertThat(record.getPolygon()).isNull();
+    }
+
     public static final class PostgisRecord {
 
         private Integer id;


### PR DESCRIPTION
If a column contained a null geometry the registered Geometry ColumnMapper (from PostGISCodec) would throw a NPE while trying to convert the null value to a byte array. 

If a null value is now processed by the ColumnMapper, a null value is returned