### PR TITLE
Add Maven profile for revapi API compatibility checks

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -31,6 +31,7 @@
         <basepom.check.skip-pmd>true</basepom.check.skip-pmd>
         <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
         <basepom.deploy.skip>true</basepom.deploy.skip>
+        <jdbi.check.skip-revapi>true</jdbi.check.skip-revapi>
         <dep.jmh.version>1.36</dep.jmh.version>
         <moduleName>org.jdbi.v3.benchmark</moduleName>
         <uberjar.name>benchmarks</uberjar.name>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -41,6 +41,7 @@
         <basepom.site.scm.site-path>/</basepom.site.scm.site-path>
         <basepom.site.scm.skip-deploy>false</basepom.site.scm.skip-deploy>
         <basepom.site.scm.url>scm:git:https://github.com/jdbi/jdbi.github.io</basepom.site.scm.url>
+        <jdbi.check.skip-revapi>true</jdbi.check.skip-revapi>
         <moduleName>org.jdbi.v3.docs</moduleName>
     </properties>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -28,6 +28,7 @@
     <description>Jdbi code examples.</description>
 
     <properties>
+        <jdbi.check.skip-revapi>true</jdbi.check.skip-revapi>
         <moduleName>org.jdbi.v3.examples</moduleName>
     </properties>
 

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -79,6 +79,32 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.revapi</groupId>
+                    <artifactId>revapi-maven-plugin</artifactId>
+                    <configuration>
+                        <analysisConfiguration>
+                            <revapi.filter>
+                                <elements>
+                                    <exclude>
+                                        <item>
+                                            <matcher>java-package</matcher>
+                                            <match>/freemarker\\..*/</match>
+                                        </item>
+                                    </exclude>
+                                </elements>
+                            </revapi.filter>
+
+                        </analysisConfiguration>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
     <profiles>
         <profile>
             <id>jdk8</id>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -107,6 +107,8 @@
         <dep.plugin.inline.version>1.1.0</dep.plugin.inline.version>
         <dep.plugin.kotlin.version>1.8.21</dep.plugin.kotlin.version>
         <dep.plugin.ktlint.version>1.16.0</dep.plugin.ktlint.version>
+        <dep.plugin.revapi.version>0.15.0</dep.plugin.revapi.version>
+        <dep.plugin.revapi-java.version>0.28.0</dep.plugin.revapi-java.version>
         <dep.plugin.sortpom.version>3.2.1</dep.plugin.sortpom.version>
         <dep.postgresql.version>42.6.0</dep.postgresql.version>
         <dep.slf4j.version>1.7.36</dep.slf4j.version>
@@ -775,6 +777,52 @@
                     </dependencies>
                 </plugin>
                 <plugin>
