### PR TITLE
SqlObject Factory rewrite

### DIFF
--- a/generator/src/main/java/org/jdbi/v3/generator/GenerateSqlObjectProcessor.java
+++ b/generator/src/main/java/org/jdbi/v3/generator/GenerateSqlObjectProcessor.java
@@ -47,6 +47,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.sqlobject.GeneratorSqlObjectFactory;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.internal.SqlObjectInitData;
 import org.jdbi.v3.sqlobject.internal.SqlObjectInitData.InContextInvoker;
@@ -105,7 +106,7 @@ public class GenerateSqlObjectProcessor extends AbstractProcessor {
         implSpec.addSuperinterface(SqlObject.class);
 
         final CodeBlock.Builder staticInit = CodeBlock.builder()
-                .add("initData = $T.initData();\n", SqlObjectInitData.class);
+                .add("initData = $T.initData();\n", GeneratorSqlObjectFactory.class);
         final CodeBlock.Builder constructor = CodeBlock.builder();
 
         implSpec.addField(SqlObjectInitData.class, "initData", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL);
@@ -166,8 +167,9 @@ public class GenerateSqlObjectProcessor extends AbstractProcessor {
         typeBuilder.addField(Method.class, methodField, Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL);
         typeBuilder.addField(new GenericType<Supplier<InContextInvoker>>() {}.getType(), invokerField, Modifier.PRIVATE, Modifier.FINAL);
 
-        staticInit.add("$L = initData.lookupMethod($S, new Class<?>[] {$L});\n",
+        staticInit.add("$L = $T.lookupMethod($S, new Class<?>[] {$L});\n",
                 methodField,
+                GeneratorSqlObjectFactory.class,
                 el.getSimpleName(),
                 paramTypes);
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GeneratorSqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GeneratorSqlObjectFactory.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.extension.ExtensionFactory;
+import org.jdbi.v3.core.extension.HandleSupplier;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
+import org.jdbi.v3.core.internal.OnDemandExtensions;
+import org.jdbi.v3.sqlobject.internal.SqlObjectInitData;
+
+import static java.lang.String.format;
+
+/**
+ * Support for generator instances (concrete classes that have been create by the Jdbi generator.
+ */
+public final class GeneratorSqlObjectFactory implements ExtensionFactory, OnDemandExtensions.Factory {
+    private static final ThreadLocal<SqlObjectInitData> CURRENT_INIT_DATA = new ThreadLocal<>();
+
+    GeneratorSqlObjectFactory() {}
+
+    @Override
+    public boolean accepts(Class<?> extensionType) {
+        return SqlObjectInitData.isConcrete(extensionType);
+    }
+
+    /**
+     * Create a sql object from a jdbi generator created class.
+     *
+     * @param extensionType  the type of sql object to create.
+     * @param handleSupplier the Handle instance to attach this sql object to.
+     * @return the new sql object bound to this handle.
+     */
+    @Override
+    public <E> E attach(Class<E> extensionType, HandleSupplier handleSupplier) {
+        if (!SqlObjectInitData.isConcrete(extensionType)) {
+            throw new IllegalStateException(format("Can not process %s, not generated SQL object", extensionType.getSimpleName()));
+        }
+
+        final SqlObjectInitData sqlObjectInitData = SqlObjectInitData.lookup(extensionType, handleSupplier.getConfig());
+        final ConfigRegistry instanceConfig = sqlObjectInitData
+                .configureInstance(handleSupplier.getConfig().createCopy());
+
+        try {
+            // prime the init data holder to the specific data object
+            CURRENT_INIT_DATA.set(sqlObjectInitData);
+
+            // matches the class structure that the jdbi-generator writes
+            return extensionType.cast(
+                    Class.forName(getGeneratedClassName(extensionType))
+                            .getConstructor(HandleSupplier.class, ConfigRegistry.class)
+                            .newInstance(handleSupplier, instanceConfig));
+        } catch (Exception | ExceptionInInitializerError e) {
+            throw new UnableToCreateSqlObjectException(e);
+        } finally {
+            // clean the init data holder again
+            CURRENT_INIT_DATA.remove();
+        }
+    }
+
+    @Override
+    public Optional<Object> onDemand(Jdbi jdbi, Class<?> extensionType, Class<?>... extraTypes) {
+        if (!SqlObjectInitData.isConcrete(extensionType)) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(Class.forName(getOnDemandClassName(extensionType))
+                    .getConstructor(Jdbi.class)
+                    .newInstance(jdbi));
+        } catch (ReflectiveOperationException | ExceptionInInitializerError e) {
+            throw new UnableToCreateSqlObjectException(e);
+        }
+    }
+
+    private String getGeneratedClassName(Class<?> extensionType) {
+        return extensionType.getPackage().getName() + "." + extensionType.getSimpleName() + "Impl";
+    }
+
+    private String getOnDemandClassName(Class<?> extensionType) {
+        return getGeneratedClassName(extensionType) + "$OnDemand";
+    }
+
+
+    //
+    // The following methods are matched by the jdbi-generator code. Do not change their signatures unless also changing the generator code
+    //
+    public static SqlObjectInitData initData() {
+        final SqlObjectInitData result = CURRENT_INIT_DATA.get();
+        if (result == null) {
+            throw new IllegalStateException("Implemented SqlObject types must be initialized by the GeneratorSqlObjectFactory");
+        }
+        return result;
+    }
+
+    public static Method lookupMethod(String methodName, Class<?>... parameterTypes) {
+        return JdbiClassUtils.safeMethodLookup(initData().extensionType(), methodName, parameterTypes)
+                .orElseGet(() -> JdbiClassUtils.methodLookup(SqlObject.class, methodName, parameterTypes));
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handler.java
@@ -22,11 +22,17 @@ import org.jdbi.v3.meta.Beta;
  */
 @FunctionalInterface
 public interface Handler {
+
+    Handler EQUALS_HANDLER = (target, args, handleSupplier) -> target == args[0];
+    Handler HASHCODE_HANDLER = (target, args, handleSupplier) -> System.identityHashCode(target);
+    Handler GET_HANDLE_HANDLER = (target, args, handleSupplier) -> handleSupplier.getHandle();
+    Handler NULL_HANDLER = (target, args, handleSupplier) -> null;
+
     /**
      * Executes a SQL Object method, and returns the result.
      *
-     * @param target the SQL Object instance being invoked
-     * @param args   the arguments that were passed to the method.
+     * @param target         the SQL Object instance being invoked
+     * @param args           the arguments that were passed to the method.
      * @param handleSupplier a (possibly lazy) Handle supplier.
      * @return the method return value, or null if the method has a void return type.
      * @throws Exception any exception thrown by the method.
@@ -36,6 +42,7 @@ public interface Handler {
     /**
      * Called after the method handler is constructed to pre-initialize any important
      * configuration data structures.
+     *
      * @param config the method configuration to warm
      */
     @Beta

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -13,71 +13,48 @@
  */
 package org.jdbi.v3.sqlobject;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.config.internal.ConfigCache;
-import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.extension.ExtensionFactory;
 import org.jdbi.v3.core.extension.Extensions;
 import org.jdbi.v3.core.extension.HandleSupplier;
-import org.jdbi.v3.core.internal.JdbiClassUtils;
-import org.jdbi.v3.core.internal.OnDemandExtensions;
-import org.jdbi.v3.sqlobject.config.Configurer;
-import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation;
 import org.jdbi.v3.sqlobject.internal.SqlObjectInitData;
 import org.jdbi.v3.sqlobject.internal.SqlObjectInitData.InContextInvoker;
+
+import static java.lang.String.format;
 
 /**
  * Creates implementations for SqlObject interfaces.
  */
-public class SqlObjectFactory implements ExtensionFactory, OnDemandExtensions.Factory {
-    private final ConfigCache<Class<?>, SqlObjectInitData> sqlObjectCache =
-            ConfigCaches.declare(SqlObjectFactory::initDataFor);
+public class SqlObjectFactory implements ExtensionFactory {
 
     SqlObjectFactory() {}
 
     @Override
     public boolean accepts(Class<?> extensionType) {
-        if (looksLikeSqlObject(extensionType)) {
-            if (extensionType.getAnnotation(GenerateSqlObject.class) != null) {
-                return true;
-            }
 
-            if (!extensionType.isInterface()) {
-                throw new IllegalArgumentException("SQL Objects are only supported for interfaces.");
-            }
-
-            return true;
+        // the sql generator only deals with interfaces
+        if (!extensionType.isInterface()) {
+            return false;
         }
 
-        return false;
-    }
+        // ignore generator types
+        if (SqlObjectInitData.isConcrete(extensionType)) {
+            return false;
+        }
 
-    private boolean looksLikeSqlObject(Class<?> extensionType) {
+        // extending SqlObject is ok
         if (SqlObject.class.isAssignableFrom(extensionType)) {
             return true;
         }
 
+        // otherwise at least one method must be marked with a SqlOperation
         return Stream.of(extensionType.getMethods())
                 .flatMap(m -> Stream.of(m.getAnnotations()))
                 .anyMatch(a -> a.annotationType().isAnnotationPresent(SqlOperation.class));
@@ -87,18 +64,18 @@ public class SqlObjectFactory implements ExtensionFactory, OnDemandExtensions.Fa
      * Create a sql object of the specified type bound to this handle. Any state changes to the handle, or the sql
      * object, such as transaction status, closing it, etc, will apply to both the object and the handle.
      *
-     * @param extensionType the type of sql object to create
+     * @param extensionType  the type of sql object to create
      * @param handleSupplier the Handle instance to attach ths sql object to
      * @return the new sql object bound to this handle
      */
     @Override
     public <E> E attach(Class<E> extensionType, HandleSupplier handleSupplier) {
-        final SqlObjectInitData sqlObjectInitData = sqlObjectCache.get(extensionType, handleSupplier.getConfig());
-        final ConfigRegistry instanceConfig = sqlObjectInitData.configureInstance(handleSupplier.getConfig().createCopy());
-
         if (SqlObjectInitData.isConcrete(extensionType)) {
-            return sqlObjectInitData.instantiate(extensionType, handleSupplier, instanceConfig);
+            throw new IllegalStateException(format("Can not process %s, it is a generated SQL object", extensionType.getSimpleName()));
         }
+
+        final SqlObjectInitData sqlObjectInitData = SqlObjectInitData.lookup(extensionType, handleSupplier.getConfig());
+        final ConfigRegistry instanceConfig = sqlObjectInitData.configureInstance(handleSupplier.getConfig().createCopy());
 
         instanceConfig.get(Extensions.class).onCreateProxy();
 
@@ -111,158 +88,5 @@ public class SqlObjectFactory implements ExtensionFactory, OnDemandExtensions.Fa
         sqlObjectInitData.forEachMethodHandler((method, handler) ->
                 handlers.put(method, sqlObjectInitData.lazyInvoker(proxy, method, handleSupplier, instanceConfig)));
         return extensionType.cast(proxy);
-    }
-
-    @Override
-    public Optional<Object> onDemand(Jdbi jdbi, Class<?> extensionType, Class<?>... extraTypes) {
-        if (!SqlObjectInitData.isConcrete(extensionType)) {
-            return Optional.empty();
-        }
-
-        try {
-            return Optional.of(Class.forName(
-                    extensionType.getPackage().getName() + "." + extensionType.getSimpleName() + "Impl$OnDemand")
-                .getConstructor(Jdbi.class)
-                .newInstance(jdbi));
-        } catch (ReflectiveOperationException | ExceptionInInitializerError e) {
-            throw new UnableToCreateSqlObjectException(e);
-        }
-    }
-
-    private static Map<Method, Handler> buildMethodHandlers(
-            Class<?> sqlObjectType,
-            Handlers registry,
-            HandlerDecorators decorators) {
-        final Map<Method, Handler> handlerMap = new HashMap<>();
-
-        addMethodHandler(handlerMap, (target, args, handleSupplier) ->
-                        "Jdbi sqlobject proxy for " + sqlObjectType.getName() + "@" + Integer.toHexString(target.hashCode()),
-                Object.class, "toString");
-        addMethodHandler(handlerMap, (target, args, handleSupplier) -> target == args[0],
-                Object.class, "equals", Object.class);
-        addMethodHandler(handlerMap, (target, args, handleSupplier) -> System.identityHashCode(target),
-                Object.class, "hashCode");
-
-        // this should probably have a check whether the sqlObjectType actually implements SqlObject
-        addMethodHandler(handlerMap, (target, args, handleSupplier) -> handleSupplier.getHandle(),
-                SqlObject.class, "getHandle");
-
-        try {
-            addMethodHandler(handlerMap, (target, args, handleSupplier) -> null, sqlObjectType, "finalize");
-        } catch (IllegalStateException expected) {
-            // ignore - optional implementation
-        }
-
-        final Set<Method> methods = new LinkedHashSet<>();
-        methods.addAll(Arrays.asList(sqlObjectType.getMethods()));
-        methods.addAll(Arrays.asList(sqlObjectType.getDeclaredMethods()));
-
-        final Set<Method> seen = new HashSet<>(handlerMap.keySet());
-        for (Method method : methods) {
-            if (Modifier.isStatic(method.getModifiers()) || !seen.add(method)) {
-                continue;
-            }
-            handlerMap.put(method, decorators.applyDecorators(
-                        registry.findFor(sqlObjectType, method)
-                            .orElseGet(() -> {
-                                Supplier<IllegalStateException> x = () -> new IllegalStateException(String.format(
-                                        "Method %s.%s must have an implementation or be annotated with a SQL method annotation.",
-                                        method.getDeclaringClass().getSimpleName(),
-                                        method.getName()));
-                                if (!SqlObjectInitData.isConcrete(sqlObjectType) && !method.isSynthetic() && !Modifier.isPrivate(method.getModifiers())) {
-                                    throw x.get();
-                                }
-                                return (target, args, handleSupplier) -> {
-                                    throw x.get();
-                                };
-                            }),
-                        sqlObjectType,
-                        method));
-        }
-
-        methods.stream()
-            .filter(m -> !m.isSynthetic())
-            .collect(Collectors.groupingBy(m -> Arrays.asList(m.getName(), Arrays.asList(m.getParameterTypes()))))
-            .values()
-            .stream()
-            .filter(l -> l.size() > 1)
-            .findAny()
-            .ifPresent(ms -> {
-                throw new UnableToCreateSqlObjectException(sqlObjectType + " has ambiguous methods " + ms + ", please resolve with an explicit override");
-            });
-
-        return handlerMap;
-    }
-
-    private static void addMethodHandler(Map<Method, Handler> handlerMap, Handler handler, Class<?> klass, String methodName, Class<?>... parameterTypes) {
-        Method method = JdbiClassUtils.methodLookup(klass, methodName, parameterTypes);
-        handlerMap.put(method, handler);
-    }
-
-    private static UnaryOperator<ConfigRegistry> buildConfigurers(Stream<AnnotatedElement> elements, ConfigurerMethod consumer) {
-        List<Consumer<ConfigRegistry>> myConfigurers = elements
-                .flatMap(ae -> Arrays.stream(ae.getAnnotations()))
-                .filter(a -> a.annotationType().isAnnotationPresent(ConfiguringAnnotation.class))
-                .map(a -> {
-                    ConfiguringAnnotation meta = a.annotationType()
-                            .getAnnotation(ConfiguringAnnotation.class);
-
-                    Configurer configurer = getConfigurer(meta.value());
-                    return (Consumer<ConfigRegistry>) config -> consumer.configure(configurer, config, a);
-                })
-                .collect(Collectors.toList());
-        return config -> {
-            myConfigurers.forEach(configurer -> configurer.accept(config));
-            return config;
-        };
-    }
-
-    private static Configurer getConfigurer(Class<? extends Configurer> factoryClass) {
-        try {
-            return factoryClass.getDeclaredConstructor().newInstance();
-        } catch (ReflectiveOperationException e) {
-            throw new IllegalStateException("Unable to instantiate configurer factory class " + factoryClass, e);
-        }
-    }
-
-    static SqlObjectInitData initDataFor(ConfigRegistry handlersConfig, Class<?> sqlObjectType) {
-        Map<Method, Handler> methodHandlers = buildMethodHandlers(
-                sqlObjectType,
-                handlersConfig.get(Handlers.class),
-                handlersConfig.get(HandlerDecorators.class));
-
-        UnaryOperator<ConfigRegistry> instanceConfigurer = buildConfigurers(
-                Stream.concat(
-                    superTypes(sqlObjectType),
-                    Stream.of(sqlObjectType)),
-                (configurer, config, annotation) ->
-                    configurer.configureForType(config, annotation, sqlObjectType));
-
-        Map<Method, UnaryOperator<ConfigRegistry>> methodConfigurers =
-            methodHandlers.keySet().stream().collect(
-                Collectors.toMap(
-                        Function.identity(),
-                        method -> buildConfigurers(
-                            Stream.of(method),
-                            (configurer, config, annotation) ->
-                                configurer.configureForMethod(config, annotation, sqlObjectType, method))));
-
-        return new SqlObjectInitData(
-                sqlObjectType,
-                instanceConfigurer,
-                methodConfigurers,
-                methodHandlers);
-    }
-
-    // duplicate implementation in CustomizingStatementHandler
-    private static Stream<Class<?>> superTypes(Class<?> type) {
-        Class<?>[] interfaces = type.getInterfaces();
-        return Stream.concat(
-            Arrays.stream(interfaces).flatMap(SqlObjectFactory::superTypes),
-            Arrays.stream(interfaces));
-    }
-
-    interface ConfigurerMethod {
-        void configure(Configurer configurer, ConfigRegistry config, Annotation annotation);
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectPlugin.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectPlugin.java
@@ -24,9 +24,15 @@ import org.jdbi.v3.sqlobject.statement.internal.SqlObjectStatementConfiguration;
 public class SqlObjectPlugin extends JdbiPlugin.Singleton {
     @Override
     public void customizeJdbi(Jdbi db) {
-        SqlObjectFactory sqlObjectFactory = new SqlObjectFactory();
-        db.registerExtension(sqlObjectFactory);
-        db.getConfig(OnDemandExtensions.class).setFactory(sqlObjectFactory);
+
+        // support for generated classes (jdbi-generator)
+        GeneratorSqlObjectFactory generatorSqlObjectFactory = new GeneratorSqlObjectFactory();
+        db.registerExtension(generatorSqlObjectFactory);
+        db.getConfig(OnDemandExtensions.class).setFactory(generatorSqlObjectFactory);
+
+        // register SQL object proxy factory
+        db.registerExtension(new SqlObjectFactory());
+
         db.getConfig(SqlObjectStatementConfiguration.class);
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/SqlObjectInitData.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/SqlObjectInitData.java
@@ -13,35 +13,61 @@
  */
 package org.jdbi.v3.sqlobject.internal;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.config.internal.ConfigCache;
+import org.jdbi.v3.core.config.internal.ConfigCaches;
 import org.jdbi.v3.core.extension.ExtensionContext;
 import org.jdbi.v3.core.extension.HandleSupplier;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.internal.MemoizingSupplier;
 import org.jdbi.v3.core.internal.exceptions.Sneaky;
 import org.jdbi.v3.sqlobject.GenerateSqlObject;
+import org.jdbi.v3.sqlobject.GeneratorSqlObjectFactory;
 import org.jdbi.v3.sqlobject.Handler;
+import org.jdbi.v3.sqlobject.HandlerDecorators;
+import org.jdbi.v3.sqlobject.Handlers;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.UnableToCreateSqlObjectException;
+import org.jdbi.v3.sqlobject.config.Configurer;
+import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation;
+
+import static org.jdbi.v3.sqlobject.Handler.EQUALS_HANDLER;
+import static org.jdbi.v3.sqlobject.Handler.GET_HANDLE_HANDLER;
+import static org.jdbi.v3.sqlobject.Handler.HASHCODE_HANDLER;
+import static org.jdbi.v3.sqlobject.Handler.NULL_HANDLER;
 
 public final class SqlObjectInitData {
 
+    // This should be a field in InContextInvoker but static fields are not allowed in inner classes in Java 8
     private static final Object[] NO_ARGS = new Object[0];
-    public static final ThreadLocal<SqlObjectInitData> INIT_DATA = new ThreadLocal<>();
-
+    private static final ConfigCache<Class<?>, SqlObjectInitData> INIT_DATA_CACHE =
+            ConfigCaches.declare(SqlObjectInitData::initDataFor);
     private final Class<?> extensionType;
     private final UnaryOperator<ConfigRegistry> instanceConfigurer;
     private final Map<Method, UnaryOperator<ConfigRegistry>> methodConfigurers;
     private final Map<Method, Handler> methodHandlers;
 
-    public SqlObjectInitData(
+    private SqlObjectInitData(
             Class<?> extensionType,
             UnaryOperator<ConfigRegistry> instanceConfigurer,
             Map<Method, UnaryOperator<ConfigRegistry>> methodConfigurers,
@@ -52,61 +78,16 @@ public final class SqlObjectInitData {
         this.methodHandlers = methodHandlers;
     }
 
-    public static boolean isConcrete(Class<?> extensionType) {
-        return extensionType.getAnnotation(GenerateSqlObject.class) != null;
+    public static boolean isConcrete(Class<?> extensionTypeClass) {
+        return extensionTypeClass.getAnnotation(GenerateSqlObject.class) != null;
     }
 
-    public static SqlObjectInitData initData() {
-        final SqlObjectInitData result = INIT_DATA.get();
-        if (result == null) {
-            throw new IllegalStateException("Implemented SqlObject types must be initialized by SqlObjectFactory");
-        }
-        return result;
-    }
-
-    public static Method lookupMethod(String methodName, Class<?>... parameterTypes) {
-        return lookupMethod(initData().extensionType, methodName, parameterTypes);
-    }
-
-    private static Method lookupMethod(Class<?> klass, String methodName, Class<?>... parameterTypes) {
-        try {
-            return klass.getMethod(methodName, parameterTypes);
-        } catch (NoSuchMethodException | SecurityException e) {
-            try {
-                return klass.getDeclaredMethod(methodName, parameterTypes);
-            } catch (Exception x) {
-                e.addSuppressed(x);
-                try {
-                    return SqlObject.class.getMethod(methodName, parameterTypes);
-                } catch (Exception x2) {
-                    e.addSuppressed(x2);
-                }
-            }
-            throw new IllegalStateException(
-                    String.format("can't find %s#%s%s", klass.getName(), methodName, Arrays.asList(parameterTypes)), e);
-        }
+    public static SqlObjectInitData lookup(Class<?> key, ConfigRegistry config) {
+        return INIT_DATA_CACHE.get(key, config);
     }
 
     public Class<?> extensionType() {
         return extensionType;
-    }
-
-    public <E> E instantiate(Class<E> passExtensionType, HandleSupplier handleSupplier, ConfigRegistry instanceConfig) {
-        if (!extensionType.equals(passExtensionType)) {
-            throw new IllegalArgumentException("mismatch extension type");
-        }
-
-        try {
-            SqlObjectInitData.INIT_DATA.set(this);
-            return passExtensionType.cast(
-                Class.forName(extensionType.getPackage().getName() + "." + extensionType.getSimpleName() + "Impl")
-                    .getConstructor(HandleSupplier.class, ConfigRegistry.class)
-                    .newInstance(handleSupplier, instanceConfig));
-        } catch (Exception | ExceptionInInitializerError e) {
-            throw new UnableToCreateSqlObjectException(e);
-        } finally {
-            SqlObjectInitData.INIT_DATA.remove();
-        }
     }
 
     public ConfigRegistry configureInstance(ConfigRegistry config) {
@@ -119,6 +100,139 @@ public final class SqlObjectInitData {
 
     public Supplier<InContextInvoker> lazyInvoker(Object target, Method method, HandleSupplier handleSupplier, ConfigRegistry instanceConfig) {
         return MemoizingSupplier.of(() -> new InContextInvoker(target, method, handleSupplier, instanceConfig));
+    }
+
+    /**
+     * Legacy generator classes that refer to this method directly. Do not use in new code.
+     * @deprecated
+     */
+    @Deprecated
+    SqlObjectInitData initData() {
+        return GeneratorSqlObjectFactory.initData();
+    }
+
+    /**
+     * Legacy generator classes that refer to this method directly. Do not use in new code.
+     * @deprecated
+     */
+    @Deprecated
+    public static Method lookupMethod(String methodName, Class<?>... parameterTypes) {
+        return GeneratorSqlObjectFactory.lookupMethod(methodName, parameterTypes);
+    }
+
+    private static SqlObjectInitData initDataFor(ConfigRegistry handlersConfig, Class<?> sqlObjectType) {
+        Map<Method, Handler> methodHandlers = buildMethodHandlers(handlersConfig, sqlObjectType);
+
+        // process all annotations on the type.
+        final ConfigurerMethod forType = (configurer, config, annotation) -> configurer.configureForType(config, annotation, sqlObjectType);
+
+        // build a configurer for the type and all supertypes. This processes all annotations on classes and interfaces
+        UnaryOperator<ConfigRegistry> instanceConfigurer = buildConfigurers(
+                Stream.concat(JdbiClassUtils.superTypes(sqlObjectType), Stream.of(sqlObjectType)), forType);
+
+        // A map for all methods that contains the annotations for each method on the type
+        Map<Method, UnaryOperator<ConfigRegistry>> methodConfigurers = methodHandlers.keySet().stream().collect(Collectors.toMap(
+                        Function.identity(),
+                        method -> {
+                            // process all annotations on a single method.
+                            final ConfigurerMethod forMethod = (configurer, config, annotation) ->
+                                    configurer.configureForMethod(config, annotation, sqlObjectType, method);
+                            // build a configurer that processes all annotations on the method itself.
+                            return buildConfigurers(Stream.of(method), forMethod);
+                        }));
+
+        return new SqlObjectInitData(
+                sqlObjectType,
+                instanceConfigurer,
+                methodConfigurers,
+                methodHandlers);
+    }
+
+    private static Map<Method, Handler> buildMethodHandlers(
+            ConfigRegistry config,
+            Class<?> sqlObjectType) {
+
+        final Handlers handlers = config.get(Handlers.class);
+        final HandlerDecorators handlerDecorators = config.get(HandlerDecorators.class);
+        final Map<Method, Handler> handlerMap = new HashMap<>();
+
+        // tostring can not be constant, different for every object
+        Handler toStringHandler = (target, args, handleSupplier) ->
+                "Jdbi sqlobject proxy for " + sqlObjectType.getName() + "@" + Integer.toHexString(target.hashCode());
+
+        addMethodHandler(handlerMap, toStringHandler, Object.class, "toString");
+        addMethodHandler(handlerMap, EQUALS_HANDLER, Object.class, "equals", Object.class);
+        addMethodHandler(handlerMap, HASHCODE_HANDLER, Object.class, "hashCode");
+
+        // SQL Object methods
+        addMethodHandler(handlerMap, GET_HANDLE_HANDLER, SqlObject.class, "getHandle");
+
+        addMethodHandler(handlerMap, NULL_HANDLER, sqlObjectType, "finalize");
+
+        final Set<Method> methods = new LinkedHashSet<>();
+        methods.addAll(Arrays.asList(sqlObjectType.getMethods()));
+        methods.addAll(Arrays.asList(sqlObjectType.getDeclaredMethods()));
+
+        final Set<Method> seen = new HashSet<>(handlerMap.keySet());
+        for (Method method : methods) {
+            if (Modifier.isStatic(method.getModifiers()) || !seen.add(method)) {
+                continue;
+            }
+            handlerMap.put(method, handlerDecorators.applyDecorators(
+                        handlers.findFor(sqlObjectType, method)
+                            .orElseGet(() -> {
+                                Supplier<IllegalStateException> x = () -> new IllegalStateException(String.format(
+                                        "Method %s.%s must have an implementation or be annotated with a SQL method annotation.",
+                                        method.getDeclaringClass().getSimpleName(),
+                                        method.getName()));
+                                if (!SqlObjectInitData.isConcrete(sqlObjectType) && !method.isSynthetic() && !Modifier.isPrivate(method.getModifiers())) {
+                                    throw x.get();
+                                }
+                                return (target, args, handleSupplier) -> {
+                                    throw x.get();
+                                };
+                            }),
+                        sqlObjectType,
+                        method));
+        }
+
+        methods.stream()
+            .filter(m -> !m.isSynthetic())
+            .collect(Collectors.groupingBy(m -> Arrays.asList(m.getName(), Arrays.asList(m.getParameterTypes()))))
+            .values()
+            .stream()
+            .filter(l -> l.size() > 1)
+            .findAny()
+            .ifPresent(ms -> {
+                throw new UnableToCreateSqlObjectException(sqlObjectType + " has ambiguous methods " + ms + ", please resolve with an explicit override");
+            });
+
+        return handlerMap;
+    }
+
+    private static void addMethodHandler(Map<Method, Handler> handlerMap, Handler handler, Class<?> klass, String methodName, Class<?>... parameterTypes) {
+        JdbiClassUtils.safeMethodLookup(klass, methodName, parameterTypes)
+                .ifPresent(method -> handlerMap.put(method, handler));
+    }
+
+    private static UnaryOperator<ConfigRegistry> buildConfigurers(Stream<AnnotatedElement> elements, ConfigurerMethod consumer) {
+        List<Consumer<ConfigRegistry>> myConfigurers = elements
+                .flatMap(ae -> Arrays.stream(ae.getAnnotations()))
+                .filter(a -> a.annotationType().isAnnotationPresent(ConfiguringAnnotation.class))
+                .map(a -> {
+                    ConfiguringAnnotation meta = a.annotationType().getAnnotation(ConfiguringAnnotation.class);
+                    Configurer configurer = JdbiClassUtils.createInstance(meta.value());
+                    return (Consumer<ConfigRegistry>) config -> consumer.configure(configurer, config, a);
+                })
+                .collect(Collectors.toList());
+        return config -> {
+            myConfigurers.forEach(configurer -> configurer.accept(config));
+            return config;
+        };
+    }
+
+    private interface ConfigurerMethod {
+        void configure(Configurer configurer, ConfigRegistry config, Annotation annotation);
     }
 
     public final class InContextInvoker {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/CustomizingStatementHandler.java
@@ -19,7 +19,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -31,6 +30,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.generic.GenericTypes;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.result.RowReducer;
 import org.jdbi.v3.core.statement.SqlStatement;
@@ -61,7 +61,7 @@ abstract class CustomizingStatementHandler<StatementType extends SqlStatement<St
         this.method = method;
 
         // Include annotations on the interface's supertypes
-        final Stream<BoundCustomizer> typeCustomizers = concat(superTypes(type), Stream.of(type))
+        final Stream<BoundCustomizer> typeCustomizers = concat(JdbiClassUtils.superTypes(type), Stream.of(type))
             .flatMap(CustomizingStatementHandler::annotationsFor)
             .map(a -> instantiateFactory(a).createForType(a, type))
             .map(BoundCustomizer::of);
@@ -78,14 +78,6 @@ abstract class CustomizingStatementHandler<StatementType extends SqlStatement<St
     @Override
     public void warm(ConfigRegistry config) {
         statementCustomizers.forEach(s -> s.warm(config));
-    }
-
-    // duplicate implementation in SqlObjectFactory
-    private static Stream<Class<?>> superTypes(Class<?> type) {
-        Class<?>[] interfaces = type.getInterfaces();
-        return concat(
-            Arrays.stream(interfaces).flatMap(CustomizingStatementHandler::superTypes),
-            Arrays.stream(interfaces));
     }
 
     private static Stream<Annotation> annotationsFor(AnnotatedElement... elements) {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectFactory.java
@@ -17,7 +17,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestSqlObjectFactory {
     private SqlObjectFactory factory = new SqlObjectFactory();
@@ -26,8 +25,7 @@ public class TestSqlObjectFactory {
     public void accepts() {
         assertThat(factory.accepts(NotASqlObject.class)).isFalse();
 
-        assertThatThrownBy(() -> factory.accepts(SqlObjectClass.class))
-                .hasMessageContaining("only supported for interfaces");
+        assertThat(factory.accepts(SqlObjectClass.class)).isFalse();
 
         assertThat(factory.accepts(HasAnnotatedMethod.class)).isTrue();
         assertThat(factory.accepts(ExtendsSqlObject.class)).isTrue();


### PR DESCRIPTION
- factor all the Generator specific code into GeneratorSqlObjectFactory, a new ExtensionFactory that deals specifically with the generated classes.
- strip all code that is not specific to the SqlObject Proxy extensions out of SqlObjectFactory
- register both factories in SqlObjectModule, so no user visible changes
- remove the specific code for generated classes (initData and lookupMethod) out of the SqlObjectInitData, this is now in the generator factory. Leave deprecated stubs in place for old, non-compiled classes. Those stubs will go away
- move the threadlocal that holds the init data into the generator factory
- move all init code for SqlObjectInitData into the class itself
- move duplicate superTypes code also into JdbiClassUtils

Even if the work stops here, this is a big improvement to make the SqlObject code actually understandable. The code is not that complicated, it was just split in very complicated ways and hard to follow. The PR splits it into three major pieces:

- everything that deals with the Proxy SqlObjects
- everything that deals with the generated SqlObjects
- everything that initializes the SqlObjectInitData object and its cache

When this is done, it should be possible to address the whole `invokeInContext` stuff on the HandleSupplier, the plan is to move this out of the handle supplier and into a wrapper around the method invocations itself, which would then allow things like annotations on default methods. Still a work in progress.