### PR TITLE
Factor out common code in HandleSupplier

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/AbstractHandleSupplier.java
+++ b/core/src/main/java/org/jdbi/v3/core/AbstractHandleSupplier.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import org.jdbi.v3.core.extension.ExtensionContext;
+import org.jdbi.v3.core.extension.HandleSupplier;
+
+abstract class AbstractHandleSupplier implements HandleSupplier {
+
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final Deque<ExtensionContext> extensionContexts = new LinkedList<>();
+
+    protected AbstractHandleSupplier() {}
+
+    @Override
+    public <V> V invokeInContext(ExtensionContext extensionContext, Callable<V> task) throws Exception {
+        try {
+            pushExtensionContext(extensionContext);
+            return task.call();
+        } finally {
+            popExtensionContext();
+        }
+    }
+
+    /** Returns the current extension context or null if none exists. */
+    protected ExtensionContext currentExtensionContext() {
+        return extensionContexts.peek();
+    }
+
+    protected abstract void withHandle(Consumer<Handle> handleConsumer);
+
+    @Override
+    public void close() {
+        if (closed.getAndSet(true)) {
+            throw new IllegalStateException("Handle is closed");
+        }
+        extensionContexts.clear();
+    }
+
+    private void pushExtensionContext(ExtensionContext extensionContext) {
+        extensionContexts.addFirst(extensionContext);
+        withHandle(handle -> handle.acceptExtensionContext(extensionContext));
+    }
+
+    private void popExtensionContext() {
+        // pop the current context
+        extensionContexts.pollFirst();
+        // set to the previous context (or the default if no previous context exists)
+        withHandle(h -> h.acceptExtensionContext(currentExtensionContext()));
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/HandleSupplier.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/HandleSupplier.java
@@ -18,61 +18,45 @@ import java.util.concurrent.Callable;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.config.Configurable;
 
 /**
  * A handle supplier for extension implementors.
  */
-public interface HandleSupplier extends Configurable<HandleSupplier>, AutoCloseable {
+public interface HandleSupplier extends AutoCloseable {
+
     /**
      * Returns a handle, possibly creating it lazily. A Handle holds a database connection, so extensions should only
      * call this method in order to interact with the database.
      *
-     * @return an open Handle
+     * @return An open Handle.
      */
     Handle getHandle();
 
     /**
      * Returns the owning Jdbi instance.
      *
-     * @return the owning Jdbi instance.
+     * @return The owning Jdbi instance.
      */
     Jdbi getJdbi();
 
     /**
-     * Bind an extension method and configuration registry to the Handle,
-     * invoke the given task, then reset the Handle's extension state.
+     * Returns the current Jdbi config.
      *
-     * Note that the binding is done by a thread local, so the binding
-     * will not propagate to other threads you may call out to.
-     *
-     * @param <V> the result type of the task
-     * @param extensionMethod the method invoked
-     * @param config the configuration registry
-     * @param task the code to execute in an extension context
-     * @return the callable's result
-     * @throws Exception if any exception is thrown
-     * @deprecated New code should implement the {@link #invokeInContext(ExtensionContext, Callable)} method and use this as a retrofit.
-     * @see HandleSupplier#invokeInContext(ExtensionContext, Callable)
+     * @return The current Jdbi configuration.
      */
-    @Deprecated
-    <V> V invokeInContext(ExtensionMethod extensionMethod, ConfigRegistry config, Callable<V> task) throws Exception;
+    ConfigRegistry getConfig();
 
     /**
      * Bind a new {@link ExtensionContext} to the Handle, invoke the given task, then restore the Handle's extension state.
      *
-     * @param <V> the result type of the task
+     * @param <V>              the result type of the task
      * @param extensionContext An {@link ExtensionContext} object that manages the extension state.
-     * @param task the code to execute in an extension context
+     * @param task             the code to execute in an extension context
      * @return the callable's result
      * @throws Exception if any exception is thrown
      */
-    default <V> V invokeInContext(ExtensionContext extensionContext, Callable<V> task) throws Exception {
-        return invokeInContext(extensionContext.getExtensionMethod(), extensionContext.getConfig(), task);
-    }
+    <V> V invokeInContext(ExtensionContext extensionContext, Callable<V> task) throws Exception;
 
     @Override
-    default void close() {
-        // does nothing.
-    }
+    default void close() {}
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/CreateSqlObjectHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/CreateSqlObjectHandler.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.sqlobject.internal;
 
 import java.lang.reflect.Method;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.Extensions;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.internal.OnDemandExtensions;
@@ -32,10 +33,12 @@ public class CreateSqlObjectHandler implements Handler {
 
     @Override
     public Object invoke(Object target, Object[] args, HandleSupplier handleSupplier) throws Exception {
+        ConfigRegistry config = handleSupplier.getConfig();
+
         if (handleSupplier instanceof OnDemandHandleSupplier) {
-            return handleSupplier.getConfig(OnDemandExtensions.class).create(handleSupplier.getJdbi(), method.getReturnType(), SqlObject.class);
+            return config.get(OnDemandExtensions.class).create(handleSupplier.getJdbi(), method.getReturnType(), SqlObject.class);
         }
-        return handleSupplier.getConfig(Extensions.class)
+        return config.get(Extensions.class)
                 .findFactory(SqlObjectFactory.class)
                 .orElseThrow(() -> new IllegalStateException("Can't locate SqlObject factory"))
                 .attach(method.getReturnType(), handleSupplier);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectMethodBehavior.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlObjectMethodBehavior.java
@@ -19,7 +19,7 @@ import java.util.concurrent.Callable;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.extension.ExtensionMethod;
+import org.jdbi.v3.core.extension.ExtensionContext;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +50,7 @@ public class TestSqlObjectMethodBehavior {
             }
 
             @Override
-            public <V> V invokeInContext(ExtensionMethod extensionMethod, ConfigRegistry config, Callable<V> task) throws Exception {
+            public <V> V invokeInContext(ExtensionContext extensionContext, Callable<V> task) throws Exception {
                 return task.call();
             }
         };


### PR DESCRIPTION
Starting to reduce the code sprawl around HandleSupplier. Remove the convoluted back and forth between the invokeInContext methods that no user can actually get right and the only implementations are in Jdbi anyway.