+                    <groupId>org.revapi</groupId>
+                    <artifactId>revapi-maven-plugin</artifactId>
+                    <version>${dep.plugin.revapi.version}</version>
+                    <configuration>
+                        <skip>${jdbi.check.skip-revapi}</skip>
+                        <failBuildOnProblemsFound>${jdbi.check.fail-revapi}</failBuildOnProblemsFound>
+                        <failSeverity>breaking</failSeverity>
+                        <checkDependencies>false</checkDependencies>
+                        <ignoreSuggestionsFormat>xml</ignoreSuggestionsFormat>
+                        <analysisConfiguration>
+                            <revapi.versions>
+                                <enabled>true</enabled>
+                            </revapi.versions>
+                            <revapi.differences>
+                                <classify>
+                                    <SOURCE>EQUIVALENT</SOURCE>
+                                    <SEMANTIC>EQUIVALENT</SEMANTIC>
+                                    <OTHER>EQUIVALENT</OTHER>
+                                </classify>
+                            </revapi.differences>
+                            <revapi.filter>
+                                <elements>
+                                    <exclude>
+                                        <item>
+                                            <matcher>java-package</matcher>
+                                            <match>/.*\\..(?:impl|internal)\\..*</match>
+                                        </item>
+                                    </exclude>
+                                </elements>
+                            </revapi.filter>
+                            <revapi.java>
+                                <missing-classes>
+                                    <behavior>ignore</behavior>
+                                </missing-classes>
+                            </revapi.java>
+                        </analysisConfiguration>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.revapi</groupId>
+                            <artifactId>revapi-java</artifactId>
+                            <version>${dep.plugin.revapi-java.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
                     <version>${dep.plugin.flatten.version}</version>
@@ -1147,5 +1195,50 @@
                 <jdbi.test.pg-version>15</jdbi.test.pg-version>
             </properties>
         </profile>
+
+        <!-- Profiles for Revapi API analysis (https://revapi.org/) -->
+        <profile>
+            <id>revapi</id>
+            <properties>
+                <jdbi.check.fail-revapi>true</jdbi.check.fail-revapi>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.revapi</groupId>
+                        <artifactId>revapi-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!-- Binds by default to the lifecycle phase verify -->
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>revapi-report</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.revapi</groupId>
+                        <artifactId>revapi-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 </project>

--- a/java17/pom.xml
+++ b/java17/pom.xml
@@ -30,6 +30,7 @@
     <properties>
         <basepom.deploy.skip>true</basepom.deploy.skip>
         <basepom.install.skip>true</basepom.install.skip>
+        <jdbi.check.skip-revapi>true</jdbi.check.skip-revapi>
         <moduleName>org.jdbi.v3.java17</moduleName>
         <project.build.targetJdk>17</project.build.targetJdk>
     </properties>

--- a/lombok/pom.xml
+++ b/lombok/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <basepom.deploy.skip>true</basepom.deploy.skip>
         <basepom.install.skip>true</basepom.install.skip>
+        <jdbi.check.skip-revapi>true</jdbi.check.skip-revapi>
         <moduleName>org.jdbi.v3.lombok</moduleName>
     </properties>
 

--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -33,6 +33,7 @@
 
         <basepom.deploy.skip>true</basepom.deploy.skip>
         <basepom.install.skip>true</basepom.install.skip>
+        <jdbi.check.skip-revapi>true</jdbi.check.skip-revapi>
         <moduleName>org.jdbi.v3.noparameters</moduleName>
     </properties>
 

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -34,6 +34,7 @@
         <basepom.test.skip>true</basepom.test.skip>
         <!-- docker tests run long -->
         <basepom.test.timeout>600</basepom.test.timeout>
+        <jdbi.check.skip-revapi>true</jdbi.check.skip-revapi>
         <!-- Sigh. Java is really hard. Leave this at 0.3.2, all other versions are worse -->
         <dep.clickhouse.version>0.3.2</dep.clickhouse.version>
         <dep.mysql.version>8.0.33</dep.mysql.version>


### PR DESCRIPTION
Revapi and revapi-maven-plugin can be found here: https://revapi.org/

- Main revapi configuration and versions defined in `jdbi3-build-parent`
- Maven profile 'revapi' defined in `jdbi3-build-parent`, goal `revapi:check`
- Maven profile 'revapi-report' defined in jdbi3-build-parent, goal revapi:report
- Modules not to be checked may set property `jdbi.check.skip-revapi=true` (e.g. modules for internal or testing use)
- Modules for which violations should not fail the build should set property `jdbi.check.fail-revapi=false`

Revapi compares the project to the most recent release (e.g. 3.37.1-SNAPSHOT to 3.37.0) looking for violations of semantic versioning rules. The ruleset can be relaxed by configuration.

Violations found by revapi can be explicitly ignored.
I've done this in modules `core` and `freemarker` by example (they would have otherwise failed, would revert this of course before merging into master). **Update:** Configuration now rolled back

To other failing modules I've added `jdbi.check.fail-revapi=false`.  **Update:** Configuration now rolled back

To see the problems look for 'revapi' in the build output, in particular for string 'API problems found' and onwards (examples below).

## Maven command line
`mvn clean install -P revapi,fast -D no-docker`

This takes a little over 2 minutes on my lame Ubuntu laptop as opposed to 1:20 min without revapi. So it does add overhead but less than one would expect.

## Maven command line to create and view revapi reports
```
mvn clean install -P revapi-report,fast -D no-docker
find . -name revapi-report.html -exec firefox {} \;
```

## Build output / no compatibility problems
```
[INFO] --- revapi-maven-plugin:0.15.0:check (default) @ jdbi3-core ---
Downloading from nexus: http://nexus-swe.baag:8081/nexus/content/groups/public/org/jdbi/jdbi3-core/maven-metadata.xml
Downloaded from nexus: http://nexus-swe.baag:8081/nexus/content/groups/public/org/jdbi/jdbi3-core/maven-metadata.xml (3.0 kB at 5.7 kB/s)
[INFO] Comparing [org.jdbi:jdbi3-core:jar:3.37.0] against [org.jdbi:jdbi3-core:jar:3.37.1-SNAPSHOT] (including their transitive dependencies).
[INFO] API checks completed without failures.
```

## Build output / with compatibility problems

```
[INFO] --- revapi-maven-plugin:0.15.0:check (default) @ jdbi3-jpa ---
Downloading from nexus: http://nexus-swe.baag:8081/nexus/content/groups/public/org/jdbi/jdbi3-jpa/maven-metadata.xml
Downloaded from nexus: http://nexus-swe.baag:8081/nexus/content/groups/public/org/jdbi/jdbi3-jpa/maven-metadata.xml (3.6 kB at 10 kB/s)
[INFO] Comparing [org.jdbi:jdbi3-jpa:jar:3.37.0] against [org.jdbi:jdbi3-jpa:jar:3.37.1-SNAPSHOT] (including their transitive dependencies).
[INFO] API problems found.
[INFO] If you're using the semver-ignore extension, update your module's version to one compatible with the current changes (e.g. mvn package revapi:update-versions). If you want to explicitly ignore these changes or provide justifications for them, add the xml snippets to your Revapi configuration for the "revapi.differences" extension.

```