### PR TITLE
Remove visible supplier for InContextInvoker

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -79,14 +78,14 @@ public class SqlObjectFactory implements ExtensionFactory {
 
         instanceConfig.get(Extensions.class).onCreateProxy();
 
-        Map<Method, Supplier<InContextInvoker>> handlers = new HashMap<>();
+        Map<Method, InContextInvoker> handlers = new HashMap<>();
         final Object proxy = Proxy.newProxyInstance(
                 extensionType.getClassLoader(),
                 new Class[] {extensionType},
-                (proxyInstance, method, args) -> handlers.get(method).get().invoke(args));
+                (proxyInstance, method, args) -> handlers.get(method).invoke(args));
 
         sqlObjectInitData.forEachMethodHandler((method, handler) ->
-                handlers.put(method, sqlObjectInitData.lazyInvoker(proxy, method, handleSupplier, instanceConfig)));
+                handlers.put(method, sqlObjectInitData.getInvoker(proxy, method, handleSupplier, instanceConfig)));
         return extensionType.cast(proxy);
     }
 }


### PR DESCRIPTION
Move the memoizing supplier inside the InContextInvoker, allowing callers to just hold an instance that wraps a supplier, not a supplier that creates an instance. As all parameters for the supplier are locked down at creation time anyway, this makes no difference but replaces various Supplier<InContextInvoker> fields that need get() methods with simpler code.