### PR TITLE
Clean up extension context and invoker

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionContext.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.core.extension;
 
+import java.lang.reflect.Method;
+
 import org.jdbi.v3.core.config.ConfigRegistry;
 
 /**
@@ -23,8 +25,17 @@ public final class ExtensionContext {
     private final ConfigRegistry config;
     private final ExtensionMethod extensionMethod;
 
+    /**
+     * Create an extension context for a configuration only. No extension method information is set.
+     * @param config A {@link ConfigRegistry} object.
+     * @return An ExtensionContext.
+     */
     public static ExtensionContext forConfig(ConfigRegistry config) {
         return new ExtensionContext(config, null);
+    }
+
+    public static ExtensionContext forExtensionMethod(ConfigRegistry config, Class<?> type, Method method) {
+        return new ExtensionContext(config, new ExtensionMethod(type, method));
     }
 
     public ExtensionContext(ConfigRegistry config, ExtensionMethod extensionMethod) {

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/WithHandleMethodHandlerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/WithHandleMethodHandlerFactory.java
@@ -17,10 +17,9 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.jdbi.v3.core.HandleCallback;
-import org.jdbi.v3.core.extension.ExtensionContext;
-import org.jdbi.v3.core.extension.ExtensionMethod;
 
 class WithHandleMethodHandlerFactory implements HandlerFactory {
+
     private static final Method WITH_HANDLE = Handlers.methodLookup(SqlObject.class, "withHandle", HandleCallback.class);
 
     @SuppressWarnings("unchecked")
@@ -29,11 +28,9 @@ class WithHandleMethodHandlerFactory implements HandlerFactory {
         if (!WITH_HANDLE.equals(method)) {
             return Optional.empty();
         }
-        ExtensionMethod extensionMethod = new ExtensionMethod(sqlObjectType, method);
-        return Optional.of((target, args, handleSupplier) -> {
-            ExtensionContext extensionContext = new ExtensionContext(handleSupplier.getConfig(), extensionMethod);
-            return handleSupplier.invokeInContext(extensionContext,
-                () -> ((HandleCallback<?, RuntimeException>) args[0]).withHandle(handleSupplier.getHandle()));
+        return Optional.of((target, arguments, handleSupplier) -> {
+            HandleCallback<?, RuntimeException> handleCallback = (HandleCallback<?, RuntimeException>) arguments[0];
+            return handleCallback.withHandle(handleSupplier.getHandle());
         });
     }
 }


### PR DESCRIPTION
- Simplify code, make more readable.

- Remove anonymous implementation of InContextInvoker, use a concrete class.