### PR TITLE
executor wrapper to use jdbi in async services

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/async/AbstractJdbiExecutor.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/AbstractJdbiExecutor.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.async;
+
+import java.util.concurrent.CompletionStage;
+
+import org.jdbi.v3.core.HandleCallback;
+import org.jdbi.v3.core.HandleConsumer;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.extension.ExtensionCallback;
+import org.jdbi.v3.core.extension.ExtensionConsumer;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
+
+public abstract class AbstractJdbiExecutor implements JdbiExecutor {
+
+    /**
+     * Single method through which all other methods converge. If you want to override JdbiExecutorImpl, you only need to override this one method.
+     *
+     * @param handler the handler that takes a Jdbi instance and returns a value
+     * @param <R>     type returned by the callback
+     * @param <X>     exception type thrown by the callback, if any.
+     * @return a completion stage that will complete when the handler returns or throws an exception
+     */
+    protected abstract <R, X extends Exception> CompletionStage<R> doExecute(Handler<R, X> handler);
+
+    @Override
+    public <R, X extends Exception> CompletionStage<R> withHandle(final HandleCallback<R, X> callback) {
+        return doExecute(jdbi -> jdbi.withHandle(callback));
+    }
+
+    @Override
+    public <R, X extends Exception> CompletionStage<R> inTransaction(final HandleCallback<R, X> callback) {
+        return doExecute(jdbi -> jdbi.inTransaction(callback));
+    }
+
+    @Override
+    public <R, X extends Exception> CompletionStage<R> inTransaction(final TransactionIsolationLevel level, final HandleCallback<R, X> callback) {
+        return doExecute(jdbi -> jdbi.inTransaction(level, callback));
+    }
+
+    @Override
+    public <X extends Exception> CompletionStage<Void> useHandle(final HandleConsumer<X> consumer) {
+        return doExecute(jdbi -> {
+            jdbi.useHandle(consumer);
+            return null;
+        });
+    }
+
+    @Override
+    public <X extends Exception> CompletionStage<Void> useTransaction(final HandleConsumer<X> callback) {
+        return doExecute(jdbi -> {
+            jdbi.useTransaction(callback);
+            return null;
+        });
+    }
+
+    @Override
+    public <X extends Exception> CompletionStage<Void> useTransaction(final TransactionIsolationLevel level, final HandleConsumer<X> callback) {
+        return doExecute(jdbi -> {
+            jdbi.useTransaction(level, callback);
+            return null;
+        });
+    }
+
+    @Override
+    public <R, E, X extends Exception> CompletionStage<R> withExtension(final Class<E> extensionType, final ExtensionCallback<R, E, X> callback) {
+        return doExecute(jdbi -> jdbi.withExtension(extensionType, callback));
+    }
+
+    @Override
+    public <E, X extends Exception> CompletionStage<Void> useExtension(final Class<E> extensionType, final ExtensionConsumer<E, X> callback) {
+        return doExecute(jdbi -> {
+            jdbi.useExtension(extensionType, callback);
+            return null;
+        });
+    }
+
+    protected interface Handler<R, X extends Exception> {
+
+        R apply(Jdbi jdbi) throws X;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/async/AbstractJdbiExecutor.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/AbstractJdbiExecutor.java
@@ -25,7 +25,7 @@ import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 public abstract class AbstractJdbiExecutor implements JdbiExecutor {
 
     /**
-     * Single method through which all other methods converge. If you want to override JdbiExecutorImpl, you only need to override this one method.
+     * Single method through which all other methods converge. If you want to override AbstractJdbiExecutor, you only need to override this one method.
      *
      * @param handler the handler that takes a Jdbi instance and returns a value
      * @param <R>     type returned by the callback

--- a/core/src/main/java/org/jdbi/v3/core/async/AbstractJdbiExecutor.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/AbstractJdbiExecutor.java
@@ -23,7 +23,9 @@ import org.jdbi.v3.core.extension.ExtensionConsumer;
 import org.jdbi.v3.core.internal.exceptions.CheckedConsumer;
 import org.jdbi.v3.core.internal.exceptions.CheckedFunction;
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
+import org.jdbi.v3.meta.Beta;
 
+@Beta
 public abstract class AbstractJdbiExecutor implements JdbiExecutor {
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutor.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutor.java
@@ -23,7 +23,9 @@ import org.jdbi.v3.core.extension.ExtensionCallback;
 import org.jdbi.v3.core.extension.ExtensionConsumer;
 import org.jdbi.v3.core.extension.ExtensionFactory;
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
+import org.jdbi.v3.meta.Beta;
 
+@Beta
 public interface JdbiExecutor {
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutor.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutor.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.async;
+
+import java.util.concurrent.CompletionStage;
+
+import org.jdbi.v3.core.HandleCallback;
+import org.jdbi.v3.core.HandleConsumer;
+import org.jdbi.v3.core.extension.ExtensionCallback;
+import org.jdbi.v3.core.extension.ExtensionConsumer;
+import org.jdbi.v3.core.extension.ExtensionFactory;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
+
+public interface JdbiExecutor {
+
+    /**
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback
+     * for use by clients.
+     *
+     * <p>
+     * The callback will be executed in a separate thread
+     * </p>
+     *
+     * @param callback A callback which will receive an open Handle
+     * @param <R> type returned by the callback
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @return a completion stage which completes when the callback returns a value or throws an exception
+     */
+    <R, X extends Exception> CompletionStage<R> withHandle(HandleCallback<R, X> callback);
+
+    /**
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback
+     * for use by clients. The handle will be in a transaction when the callback is invoked, and
+     * that transaction will be committed if the callback finishes normally, or rolled back if the
+     * callback raises an exception.
+     *
+     * <p>
+     * The callback will be executed in a separate thread
+     * </p>
+     *
+     * @param callback A callback which will receive an open Handle, in a transaction
+     * @param <R> type returned by the callback
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @return a completion stage which completes when the callback returns a value or throws an exception
+     */
+    <R, X extends Exception> CompletionStage<R> inTransaction(HandleCallback<R, X> callback);
+
+    /**
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback
+     * for use by clients. The handle will be in a transaction when the callback is invoked, and
+     * that transaction will be committed if the callback finishes normally, or rolled back if the
+     * callback raises an exception.
+     *
+     * <p>
+     * This form accepts a transaction isolation level which will be applied to the connection
+     * for the scope of this transaction, after which the original isolation level will be restored.
+     * </p>
+     *
+     * <p>
+     * The callback will be executed in a separate thread
+     * </p>
+     *
+     * @param level the transaction isolation level which will be applied to the connection for the scope of this
+     *              transaction, after which the original isolation level will be restored.
+     * @param callback A callback which will receive an open Handle, in a transaction
+     * @param <R> type returned by the callback
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @return a completion stage which completes when the callback returns a value or throws an exception
+     */
+    <R, X extends Exception> CompletionStage<R> inTransaction(TransactionIsolationLevel level, HandleCallback<R, X> callback);
+
+    /**
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback
+     * for use by clients.
+     *
+     * <p>
+     * The callback will be executed in a separate thread
+     * </p>
+     *
+     * @param consumer A callback which will receive an open Handle
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @return a completion stage which completes when the callback returns or throws an exception
+     */
+    <X extends Exception> CompletionStage<Void> useHandle(HandleConsumer<X> consumer);
+
+    /**
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback
+     * for use by clients. The handle will be in a transaction when the callback is invoked, and
+     * that transaction will be committed if the callback finishes normally, or rolled back if the
+     * callback raises an exception.
+     *
+     * <p>
+     * The callback will be executed in a separate thread
+     * </p>
+     *
+     * @param callback A callback which will receive an open Handle, in a transaction
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @return a completion stage which completes when the callback returns or throws an exception
+     */
+    <X extends Exception> CompletionStage<Void> useTransaction(HandleConsumer<X> callback);
+
+    /**
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback
+     * for use by clients. The handle will be in a transaction when the callback is invoked, and
+     * that transaction will be committed if the callback finishes normally, or rolled back if the
+     * callback raises an exception.
+     *
+     * <p>
+     * This form accepts a transaction isolation level which will be applied to the connection
+     * for the scope of this transaction, after which the original isolation level will be restored.
+     * </p>
+     *
+     * <p>
+     * The callback will be executed in a separate thread
+     * </p>
+     *
+     * @param level the transaction isolation level which will be applied to the connection for the scope of this
+     *              transaction, after which the original isolation level will be restored.
+     * @param callback A callback which will receive an open Handle, in a transaction
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @return a completion stage which completes when the callback returns or throws an exception
+     */
+    <X extends Exception> CompletionStage<Void> useTransaction(TransactionIsolationLevel level, HandleConsumer<X> callback);
+
+    /**
+     * A convenience method which opens an extension of the given type, yields it to a callback, and returns the result
+     * of the callback. A handle is opened if needed by the extension, and closed before returning to the caller.
+     *
+     * <p>
+     * The callback will be executed in a separate thread
+     * </p>
+     *
+     * @param extensionType the type of extension.
+     * @param callback      a callback which will receive the extension.
+     * @param <R> the return type
+     * @param <E> the extension type
+     * @param <X> the exception type optionally thrown by the callback
+     * @return a completion stage which completes when the callback returns a value
+     * or throws an exception, or will complete with NoSuchExtensionException if no
+     * {@link ExtensionFactory} is registered which supports the given extension type.
+     */
+    <R, E, X extends Exception> CompletionStage<R> withExtension(Class<E> extensionType, ExtensionCallback<R, E, X> callback);
+
+    /**
+     * A convenience method which opens an extension of the given type, and yields it to a callback. A handle is opened
+     * if needed by the extention, and closed before returning to the caller.
+     *
+     * <p>
+     * The callback will be executed in a separate thread
+     * </p>
+     *
+     * @param extensionType the type of extension
+     * @param callback      a callback which will receive the extension
+     * @param <E>           the extension type
+     * @param <X>           the exception type optionally thrown by the callback
+     * @return a completion stage which completes when the callback returns
+     * or throws an exception, or will complete with NoSuchExtensionException if no
+     * {@link ExtensionFactory} is registered which supports the given extension type.
+     */
+    <E, X extends Exception> CompletionStage<Void> useExtension(Class<E> extensionType, ExtensionConsumer<E, X> callback);
+}

--- a/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutor.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutor.java
@@ -14,9 +14,11 @@
 package org.jdbi.v3.core.async;
 
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 
 import org.jdbi.v3.core.HandleCallback;
 import org.jdbi.v3.core.HandleConsumer;
+import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.extension.ExtensionCallback;
 import org.jdbi.v3.core.extension.ExtensionConsumer;
 import org.jdbi.v3.core.extension.ExtensionFactory;
@@ -25,153 +27,152 @@ import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 public interface JdbiExecutor {
 
     /**
-     * A convenience function which manages the lifecycle of a handle and yields it to a callback
-     * for use by clients.
+     * Create a {@link JdbiExecutor}.
      *
      * <p>
-     * The callback will be executed in a separate thread
+     * The executor to pass in needs to be sized to the use case. A rule of thumb is to have the max number of workers be equal to the max number of connections
+     * in the connection pool. The worker queue in the executor should probably be bounded, unless the caller(s) already has a bound for the number of
+     * outstanding requests. Making the queue bounded will mean you are blocking the calling thread when the queue fills up. Whether or not that is acceptable
+     * depends on if and how your service limits incoming requests
+     * </p>
+     *
+     * @param jdbi     the initialized Jdbi class
+     * @param executor an executor to use for all database calls
+     */
+    static JdbiExecutor create(Jdbi jdbi, Executor executor) {
+        return new JdbiExecutorImpl(jdbi, executor);
+    }
+
+    /**
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback for use by clients.
+     *
+     * <p>
+     * The callback will be executed in a thread supplied by the executor
      * </p>
      *
      * @param callback A callback which will receive an open Handle
-     * @param <R> type returned by the callback
-     * @param <X> exception type thrown by the callback, if any.
-     *
+     * @param <R>      type returned by the callback
+     * @param <X>      exception type thrown by the callback, if any.
      * @return a completion stage which completes when the callback returns a value or throws an exception
      */
     <R, X extends Exception> CompletionStage<R> withHandle(HandleCallback<R, X> callback);
 
     /**
-     * A convenience function which manages the lifecycle of a handle and yields it to a callback
-     * for use by clients. The handle will be in a transaction when the callback is invoked, and
-     * that transaction will be committed if the callback finishes normally, or rolled back if the
-     * callback raises an exception.
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback for use by clients. The handle will be in a transaction when
+     * the callback is invoked, and that transaction will be committed if the callback finishes normally, or rolled back if the callback raises an exception.
      *
      * <p>
-     * The callback will be executed in a separate thread
+     * The callback will be executed in a thread supplied by the executor
      * </p>
      *
      * @param callback A callback which will receive an open Handle, in a transaction
-     * @param <R> type returned by the callback
-     * @param <X> exception type thrown by the callback, if any.
-     *
+     * @param <R>      type returned by the callback
+     * @param <X>      exception type thrown by the callback, if any.
      * @return a completion stage which completes when the callback returns a value or throws an exception
      */
     <R, X extends Exception> CompletionStage<R> inTransaction(HandleCallback<R, X> callback);
 
     /**
-     * A convenience function which manages the lifecycle of a handle and yields it to a callback
-     * for use by clients. The handle will be in a transaction when the callback is invoked, and
-     * that transaction will be committed if the callback finishes normally, or rolled back if the
-     * callback raises an exception.
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback for use by clients. The handle will be in a transaction when
+     * the callback is invoked, and that transaction will be committed if the callback finishes normally, or rolled back if the callback raises an exception.
      *
      * <p>
-     * This form accepts a transaction isolation level which will be applied to the connection
-     * for the scope of this transaction, after which the original isolation level will be restored.
+     * This form accepts a transaction isolation level which will be applied to the connection for the scope of this transaction, after which the original
+     * isolation level will be restored.
      * </p>
      *
      * <p>
-     * The callback will be executed in a separate thread
+     * The callback will be executed in a thread supplied by the executor
      * </p>
      *
-     * @param level the transaction isolation level which will be applied to the connection for the scope of this
-     *              transaction, after which the original isolation level will be restored.
+     * @param level    the transaction isolation level which will be applied to the connection for the scope of this transaction, after which the original
+     *                 isolation level will be restored.
      * @param callback A callback which will receive an open Handle, in a transaction
-     * @param <R> type returned by the callback
-     * @param <X> exception type thrown by the callback, if any.
-     *
+     * @param <R>      type returned by the callback
+     * @param <X>      exception type thrown by the callback, if any.
      * @return a completion stage which completes when the callback returns a value or throws an exception
      */
     <R, X extends Exception> CompletionStage<R> inTransaction(TransactionIsolationLevel level, HandleCallback<R, X> callback);
 
     /**
-     * A convenience function which manages the lifecycle of a handle and yields it to a callback
-     * for use by clients.
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback for use by clients.
      *
      * <p>
-     * The callback will be executed in a separate thread
+     * The callback will be executed in a thread supplied by the executor
      * </p>
      *
      * @param consumer A callback which will receive an open Handle
-     * @param <X> exception type thrown by the callback, if any.
-     *
+     * @param <X>      exception type thrown by the callback, if any.
      * @return a completion stage which completes when the callback returns or throws an exception
      */
     <X extends Exception> CompletionStage<Void> useHandle(HandleConsumer<X> consumer);
 
     /**
-     * A convenience function which manages the lifecycle of a handle and yields it to a callback
-     * for use by clients. The handle will be in a transaction when the callback is invoked, and
-     * that transaction will be committed if the callback finishes normally, or rolled back if the
-     * callback raises an exception.
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback for use by clients. The handle will be in a transaction when
+     * the callback is invoked, and that transaction will be committed if the callback finishes normally, or rolled back if the callback raises an exception.
      *
      * <p>
-     * The callback will be executed in a separate thread
+     * The callback will be executed in a thread supplied by the executor
      * </p>
      *
      * @param callback A callback which will receive an open Handle, in a transaction
-     * @param <X> exception type thrown by the callback, if any.
-     *
+     * @param <X>      exception type thrown by the callback, if any.
      * @return a completion stage which completes when the callback returns or throws an exception
      */
     <X extends Exception> CompletionStage<Void> useTransaction(HandleConsumer<X> callback);
 
     /**
-     * A convenience function which manages the lifecycle of a handle and yields it to a callback
-     * for use by clients. The handle will be in a transaction when the callback is invoked, and
-     * that transaction will be committed if the callback finishes normally, or rolled back if the
-     * callback raises an exception.
+     * A convenience function which manages the lifecycle of a handle and yields it to a callback for use by clients. The handle will be in a transaction when
+     * the callback is invoked, and that transaction will be committed if the callback finishes normally, or rolled back if the callback raises an exception.
      *
      * <p>
-     * This form accepts a transaction isolation level which will be applied to the connection
-     * for the scope of this transaction, after which the original isolation level will be restored.
+     * This form accepts a transaction isolation level which will be applied to the connection for the scope of this transaction, after which the original
+     * isolation level will be restored.
      * </p>
      *
      * <p>
-     * The callback will be executed in a separate thread
+     * The callback will be executed in a thread supplied by the executor
      * </p>
      *
-     * @param level the transaction isolation level which will be applied to the connection for the scope of this
-     *              transaction, after which the original isolation level will be restored.
+     * @param level    the transaction isolation level which will be applied to the connection for the scope of this transaction, after which the original
+     *                 isolation level will be restored.
      * @param callback A callback which will receive an open Handle, in a transaction
-     * @param <X> exception type thrown by the callback, if any.
-     *
+     * @param <X>      exception type thrown by the callback, if any.
      * @return a completion stage which completes when the callback returns or throws an exception
      */
     <X extends Exception> CompletionStage<Void> useTransaction(TransactionIsolationLevel level, HandleConsumer<X> callback);
 
     /**
-     * A convenience method which opens an extension of the given type, yields it to a callback, and returns the result
-     * of the callback. A handle is opened if needed by the extension, and closed before returning to the caller.
+     * A convenience method which opens an extension of the given type, yields it to a callback, and returns the result of the callback. A handle is opened if
+     * needed by the extension, and closed before returning to the caller.
      *
      * <p>
-     * The callback will be executed in a separate thread
+     * The callback will be executed in a thread supplied by the executor
      * </p>
      *
      * @param extensionType the type of extension.
      * @param callback      a callback which will receive the extension.
-     * @param <R> the return type
-     * @param <E> the extension type
-     * @param <X> the exception type optionally thrown by the callback
-     * @return a completion stage which completes when the callback returns a value
-     * or throws an exception, or will complete with NoSuchExtensionException if no
+     * @param <R>           the return type
+     * @param <E>           the extension type
+     * @param <X>           the exception type optionally thrown by the callback
+     * @return a completion stage which completes when the callback returns a value or throws an exception, or will complete with NoSuchExtensionException if no
      * {@link ExtensionFactory} is registered which supports the given extension type.
      */
     <R, E, X extends Exception> CompletionStage<R> withExtension(Class<E> extensionType, ExtensionCallback<R, E, X> callback);
 
     /**
-     * A convenience method which opens an extension of the given type, and yields it to a callback. A handle is opened
-     * if needed by the extention, and closed before returning to the caller.
+     * A convenience method which opens an extension of the given type, and yields it to a callback. A handle is opened if needed by the extention, and closed
+     * before returning to the caller.
      *
      * <p>
-     * The callback will be executed in a separate thread
+     * The callback will be executed in a thread supplied by the executor
      * </p>
      *
      * @param extensionType the type of extension
      * @param callback      a callback which will receive the extension
      * @param <E>           the extension type
      * @param <X>           the exception type optionally thrown by the callback
-     * @return a completion stage which completes when the callback returns
-     * or throws an exception, or will complete with NoSuchExtensionException if no
+     * @return a completion stage which completes when the callback returns or throws an exception, or will complete with NoSuchExtensionException if no
      * {@link ExtensionFactory} is registered which supports the given extension type.
      */
     <E, X extends Exception> CompletionStage<Void> useExtension(Class<E> extensionType, ExtensionConsumer<E, X> callback);

--- a/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutorImpl.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutorImpl.java
@@ -18,14 +18,9 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
-import org.jdbi.v3.core.HandleCallback;
-import org.jdbi.v3.core.HandleConsumer;
 import org.jdbi.v3.core.Jdbi;
-import org.jdbi.v3.core.extension.ExtensionCallback;
-import org.jdbi.v3.core.extension.ExtensionConsumer;
-import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 
-public class JdbiExecutorImpl implements JdbiExecutor {
+class JdbiExecutorImpl extends AbstractJdbiExecutor {
 
     private final Jdbi jdbi;
     private final Executor executor;
@@ -33,31 +28,23 @@ public class JdbiExecutorImpl implements JdbiExecutor {
     /**
      * Construct a {@link JdbiExecutor}.
      *
-     * <p>
-     * The executor to pass in needs to be sized to the use case. A rule of thumb is to
-     * have the max number of workers be equal to the max number of connections in the
-     * connection pool. The worker queue in the executor should probably be bounded, unless
-     * the caller(s) already has a bound for the number of outstanding requests. Making the
-     * queue bounded will mean you are blocking the calling thread when the queue fills up.
-     * Whether or not that is a
-     * </p>
-     *
-     * @param jdbi the initialized Jdbi class
+     * @param jdbi     the initialized Jdbi class
      * @param executor an executor to use for all database calls
      */
-    public JdbiExecutorImpl(Jdbi jdbi, Executor executor) {
+    JdbiExecutorImpl(Jdbi jdbi, Executor executor) {
         this.jdbi = jdbi;
         this.executor = executor;
     }
 
     /**
-     * Single method through which all other methods converge. If you want to override JdbiExecutorImpl, you only need to override this one method.
+     * Make sure to run the handler in a thread supplied by the executor
      *
      * @param handler the handler that takes a Jdbi instance and returns a value
      * @param <R>     type returned by the callback
      * @param <X>     exception type thrown by the callback, if any.
      * @return a completion stage that will complete when the handler returns or throws an exception
      */
+    @Override
     protected <R, X extends Exception> CompletionStage<R> doExecute(final Handler<R, X> handler) {
         return CompletableFuture.supplyAsync(() -> {
             try {
@@ -66,62 +53,5 @@ public class JdbiExecutorImpl implements JdbiExecutor {
                 throw new CompletionException(e);
             }
         }, executor);
-    }
-
-    @Override
-    public <R, X extends Exception> CompletionStage<R> withHandle(final HandleCallback<R, X> callback) {
-        return doExecute(jdbi -> jdbi.withHandle(callback));
-    }
-
-    @Override
-    public <R, X extends Exception> CompletionStage<R> inTransaction(final HandleCallback<R, X> callback) {
-        return doExecute(jdbi -> jdbi.inTransaction(callback));
-    }
-
-    @Override
-    public <R, X extends Exception> CompletionStage<R> inTransaction(final TransactionIsolationLevel level, final HandleCallback<R, X> callback) {
-        return doExecute(jdbi -> jdbi.inTransaction(level, callback));
-    }
-
-    @Override
-    public <X extends Exception> CompletionStage<Void> useHandle(final HandleConsumer<X> consumer) {
-        return doExecute(jdbi -> {
-            jdbi.useHandle(consumer);
-            return null;
-        });
-    }
-
-    @Override
-    public <X extends Exception> CompletionStage<Void> useTransaction(final HandleConsumer<X> callback) {
-        return doExecute(jdbi -> {
-            jdbi.useTransaction(callback);
-            return null;
-        });
-    }
-
-    @Override
-    public <X extends Exception> CompletionStage<Void> useTransaction(final TransactionIsolationLevel level, final HandleConsumer<X> callback) {
-        return doExecute(jdbi -> {
-            jdbi.useTransaction(level, callback);
-            return null;
-        });
-    }
-
-    @Override
-    public <R, E, X extends Exception> CompletionStage<R> withExtension(final Class<E> extensionType, final ExtensionCallback<R, E, X> callback) {
-        return doExecute(jdbi -> jdbi.withExtension(extensionType, callback));
-    }
-
-    @Override
-    public <E, X extends Exception> CompletionStage<Void> useExtension(final Class<E> extensionType, final ExtensionConsumer<E, X> callback) {
-        return doExecute(jdbi -> {
-            jdbi.useExtension(extensionType, callback);
-            return null;
-        });
-    }
-
-    protected interface Handler<R, X extends Exception> {
-
-        R apply(Jdbi jdbi) throws X;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutorImpl.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutorImpl.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.async;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import org.jdbi.v3.core.HandleCallback;
+import org.jdbi.v3.core.HandleConsumer;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.extension.ExtensionCallback;
+import org.jdbi.v3.core.extension.ExtensionConsumer;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
+
+public class JdbiExecutorImpl implements JdbiExecutor {
+
+    private final Jdbi jdbi;
+    private final Executor executor;
+
+    /**
+     * Construct a {@link JdbiExecutor}.
+     *
+     * <p>
+     * The executor to pass in needs to be sized to the use case. A rule of thumb is to
+     * have the max number of workers be equal to the max number of connections in the
+     * connection pool. The worker queue in the executor should probably be bounded, unless
+     * the caller(s) already has a bound for the number of outstanding requests. Making the
+     * queue bounded will mean you are blocking the calling thread when the queue fills up.
+     * Whether or not that is a
+     * </p>
+     *
+     * @param jdbi the initialized Jdbi class
+     * @param executor an executor to use for all database calls
+     */
+    public JdbiExecutorImpl(Jdbi jdbi, Executor executor) {
+        this.jdbi = jdbi;
+        this.executor = executor;
+    }
+
+    /**
+     * Single method through which all other methods converge. If you want to override JdbiExecutorImpl, you only need to override this one method.
+     *
+     * @param handler the handler that takes a Jdbi instance and returns a value
+     * @param <R>     type returned by the callback
+     * @param <X>     exception type thrown by the callback, if any.
+     * @return a completion stage that will complete when the handler returns or throws an exception
+     */
+    protected <R, X extends Exception> CompletionStage<R> doExecute(final Handler<R, X> handler) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return handler.apply(jdbi);
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        }, executor);
+    }
+
+    @Override
+    public <R, X extends Exception> CompletionStage<R> withHandle(final HandleCallback<R, X> callback) {
+        return doExecute(jdbi -> jdbi.withHandle(callback));
+    }
+
+    @Override
+    public <R, X extends Exception> CompletionStage<R> inTransaction(final HandleCallback<R, X> callback) {
+        return doExecute(jdbi -> jdbi.inTransaction(callback));
+    }
+
+    @Override
+    public <R, X extends Exception> CompletionStage<R> inTransaction(final TransactionIsolationLevel level, final HandleCallback<R, X> callback) {
+        return doExecute(jdbi -> jdbi.inTransaction(level, callback));
+    }
+
+    @Override
+    public <X extends Exception> CompletionStage<Void> useHandle(final HandleConsumer<X> consumer) {
+        return doExecute(jdbi -> {
+            jdbi.useHandle(consumer);
+            return null;
+        });
+    }
+
+    @Override
+    public <X extends Exception> CompletionStage<Void> useTransaction(final HandleConsumer<X> callback) {
+        return doExecute(jdbi -> {
+            jdbi.useTransaction(callback);
+            return null;
+        });
+    }
+
+    @Override
+    public <X extends Exception> CompletionStage<Void> useTransaction(final TransactionIsolationLevel level, final HandleConsumer<X> callback) {
+        return doExecute(jdbi -> {
+            jdbi.useTransaction(level, callback);
+            return null;
+        });
+    }
+
+    @Override
+    public <R, E, X extends Exception> CompletionStage<R> withExtension(final Class<E> extensionType, final ExtensionCallback<R, E, X> callback) {
+        return doExecute(jdbi -> jdbi.withExtension(extensionType, callback));
+    }
+
+    @Override
+    public <E, X extends Exception> CompletionStage<Void> useExtension(final Class<E> extensionType, final ExtensionConsumer<E, X> callback) {
+        return doExecute(jdbi -> {
+            jdbi.useExtension(extensionType, callback);
+            return null;
+        });
+    }
+
+    protected interface Handler<R, X extends Exception> {
+
+        R apply(Jdbi jdbi) throws X;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutorImpl.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/JdbiExecutorImpl.java
@@ -20,7 +20,9 @@ import java.util.concurrent.Executor;
 
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.internal.exceptions.CheckedFunction;
+import org.jdbi.v3.meta.Beta;
 
+@Beta
 class JdbiExecutorImpl extends AbstractJdbiExecutor {
 
     private final Jdbi jdbi;

--- a/core/src/test/java/org/jdbi/v3/core/async/JdbiExecutorTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/async/JdbiExecutorTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.async;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.HandleCallback;
+import org.jdbi.v3.core.HandleConsumer;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.extension.ExtensionFactory;
+import org.jdbi.v3.core.extension.HandleSupplier;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class JdbiExecutorTest {
+
+    private static final HandleCallback<Integer, Exception> RUN_QUERY =
+        handle -> handle.createQuery("SELECT COUNT(*) FROM users").mapTo(Integer.class).one();
+
+    private static final HandleConsumer<Exception> RUN_UPDATE =
+        handle -> handle.execute("INSERT INTO users VALUES (3, 'Jim')");
+
+    static class TestExtensionFactory implements ExtensionFactory {
+
+        @Override
+        public boolean accepts(Class<?> extensionType) {
+            return TestExtension.class.equals(extensionType);
+        }
+
+        @Override
+        public <E> E attach(Class<E> extensionType, HandleSupplier handleSupplier) {
+            return extensionType.cast(new TestExtensionImpl(handleSupplier));
+        }
+    }
+
+    public interface TestExtension {
+
+        Handle getHandle();
+
+        default int get() {
+            return 5;
+        }
+
+        default void set() {}
+    }
+
+    public static class TestExtensionImpl implements TestExtension {
+
+        private final HandleSupplier handleSupplier;
+
+        TestExtensionImpl(HandleSupplier handleSupplier) {
+            this.handleSupplier = handleSupplier;
+        }
+
+        @Override
+        public Handle getHandle() {
+            return handleSupplier.getHandle();
+        }
+    }
+
+    @RegisterExtension
+    private final H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+
+    private JdbiExecutor jdbiExecutor = null;
+    private Jdbi jdbi;
+
+    @BeforeEach
+    void setup() {
+        h2Extension.getJdbi().useHandle(H2DatabaseExtension.USERS_INITIALIZER::initialize);
+        jdbi = spy(h2Extension.getJdbi().registerExtension(new TestExtensionFactory()));
+        jdbiExecutor = new JdbiExecutorImpl(jdbi, Executors.newSingleThreadExecutor());
+    }
+
+    @Test
+    void testWithHandle() {
+        assertThat(
+            jdbiExecutor.withHandle(RUN_QUERY))
+            .succeedsWithin(Duration.ofSeconds(10))
+            .isEqualTo(2);
+        verify(jdbi).withHandle(any());
+    }
+
+    @Test
+    void testWithHandleThrowsException() {
+        assertThat(
+            jdbiExecutor.withHandle(
+                handle -> {
+                    throw new RuntimeException();
+                }))
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableOfType(ExecutionException.class)
+            .withCauseInstanceOf(RuntimeException.class);
+        verify(jdbi).withHandle(any());
+    }
+
+    @Test
+    void testUseHandle() {
+        assertThat(
+            jdbiExecutor.useHandle(RUN_UPDATE))
+            .succeedsWithin(Duration.ofSeconds(10));
+        assertThat(jdbiExecutor.withHandle(RUN_QUERY))
+            .succeedsWithin(Duration.ofSeconds(10))
+            .isEqualTo(3);
+        verify(jdbi).useHandle(any());
+    }
+
+    @Test
+    void testInTransaction() {
+        assertThat(
+            jdbiExecutor.inTransaction(RUN_QUERY))
+            .succeedsWithin(Duration.ofSeconds(10))
+            .isEqualTo(2);
+        verify(jdbi).inTransaction(any());
+    }
+
+    @Test
+    void testInTransactionWithLevel() {
+        assertThat(
+            jdbiExecutor.inTransaction(TransactionIsolationLevel.READ_COMMITTED, RUN_QUERY))
+            .succeedsWithin(Duration.ofSeconds(10))
+            .isEqualTo(2);
+        verify(jdbi).inTransaction(eq(TransactionIsolationLevel.READ_COMMITTED), any());
+    }
+
+    @Test
+    void testUseTransaction() {
+        assertThat(
+            jdbiExecutor.useTransaction(RUN_UPDATE))
+            .succeedsWithin(Duration.ofSeconds(10));
+        assertThat(jdbiExecutor.withHandle(RUN_QUERY))
+            .succeedsWithin(Duration.ofSeconds(10))
+            .isEqualTo(3);
+        verify(jdbi).useTransaction(any());
+    }
+
+    @Test
+    void testUseTransactionWithLevel() {
+        assertThat(
+            jdbiExecutor.useTransaction(TransactionIsolationLevel.READ_COMMITTED, RUN_UPDATE))
+            .succeedsWithin(Duration.ofSeconds(10));
+        assertThat(jdbiExecutor.withHandle(RUN_QUERY))
+            .succeedsWithin(Duration.ofSeconds(10))
+            .isEqualTo(3);
+        verify(jdbi).useTransaction(eq(TransactionIsolationLevel.READ_COMMITTED), any());
+    }
+
+    @Test
+    void testWithExtension() {
+        assertThat(
+            jdbiExecutor.withExtension(TestExtension.class, TestExtension::get)
+        ).succeedsWithin(Duration.ofSeconds(10))
+            .isEqualTo(5);
+        verify(jdbi).withExtension(eq(TestExtension.class), any());
+    }
+
+    @Test
+    void testUseExtension() {
+        assertThat(
+            jdbiExecutor.useExtension(TestExtension.class, TestExtension::set)
+        ).succeedsWithin(Duration.ofSeconds(10));
+        verify(jdbi).useExtension(eq(TestExtension.class), any());
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/async/JdbiExecutorTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/async/JdbiExecutorTest.java
@@ -95,7 +95,7 @@ public class JdbiExecutorTest {
     void setup() {
         h2Extension.getJdbi().useHandle(H2DatabaseExtension.USERS_INITIALIZER::initialize);
         jdbi = spy(h2Extension.getJdbi().registerExtension(new TestExtensionFactory()));
-        jdbiExecutor = new JdbiExecutorImpl(jdbi, Executors.newFixedThreadPool(2));
+        jdbiExecutor = JdbiExecutor.create(jdbi, Executors.newFixedThreadPool(2));
     }
 
     @Test


### PR DESCRIPTION
This comes from having seen jdbi used in async services. The common pattern is to use jdbi like this:

```java
CompletionStage<String> doSelect() {
  return CompletableFuture.supplyAsync(() -> {
      return jdbi.withHandle(h ->
        h.createQuery(....
    }, executor);
}
```

This turns out to be very error prone (especially with multiple contributors), because each call to the database requires this exact boilerplate to surround the call. Easy to forget to pass in the executor, exceptions have to be handled. etc. Some of these errors don't show in tests either, only in prod, because the database call is executed on the wrong threadpool, which only shows up under load.

Having a class like this JdbiExecutor to pass around, instead of Jdbi, eliminates most possibilities of using things wrong, which in turn eliminates risk. Same code now looks like:

```java
CompletionStage<String> doSelect() {
  return jdbiExecutor.withHandle(h ->
    h.createQuery(....
  );
}
```

Would like to add this as a standard feature of jdbi.

In the end, it's just a very thin wrapper on top of the Jdbi class, but it eliminates a class of errors in Jdbi usage in async services