### PR TITLE
Rewrite of the core extension framework

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/config/ConfigCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/ConfigCustomizer.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.config;
+
+import org.jdbi.v3.meta.Beta;
+
+/**
+ * Customizes a given {@link ConfigRegistry}.
+ *
+ * @since 3.38.0
+ */
+@FunctionalInterface
+@Beta
+public interface ConfigCustomizer {
+
+    /**
+     * Manipulates the {@link ConfigRegistry} object.
+     *
+     * @param config A {@link ConfigRegistry} object.
+     */
+    void customize(ConfigRegistry config);
+}

--- a/core/src/main/java/org/jdbi/v3/core/config/ConfigCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/ConfigCustomizer.java
@@ -27,7 +27,7 @@ public interface ConfigCustomizer {
     /**
      * Manipulates the {@link ConfigRegistry} object.
      *
-     * @param config A {@link ConfigRegistry} object.
+     * @param config A {@link ConfigRegistry} object
      */
     void customize(ConfigRegistry config);
 }

--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCustomizerChain.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCustomizerChain.java
@@ -32,7 +32,7 @@ public final class ConfigCustomizerChain implements ConfigCustomizer {
 
     /**
      * Adds a customizer to the end of the chain.
-     * @param configCustomizer A {@link ConfigCustomizer} instance. Must not be null.
+     * @param configCustomizer A {@link ConfigCustomizer} instance. Must not be null
      */
     public void addCustomizer(final ConfigCustomizer configCustomizer) {
         configCustomizers.add(configCustomizer);
@@ -40,7 +40,7 @@ public final class ConfigCustomizerChain implements ConfigCustomizer {
 
     /**
      * Applies all customizers in the chain to the given {@link ConfigRegistry} object.
-     * @param config A {@link ConfigRegistry} object.
+     * @param config A {@link ConfigRegistry} object
      */
     @Override
     public void customize(final ConfigRegistry config) {

--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCustomizerChain.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCustomizerChain.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.config.internal;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.jdbi.v3.core.config.ConfigCustomizer;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.meta.Beta;
+
+/**
+ * Applies a set of {@link ConfigCustomizer}s sequentially to a {@link ConfigRegistry} object.
+ *
+ * @since 3.38.0
+ */
+@Beta
+public final class ConfigCustomizerChain implements ConfigCustomizer {
+
+    private final Set<ConfigCustomizer> configCustomizers = new LinkedHashSet<>();
+
+    /**
+     * Adds a customizer to the end of the chain.
+     * @param configCustomizer A {@link ConfigCustomizer} instance. Must not be null.
+     */
+    public void addCustomizer(final ConfigCustomizer configCustomizer) {
+        configCustomizers.add(configCustomizer);
+    }
+
+    /**
+     * Applies all customizers in the chain to the given {@link ConfigRegistry} object.
+     * @param config A {@link ConfigRegistry} object.
+     */
+    @Override
+    public void customize(final ConfigRegistry config) {
+        configCustomizers.forEach(configCustomizer -> configCustomizer.customize(config));
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/BridgeMethodExtensionHandlerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/BridgeMethodExtensionHandlerFactory.java
@@ -25,8 +25,6 @@ import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
 
 /**
  * Extension handler factory for bridge methods. Forwards bridge methods to matching candidates.
- *
- * @since 3.38.0
  */
 final class BridgeMethodExtensionHandlerFactory implements ExtensionHandlerFactory {
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/BridgeMethodExtensionHandlerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/BridgeMethodExtensionHandlerFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
+
+/**
+ * Extension handler factory for bridge methods. Forwards bridge methods to matching candidates.
+ *
+ * @since 3.38.0
+ */
+final class BridgeMethodExtensionHandlerFactory implements ExtensionHandlerFactory {
+
+    static final ExtensionHandlerFactory INSTANCE = new BridgeMethodExtensionHandlerFactory();
+
+    @Override
+    public boolean accepts(Class<?> extensionType, Method method) {
+        return method.isBridge();
+    }
+
+    @Override
+    public Optional<ExtensionHandler> buildExtensionHandler(Class<?> extensionType, Method method) {
+
+        List<Method> candidates = Stream.of(extensionType.getMethods())
+                .filter(candidate -> !candidate.isBridge())
+                .filter(candidate -> Objects.equals(candidate.getName(), method.getName()))
+                .filter(candidate -> candidate.getParameterCount() == method.getParameterCount())
+                .filter(candidate -> {
+                    Class<?>[] candidateParamTypes = candidate.getParameterTypes();
+                    Class<?>[] methodParamTypes = method.getParameterTypes();
+                    return IntStream.range(0, method.getParameterCount())
+                            .allMatch(i -> methodParamTypes[i].isAssignableFrom(candidateParamTypes[i]));
+                })
+                .collect(Collectors.toList());
+
+        for (Method candidate : candidates) {
+            try {
+                return Optional.of(ExtensionHandler.createForMethod(candidate));
+            } catch (IllegalAccessException ignored) {}
+        }
+        throw new UnableToCreateExtensionException(
+                "Could not create an extension handler for bridge method %s#%s.", extensionType, method);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/ConfigCustomizerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ConfigCustomizerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+import org.jdbi.v3.core.config.ConfigCustomizer;
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Factory interface to create collections of {@link ConfigCustomizer} instances.
+ *
+ * @since 3.38.0
+ */
+@Alpha
+public interface ConfigCustomizerFactory {
+
+    /**
+     * Creates a collection of {@link ConfigCustomizer} instances for an extension type.
+     *
+     * @param extensionType The extension type.
+     * @return A {@link Collection} of {@link ConfigCustomizer} objects. Must not be null.
+     */
+    Collection<ConfigCustomizer> forExtensionType(Class<?> extensionType);
+
+    /**
+     * Creates a collection of {@link ConfigCustomizer} instances for an extension type method.
+     *
+     * @param extensionType The extension type.
+     * @param method        The method on the extension type.
+     * @return A {@link Collection} of {@link ConfigCustomizer} objects. Must not be null.
+     */
+    Collection<ConfigCustomizer> forExtensionMethod(Class<?> extensionType, Method method);
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/ConfigCustomizerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ConfigCustomizerFactory.java
@@ -30,17 +30,17 @@ public interface ConfigCustomizerFactory {
     /**
      * Creates a collection of {@link ConfigCustomizer} instances for an extension type.
      *
-     * @param extensionType The extension type.
-     * @return A {@link Collection} of {@link ConfigCustomizer} objects. Must not be null.
+     * @param extensionType The extension type
+     * @return A {@link Collection} of {@link ConfigCustomizer} objects. Must not be null
      */
     Collection<ConfigCustomizer> forExtensionType(Class<?> extensionType);
 
     /**
      * Creates a collection of {@link ConfigCustomizer} instances for an extension type method.
      *
-     * @param extensionType The extension type.
-     * @param method        The method on the extension type.
-     * @return A {@link Collection} of {@link ConfigCustomizer} objects. Must not be null.
+     * @param extensionType The extension type
+     * @param method        The method on the extension type
+     * @return A {@link Collection} of {@link ConfigCustomizer} objects. Must not be null
      */
     Collection<ConfigCustomizer> forExtensionMethod(Class<?> extensionType, Method method);
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/DefaultMethodExtensionHandlerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/DefaultMethodExtensionHandlerFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
+
+/**
+ * Provides {@link ExtensionHandler} instances for interface default methods.
+ *
+ * @since 3.38.0
+ */
+final class DefaultMethodExtensionHandlerFactory implements ExtensionHandlerFactory {
+
+    static final ExtensionHandlerFactory INSTANCE = new DefaultMethodExtensionHandlerFactory();
+
+    @Override
+    public boolean accepts(Class<?> extensionType, Method method) {
+        return extensionType.isInterface() && method.isDefault();  // interface default method
+    }
+
+    @Override
+    public Optional<ExtensionHandler> buildExtensionHandler(Class<?> extensionType, Method method) {
+        try {
+            return Optional.of(ExtensionHandler.createForSpecialMethod(method));
+        } catch (IllegalAccessException e) {
+            throw new UnableToCreateExtensionException(e, "Default method handler for %s couldn't unreflect %s", extensionType, method);
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/DefaultMethodExtensionHandlerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/DefaultMethodExtensionHandlerFactory.java
@@ -20,8 +20,6 @@ import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
 
 /**
  * Provides {@link ExtensionHandler} instances for interface default methods.
- *
- * @since 3.38.0
  */
 final class DefaultMethodExtensionHandlerFactory implements ExtensionHandlerFactory {
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionConfigurer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionConfigurer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Configures {@link ConfigRegistry} instances. Implementation classes
+ * are referenced from annotations that are marked with the {@link org.jdbi.v3.core.extension.annotation.UseExtensionConfigurer} annotation.
+ * <br>
+ * Instances of this interface update the configuration used to execute a specific method e.g. to
+ * register row mapper needed for the execution of the underlying ExtensionHandler.
+ *
+ * @since 3.38.0
+ */
+@Alpha
+public interface ExtensionConfigurer {
+    /**
+     * Updates configuration for the given annotation on an extension type.
+     *
+     * @param registry      the registry to configure
+     * @param annotation    the annotation
+     * @param extensionType the extension type which was annotated
+     */
+    default void configureForType(ConfigRegistry registry, Annotation annotation, Class<?> extensionType) {
+        throw new UnsupportedOperationException("Not supported for type");
+    }
+
+    /**
+     * Configures the registry for the given annotation on a extension type method.
+     *
+     * @param registry      the registry to configure
+     * @param annotation    the annotation
+     * @param extensionType the extension type
+     * @param method        the method which was annotated
+     */
+    default void configureForMethod(ConfigRegistry registry, Annotation annotation, Class<?> extensionType, Method method) {
+        throw new UnsupportedOperationException("Not supported for method");
+    }
+
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactory.java
@@ -59,21 +59,21 @@ public interface ExtensionFactory {
     /**
      * Returns true if the factory can process the given extension type.
      *
-     * @param extensionType the extension type.
-     * @return whether the factory can produce an extension of the given type.
+     * @param extensionType the extension type
+     * @return whether the factory can produce an extension of the given type
      */
     boolean accepts(Class<?> extensionType);
 
     /**
      * Attaches an extension type. This method is not called if {@link #getFactoryFlags()} contains {@link FactoryFlag#VIRTUAL_FACTORY}.
      *
-     * @param extensionType  The extension type.
+     * @param extensionType  The extension type
      * @param handleSupplier Supplies the database handle. This supplier may lazily open a Handle on the first
      *                       invocation. Extension implementors should take care not to fetch the handle before it is
-     *                       needed, to avoid opening handles unnecessarily.
+     *                       needed, to avoid opening handles unnecessarily
      * @param <E>            the extension type
-     * @return An extension of the given type, attached to the given handle.
-     * @throws IllegalArgumentException if the extension type is not supported by this factory.
+     * @return An extension of the given type, attached to the given handle
+     * @throws IllegalArgumentException if the extension type is not supported by this factory
      * @see org.jdbi.v3.core.Jdbi#onDemand(Class)
      */
     <E> E attach(Class<E> extensionType, HandleSupplier handleSupplier);
@@ -84,7 +84,8 @@ public interface ExtensionFactory {
      * <br>
      * Handler factories returned here can customize the behavior of the Extension factory itself.
      *
-     * @return A collection of {@link ExtensionHandlerFactory} objects. Can be empty, must not be null.
+     * @param config A Configuration registry object that can be used to look up additional information
+     * @return A collection of {@link ExtensionHandlerFactory} objects. Can be empty, must not be null
      *
      * @since 3.38.0
      */
@@ -99,8 +100,8 @@ public interface ExtensionFactory {
      * <br>
      * Handler customizers returned here can customize the behavior of the Handlers returned by the handler factories.
      *
-     * @param config A Configuration registry object that can be used to look up additional information.
-     * @return A collection of {@link ExtensionHandlerCustomizer} objects. Can be empty, must not be null.
+     * @param config A Configuration registry object that can be used to look up additional information
+     * @return A collection of {@link ExtensionHandlerCustomizer} objects. Can be empty, must not be null
      *
      * @since 3.38.0
      */
@@ -116,8 +117,8 @@ public interface ExtensionFactory {
      * type. They can return {@link ConfigCustomizer} instances that will affect the specific configuration for
      * each method and extension type.
      *
-     * @param config A Configuration registry object that can be used to look up additional information.
-     * @return A collection of {@link ConfigCustomizerFactory} objects. Can be empty, must not be null.
+     * @param config A Configuration registry object that can be used to look up additional information
+     * @return A collection of {@link ConfigCustomizerFactory} objects. Can be empty, must not be null
      *
      * @since 3.38.0
      */
@@ -132,6 +133,8 @@ public interface ExtensionFactory {
      * <br/>
      * Code here can call methods on the builder to configure the metadata object.
      *
+     * @param builder The builder object that is used to create the {@link ExtensionMetadata} object
+     *
      * @since 3.38.0
      */
     @Alpha
@@ -140,7 +143,7 @@ public interface ExtensionFactory {
     /**
      * Returns a set of {@link FactoryFlag}s that describe the extension factory.
      *
-     * @return A set of {@link FactoryFlag} elements. Default is the empty set.
+     * @return A set of {@link FactoryFlag} elements. Default is the empty set
      *
      * @since 3.38.0
      */

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactory.java
@@ -13,13 +13,51 @@
  */
 package org.jdbi.v3.core.extension;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import org.jdbi.v3.core.config.ConfigCustomizer;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
+import org.jdbi.v3.meta.Alpha;
+
 /**
- * Factory interface used to produce Jdbi extension objects.
+ * Factory interface used to produce Jdbi extension objects. A factory can provide additional
+ * pieces of information by overriding the various default methods.
  */
 public interface ExtensionFactory {
 
     /**
-     * Returns true if the factory can attach the given extension type.
+     * Flags that the factory can return to control aspects of the extension framework.
+     *
+     * @since 3.38.0
+     */
+    @Alpha
+    enum FactoryFlag {
+        /**
+         * The factory has no actual object to attach to. It will register a method handler for every method on an extension type.
+         * <br>
+         * E.g. the SQLObject handler will process every method in an interface class without requiring an implementation of the extension
+         * type. The extension framework will execute the method handlers and pass in a proxy object instead of an underlying instance.
+         * <br>
+         * When this flag is present, the {@link ExtensionFactory#attach(Class, HandleSupplier)} method will never be called.
+         */
+        VIRTUAL_FACTORY,
+        /**
+         * The factory supports extending class objects (not just interfaces). Class objects are not wrapped into a proxy and
+         * the factory takes full responsibility for creating and managing invocation handlers.
+         * <br>
+         * This is a corner use case and should normally not be used by any standard extension.
+         * <br>
+         * Legacy extension factories that need every method on an interface forwarded to the underlying implementation class
+         * can set this flag to bypass metadata creation and the proxy logic of the extension framework.
+         */
+        CLASSES_ARE_SUPPORTED
+    }
+
+    /**
+     * Returns true if the factory can process the given extension type.
      *
      * @param extensionType the extension type.
      * @return whether the factory can produce an extension of the given type.
@@ -27,16 +65,87 @@ public interface ExtensionFactory {
     boolean accepts(Class<?> extensionType);
 
     /**
-     * Attaches an extension type.
+     * Attaches an extension type. This method is not called if {@link #getFactoryFlags()} contains {@link FactoryFlag#VIRTUAL_FACTORY}.
      *
-     * @param extensionType  the extension type.
+     * @param extensionType  The extension type.
      * @param handleSupplier Supplies the database handle. This supplier may lazily open a Handle on the first
      *                       invocation. Extension implementors should take care not to fetch the handle before it is
      *                       needed, to avoid opening handles unnecessarily.
      * @param <E>            the extension type
-     * @return an extension of the given type, attached to the given handle.
+     * @return An extension of the given type, attached to the given handle.
      * @throws IllegalArgumentException if the extension type is not supported by this factory.
      * @see org.jdbi.v3.core.Jdbi#onDemand(Class)
      */
     <E> E attach(Class<E> extensionType, HandleSupplier handleSupplier);
+
+    /**
+     * Returns a collection of {@link ExtensionHandlerFactory} objects. These factories are used in
+     * addition to the factories that have been registered with {@link Extensions#registerHandlerFactory}.
+     * <br>
+     * Handler factories returned here can customize the behavior of the Extension factory itself.
+     *
+     * @return A collection of {@link ExtensionHandlerFactory} objects. Can be empty, must not be null.
+     *
+     * @since 3.38.0
+     */
+    @Alpha
+    default Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigRegistry config) {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Returns a collection of {@link ExtensionHandlerCustomizer} objects. These customizers are used
+     * in addition to the customizers that have been registered with {@link Extensions#registerHandlerCustomizer}.
+     * <br>
+     * Handler customizers returned here can customize the behavior of the Handlers returned by the handler factories.
+     *
+     * @param config A Configuration registry object that can be used to look up additional information.
+     * @return A collection of {@link ExtensionHandlerCustomizer} objects. Can be empty, must not be null.
+     *
+     * @since 3.38.0
+     */
+    @Alpha
+    default Collection<ExtensionHandlerCustomizer> getExtensionHandlerCustomizers(ConfigRegistry config) {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Returns a collection of {@link ConfigCustomizerFactory} objects.
+     * <br>
+     * Each factory is called once for every type that is attached by the factory and once for each method in the
+     * type. They can return {@link ConfigCustomizer} instances that will affect the specific configuration for
+     * each method and extension type.
+     *
+     * @param config A Configuration registry object that can be used to look up additional information.
+     * @return A collection of {@link ConfigCustomizerFactory} objects. Can be empty, must not be null.
+     *
+     * @since 3.38.0
+     */
+    @Alpha
+    default Collection<ConfigCustomizerFactory> getConfigCustomizerFactories(ConfigRegistry config) {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Receives the {@link ExtensionMetadata.Builder} when the {@link ExtensionMetadata} object for this extension
+     * is created. The factory can add additional method handlers or specific instance and method customizers as needed.
+     * <br/>
+     * Code here can call methods on the builder to configure the metadata object.
+     *
+     * @since 3.38.0
+     */
+    @Alpha
+    default void buildExtensionInitData(ExtensionMetadata.Builder builder) {}
+
+    /**
+     * Returns a set of {@link FactoryFlag}s that describe the extension factory.
+     *
+     * @return A set of {@link FactoryFlag} elements. Default is the empty set.
+     *
+     * @since 3.38.0
+     */
+    @Alpha
+    default Set<FactoryFlag> getFactoryFlags() {
+        return Collections.emptySet();
+    }
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactoryDelegate.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactoryDelegate.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
+import org.jdbi.v3.core.extension.ExtensionMetadata.Builder;
+import org.jdbi.v3.core.extension.ExtensionMetadata.ExtensionHandlerInvoker;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
+
+import static org.jdbi.v3.core.extension.ExtensionFactory.FactoryFlag.CLASSES_ARE_SUPPORTED;
+import static org.jdbi.v3.core.extension.ExtensionFactory.FactoryFlag.VIRTUAL_FACTORY;
+import static org.jdbi.v3.core.extension.ExtensionHandler.EQUALS_HANDLER;
+import static org.jdbi.v3.core.extension.ExtensionHandler.HASHCODE_HANDLER;
+import static org.jdbi.v3.core.extension.ExtensionHandler.NULL_HANDLER;
+
+final class ExtensionFactoryDelegate implements ExtensionFactory {
+
+    private final ExtensionFactory delegatedFactory;
+
+    ExtensionFactoryDelegate(ExtensionFactory delegatedFactory) {
+        this.delegatedFactory = delegatedFactory;
+    }
+
+    @Override
+    public boolean accepts(Class<?> extensionType) {
+        return delegatedFactory.accepts(extensionType);
+    }
+
+    ExtensionFactory getDelegatedFactory() {
+        return delegatedFactory;
+    }
+
+    @Override
+    public Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigRegistry config) {
+        return delegatedFactory.getExtensionHandlerFactories(config);
+    }
+
+    @Override
+    public Collection<ExtensionHandlerCustomizer> getExtensionHandlerCustomizers(ConfigRegistry config) {
+        return delegatedFactory.getExtensionHandlerCustomizers(config);
+    }
+
+    @Override
+    public Collection<ConfigCustomizerFactory> getConfigCustomizerFactories(ConfigRegistry config) {
+        return delegatedFactory.getConfigCustomizerFactories(config);
+    }
+
+    @Override
+    public void buildExtensionInitData(Builder builder) {
+        delegatedFactory.buildExtensionInitData(builder);
+    }
+
+    @Override
+    public Set<FactoryFlag> getFactoryFlags() {
+        return delegatedFactory.getFactoryFlags();
+    }
+
+    @Override
+    public <E> E attach(Class<E> extensionType, HandleSupplier handleSupplier) {
+
+        Set<FactoryFlag> factoryFlags = getFactoryFlags();
+
+        // backstop for anything that supports classes or abstract classes. if those get
+        // passed in, then the delegated factory is responsible for everything else as the
+        // proxy code can not extend abstract classes. While it would be possible to
+        // wrap an abstract class, any subsequent cast would fail.
+        //
+        // this is a hack to be backwards compatible with the old extension framework.
+        //
+        if (!extensionType.isInterface() || factoryFlags.contains(CLASSES_ARE_SUPPORTED)) {
+            return delegatedFactory.attach(extensionType, handleSupplier);
+        }
+
+        final ConfigRegistry config = handleSupplier.getConfig();
+        final Extensions extensions = config.get(Extensions.class);
+
+        extensions.onCreateProxy();
+
+        final ExtensionMetadata extensionMetaData = extensions.findMetadata(extensionType, config, delegatedFactory);
+        final ConfigRegistry instanceConfig = extensionMetaData.createInstanceConfiguration(config);
+
+        Map<Method, ExtensionHandlerInvoker> handlers = new HashMap<>();
+        final Object proxy = Proxy.newProxyInstance(
+                extensionType.getClassLoader(),
+                new Class[] {extensionType},
+                (proxyInstance, method, args) -> handlers.get(method).invoke(args));
+
+        // if the object created by the delegated factory has actual methods (it is not delegating), attach the
+        // delegate and pass it to the handlers. Otherwise assume that there is no backing object and do not call
+        // attach.
+        final Object delegatedInstance = factoryFlags.contains(VIRTUAL_FACTORY) ? proxy : delegatedFactory.attach(extensionType, handleSupplier);
+
+        // add proxy specific methods (toString, equals, hashCode, finalize)
+        // those will only be added if they don't already exist in the method handler map.
+
+        // If these methods are added, they are special because they operate on the proxy object itself, not the underlying object
+        checkMethodPresent(extensionType, Object.class, "toString").ifPresent(method -> {
+            ExtensionHandler toStringHandler = (h, target, args) ->
+                    "Jdbi extension proxy for " + extensionType.getName() + "@" + Integer.toHexString(proxy.hashCode());
+            handlers.put(method, extensionMetaData.new ExtensionHandlerInvoker(proxy, method, toStringHandler, handleSupplier, instanceConfig));
+        });
+
+        checkMethodPresent(extensionType, Object.class, "equals", Object.class).ifPresent(method -> handlers.put(method,
+                extensionMetaData.new ExtensionHandlerInvoker(proxy, method, EQUALS_HANDLER, handleSupplier, instanceConfig)));
+        checkMethodPresent(extensionType, Object.class, "hashCode").ifPresent(method -> handlers.put(method,
+                extensionMetaData.new ExtensionHandlerInvoker(proxy, method, HASHCODE_HANDLER, handleSupplier, instanceConfig)));
+
+        // add all methods that are delegated to the underlying object / existing handlers
+        extensionMetaData.getExtensionMethods().forEach(method ->
+                handlers.put(method, extensionMetaData.createExtensionHandlerInvoker(delegatedInstance, method, handleSupplier, instanceConfig)));
+
+        // finalize is double special. Add this unconditionally, even if subclasses try to override it.
+        JdbiClassUtils.safeMethodLookup(extensionType, "finalize").ifPresent(method -> handlers.put(method,
+                extensionMetaData.new ExtensionHandlerInvoker(proxy, method, NULL_HANDLER, handleSupplier, instanceConfig)));
+
+
+        return extensionType.cast(proxy);
+    }
+
+    /** returns Optional.empty() if the method exists in the extension type, otherwise a fallback method. */
+    private Optional<Method> checkMethodPresent(Class<?> extensionType, Class<?> klass, String methodName, Class<?>... parameterTypes) {
+        Optional<Method> method = JdbiClassUtils.safeMethodLookup(extensionType, methodName, parameterTypes);
+        if (method.isPresent()) {
+            // does the method actually exist in the type itself (e.g. overridden by the implementation class?)
+            // if yes, return absent, so the default hander is not added.
+            return Optional.empty();
+        } else {
+            return JdbiClassUtils.safeMethodLookup(klass, methodName, parameterTypes);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ExtensionFactoryDelegate for " + delegatedFactory.toString();
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandler.java
@@ -46,11 +46,11 @@ public interface ExtensionHandler {
 
     /**
      * Gets invoked to return a value for the method that this handler was bound to.
-     * @param handleSupplier A {@link HandleSupplier} instance for accessing the handle and its related objects.
-     * @param target The target object on which the handler should operate.
-     * @param args Optional arguments for the handler.
-     * @return The return value for the method that was bound to the extension handler. Can be null.
-     * @throws Exception Any exception from the underlying code.
+     * @param handleSupplier A {@link HandleSupplier} instance for accessing the handle and its related objects
+     * @param target The target object on which the handler should operate
+     * @param args Optional arguments for the handler
+     * @return The return value for the method that was bound to the extension handler. Can be null
+     * @throws Exception Any exception from the underlying code
      */
     Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception;
 
@@ -58,15 +58,15 @@ public interface ExtensionHandler {
      * Called after the method handler is constructed to pre-initialize any important
      * configuration data structures.
      *
-     * @param config the method configuration to use for warming up.
+     * @param config the method configuration to use for warming up
      */
     @Beta
     default void warm(ConfigRegistry config) {}
 
     /**
      * Returns a default handler for missing functionality. The handler will throw an exception when invoked.
-     * @param method The method to which this specific handler instance is bound.
-     * @return An {@link ExtensionHandler} instance.
+     * @param method The method to which this specific handler instance is bound
+     * @return An {@link ExtensionHandler} instance
      */
     static ExtensionHandler missingExtensionHandler(Method method) {
         return (target, args, handleSupplier) -> {
@@ -80,9 +80,9 @@ public interface ExtensionHandler {
     /**
      * Create an extension handler and bind it to a method that will be called on the
      * target object when invoked.
-     * @param method The {@link Method} to bind to.
-     * @return An {@link ExtensionHandler}.
-     * @throws IllegalAccessException If the method could not be unreflected.
+     * @param method The {@link Method} to bind to
+     * @return An {@link ExtensionHandler}
+     * @throws IllegalAccessException If the method could not be unreflected
      */
     static ExtensionHandler createForMethod(Method method) throws IllegalAccessException {
         Class<?> declaringClass = method.getDeclaringClass();
@@ -93,9 +93,9 @@ public interface ExtensionHandler {
     /**
      * Create an extension handler and bind it to a special method that will be called on the
      * target object when invoked. This is needed e.g. for interface default methods.
-     * @param method The {@link Method} to bind to.
-     * @return An {@link ExtensionHandler}.
-     * @throws IllegalAccessException If the method could not be unreflected.
+     * @param method The {@link Method} to bind to
+     * @return An {@link ExtensionHandler}
+     * @throws IllegalAccessException If the method could not be unreflected
      */
     static ExtensionHandler createForSpecialMethod(Method method) throws IllegalAccessException {
         Class<?> declaringClass = method.getDeclaringClass();
@@ -105,9 +105,9 @@ public interface ExtensionHandler {
 
     /**
      * Create an extension handler and bind it to a {@link MethodHandle} instance.
-     * @param methodHandle The {@link MethodHandle} to bind to.
-     * @return An {@link ExtensionHandler}.
-     * @throws IllegalAccessException If the method could not be unreflected.
+     * @param methodHandle The {@link MethodHandle} to bind to
+     * @return An {@link ExtensionHandler}
+     * @throws IllegalAccessException If the method could not be unreflected
      */
     static ExtensionHandler createForMethodHandle(MethodHandle methodHandle) {
         return (handleSupplier, target, args) -> {
@@ -126,19 +126,19 @@ public interface ExtensionHandler {
         /**
          * Determines whether the factory can create an {@link ExtensionHandler} for combination of extension type and method.
          *
-         * @param extensionType The extension type class.
-         * @param method A method.
-         * @return True if the factory can create an extension handler for extension type and method, false otherwise.
+         * @param extensionType The extension type class
+         * @param method A method
+         * @return True if the factory can create an extension handler for extension type and method, false otherwise
          */
         boolean accepts(Class<?> extensionType, Method method);
 
         /**
          * Returns an {@link ExtensionHandler} for a extension type and method combination.
-         * @param extensionType The extension type class.
-         * @param method A method.
+         * @param extensionType The extension type class
+         * @param method A method
          * @return An {@link ExtensionHandler} instance wrapped into an {@link Optional}. The optional can be empty. This is necessary to retrofit old code
          * that does not have an accept/build code pair but unconditionally tries to build a handler and returns empty if it can not. New code should always
-         * return <code>Optional.of(extensionHandler}</code> and never return <code>Optional.empty()</code>.
+         * return <code>Optional.of(extensionHandler}</code> and never return <code>Optional.empty()</code>
          */
         Optional<ExtensionHandler> buildExtensionHandler(Class<?> extensionType, Method method);
     }

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandler.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.internal.exceptions.Unchecked;
+import org.jdbi.v3.meta.Alpha;
+import org.jdbi.v3.meta.Beta;
+
+import static java.lang.String.format;
+
+/**
+ * Provides functionality for a single method on an extension object. Each extension handler can either
+ * call another piece of code to return the result (e.g. the method on the underlying object) or return the
+ * result itself.
+ *
+ * @since 3.38.0
+ */
+@FunctionalInterface
+@Alpha
+public interface ExtensionHandler {
+
+    /** Implementation for the {@link Object#equals(Object)} method. Each object using this handler is only equal to ifself. */
+    ExtensionHandler EQUALS_HANDLER = (handleSupplier, target, args) -> target == args[0];
+
+    /** Implementation for the {@link Object#hashCode()} method. */
+    ExtensionHandler HASHCODE_HANDLER = (handleSupplier, target, args) -> System.identityHashCode(target);
+
+    /** Handler that only returns null independent of any input parameters. */
+    ExtensionHandler NULL_HANDLER = (handleSupplier, target, args) -> null;
+
+    /**
+     * Gets invoked to return a value for the method that this handler was bound to.
+     * @param handleSupplier A {@link HandleSupplier} instance for accessing the handle and its related objects.
+     * @param target The target object on which the handler should operate.
+     * @param args Optional arguments for the handler.
+     * @return The return value for the method that was bound to the extension handler. Can be null.
+     * @throws Exception Any exception from the underlying code.
+     */
+    Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception;
+
+    /**
+     * Called after the method handler is constructed to pre-initialize any important
+     * configuration data structures.
+     *
+     * @param config the method configuration to use for warming up.
+     */
+    @Beta
+    default void warm(ConfigRegistry config) {}
+
+    /**
+     * Returns a default handler for missing functionality. The handler will throw an exception when invoked.
+     * @param method The method to which this specific handler instance is bound.
+     * @return An {@link ExtensionHandler} instance.
+     */
+    static ExtensionHandler missingExtensionHandler(Method method) {
+        return (target, args, handleSupplier) -> {
+            throw new IllegalStateException(format(
+                    "Method %s.%s has no registered extension handler!",
+                    method.getDeclaringClass().getSimpleName(),
+                    method.getName()));
+        };
+    }
+
+    /**
+     * Create an extension handler and bind it to a method that will be called on the
+     * target object when invoked.
+     * @param method The {@link Method} to bind to.
+     * @return An {@link ExtensionHandler}.
+     * @throws IllegalAccessException If the method could not be unreflected.
+     */
+    static ExtensionHandler createForMethod(Method method) throws IllegalAccessException {
+        Class<?> declaringClass = method.getDeclaringClass();
+        final MethodHandle methodHandle = PrivateLookupInKludge.lookupFor(declaringClass).unreflect(method);
+        return createForMethodHandle(methodHandle);
+    }
+
+    /**
+     * Create an extension handler and bind it to a special method that will be called on the
+     * target object when invoked. This is needed e.g. for interface default methods.
+     * @param method The {@link Method} to bind to.
+     * @return An {@link ExtensionHandler}.
+     * @throws IllegalAccessException If the method could not be unreflected.
+     */
+    static ExtensionHandler createForSpecialMethod(Method method) throws IllegalAccessException {
+        Class<?> declaringClass = method.getDeclaringClass();
+        final MethodHandle methodHandle = PrivateLookupInKludge.lookupFor(declaringClass).unreflectSpecial(method, declaringClass);
+        return createForMethodHandle(methodHandle);
+    }
+
+    /**
+     * Create an extension handler and bind it to a {@link MethodHandle} instance.
+     * @param methodHandle The {@link MethodHandle} to bind to.
+     * @return An {@link ExtensionHandler}.
+     * @throws IllegalAccessException If the method could not be unreflected.
+     */
+    static ExtensionHandler createForMethodHandle(MethodHandle methodHandle) {
+        return (handleSupplier, target, args) -> {
+            if (target == null) {
+                throw new IllegalStateException("no target object present, called from a proxy factory?");
+            }
+            return Unchecked.<Object[], Object>function(methodHandle.bindTo(target)::invokeWithArguments).apply(args);
+        };
+    }
+
+    /**
+     * A factory to create {@link ExtensionHandler} instances.
+     */
+    interface ExtensionHandlerFactory {
+
+        /**
+         * Determines whether the factory can create an {@link ExtensionHandler} for combination of extension type and method.
+         *
+         * @param extensionType The extension type class.
+         * @param method A method.
+         * @return True if the factory can create an extension handler for extension type and method, false otherwise.
+         */
+        boolean accepts(Class<?> extensionType, Method method);
+
+        /**
+         * Returns an {@link ExtensionHandler} for a extension type and method combination.
+         * @param extensionType The extension type class.
+         * @param method A method.
+         * @return An {@link ExtensionHandler} instance wrapped into an {@link Optional}. The optional can be empty. This is necessary to retrofit old code
+         * that does not have an accept/build code pair but unconditionally tries to build a handler and returns empty if it can not. New code should always
+         * return <code>Optional.of(extensionHandler}</code> and never return <code>Optional.empty()</code>.
+         */
+        Optional<ExtensionHandler> buildExtensionHandler(Class<?> extensionType, Method method);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandlerCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandlerCustomizer.java
@@ -29,11 +29,11 @@ public interface ExtensionHandlerCustomizer {
     /**
      * Customize an extension handler.
      *
-     * @param handler       The {@link ExtensionHandler} to customize.
-     * @param extensionType The extension type class.
-     * @param method        A method.
+     * @param handler       The {@link ExtensionHandler} to customize
+     * @param extensionType The extension type class
+     * @param method        A method
      * @return An {@link ExtensionHandler} object. This can be the same as the <code>handler</code> parameter
-     * or another instance that delegates to the original handler.
+     * or another instance that delegates to the original handler
      */
     ExtensionHandler customize(ExtensionHandler handler, Class<?> extensionType, Method method);
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandlerCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandlerCustomizer.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.reflect.Method;
+
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Supports customization of an extension handler. Common use cases are decorators through annotations on the method
+ * itself. The SqlObject extension implements its annotations through {@link ExtensionHandlerCustomizer} instances.
+ *
+ * @since 3.38.0
+ */
+@Alpha
+public interface ExtensionHandlerCustomizer {
+
+    /**
+     * Customize an extension handler.
+     *
+     * @param handler       The {@link ExtensionHandler} to customize.
+     * @param extensionType The extension type class.
+     * @param method        A method.
+     * @return An {@link ExtensionHandler} object. This can be the same as the <code>handler</code> parameter
+     * or another instance that delegates to the original handler.
+     */
+    ExtensionHandler customize(ExtensionHandler handler, Class<?> extensionType, Method method);
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
@@ -51,8 +51,8 @@ public final class ExtensionMetadata {
 
     /**
      * Returns a new {@link ExtensionMetadata.Builder} instance.
-     * @param extensionType The extension type for which metadata is collected.
-     * @return A new {@link ExtensionMetadata.Builder} instance.
+     * @param extensionType The extension type for which metadata is collected
+     * @return A new {@link ExtensionMetadata.Builder} instance
      */
     public static ExtensionMetadata.Builder builder(Class<?> extensionType) {
         return new Builder(extensionType);
@@ -77,8 +77,8 @@ public final class ExtensionMetadata {
      * Create an instance specific configuration based on all instance customizers. The instance configuration holds all
      * custom configuration that was applied e.g. through instance annotations.
      *
-     * @param config A configuration object. The object is not changed.
-     * @return A new configuration object with all changes applied.
+     * @param config A configuration object. The object is not changed
+     * @return A new configuration object with all changes applied
      */
     public ConfigRegistry createInstanceConfiguration(ConfigRegistry config) {
         ConfigRegistry instanceConfiguration = config.createCopy();
@@ -90,9 +90,9 @@ public final class ExtensionMetadata {
      * Create an method specific configuration based on all method customizers. The method configuration holds all
      * custom configuration that was applied e.g. through method annotations.
      *
-     * @param method The method that is about to be called.
-     * @param config A configuration object. The object is not changed.
-     * @return A new configuration object with all changes applied.
+     * @param method The method that is about to be called
+     * @param config A configuration object. The object is not changed
+     * @return A new configuration object with all changes applied
      */
     public ConfigRegistry createMethodConfiguration(Method method, ConfigRegistry config) {
         ConfigRegistry methodConfiguration = config.createCopy();
@@ -112,12 +112,12 @@ public final class ExtensionMetadata {
 
     /**
      * Creates an {@link ExtensionHandlerInvoker} instance for a specific method.
-     * @param target The target object on which the invoker should work.
-     * @param method The method which will trigger the invocation.
-     * @param handleSupplier A {@link HandleSupplier} that will provide the handle object for the extension method.
-     * @param config The configuration object which should be used as base for the method specific configuration.
-     * @return A {@link ExtensionHandlerInvoker} object that is linked to the method.
-     * @param <E> THe type of the target object.
+     * @param target The target object on which the invoker should work
+     * @param method The method which will trigger the invocation
+     * @param handleSupplier A {@link HandleSupplier} that will provide the handle object for the extension method
+     * @param config The configuration object which should be used as base for the method specific configuration
+     * @return A {@link ExtensionHandlerInvoker} object that is linked to the method
+     * @param <E> THe type of the target object
      */
     public <E> ExtensionHandlerInvoker createExtensionHandlerInvoker(E target, Method method,
             HandleSupplier handleSupplier, ConfigRegistry config) {
@@ -162,8 +162,8 @@ public final class ExtensionMetadata {
 
         /**
          * Adds an {@link ExtensionHandlerFactory} that will be used to find extension handlers when the {@link Builder#build()}} method is called.
-         * @param extensionHandlerFactory An {@link ExtensionHandlerFactory} instance.
-         * @return The builder instance.
+         * @param extensionHandlerFactory An {@link ExtensionHandlerFactory} instance
+         * @return The builder instance
          */
         public Builder addExtensionHandlerFactory(ExtensionHandlerFactory extensionHandlerFactory) {
             this.extensionHandlerFactories.add(extensionHandlerFactory);
@@ -172,8 +172,8 @@ public final class ExtensionMetadata {
 
         /**
          * Adds an {@link ExtensionHandlerCustomizer} that will be used to customize extension handlers when the {@link Builder#build()}} method is called.
-         * @param extensionHandlerCustomizer An {@link ExtensionHandlerCustomizer} instance.
-         * @return
+         * @param extensionHandlerCustomizer An {@link ExtensionHandlerCustomizer} instance
+         * @return The builder instance
          */
         public Builder addExtensionHandlerCustomizer(ExtensionHandlerCustomizer extensionHandlerCustomizer) {
             this.extensionHandlerCustomizers.add(extensionHandlerCustomizer);
@@ -182,8 +182,8 @@ public final class ExtensionMetadata {
 
         /**
          * Adds an {@link ConfigCustomizerFactory} that will be used to find configuration customizers when the {@link Builder#build()}} method is called.
-         * @param configCustomizerFactory An {@link ConfigCustomizerFactory} instance.
-         * @return The builder instance.
+         * @param configCustomizerFactory An {@link ConfigCustomizerFactory} instance
+         * @return The builder instance
          */
         public Builder addConfigCustomizerFactory(ConfigCustomizerFactory configCustomizerFactory) {
             this.configCustomizerFactories.add(configCustomizerFactory);
@@ -192,8 +192,8 @@ public final class ExtensionMetadata {
 
         /**
          * Add an instance specific configuration customizer. This customizer will be applied to all methods on the extension type.
-         * @param configCustomizer A {@link ConfigCustomizer}.
-         * @return The builder instance.
+         * @param configCustomizer A {@link ConfigCustomizer}
+         * @return The builder instance
          */
         public Builder addInstanceConfigCustomizer(ConfigCustomizer configCustomizer) {
             instanceConfigCustomizer.addCustomizer(configCustomizer);
@@ -202,9 +202,9 @@ public final class ExtensionMetadata {
 
         /**
          * Add a method specific configuration customizer. This customizer will be applied only to the method given here.
-         * @param method A method object.
-         * @param configCustomizer A {@link ConfigCustomizer}.
-         * @return The builder instance.
+         * @param method A method object
+         * @param configCustomizer A {@link ConfigCustomizer}
+         * @return The builder instance
          */
         public Builder addMethodConfigCustomizer(Method method, ConfigCustomizer configCustomizer) {
             ConfigCustomizerChain methodConfigCustomizer = methodConfigCustomizers.computeIfAbsent(method, m -> new ConfigCustomizerChain());
@@ -216,8 +216,8 @@ public final class ExtensionMetadata {
          * Adds a new extension handler for a method.
          *
          * @param method The method for which an extension handler should be registered.
-         * @param handler An {@link ExtensionHandler} instance.
-         * @return The builder instance.
+         * @param handler An {@link ExtensionHandler} instance
+         * @return The builder instance
          */
         public Builder addMethodHandler(Method method, ExtensionHandler handler) {
             methodHandlers.put(method, handler);
@@ -226,7 +226,7 @@ public final class ExtensionMetadata {
 
         /**
          * Returns the extension type from the builder.
-         * @return The extension type.
+         * @return The extension type
          */
         public Class<?> getExtensionType() {
             return extensionType;
@@ -235,7 +235,7 @@ public final class ExtensionMetadata {
         /**
          * Creates a new {@link ExtensionMetadata} object.
          *
-         * @return A {@link ExtensionMetadata} object.
+         * @return A {@link ExtensionMetadata} object
          */
         public ExtensionMetadata build() {
             // add all methods that are declared on the extension type and
@@ -315,8 +315,8 @@ public final class ExtensionMetadata {
          * extension context is registered with the underlying handle to configure the handle when
          * executing the registered {@link ExtensionHandler}.
          *
-         * @param args The arguments to pass into the extension handler.
-         * @return The result of the extension handler invocation.
+         * @param args The arguments to pass into the extension handler
+         * @return The result of the extension handler invocation
          */
         public Object invoke(Object... args) {
             final Object[] handlerArgs = JdbiClassUtils.safeVarargs(args);
@@ -333,8 +333,8 @@ public final class ExtensionMetadata {
          * This method is used by the generated classes from the <code>jdbi3-generator</code> annotation
          * processor to execute predefined {@link ExtensionHandler} instances.
          *
-         * @param callable The callable to use.
-         * @return The result of the extension handler invocation.
+         * @param callable The callable to use
+         * @return The result of the extension handler invocation
          */
         public Object call(Callable<?> callable) {
             try {
@@ -353,7 +353,7 @@ public final class ExtensionMetadata {
          * This method is used by the generated classes from the <code>jdbi3-generator</code> annotation
          * processor to execute predefined {@link ExtensionHandler} instances.
          *
-         * @param runnable The runnable to use.
+         * @param runnable The runnable to use
          */
         public void call(Runnable runnable) {
             call(() -> {

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import org.jdbi.v3.core.config.ConfigCustomizer;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.config.internal.ConfigCustomizerChain;
+import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
+import org.jdbi.v3.core.internal.exceptions.Sneaky;
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Metadata that was detected when analyzing an extension class before attaching.
+ * Represents a resolved extension type with all config customizers and method handlers.
+ *
+ * @since 3.38.0
+ */
+@Alpha
+public final class ExtensionMetadata {
+
+    private final Class<?> extensionType;
+    private final ConfigCustomizer instanceConfigCustomizer;
+    private final Map<Method, ? extends ConfigCustomizer> methodConfigCustomizers;
+    private final Map<Method, ExtensionHandler> methodHandlers;
+
+    /**
+     * Returns a new {@link ExtensionMetadata.Builder} instance.
+     * @param extensionType The extension type for which metadata is collected.
+     * @return A new {@link ExtensionMetadata.Builder} instance.
+     */
+    public static ExtensionMetadata.Builder builder(Class<?> extensionType) {
+        return new Builder(extensionType);
+    }
+
+    private ExtensionMetadata(
+            Class<?> extensionType,
+            ConfigCustomizer instanceConfigCustomizer,
+            Map<Method, ? extends ConfigCustomizer> methodConfigCustomizers,
+            Map<Method, ExtensionHandler> methodHandlers) {
+        this.extensionType = extensionType;
+        this.instanceConfigCustomizer = instanceConfigCustomizer;
+        this.methodConfigCustomizers = Collections.unmodifiableMap(methodConfigCustomizers);
+        this.methodHandlers = Collections.unmodifiableMap(methodHandlers);
+    }
+
+    public Class<?> extensionType() {
+        return extensionType;
+    }
+
+    /**
+     * Create an instance specific configuration based on all instance customizers. The instance configuration holds all
+     * custom configuration that was applied e.g. through instance annotations.
+     *
+     * @param config A configuration object. The object is not changed.
+     * @return A new configuration object with all changes applied.
+     */
+    public ConfigRegistry createInstanceConfiguration(ConfigRegistry config) {
+        ConfigRegistry instanceConfiguration = config.createCopy();
+        instanceConfigCustomizer.customize(instanceConfiguration);
+        return instanceConfiguration;
+    }
+
+    /**
+     * Create an method specific configuration based on all method customizers. The method configuration holds all
+     * custom configuration that was applied e.g. through method annotations.
+     *
+     * @param method The method that is about to be called.
+     * @param config A configuration object. The object is not changed.
+     * @return A new configuration object with all changes applied.
+     */
+    public ConfigRegistry createMethodConfiguration(Method method, ConfigRegistry config) {
+        ConfigRegistry methodConfiguration = config.createCopy();
+        ConfigCustomizer methodConfigCustomizer = methodConfigCustomizers.get(method);
+        if (methodConfigCustomizer != null) {
+            methodConfigCustomizer.customize(methodConfiguration);
+        }
+        return methodConfiguration;
+    }
+
+    /**
+     * Returns a set of all Methods that have {@link ExtensionHandler} objects associated with them.
+     */
+    public Set<Method> getExtensionMethods() {
+        return methodHandlers.keySet();
+    }
+
+    /**
+     * Creates an {@link ExtensionHandlerInvoker} instance for a specific method.
+     * @param target The target object on which the invoker should work.
+     * @param method The method which will trigger the invocation.
+     * @param handleSupplier A {@link HandleSupplier} that will provide the handle object for the extension method.
+     * @param config The configuration object which should be used as base for the method specific configuration.
+     * @return A {@link ExtensionHandlerInvoker} object that is linked to the method.
+     * @param <E> THe type of the target object.
+     */
+    public <E> ExtensionHandlerInvoker createExtensionHandlerInvoker(E target, Method method,
+            HandleSupplier handleSupplier, ConfigRegistry config) {
+        return new ExtensionHandlerInvoker(target, method, methodHandlers.get(method), handleSupplier, config);
+    }
+
+    /**
+     * Builder class for the {@link ExtensionMetadata} object.
+     * See {@link ExtensionMetadata#builder(Class)}.
+     */
+    public static final class Builder {
+
+        private final Class<?> extensionType;
+        private final Collection<ExtensionHandlerFactory> extensionHandlerFactories = new ArrayList<>();
+        private final Collection<ExtensionHandlerCustomizer> extensionHandlerCustomizers = new ArrayList<>();
+        private final Collection<ConfigCustomizerFactory> configCustomizerFactories = new ArrayList<>();
+
+        private final ConfigCustomizerChain instanceConfigCustomizer = new ConfigCustomizerChain();
+        private final Map<Method, ConfigCustomizerChain> methodConfigCustomizers = new HashMap<>();
+        private final Map<Method, ExtensionHandler> methodHandlers = new HashMap<>();
+
+        private final Collection<Method> extensionTypeMethods = new HashSet<>();
+
+        Builder(Class<?> extensionType) {
+            this.extensionType = extensionType;
+
+            this.extensionTypeMethods.addAll(Arrays.asList(extensionType.getMethods()));
+            this.extensionTypeMethods.addAll(Arrays.asList(extensionType.getDeclaredMethods()));
+
+            this.extensionTypeMethods.stream()
+                    .filter(m -> !m.isSynthetic())
+                    .collect(Collectors.groupingBy(m -> Arrays.asList(m.getName(), Arrays.asList(m.getParameterTypes()))))
+                    .values()
+                    .stream()
+                    .filter(methodCount -> methodCount.size() > 1)
+                    .findAny()
+                    .ifPresent(methods -> {
+                        throw new UnableToCreateExtensionException("%s has ambiguous methods (%s) found, please resolve with an explicit override",
+                                extensionType, methods);
+                    });
+        }
+
+        /**
+         * Adds an {@link ExtensionHandlerFactory} that will be used to find extension handlers when the {@link Builder#build()}} method is called.
+         * @param extensionHandlerFactory An {@link ExtensionHandlerFactory} instance.
+         * @return The builder instance.
+         */
+        public Builder addExtensionHandlerFactory(ExtensionHandlerFactory extensionHandlerFactory) {
+            this.extensionHandlerFactories.add(extensionHandlerFactory);
+            return this;
+        }
+
+        /**
+         * Adds an {@link ExtensionHandlerCustomizer} that will be used to customize extension handlers when the {@link Builder#build()}} method is called.
+         * @param extensionHandlerCustomizer An {@link ExtensionHandlerCustomizer} instance.
+         * @return
+         */
+        public Builder addExtensionHandlerCustomizer(ExtensionHandlerCustomizer extensionHandlerCustomizer) {
+            this.extensionHandlerCustomizers.add(extensionHandlerCustomizer);
+            return this;
+        }
+
+        /**
+         * Adds an {@link ConfigCustomizerFactory} that will be used to find configuration customizers when the {@link Builder#build()}} method is called.
+         * @param configCustomizerFactory An {@link ConfigCustomizerFactory} instance.
+         * @return The builder instance.
+         */
+        public Builder addConfigCustomizerFactory(ConfigCustomizerFactory configCustomizerFactory) {
+            this.configCustomizerFactories.add(configCustomizerFactory);
+            return this;
+        }
+
+        /**
+         * Add an instance specific configuration customizer. This customizer will be applied to all methods on the extension type.
+         * @param configCustomizer A {@link ConfigCustomizer}.
+         * @return The builder instance.
+         */
+        public Builder addInstanceConfigCustomizer(ConfigCustomizer configCustomizer) {
+            instanceConfigCustomizer.addCustomizer(configCustomizer);
+            return this;
+        }
+
+        /**
+         * Add a method specific configuration customizer. This customizer will be applied only to the method given here.
+         * @param method A method object.
+         * @param configCustomizer A {@link ConfigCustomizer}.
+         * @return The builder instance.
+         */
+        public Builder addMethodConfigCustomizer(Method method, ConfigCustomizer configCustomizer) {
+            ConfigCustomizerChain methodConfigCustomizer = methodConfigCustomizers.computeIfAbsent(method, m -> new ConfigCustomizerChain());
+            methodConfigCustomizer.addCustomizer(configCustomizer);
+            return this;
+        }
+
+        /**
+         * Adds a new extension handler for a method.
+         *
+         * @param method The method for which an extension handler should be registered.
+         * @param handler An {@link ExtensionHandler} instance.
+         * @return The builder instance.
+         */
+        public Builder addMethodHandler(Method method, ExtensionHandler handler) {
+            methodHandlers.put(method, handler);
+            return this;
+        }
+
+        /**
+         * Returns the extension type from the builder.
+         * @return The extension type.
+         */
+        public Class<?> getExtensionType() {
+            return extensionType;
+        }
+
+        /**
+         * Creates a new {@link ExtensionMetadata} object.
+         *
+         * @return A {@link ExtensionMetadata} object.
+         */
+        public ExtensionMetadata build() {
+            // add all methods that are declared on the extension type and
+            // are not static and don't already have a handler
+
+            final Set<Method> seen = new HashSet<>(methodHandlers.keySet());
+            for (Method method : extensionTypeMethods) {
+                // skip static methods and methods that already have method handlers
+                if (Modifier.isStatic(method.getModifiers()) || !seen.add(method)) {
+                    continue;
+                }
+
+                // look through the registered extension handler factories to find extension handlers
+                ExtensionHandler handler = ((Optional<ExtensionHandler>) findExtensionHandlerFor(extensionType, method))
+                        .orElseGet(() -> ExtensionHandler.missingExtensionHandler(method));
+
+
+                // apply extension handler customizers
+                for (ExtensionHandlerCustomizer extensionHandlerCustomizer : extensionHandlerCustomizers) {
+                    handler = extensionHandlerCustomizer.customize(handler, extensionType, method);
+                }
+
+                methodHandlers.put(method, handler);
+            }
+
+            configCustomizerFactories.forEach(configCustomizerFactory -> configCustomizerFactory.forExtensionType(extensionType)
+                    .forEach(this::addInstanceConfigCustomizer));
+
+            for (Method method : methodHandlers.keySet()) {
+                // call all method configurer factories.
+                configCustomizerFactories.forEach(configCustomizerFactory ->
+                        configCustomizerFactory.forExtensionMethod(extensionType, method)
+                                .forEach(configCustomizer -> this.addMethodConfigCustomizer(method, configCustomizer)));
+            }
+
+            return new ExtensionMetadata(extensionType, instanceConfigCustomizer, methodConfigCustomizers, methodHandlers);
+        }
+
+        private Optional<? extends ExtensionHandler> findExtensionHandlerFor(Class<?> extensionType, Method method) {
+            for (ExtensionHandlerFactory extensionHandlerFactory : extensionHandlerFactories) {
+                if (extensionHandlerFactory.accepts(extensionType, method)) {
+                    Optional<? extends ExtensionHandler> result = extensionHandlerFactory.buildExtensionHandler(extensionType, method);
+                    if (result.isPresent()) {
+                        return result;
+                    }
+                }
+            }
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Wraps all config customizers and the handler for a specific method execution.
+     * An invoker is created using {@link ExtensionMetadata#createExtensionHandlerInvoker(Object, Method, HandleSupplier, ConfigRegistry)}.
+     */
+    public final class ExtensionHandlerInvoker {
+
+        private final Object target;
+        private final HandleSupplier handleSupplier;
+        private final ExtensionContext extensionContext;
+        private final ExtensionHandler extensionHandler;
+
+        ExtensionHandlerInvoker(Object target, Method method, ExtensionHandler extensionHandler, HandleSupplier handleSupplier, ConfigRegistry config) {
+            this.target = target;
+            this.handleSupplier = handleSupplier;
+            ConfigRegistry methodConfig = createMethodConfiguration(method, config);
+            this.extensionContext = ExtensionContext.forExtensionMethod(methodConfig, extensionType, method);
+
+            this.extensionHandler = extensionHandler;
+            this.extensionHandler.warm(methodConfig);
+        }
+
+        /**
+         * Invoke the registered extension handler code in the extension context. The
+         * extension context wraps the method that gets executed and a full customized configuration
+         * (both instance and method specific configuration customizers have been applied). The
+         * extension context is registered with the underlying handle to configure the handle when
+         * executing the registered {@link ExtensionHandler}.
+         *
+         * @param args The arguments to pass into the extension handler.
+         * @return The result of the extension handler invocation.
+         */
+        public Object invoke(Object... args) {
+            final Object[] handlerArgs = JdbiClassUtils.safeVarargs(args);
+            final Callable<Object> callable = () -> extensionHandler.invoke(handleSupplier, target, handlerArgs);
+            return call(callable);
+        }
+
+        /**
+         * Invoke a callable in the extension context. The extension context wraps the method that
+         * gets executed and a full customized configuration (both instance and method specific
+         * configuration customizers have been applied). The extension context is registered with
+         * the underlying handle to configure the handle when calling the {@link Callable#call()} method.
+         * <br>
+         * This method is used by the generated classes from the <code>jdbi3-generator</code> annotation
+         * processor to execute predefined {@link ExtensionHandler} instances.
+         *
+         * @param callable The callable to use.
+         * @return The result of the extension handler invocation.
+         */
+        public Object call(Callable<?> callable) {
+            try {
+                return handleSupplier.invokeInContext(extensionContext, callable);
+            } catch (Exception x) {
+                throw Sneaky.throwAnyway(x);
+            }
+        }
+
+        /**
+         * Invoke a runnable in the extension context. The extension context wraps the method that
+         * gets executed and a full customized configuration (both instance and method specific
+         * configuration customizers have been applied). The extension context is registered with
+         * the underlying handle to configure the handle when calling the {@link Runnable#run()} method.
+         * <br>
+         * This method is used by the generated classes from the <code>jdbi3-generator</code> annotation
+         * processor to execute predefined {@link ExtensionHandler} instances.
+         *
+         * @param runnable The runnable to use.
+         */
+        public void call(Runnable runnable) {
+            call(() -> {
+                runnable.run();
+                return null;
+            });
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/Extensions.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/Extensions.java
@@ -15,60 +15,145 @@ package org.jdbi.v3.core.extension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
+import org.jdbi.v3.core.extension.annotation.UseExtensionHandler;
+import org.jdbi.v3.meta.Alpha;
 import org.jdbi.v3.meta.Beta;
+
+import static org.jdbi.v3.core.extension.ExtensionFactory.FactoryFlag.VIRTUAL_FACTORY;
 
 /**
  * Configuration class for defining {@code Jdbi} extensions via {@link ExtensionFactory}
  * instances.
  */
 public class Extensions implements JdbiConfig<Extensions> {
-    private final List<ExtensionFactory> factories = new CopyOnWriteArrayList<>();
+
+    private final List<ExtensionFactoryDelegate> extensionFactories = new CopyOnWriteArrayList<>();
+    private final ConcurrentMap<Class<?>, ExtensionMetadata> extensionMetadataCache = new ConcurrentHashMap<>();
+
+    private final List<ExtensionHandlerCustomizer> extensionHandlerCustomizers = new CopyOnWriteArrayList<>();
+    private final List<ExtensionHandlerFactory> extensionHandlerFactories = new CopyOnWriteArrayList<>();
+    private final List<ConfigCustomizerFactory> configCustomizerFactories = new CopyOnWriteArrayList<>();
+
     private boolean allowProxy = true;
 
     /**
-     * Create an empty {@link ExtensionFactory} configuration.
+     * Creates a new instance.
+     * <ul>
+     * <li>registers extension handlers factories for bridge and interface default methods and for the {@link UseExtensionHandler} annotation.</li>
+     * <li>registers extension handler customizers for the {@link org.jdbi.v3.core.extension.annotation.UseExtensionCustomizer} annotation.</li>
+     * <li>registers extension configurer factories for {@link org.jdbi.v3.core.extension.annotation.UseExtensionConfigurer} annotation.</li>
+     * </ul>
      */
-    public Extensions() {}
+    public Extensions() {
+        // default handler factories for bridge and default methods
+        registerHandlerFactory(DefaultMethodExtensionHandlerFactory.INSTANCE);
+        registerHandlerFactory(BridgeMethodExtensionHandlerFactory.INSTANCE);
 
-    /**
-     * Create an extension configuration by cloning another
-     * @param that the configuration to clone
-     */
-    private Extensions(Extensions that) {
-        allowProxy = that.allowProxy;
-        factories.addAll(that.factories);
+        // default handler factory for the UseExtensionHandler annotation.
+        registerHandlerFactory(UseExtensionAnnotationHandlerFactory.FACTORY);
+
+        // default handler customizer for the UseExtensionCustomizer annotation.
+        registerHandlerCustomizer(UseExtensionAnnotationHandlerCustomizer.HANDLER);
+
+        registerConfigCustomizerFactory(UseExtensionAnnotationConfigCustomizerFactory.FACTORY);
     }
 
     /**
-     * Register an extension factory.
+     * Create an extension configuration by cloning another.
+     *
+     * @param that the configuration to clone.
+     */
+    private Extensions(Extensions that) {
+        allowProxy = that.allowProxy;
+        extensionFactories.addAll(that.extensionFactories);
+        extensionMetadataCache.putAll(that.extensionMetadataCache);
+        extensionHandlerCustomizers.addAll(that.extensionHandlerCustomizers);
+        extensionHandlerFactories.addAll(that.extensionHandlerFactories);
+        configCustomizerFactories.addAll(that.configCustomizerFactories);
+    }
+
+    /**
+     * Register a {@link ExtensionFactory} instance with the extension framework.
+     *
      * @param factory the factory to register
-     * @return this
+     * @return This instance.
      */
     public Extensions register(ExtensionFactory factory) {
-        factories.add(0, factory);
+        extensionFactories.add(0, new ExtensionFactoryDelegate(factory));
         return this;
     }
 
     /**
-     * Returns true if an extension is registered for the given type.
+     * Registers a global {@link ExtensionHandlerFactory} instance. This factory is registered globally and will be used
+     * with all registered {@link ExtensionFactory} instances.
+     * @param extensionHandlerFactory The {@link ExtensionHandlerFactory} to register.
+     * @return This instance.
      *
-     * @param extensionType the type to query.
-     * @return true if a registered extension handles the type.
+     * @since 3.38.0
+     */
+    @Alpha
+    public Extensions registerHandlerFactory(ExtensionHandlerFactory extensionHandlerFactory) {
+        extensionHandlerFactories.add(0, extensionHandlerFactory);
+        return this;
+    }
+
+    /**
+     * Registers a global {@link ExtensionHandlerCustomizer} instance. This customizer is registered globally and will be used
+     * with all registered {@link ExtensionFactory} instances.
+     * @param extensionHandlerCustomizer The {@link ExtensionHandlerCustomizer} to register.
+     * @return This instance.
+     *
+     * @since 3.38.0
+     */
+    @Alpha
+    public Extensions registerHandlerCustomizer(ExtensionHandlerCustomizer extensionHandlerCustomizer) {
+        extensionHandlerCustomizers.add(0, extensionHandlerCustomizer);
+        return this;
+    }
+
+    /**
+     * Registers a global {@link ConfigCustomizerFactory} instance. This factory is registered globally and will be used
+     * with all registered {@link ExtensionFactory} instances.
+     * @param configCustomizerFactory The {@link ConfigCustomizerFactory} to register.
+     * @return This instance.
+     *
+     * @since 3.38.0
+     */
+    @Alpha
+    public Extensions registerConfigCustomizerFactory(ConfigCustomizerFactory configCustomizerFactory) {
+        configCustomizerFactories.add(0, configCustomizerFactory);
+        return this;
+    }
+
+    /**
+     * Returns true if an extension is registered for the given extension type.
+     *
+     * @param extensionType the type to query. Must not be null.
+     * @return true if a registered extension factory handles the type.
      */
     public boolean hasExtensionFor(Class<?> extensionType) {
         return findFactoryFor(extensionType).isPresent();
     }
 
     /**
-     * Create an extension instance if we have a factory that understands
-     * the extension type which has access to a {@code Handle} through a {@link HandleSupplier}.
-     * @param <E> the extension type to create
-     * @param extensionType the extension type to create
-     * @param handleSupplier the handle supplier
-     * @return an attached extension instance if a factory is found
+     * Create an extension instance if a factory accepts the extension type.
+     *
+     * <b>This method requires access to a {@link HandleSupplier}, which is only useful either from
+     * within an extension implementation of inside the Jdbi code. It should rarely be called by
+     * user code.</b>
+     *
+     * @param <E>            the extension type to create.
+     * @param extensionType  the extension type to create.
+     * @param handleSupplier A handle supplier object.
+     * @return an attached extension instance if a factory is found, {@link Optional#empty()} otherwise.
      */
     public <E> Optional<E> findFor(Class<E> extensionType, HandleSupplier handleSupplier) {
         return findFactoryFor(extensionType)
@@ -76,26 +161,83 @@ public class Extensions implements JdbiConfig<Extensions> {
     }
 
     private Optional<ExtensionFactory> findFactoryFor(Class<?> extensionType) {
-        return factories.stream()
-                .filter(factory -> factory.accepts(extensionType))
-                .findFirst();
+        Optional<ExtensionFactory> result = Optional.empty();
+        for (ExtensionFactory factory : extensionFactories) {
+            if (factory.accepts(extensionType)) {
+                result = Optional.of(factory);
+                break;
+            }
+        }
+
+        return result;
     }
 
     /**
-     * Find the registered factory of the given type, if any
-     * @param <F> the factory type to find
-     * @param factoryType the factory's type to find
-     * @return the found factory, if any
+     * Find the registered factory of the given type. The factory returned from this call
+     * may not be the same instance that was registered with {@link Extensions#register(ExtensionFactory)}.
+     *
+     * @param factoryType the factory's type to find.
+     * @return the found factory, if any or {@link Optional#empty()} otherwise.
      */
-    public <F extends ExtensionFactory> Optional<F> findFactory(Class<F> factoryType) {
-        return factories.stream()
-                .filter(factoryType::isInstance)
-                .map(factoryType::cast)
-                .findFirst();
+    public Optional<ExtensionFactory> findFactory(Class<? extends ExtensionFactory> factoryType) {
+        Optional<ExtensionFactory> result = Optional.empty();
+        for (ExtensionFactoryDelegate factory : extensionFactories) {
+            if (factoryType.isInstance(factory.getDelegatedFactory())) {
+                result = Optional.of(factory);
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Retrieves all extension metadata for a specific extension type.
+     *
+     * @param extensionType The extension type.
+     * @param config A config registry that can be used to look up other configuration elements.
+     * @param extensionFactory The extension factory for this extension type.
+     * @return A {@link ExtensionMetadata} object describing the extension handlers and customizers for this extension type.
+     *
+     * @since 3.38.0
+     */
+    @Alpha
+    public ExtensionMetadata findMetadata(Class<?> extensionType, ConfigRegistry config, ExtensionFactory extensionFactory) {
+        return extensionMetadataCache.computeIfAbsent(extensionType, createMetadata(config, extensionFactory));
+    }
+
+    private Function<Class<?>, ExtensionMetadata> createMetadata(ConfigRegistry config, ExtensionFactory extensionFactory) {
+        return extensionType -> {
+
+            ExtensionMetadata.Builder builder = ExtensionMetadata.builder(extensionType);
+
+            // prep the extension handler set for this factory
+            extensionFactory.getExtensionHandlerFactories(config).forEach(builder::addExtensionHandlerFactory);
+            extensionHandlerFactories.forEach(builder::addExtensionHandlerFactory);
+
+            // InstanceExtensionHandlerFactory for non-virtual factories. These have a backing object and can invoke methods on those objects.
+            if (!extensionFactory.getFactoryFlags().contains(VIRTUAL_FACTORY)) {
+                builder.addExtensionHandlerFactory(InstanceExtensionHandlerFactory.INSTANCE);
+            }
+
+            // prep the extension customizer set for this factory
+            extensionFactory.getExtensionHandlerCustomizers(config).forEach(builder::addExtensionHandlerCustomizer);
+            extensionHandlerCustomizers.forEach(builder::addExtensionHandlerCustomizer);
+
+            // prep the extension configurer set for this factory
+            extensionFactory.getConfigCustomizerFactories(config).forEach(builder::addConfigCustomizerFactory);
+            configCustomizerFactories.forEach(builder::addConfigCustomizerFactory);
+
+            // build metadata
+            extensionFactory.buildExtensionInitData(builder);
+
+            return builder.build();
+        };
     }
 
     /**
      * Allow using {@link java.lang.reflect.Proxy} to implement extensions.
+     *
      * @param allowProxy whether to allow use of Proxy types
      * @return this
      */
@@ -126,7 +268,8 @@ public class Extensions implements JdbiConfig<Extensions> {
     @Beta
     public void onCreateProxy() {
         if (!isAllowProxy()) {
-            throw new IllegalStateException("Creating onDemand proxy disallowed. Ensure @GenerateSqlObject annotation is being processed by `jdbi3-generator` annotation processor.");
+            throw new IllegalStateException(
+                    "Creating onDemand proxy disallowed. Ensure @GenerateSqlObject annotation is being processed by `jdbi3-generator` annotation processor.");
         }
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/Extensions.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/Extensions.java
@@ -69,7 +69,7 @@ public class Extensions implements JdbiConfig<Extensions> {
     /**
      * Create an extension configuration by cloning another.
      *
-     * @param that the configuration to clone.
+     * @param that the configuration to clone
      */
     private Extensions(Extensions that) {
         allowProxy = that.allowProxy;
@@ -84,7 +84,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      * Register a {@link ExtensionFactory} instance with the extension framework.
      *
      * @param factory the factory to register
-     * @return This instance.
+     * @return This instance
      */
     public Extensions register(ExtensionFactory factory) {
         extensionFactories.add(0, new ExtensionFactoryDelegate(factory));
@@ -94,8 +94,8 @@ public class Extensions implements JdbiConfig<Extensions> {
     /**
      * Registers a global {@link ExtensionHandlerFactory} instance. This factory is registered globally and will be used
      * with all registered {@link ExtensionFactory} instances.
-     * @param extensionHandlerFactory The {@link ExtensionHandlerFactory} to register.
-     * @return This instance.
+     * @param extensionHandlerFactory The {@link ExtensionHandlerFactory} to register
+     * @return This instance
      *
      * @since 3.38.0
      */
@@ -108,8 +108,8 @@ public class Extensions implements JdbiConfig<Extensions> {
     /**
      * Registers a global {@link ExtensionHandlerCustomizer} instance. This customizer is registered globally and will be used
      * with all registered {@link ExtensionFactory} instances.
-     * @param extensionHandlerCustomizer The {@link ExtensionHandlerCustomizer} to register.
-     * @return This instance.
+     * @param extensionHandlerCustomizer The {@link ExtensionHandlerCustomizer} to register
+     * @return This instance
      *
      * @since 3.38.0
      */
@@ -122,8 +122,8 @@ public class Extensions implements JdbiConfig<Extensions> {
     /**
      * Registers a global {@link ConfigCustomizerFactory} instance. This factory is registered globally and will be used
      * with all registered {@link ExtensionFactory} instances.
-     * @param configCustomizerFactory The {@link ConfigCustomizerFactory} to register.
-     * @return This instance.
+     * @param configCustomizerFactory The {@link ConfigCustomizerFactory} to register
+     * @return This instance
      *
      * @since 3.38.0
      */
@@ -136,8 +136,8 @@ public class Extensions implements JdbiConfig<Extensions> {
     /**
      * Returns true if an extension is registered for the given extension type.
      *
-     * @param extensionType the type to query. Must not be null.
-     * @return true if a registered extension factory handles the type.
+     * @param extensionType the type to query. Must not be null
+     * @return true if a registered extension factory handles the type
      */
     public boolean hasExtensionFor(Class<?> extensionType) {
         return findFactoryFor(extensionType).isPresent();
@@ -150,10 +150,10 @@ public class Extensions implements JdbiConfig<Extensions> {
      * within an extension implementation of inside the Jdbi code. It should rarely be called by
      * user code.</b>
      *
-     * @param <E>            the extension type to create.
-     * @param extensionType  the extension type to create.
-     * @param handleSupplier A handle supplier object.
-     * @return an attached extension instance if a factory is found, {@link Optional#empty()} otherwise.
+     * @param <E>            the extension type to create
+     * @param extensionType  the extension type to create
+     * @param handleSupplier A handle supplier object
+     * @return an attached extension instance if a factory is found, {@link Optional#empty()} otherwise
      */
     public <E> Optional<E> findFor(Class<E> extensionType, HandleSupplier handleSupplier) {
         return findFactoryFor(extensionType)
@@ -161,43 +161,39 @@ public class Extensions implements JdbiConfig<Extensions> {
     }
 
     private Optional<ExtensionFactory> findFactoryFor(Class<?> extensionType) {
-        Optional<ExtensionFactory> result = Optional.empty();
         for (ExtensionFactory factory : extensionFactories) {
             if (factory.accepts(extensionType)) {
-                result = Optional.of(factory);
-                break;
+                return Optional.of(factory);
             }
         }
 
-        return result;
+        return Optional.empty();
     }
 
     /**
      * Find the registered factory of the given type. The factory returned from this call
      * may not be the same instance that was registered with {@link Extensions#register(ExtensionFactory)}.
      *
-     * @param factoryType the factory's type to find.
-     * @return the found factory, if any or {@link Optional#empty()} otherwise.
+     * @param factoryType the factory's type to find
+     * @return the found factory, if any or {@link Optional#empty()} otherwise
      */
     public Optional<ExtensionFactory> findFactory(Class<? extends ExtensionFactory> factoryType) {
-        Optional<ExtensionFactory> result = Optional.empty();
         for (ExtensionFactoryDelegate factory : extensionFactories) {
             if (factoryType.isInstance(factory.getDelegatedFactory())) {
-                result = Optional.of(factory);
-                break;
+                return Optional.of(factory);
             }
         }
 
-        return result;
+        return Optional.empty();
     }
 
     /**
      * Retrieves all extension metadata for a specific extension type.
      *
-     * @param extensionType The extension type.
-     * @param config A config registry that can be used to look up other configuration elements.
-     * @param extensionFactory The extension factory for this extension type.
-     * @return A {@link ExtensionMetadata} object describing the extension handlers and customizers for this extension type.
+     * @param extensionType The extension type
+     * @param config A config registry that can be used to look up other configuration elements
+     * @param extensionFactory The extension factory for this extension type
+     * @return A {@link ExtensionMetadata} object describing the extension handlers and customizers for this extension type
      *
      * @since 3.38.0
      */

--- a/core/src/main/java/org/jdbi/v3/core/extension/InstanceExtensionHandlerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/InstanceExtensionHandlerFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Optional;
+
+import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
+
+/**
+ * Provides {@link ExtensionHandler} instances for all methods that have not been covered in
+ * any other way. It forwards a call to the handler to a method invocation on the target
+ * object. For any extension factory that simply provides an implementation of the extension
+ * interface, this forwards the call to the method on the implementation. The extension framework
+ * wraps these calls into invocations that manage the extension context for the handle correctly
+ * so that logging will work for all extension.
+ *
+ * @since 3.38.0
+ */
+final class InstanceExtensionHandlerFactory implements ExtensionHandlerFactory {
+
+    static final ExtensionHandlerFactory INSTANCE = new InstanceExtensionHandlerFactory();
+
+    @Override
+    public boolean accepts(Class<?> extensionType, Method method) {
+        return Modifier.isAbstract(method.getModifiers())                                        // any abstract method
+                || (!extensionType.isInterface() && method.getDeclaringClass() != Object.class); // any non-interface type if the method is not from Object
+    }
+
+    @Override
+    public Optional<ExtensionHandler> buildExtensionHandler(Class<?> extensionType, Method method) {
+        try {
+            return Optional.of(ExtensionHandler.createForMethod(method));
+        } catch (IllegalAccessException e) {
+            throw new UnableToCreateExtensionException(e, "Instance handler for %s couldn't unreflect %s", extensionType, method);
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/InstanceExtensionHandlerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/InstanceExtensionHandlerFactory.java
@@ -26,8 +26,6 @@ import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
  * interface, this forwards the call to the method on the implementation. The extension framework
  * wraps these calls into invocations that manage the extension context for the handle correctly
  * so that logging will work for all extension.
- *
- * @since 3.38.0
  */
 final class InstanceExtensionHandlerFactory implements ExtensionHandlerFactory {
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/PrivateLookupInKludge.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/PrivateLookupInKludge.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.jdbi.v3.core.internal.UtilityClassException;
+import org.jdbi.v3.core.internal.exceptions.Unchecked;
+
+import static java.lang.invoke.MethodHandles.Lookup.PACKAGE;
+import static java.lang.invoke.MethodHandles.Lookup.PRIVATE;
+import static java.lang.invoke.MethodHandles.Lookup.PROTECTED;
+import static java.lang.invoke.MethodHandles.Lookup.PUBLIC;
+import static java.util.Collections.synchronizedMap;
+
+/**
+ * this is a required kludge for JDK 8. Remove once we move past JDK8 compatibility.
+ */
+final class PrivateLookupInKludge {
+
+    private PrivateLookupInKludge() {
+        throw new UtilityClassException();
+    }
+
+    private static final int ANY_ACCESS = PUBLIC | PRIVATE | PROTECTED | PACKAGE;
+    // MethodHandles.privateLookupIn(Class, Lookup) was added in JDK 9.
+    // JDK 9 allows us to unreflectSpecial() on an interface default method, where JDK 8 did not.
+    private static final Method PRIVATE_LOOKUP_IN = privateLookupIn();
+    private static final Map<Class<?>, Lookup> PRIVATE_LOOKUPS = synchronizedMap(new WeakHashMap<>());
+
+    private static Method privateLookupIn() {
+        try {
+            return MethodHandles.class.getMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
+        } catch (NoSuchMethodException ignored) {
+            // Method was added in JDK 9. - @TODO remove this hack when we move to JDK11+
+            return null;
+        }
+    }
+
+    static MethodHandles.Lookup lookupFor(Class<?> clazz) {
+        if (PRIVATE_LOOKUP_IN != null) {
+            try {
+                return (MethodHandles.Lookup) PRIVATE_LOOKUP_IN.invoke(null, clazz, MethodHandles.lookup());
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new UnableToCreateExtensionException(e,
+                        "Error invoking MethodHandles.privateLookupIn(%s.class, MethodHandles.lookup()) in JDK 9+ runtime", clazz);
+            }
+        }
+
+        // TERRIBLE, HORRIBLE, NO GOOD, VERY BAD HACK
+        // Courtesy of:
+        // https://rmannibucau.wordpress.com/2014/03/27/java-8-default-interface-methods-and-jdk-dynamic-proxies/
+
+        // We can use MethodHandles to look up and invoke the super method, but since this class is not an
+        // implementation of method.getDeclaringClass(), MethodHandles.Lookup will throw an exception since
+        // this class doesn't have access to the super method, according to Java's access rules. This horrible,
+        // awful workaround allows us to directly invoke MethodHandles.Lookup's private constructor, bypassing
+        // the usual access checks.
+
+        // This workaround is only used in JDK 8.x runtimes. JDK 9+ runtimes use MethodHandles.privateLookupIn()
+        // above.
+        return PRIVATE_LOOKUPS.computeIfAbsent(clazz, Unchecked.function(PrivateLookupInKludge::getConstructorLookup));
+    }
+
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    private static MethodHandles.Lookup getConstructorLookup(Class<?> type) throws ReflectiveOperationException {
+        Constructor<Lookup> constructor = MethodHandles.Lookup.class.getDeclaredConstructor(Class.class, int.class);
+
+        if (!constructor.isAccessible()) {
+            constructor.setAccessible(true);
+        }
+
+        return constructor.newInstance(type, ANY_ACCESS);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/UnableToCreateExtensionException.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UnableToCreateExtensionException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import org.jdbi.v3.core.JdbiException;
+import org.jdbi.v3.meta.Beta;
+
+import static java.lang.String.format;
+
+/**
+ * Marks that a specific extension could not be created.
+ *
+ * @since 3.38.0
+ */
+@Beta
+public class UnableToCreateExtensionException extends JdbiException {
+
+    private static final long serialVersionUID = 1L;
+
+    UnableToCreateExtensionException(String s, Object... args) {
+        super(format(s, args));
+    }
+
+    UnableToCreateExtensionException(Exception e, String s, Object... args) {
+        super(format(s, args));
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/UnableToCreateExtensionException.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UnableToCreateExtensionException.java
@@ -24,15 +24,26 @@ import static java.lang.String.format;
  * @since 3.38.0
  */
 @Beta
-public class UnableToCreateExtensionException extends JdbiException {
+public final class UnableToCreateExtensionException extends JdbiException {
 
     private static final long serialVersionUID = 1L;
 
-    UnableToCreateExtensionException(String s, Object... args) {
-        super(format(s, args));
+    /**
+     * Constructs a new instance with a message.
+     * @param format A {@link String#format} format string
+     * @param args Arguments for the format string
+     */
+    public UnableToCreateExtensionException(String format, Object... args) {
+        super(format(format, args));
     }
 
-    UnableToCreateExtensionException(Exception e, String s, Object... args) {
-        super(format(s, args));
+    /**
+     * Constructs a new instance with an exception and a message.
+     * @param throwable A throwable
+     * @param format A {@link String#format} format string
+     * @param args Arguments for the format string
+     */
+    public UnableToCreateExtensionException(Throwable throwable, String format, Object... args) {
+        super(format(format, args), throwable);
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationConfigCustomizerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationConfigCustomizerFactory.java
@@ -31,8 +31,6 @@ import static java.lang.String.format;
 /**
  * Applies configuration customizers according to {@link UseExtensionConfigurer} decorating annotations.
  * present on the method.
- *
- * @since 3.38.0
  */
 final class UseExtensionAnnotationConfigCustomizerFactory implements ConfigCustomizerFactory {
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationConfigCustomizerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationConfigCustomizerFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jdbi.v3.core.config.ConfigCustomizer;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.extension.annotation.UseExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
+
+import static java.lang.String.format;
+
+/**
+ * Applies configuration customizers according to {@link UseExtensionConfigurer} decorating annotations.
+ * present on the method.
+ *
+ * @since 3.38.0
+ */
+final class UseExtensionAnnotationConfigCustomizerFactory implements ConfigCustomizerFactory {
+
+    static final ConfigCustomizerFactory FACTORY = new UseExtensionAnnotationConfigCustomizerFactory();
+
+    @Override
+    public Collection<ConfigCustomizer> forExtensionType(Class<?> extensionType) {
+        final ConfigurerMethod forType = (configurer, config, annotation) -> configurer.configureForType(config, annotation, extensionType);
+
+        // build a configurer for the type and all supertypes. This processes all annotations on classes and interfaces
+        return buildConfigCustomizer(Stream.concat(JdbiClassUtils.superTypes(extensionType), Stream.of(extensionType)), forType);
+    }
+
+    @Override
+    public Collection<ConfigCustomizer> forExtensionMethod(Class<?> extensionType, Method method) {
+        final ConfigurerMethod forMethod = (configurer, config, annotation) -> configurer.configureForMethod(config, annotation, extensionType, method);
+        // build a configurer that processes all annotations on the method itself.
+        return buildConfigCustomizer(Stream.of(method), forMethod);
+    }
+
+    private static Collection<ConfigCustomizer> buildConfigCustomizer(Stream<AnnotatedElement> elements, ConfigurerMethod consumer) {
+        return elements.flatMap(ae -> Arrays.stream(ae.getAnnotations()))
+                .filter(a -> a.annotationType().isAnnotationPresent(UseExtensionConfigurer.class))
+                .map(a -> {
+                    UseExtensionConfigurer meta = a.annotationType().getAnnotation(UseExtensionConfigurer.class);
+                    Class<? extends ExtensionConfigurer> klass = meta.value();
+
+                    try {
+                        ExtensionConfigurer configurer = klass.getConstructor().newInstance();
+                        return (ConfigCustomizer) config -> consumer.configure(configurer, config, a);
+                    } catch (ReflectiveOperationException | SecurityException e) {
+                        throw new IllegalStateException(format("Unable to instantiate class %s", klass), e);
+                    }
+
+                })
+                .collect(Collectors.toList());
+    }
+
+    private interface ConfigurerMethod {
+
+        void configure(ExtensionConfigurer configurer, ConfigRegistry config, Annotation annotation);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationHandlerCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationHandlerCustomizer.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.extension;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -29,14 +30,13 @@ import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.internal.exceptions.CheckedCallable;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
 /**
  * Applies decorations to method handlers, according to any {@link UseExtensionCustomizer} decorating annotations
  * present on the method. If multiple decorating annotations are present, the order of application can be controlled
  * using the {@link ExtensionCustomizationOrder} annotation.
- *
- * @since 3.38.0
  */
 final class UseExtensionAnnotationHandlerCustomizer implements ExtensionHandlerCustomizer {
 
@@ -51,7 +51,7 @@ final class UseExtensionAnnotationHandlerCustomizer implements ExtensionHandlerC
                 .flatMap(Arrays::stream)
                 .map(Annotation::annotationType)
                 .filter(type -> type.isAnnotationPresent(UseExtensionCustomizer.class))
-                .collect(toList());
+                .collect(toCollection(ArrayList::new));
 
         Stream.of(method, extensionType)
                 .map(e -> e.getAnnotation(ExtensionCustomizationOrder.class))

--- a/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationHandlerCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationHandlerCustomizer.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.jdbi.v3.core.extension.annotation.ExtensionCustomizationOrder;
+import org.jdbi.v3.core.extension.annotation.UseExtensionCustomizer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
+import org.jdbi.v3.core.internal.exceptions.CheckedCallable;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Applies decorations to method handlers, according to any {@link UseExtensionCustomizer} decorating annotations
+ * present on the method. If multiple decorating annotations are present, the order of application can be controlled
+ * using the {@link ExtensionCustomizationOrder} annotation.
+ *
+ * @since 3.38.0
+ */
+final class UseExtensionAnnotationHandlerCustomizer implements ExtensionHandlerCustomizer {
+
+    static final ExtensionHandlerCustomizer HANDLER = new UseExtensionAnnotationHandlerCustomizer();
+
+    @Override
+    public ExtensionHandler customize(ExtensionHandler delegate, Class<?> extensionType, Method method) {
+        ExtensionHandler extensionHandler = delegate;
+
+        List<Class<? extends Annotation>> annotationTypes = Stream.of(method, extensionType)
+                .map(AnnotatedElement::getAnnotations)
+                .flatMap(Arrays::stream)
+                .map(Annotation::annotationType)
+                .filter(type -> type.isAnnotationPresent(UseExtensionCustomizer.class))
+                .collect(toList());
+
+        Stream.of(method, extensionType)
+                .map(e -> e.getAnnotation(ExtensionCustomizationOrder.class))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .ifPresent(order -> annotationTypes.sort(createComparator(order).reversed()));
+
+        List<ExtensionHandlerCustomizer> customizers = annotationTypes.stream()
+                .map(type -> type.getAnnotation(UseExtensionCustomizer.class))
+                .map(a -> createCustomizer(a.value(), extensionType, method))
+                .collect(toList());
+
+        for (ExtensionHandlerCustomizer customizer : customizers) {
+            extensionHandler = customizer.customize(extensionHandler, extensionType, method);
+        }
+
+        return extensionHandler;
+    }
+
+    private Comparator<Class<? extends Annotation>> createComparator(ExtensionCustomizationOrder order) {
+        List<Class<? extends Annotation>> ordering = Arrays.asList(order.value());
+
+        return Comparator.comparingInt(type -> {
+            int index = ordering.indexOf(type);
+            return index == -1 ? ordering.size() : index;
+        });
+    }
+
+    private static ExtensionHandlerCustomizer createCustomizer(Class<? extends ExtensionHandlerCustomizer> customizerType,
+            Class<?> extensionObjectType, Method method) {
+
+        CheckedCallable[] callables = {
+                () -> customizerType.getConstructor().newInstance(),
+                () -> customizerType.getConstructor(Method.class).newInstance(method),
+                () -> customizerType.getConstructor(Class.class, Method.class).newInstance(extensionObjectType, method)
+        };
+
+        for (CheckedCallable<ExtensionHandlerCustomizer> callable : callables) {
+            Optional<ExtensionHandlerCustomizer> handler = JdbiClassUtils.createInstanceIfPossible(callable);
+            if (handler.isPresent()) {
+                return handler.get();
+            }
+        }
+
+        throw new IllegalStateException(format("ExtensionHandlerCustomizer class %s cannot be instantiated. "
+                + "Expected a constructor with parameters (Class, Method), (Method), or ().", customizerType));
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationHandlerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationHandlerFactory.java
@@ -29,8 +29,6 @@ import static java.lang.String.format;
 
 /**
  * Processes {@link UseExtensionHandler} annotations on methods.
- *
- * @since 3.38.0
  */
 final class UseExtensionAnnotationHandlerFactory implements ExtensionHandlerFactory {
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationHandlerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UseExtensionAnnotationHandlerFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
+import org.jdbi.v3.core.extension.annotation.UseExtensionHandler;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
+import org.jdbi.v3.core.internal.exceptions.CheckedCallable;
+
+import static java.lang.String.format;
+
+/**
+ * Processes {@link UseExtensionHandler} annotations on methods.
+ *
+ * @since 3.38.0
+ */
+final class UseExtensionAnnotationHandlerFactory implements ExtensionHandlerFactory {
+
+    static final ExtensionHandlerFactory FACTORY = new UseExtensionAnnotationHandlerFactory();
+
+    @Override
+    public boolean accepts(Class<?> extensionType, Method method) {
+
+        if (method.isBridge()) {
+            return false;
+        }
+
+        return !findAnnotations(method).isEmpty();
+    }
+
+    private static boolean matchAnnotation(Annotation a) {
+        return a.annotationType().isAnnotationPresent(UseExtensionHandler.class);
+    }
+
+    static List<Class<?>> findAnnotations(Method method) {
+        return Stream.of(method.getAnnotations())
+                .filter(UseExtensionAnnotationHandlerFactory::matchAnnotation)
+                .map(Annotation::annotationType)
+                .collect(Collectors.toList());
+    }
+
+
+    @Override
+    public Optional<ExtensionHandler> buildExtensionHandler(Class<?> extensionType, Method method) {
+
+        List<Class<?>> extensionAnnotations = findAnnotations(method);
+
+        if (extensionAnnotations.size() > 1) {
+            throw new IllegalStateException(
+                    format("Mutually exclusive extension annotations on method %s.%s: %s",
+                            extensionType.getName(),
+                            method.getName(),
+                            extensionAnnotations));
+        }
+
+        if (method.isDefault() && !method.isSynthetic()) {
+            throw new IllegalStateException(format(
+                    "Default method %s.%s has @%s annotation. "
+                            + "Extension type methods may be default, or have a @UseExtensionHandler annotation, but not both.",
+                    extensionType.getSimpleName(),
+                    method.getName(),
+                    extensionAnnotations.get(0).getSimpleName()));
+        }
+
+
+        return extensionAnnotations.stream()
+                .map(type -> type.getAnnotation(UseExtensionHandler.class))
+                .map(a -> createExtensionHandler(a.value(), extensionType, method))
+                .findFirst();
+    }
+
+    private ExtensionHandler createExtensionHandler(Class<? extends ExtensionHandler> handlerType, Class<?> extensionObjectType, Method method) {
+
+        CheckedCallable[] callables = {
+                () -> handlerType.getConstructor(Class.class, Method.class).newInstance(extensionObjectType, method),
+                () -> handlerType.getConstructor(Method.class).newInstance(method),
+                () -> handlerType.getConstructor().newInstance()
+        };
+
+        for (CheckedCallable<ExtensionHandler> callable : callables) {
+            Optional<ExtensionHandler> handler = JdbiClassUtils.createInstanceIfPossible(callable);
+            if (handler.isPresent()) {
+                return handler.get();
+            }
+        }
+
+        throw new IllegalStateException(format("ExtensionHandler class %s cannot be instantiated. "
+                + "Expected a constructor with parameters (Class, Method), (Method), or ().", handlerType));
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/annotation/ExtensionCustomizationOrder.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/annotation/ExtensionCustomizationOrder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Determines the order in which extension method decorators are invoked. If this annotation is absent, the decorator order
+ * is undefined. A <code>@ExtensionCustomizationOrder</code> annotation on a method takes precedence over an annotation on a type.
+ *
+ * @since 3.38.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Alpha
+public @interface ExtensionCustomizationOrder {
+    /**
+     * The order that decorator annotations will be applied, from outermost to innermost. Decorator order is undefined
+     * for any decorating annotation present on a method but not on this annotation.
+     * @return the annotations in the order defined.
+     */
+    Class<? extends Annotation>[] value();
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/annotation/ExtensionCustomizationOrder.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/annotation/ExtensionCustomizationOrder.java
@@ -34,7 +34,7 @@ public @interface ExtensionCustomizationOrder {
     /**
      * The order that decorator annotations will be applied, from outermost to innermost. Decorator order is undefined
      * for any decorating annotation present on a method but not on this annotation.
-     * @return the annotations in the order defined.
+     * @return the annotations in the order defined
      */
     Class<? extends Annotation>[] value();
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionConfigurer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionConfigurer.java
@@ -35,7 +35,7 @@ public @interface UseExtensionConfigurer {
     /**
      * A {@link ExtensionConfigurer} type, which will be used to configure {@link ConfigRegistry} instances.
      *
-     * @return the Configurer type used to configure a {@link ConfigRegistry} for the configuring annotation.
+     * @return the Configurer type used to configure a {@link ConfigRegistry} for the configuring annotation
      */
     Class<? extends ExtensionConfigurer> value();
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionConfigurer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionConfigurer.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.extension.ExtensionConfigurer;
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Meta-Annotation used to identify annotations that modify configuration in the context of an extension object or method.
+ * Use this to annotate an annotation.
+ *
+ * @since 3.38.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@Alpha
+public @interface UseExtensionConfigurer {
+    /**
+     * A {@link ExtensionConfigurer} type, which will be used to configure {@link ConfigRegistry} instances.
+     *
+     * @return the Configurer type used to configure a {@link ConfigRegistry} for the configuring annotation.
+     */
+    Class<? extends ExtensionConfigurer> value();
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionCustomizer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jdbi.v3.core.extension.ExtensionHandler;
+import org.jdbi.v3.core.extension.ExtensionHandlerCustomizer;
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Meta-Annotation used to identify extension method decorating annotations. Use this to annotate an annotation.
+ *
+ * @since 3.38.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@Alpha
+public @interface UseExtensionCustomizer {
+    /**
+     * {@link ExtensionHandlerCustomizer} class that decorates {@link ExtensionHandler} instances for methods annotated with the associated annotation.
+     * <br>
+     * The extension customizer must have either a public no-arguments, a {@code (Method method)}, or
+     * a {@code (Class<?> extensionType, Method method)} constructor. If the constructor takes one or more
+     * arguments, it will get the extension type and the invoked method passed in at construction time.
+     *
+     * @return the {@link ExtensionHandlerCustomizer} class.
+     */
+    Class<? extends ExtensionHandlerCustomizer> value();
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionCustomizer.java
@@ -38,7 +38,7 @@ public @interface UseExtensionCustomizer {
      * a {@code (Class<?> extensionType, Method method)} constructor. If the constructor takes one or more
      * arguments, it will get the extension type and the invoked method passed in at construction time.
      *
-     * @return the {@link ExtensionHandlerCustomizer} class.
+     * @return the {@link ExtensionHandlerCustomizer} class
      */
     Class<? extends ExtensionHandlerCustomizer> value();
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionHandler.java
@@ -39,16 +39,16 @@ public @interface UseExtensionHandler {
      * a {@code (Class<?> extensionType, Method method)} constructor. If the constructor takes one or more
      * arguments, it will get the extension type and the invoked method passed in at construction time.
      *
-     * @return the {@link ExtensionHandler} class.
+     * @return the {@link ExtensionHandler} class
      */
     Class<? extends ExtensionHandler> value();
 
     /**
-     * An extension should declare an id and tag all annotations with it. This allows the {@link ExtensionFactory} to decide
+     * An extension must declare an id and tag all annotations with it. This allows the {@link ExtensionFactory} to decide
      * whether it will process a class or not by looking at the annotations on the class and method and determine whether these
      * have the right id for the extension.
      *
-     * @return A string with the extension identifier.
+     * @return A string with the extension identifier
      */
-    String id() default "";
+    String id();
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/annotation/UseExtensionHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jdbi.v3.core.extension.ExtensionFactory;
+import org.jdbi.v3.core.extension.ExtensionHandler;
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Meta-Annotation used to map a method to an extension handler. Use this to annotate an annotation.
+ *
+ * @since 3.38.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+@Alpha
+public @interface UseExtensionHandler {
+
+    /**
+     * {@link ExtensionHandler} factory annotation that creates the extension handler for the decorated method.
+     * <br>
+     * The extension handler must have either a public no-arguments, a {@code (Method method)}, or
+     * a {@code (Class<?> extensionType, Method method)} constructor. If the constructor takes one or more
+     * arguments, it will get the extension type and the invoked method passed in at construction time.
+     *
+     * @return the {@link ExtensionHandler} class.
+     */
+    Class<? extends ExtensionHandler> value();
+
+    /**
+     * An extension should declare an id and tag all annotations with it. This allows the {@link ExtensionFactory} to decide
+     * whether it will process a class or not by looking at the annotations on the class and method and determine whether these
+     * have the right id for the extension.
+     *
+     * @return A string with the extension identifier.
+     */
+    String id() default "";
+}

--- a/core/src/main/java/org/jdbi/v3/core/internal/JdbiClassUtils.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/JdbiClassUtils.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.core.internal;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Optional;
@@ -20,14 +21,25 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jdbi.v3.core.internal.exceptions.CheckedCallable;
+import org.jdbi.v3.core.internal.exceptions.Sneaky;
+
 import static java.lang.String.format;
 
+/**
+ * Helper class for various internal reflection operations.
+ */
 public final class JdbiClassUtils {
 
     private JdbiClassUtils() {
         throw new UtilityClassException();
     }
 
+    /**
+     * Returns true if a specific class can be loaded.
+     * @param klass The class.
+     * @return True if it can be loaded, false otherwise.
+     */
     public static boolean isPresent(String klass) {
         try {
             Class.forName(klass);
@@ -37,6 +49,15 @@ public final class JdbiClassUtils {
         }
     }
 
+    /**
+     * Lookup a specific method name related to a class. This helper tries {@link Class#getMethod(String, Class[])} first, then
+     * falls back to {@link Class#getDeclaredMethod(String, Class[])}.
+     * @param klass The class.
+     * @param methodName The method name
+     * @param parameterTypes All parameter types for the method.
+     * @return A {@link Method} object.
+     * @throws IllegalStateException If the method could not be found.
+     */
     public static Method methodLookup(Class<?> klass, String methodName, Class<?>... parameterTypes) {
         try {
             return klass.getMethod(methodName, parameterTypes);
@@ -50,6 +71,14 @@ public final class JdbiClassUtils {
         }
     }
 
+    /**
+     * Lookup a specific method name related to a class. This helper tries {@link Class#getMethod(String, Class[])} first, then
+     * falls back to {@link Class#getDeclaredMethod(String, Class[])}.
+     * @param klass The class.
+     * @param methodName The method name
+     * @param parameterTypes All parameter types for the method.
+     * @return A {@link Method} object wrapped in an {@link Optional} if the method could be found, {@link Optional#empty()} otherwise.
+     */
     public static Optional<Method> safeMethodLookup(Class<?> klass, String methodName, Class<?>... parameterTypes) {
         try {
             return Optional.of(klass.getMethod(methodName, parameterTypes));
@@ -62,14 +91,35 @@ public final class JdbiClassUtils {
         }
     }
 
-    public static <T> T createInstance(Class<T> factoryClass) {
+    /**
+     * Creates a new instance from a {@link CheckedCallable} instance if possible.
+     *
+     * @param creator A {@link CheckedCallable} instance which returns
+     *                a new instance or throws any of the exceptions out
+     *                of {@link Class#getConstructor(Class[])} or
+     *                {@link java.lang.reflect.Constructor#newInstance(Object...)}.
+     * @return A new instance wrapped in an {@link Optional} or {@link Optional#empty()}
+     * if a {@link ReflectiveOperationException} or {@link SecurityException} occured.
+     * @param <T> The type of the new instance.
+     */
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    public static <T> Optional<T> createInstanceIfPossible(CheckedCallable<T> creator) {
         try {
-            return factoryClass.getDeclaredConstructor().newInstance();
-        } catch (ReflectiveOperationException | SecurityException e) {
-            throw new IllegalStateException(format("Unable to instantiate class %s", factoryClass), e);
+            return Optional.of(creator.call());
+        } catch (InvocationTargetException e) {
+            throw Sneaky.throwAnyway(e.getCause());
+        } catch (ReflectiveOperationException | SecurityException ignored) {
+            return Optional.empty();
+        } catch (Throwable t) {
+            throw Sneaky.throwAnyway(t);
         }
     }
 
+    /**
+     * Returns all supertypes to a given type.
+     * @param type A type
+     * @return A {@link Stream} of {@link Class} objects.
+     */
     public static Stream<Class<?>> superTypes(Class<?> type) {
         Class<?>[] interfaces = type.getInterfaces();
         // collect into a set to deduplicate the classes found.
@@ -80,5 +130,16 @@ public final class JdbiClassUtils {
                 .collect(Collectors.toSet());
 
         return result.stream();
+    }
+
+    private static final Object[] NO_ARGS = new Object[0];
+
+    /**
+     * Safely move arguments passed from from a varargs call to a call that expects an array of objects.
+     * @param args A list of objects. May be null or empty.
+     * @return Returns an Array of objects. If the input was null, returns an empty array, otherwise all arguments as an array.
+     */
+    public static Object[] safeVarargs(Object... args) {
+        return (args == null) ? NO_ARGS : args;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/internal/JdbiClassUtils.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/JdbiClassUtils.java
@@ -37,8 +37,8 @@ public final class JdbiClassUtils {
 
     /**
      * Returns true if a specific class can be loaded.
-     * @param klass The class.
-     * @return True if it can be loaded, false otherwise.
+     * @param klass The class
+     * @return True if it can be loaded, false otherwise
      */
     public static boolean isPresent(String klass) {
         try {
@@ -52,11 +52,11 @@ public final class JdbiClassUtils {
     /**
      * Lookup a specific method name related to a class. This helper tries {@link Class#getMethod(String, Class[])} first, then
      * falls back to {@link Class#getDeclaredMethod(String, Class[])}.
-     * @param klass The class.
-     * @param methodName The method name
-     * @param parameterTypes All parameter types for the method.
-     * @return A {@link Method} object.
-     * @throws IllegalStateException If the method could not be found.
+     * @param klass A class
+     * @param methodName A method name
+     * @param parameterTypes All parameter types for the method
+     * @return A {@link Method} object
+     * @throws IllegalStateException If the method could not be found
      */
     public static Method methodLookup(Class<?> klass, String methodName, Class<?>... parameterTypes) {
         try {
@@ -74,10 +74,10 @@ public final class JdbiClassUtils {
     /**
      * Lookup a specific method name related to a class. This helper tries {@link Class#getMethod(String, Class[])} first, then
      * falls back to {@link Class#getDeclaredMethod(String, Class[])}.
-     * @param klass The class.
-     * @param methodName The method name
-     * @param parameterTypes All parameter types for the method.
-     * @return A {@link Method} object wrapped in an {@link Optional} if the method could be found, {@link Optional#empty()} otherwise.
+     * @param klass A class
+     * @param methodName A method name
+     * @param parameterTypes All parameter types for the method
+     * @return A {@link Method} object wrapped in an {@link Optional} if the method could be found, {@link Optional#empty()} otherwise
      */
     public static Optional<Method> safeMethodLookup(Class<?> klass, String methodName, Class<?>... parameterTypes) {
         try {
@@ -97,10 +97,10 @@ public final class JdbiClassUtils {
      * @param creator A {@link CheckedCallable} instance which returns
      *                a new instance or throws any of the exceptions out
      *                of {@link Class#getConstructor(Class[])} or
-     *                {@link java.lang.reflect.Constructor#newInstance(Object...)}.
+     *                {@link java.lang.reflect.Constructor#newInstance(Object...)}
      * @return A new instance wrapped in an {@link Optional} or {@link Optional#empty()}
-     * if a {@link ReflectiveOperationException} or {@link SecurityException} occured.
-     * @param <T> The type of the new instance.
+     * if a {@link ReflectiveOperationException} or {@link SecurityException} occured
+     * @param <T> The type of the new instance
      */
     @SuppressWarnings("PMD.PreserveStackTrace")
     public static <T> Optional<T> createInstanceIfPossible(CheckedCallable<T> creator) {
@@ -118,7 +118,7 @@ public final class JdbiClassUtils {
     /**
      * Returns all supertypes to a given type.
      * @param type A type
-     * @return A {@link Stream} of {@link Class} objects.
+     * @return A {@link Stream} of {@link Class} objects
      */
     public static Stream<Class<?>> superTypes(Class<?> type) {
         Class<?>[] interfaces = type.getInterfaces();
@@ -136,8 +136,8 @@ public final class JdbiClassUtils {
 
     /**
      * Safely move arguments passed from from a varargs call to a call that expects an array of objects.
-     * @param args A list of objects. May be null or empty.
-     * @return Returns an Array of objects. If the input was null, returns an empty array, otherwise all arguments as an array.
+     * @param args A list of objects. May be null or empty
+     * @return Returns an Array of objects. If the input was null, returns an empty array, otherwise all arguments as an array
      */
     public static Object[] safeVarargs(Object... args) {
         return (args == null) ? NO_ARGS : args;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -275,7 +275,7 @@ public final class FieldMapper<T> implements RowMapper<T> {
         private T construct() {
             try {
                 return constructor.newInstance();
-            } catch (ReflectiveOperationException e) {
+            } catch (ReflectiveOperationException | SecurityException e) {
                 throw new IllegalArgumentException(format("A type, %s, was mapped which was not instantiable", type.getName()), e);
             }
         }

--- a/core/src/test/java/org/jdbi/v3/core/extension/ExtensionFrameworkTestFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/ExtensionFrameworkTestFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.Annotation;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.jdbi.v3.core.extension.annotation.UseExtensionHandler;
+
+import static org.jdbi.v3.core.extension.ExtensionFactory.FactoryFlag.VIRTUAL_FACTORY;
+
+public class ExtensionFrameworkTestFactory implements ExtensionFactory {
+
+    @Override
+    public boolean accepts(Class<?> extensionType) {
+        return Stream.of(extensionType.getMethods())
+                .flatMap(m -> Stream.of(m.getAnnotations()))
+                .anyMatch(ExtensionFrameworkTestFactory::matchSqlAnnotations);
+
+    }
+
+    @Override
+    public <E> E attach(Class<E> extensionType, HandleSupplier handleSupplier) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<FactoryFlag> getFactoryFlags() {
+        return EnumSet.of(VIRTUAL_FACTORY);
+    }
+
+    private static boolean matchSqlAnnotations(Annotation a) {
+        UseExtensionHandler extensionHandlerAnnotation = a.annotationType().getAnnotation(UseExtensionHandler.class);
+        return extensionHandlerAnnotation != null && "test".equals(extensionHandlerAnnotation.id());
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionAnnotations.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionAnnotations.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.extension.TestExtensionAnnotations.ExtensionOne.Impl;
+import org.jdbi.v3.core.extension.annotation.UseExtensionHandler;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestExtensionAnnotations {
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+
+    private Handle handle;
+
+    @BeforeEach
+    public void setUp() {
+        handle = h2Extension.getSharedHandle();
+        handle.getConfig(Extensions.class).register(new ExtensionFrameworkTestFactory());
+    }
+
+    @Test
+    public void testMutuallyExclusiveAnnotations() {
+        assertThatThrownBy(() -> handle.attach(Broken.class)).isInstanceOf(IllegalStateException.class);
+    }
+
+    public interface Broken {
+
+        @ExtensionOne
+        @ExtensionTwo
+        void bogus();
+    }
+
+    @Test
+    public void testCustomAnnotation() {
+        Dao dao = handle.attach(Dao.class);
+
+        assertThat(dao.foo()).isEqualTo("foo");
+    }
+
+    public interface Dao {
+
+        @Foo
+        String foo();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @UseExtensionHandler(id = "test", value = Foo.Impl.class)
+    public @interface Foo {
+
+        class Impl implements ExtensionHandler {
+
+            @Override
+            public Object invoke(HandleSupplier handleSupplier, Object target, Object[] args) {
+                return "foo";
+            }
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD})
+    @UseExtensionHandler(id = "test", value = Impl.class)
+    public @interface ExtensionOne {
+
+        class Impl implements ExtensionHandler {
+
+            @Override
+            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception {
+                return null;
+            }
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD})
+    @UseExtensionHandler(id = "test", value = ExtensionTwo.Impl.class)
+    public @interface ExtensionTwo {
+
+        class Impl implements ExtensionHandler {
+
+            @Override
+            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception {
+                return null;
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionContext.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionContext.java
@@ -60,10 +60,9 @@ public class TestExtensionContext {
 
         default void checkContextInDefaultMethod() throws Exception {
             Method m = TestExtension.class.getMethod("checkContextInDefaultMethod");
-            // there is no extension method set in default methods. These methods
-            // are executed as is and not invoked in context
             Handle handle = getHandle();
-            assertThat(handle.getExtensionMethod()).isNull();
+            assertThat(handle.getExtensionMethod()).isNotNull();
+            assertThat(handle.getExtensionMethod().getMethod()).isEqualTo(m);
         }
 
         void checkContextInImplementedMethod() throws Exception;
@@ -85,14 +84,9 @@ public class TestExtensionContext {
         @Override
         public void checkContextInImplementedMethod() throws Exception {
             Method m = TestExtension.class.getMethod("checkContextInImplementedMethod");
-
-            ExtensionContext context = new ExtensionContext(handleSupplier.getConfig(), new ExtensionMethod(TestExtension.class, m));
-            handleSupplier.invokeInContext(context, () -> {
-                Handle handle = getHandle();
-                assertThat(handle.getExtensionMethod()).isNotNull();
-                assertThat(handle.getExtensionMethod().getMethod()).isEqualTo(m);
-                return null;
-            });
+            Handle handle = getHandle();
+            assertThat(handle.getExtensionMethod()).isNotNull();
+            assertThat(handle.getExtensionMethod().getMethod()).isEqualTo(m);
         }
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionCustomizers.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionCustomizers.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.extension.annotation.ExtensionCustomizationOrder;
+import org.jdbi.v3.core.extension.annotation.UseExtensionCustomizer;
+import org.jdbi.v3.core.extension.annotation.UseExtensionHandler;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static java.util.Arrays.asList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestExtensionCustomizers {
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+
+    private Handle testHandle;
+
+    private static final ThreadLocal<List<String>> INVOCATIONS = ThreadLocal.withInitial(ArrayList::new);
+
+    @BeforeEach
+    public void setUp() {
+        testHandle = h2Extension.getSharedHandle();
+        testHandle.getConfig(Extensions.class).register(new ExtensionFrameworkTestFactory());
+
+        INVOCATIONS.get().clear();
+    }
+
+    @Test
+    public void testUnordered() {
+        Dao dao = testHandle.attach(Dao.class);
+        dao.unordered();
+
+        assertThat(INVOCATIONS.get()).isIn(asList("foo", "bar", "method"), asList("bar", "foo", "method"));
+    }
+
+    @Test
+    public void testOrderedFooBar() {
+        Dao dao = testHandle.attach(Dao.class);
+        dao.orderedFooBar();
+
+        assertThat(INVOCATIONS.get()).containsExactly("foo", "bar", "method");
+    }
+
+    @Test
+    public void testOrderedBarFoo() {
+        Dao dao = testHandle.attach(Dao.class);
+        dao.orderedBarFoo();
+
+        assertThat(INVOCATIONS.get()).containsExactly("bar", "foo", "method");
+    }
+
+    @Test
+    public void testOrderedFooBarOnType() {
+        OrderedOnType dao = testHandle.attach(OrderedOnType.class);
+        dao.orderedFooBarOnType();
+
+        assertThat(INVOCATIONS.get()).containsExactly("foo", "bar", "method");
+    }
+
+    @Test
+    public void testOrderedFooBarOnTypeOverriddenToBarFooOnMethod() {
+        OrderedOnType dao = testHandle.attach(OrderedOnType.class);
+        dao.orderedBarFooOnMethod();
+
+        assertThat(INVOCATIONS.get()).containsExactly("bar", "foo", "method");
+    }
+
+    @Test
+    public void testTypeWrapsMethod() {
+        TypeDecorator dao = testHandle.attach(TypeDecorator.class);
+        dao.typeWrapsMethod();
+
+        assertThat(INVOCATIONS.get()).containsExactly("foo", "bar", "method");
+    }
+
+    @Test
+    public void testAbortingDecorator() {
+        Dao dao = testHandle.attach(Dao.class);
+        dao.abortingDecorator();
+
+        assertThat(INVOCATIONS.get()).containsExactly("foo", "abort");
+    }
+
+    @Test
+    public void testRegisteredDecorator() {
+        testHandle.getConfig(Extensions.class).registerHandlerCustomizer(
+                (base, sqlObjectType, method) ->
+                        (handleSupplier, target, args) -> {
+                            invoked("custom");
+                            return base.invoke(handleSupplier, target, args);
+                        });
+
+        testHandle.attach(Dao.class).orderedFooBar();
+
+        assertThat(INVOCATIONS.get()).containsExactlyInAnyOrder("custom", "foo", "bar", "method");
+    }
+
+    @Test
+    public void testRegisteredDecoratorReturnsBase() {
+        testHandle.getConfig(Extensions.class).registerHandlerCustomizer((base, sqlObjectType, method) -> base);
+
+        testHandle.attach(Dao.class).orderedFooBar();
+
+        assertThat(INVOCATIONS.get()).containsExactly("foo", "bar", "method");
+    }
+
+    static void invoked(String value) {
+        INVOCATIONS.get().add(value);
+    }
+
+    public interface Dao {
+
+        @Foo
+        @Bar
+        @CustomExtensionHandler
+        void unordered();
+
+        @Foo
+        @Bar
+        @CustomExtensionHandler
+        @ExtensionCustomizationOrder({Foo.class, Bar.class})
+        void orderedFooBar();
+
+        @Foo
+        @Bar
+        @CustomExtensionHandler
+        @ExtensionCustomizationOrder({Bar.class, Foo.class})
+        void orderedBarFoo();
+
+        @Foo
+        @Abort
+        @Bar
+        @CustomExtensionHandler
+        @ExtensionCustomizationOrder({Foo.class, Abort.class, Bar.class})
+        void abortingDecorator();
+    }
+
+    @ExtensionCustomizationOrder({Foo.class, Bar.class})
+    public interface OrderedOnType {
+
+        @Foo
+        @Bar
+        @CustomExtensionHandler
+        void orderedFooBarOnType();
+
+        @Foo
+        @Bar
+        @CustomExtensionHandler
+        @ExtensionCustomizationOrder({Bar.class, Foo.class})
+        void orderedBarFooOnMethod();
+    }
+
+    @Foo
+    public interface TypeDecorator {
+
+        @Bar
+        @CustomExtensionHandler
+        void typeWrapsMethod();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @UseExtensionCustomizer(Foo.Factory.class)
+    public @interface Foo {
+
+        class Factory implements ExtensionHandlerCustomizer {
+
+            @Override
+            public ExtensionHandler customize(ExtensionHandler base, Class<?> sqlObjectType, Method method) {
+                return (handleSupplier, target, args) -> {
+                    invoked("foo");
+                    return base.invoke(handleSupplier, target, args);
+                };
+            }
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @UseExtensionCustomizer(Bar.Factory.class)
+    public @interface Bar {
+
+        class Factory implements ExtensionHandlerCustomizer {
+
+            @Override
+            public ExtensionHandler customize(ExtensionHandler base, Class<?> sqlObjectType, Method method) {
+                return (handleSupplier, target, args) -> {
+                    invoked("bar");
+                    return base.invoke(handleSupplier, target, args);
+                };
+            }
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @UseExtensionCustomizer(Abort.Factory.class)
+    public @interface Abort {
+
+        class Factory implements ExtensionHandlerCustomizer {
+
+            @Override
+            public ExtensionHandler customize(ExtensionHandler base, Class<?> sqlObjectType, Method method) {
+                return (handleSupplier, target, args) -> {
+                    invoked("abort");
+                    return null;
+                };
+            }
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @UseExtensionHandler(id = "test", value = CustomExtensionHandler.Impl.class)
+    public @interface CustomExtensionHandler {
+
+        class Impl implements ExtensionHandler {
+
+            @Override
+            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) {
+                invoked("method");
+                return null;
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestInstanceExtensionHandlerFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestInstanceExtensionHandlerFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.extension.InstanceExtensionHandlerFactory.INSTANCE;
+
+class TestInstanceExtensionHandlerFactory {
+
+    @Test
+    public void testAcceptingClassMethods() throws Exception {
+
+        Method abstractTestClassMethod = AbstractTestClass.class.getMethod("testMethod");
+        Method concreteTestClassMethod = AbstractTestClass.class.getMethod("concreteMethod");
+
+        // accept methods from an abstract class...
+        assertThat(INSTANCE.accepts(AbstractTestClass.class, abstractTestClassMethod)).isTrue();
+        assertThat(INSTANCE.accepts(AbstractTestClass.class, concreteTestClassMethod)).isTrue();
+    }
+
+    @Test
+    public void testRejectObjectMethods() throws Exception {
+
+        // do not accept methods declared by Object
+        Method objectMethod = Object.class.getMethod("toString");
+        assertThat(INSTANCE.accepts(AbstractTestClass.class, objectMethod)).isFalse();
+    }
+
+    @Test
+    public void testAcceptingInterfaceMethods() throws Exception {
+
+        Method testInterfaceMethod = TestInterface.class.getMethod("testMethod");
+        Method defaultTestInterfaceMethod = TestInterface.class.getMethod("defaultMethod");
+
+        // accept methods from the interface...
+        assertThat(INSTANCE.accepts(TestInterface.class, testInterfaceMethod)).isTrue();
+        // ... but not default methods
+        assertThat(INSTANCE.accepts(TestInterface.class, defaultTestInterfaceMethod)).isFalse();
+    }
+
+    interface TestInterface {
+        int testMethod();
+
+        default int defaultMethod() {
+            return 0;
+        }
+    }
+    abstract static class AbstractTestClass {
+        public abstract int testMethod();
+
+        public int concreteMethod() {
+            return 0;
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestUseCustomExtensionHandlerFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestUseCustomExtensionHandlerFactory.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.Something;
+import org.jdbi.v3.core.extension.ExtensionHandler.ExtensionHandlerFactory;
+import org.jdbi.v3.core.extension.annotation.UseExtensionHandler;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.core.statement.Update;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestUseCustomExtensionHandlerFactory {
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
+
+    private Handle handle;
+
+    @BeforeEach
+    public void setUp() {
+        Jdbi db = h2Extension.getJdbi();
+        db.configure(Extensions.class, e -> e.register(new ExtensionFrameworkTestFactory()));
+
+        ExtensionHandlerFactory customExtensionHandlerFactory = new ExtensionHandlerFactory() {
+
+            @Override
+            public boolean accepts(Class<?> extensionType, Method method) {
+                return true;
+            }
+
+            @Override
+            public Optional<ExtensionHandler> buildExtensionHandler(Class<?> extensionType, Method method) {
+                return getImplementation(extensionType, method).map(m ->
+                        (handleSupplier, target, args) -> m.invoke(null, Stream.concat(Stream.of(target), Stream.of(args)).toArray())
+                );
+            }
+
+            private Optional<Method> getImplementation(Class<?> type, Method method) {
+                return Stream.of(type.getClasses())
+                        .filter(c -> c.getSimpleName().equals("DefaultImpls"))
+                        .flatMap(c -> Stream.of(c.getMethods()).filter(m -> m.getName().equals(method.getName())))
+                        .findAny();
+            }
+        };
+
+        db.configure(Extensions.class, c -> c.registerHandlerFactory(customExtensionHandlerFactory));
+
+        handle = db.open();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        handle.close();
+    }
+
+    @Test
+    public void shouldUseConfiguredDefaultHandler() {
+        SomethingDao h = handle.attach(SomethingDao.class);
+        Something s = h.insertAndFind(new Something(1, "Joy"));
+        assertThat(s.getName()).isEqualTo("Joy");
+    }
+
+    public interface SomethingDao {
+
+        @Insert
+        void insert(Something s);
+
+        @Retrieve
+        Something findById(int id);
+
+        Something insertAndFind(Something s);
+
+        @SuppressWarnings("unused")
+        class DefaultImpls {
+
+            private DefaultImpls() {}
+
+            public static Something insertAndFind(SomethingDao dao, Something s) {
+                dao.insert(s);
+                return dao.findById(s.getId());
+            }
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD})
+    @UseExtensionHandler(id = "test", value = Insert.Impl.class)
+    public @interface Insert {
+
+        class Impl implements ExtensionHandler {
+
+            @Override
+            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception {
+                Handle handle = handleSupplier.getHandle();
+                try (Update update = handle.createUpdate("insert into something (id, name) values (:id, :name)")) {
+                    return update.bindBean(args[0]).execute();
+                }
+            }
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD})
+    @UseExtensionHandler(id = "test", value = Retrieve.Impl.class)
+    public @interface Retrieve {
+
+        class Impl implements ExtensionHandler {
+
+            @Override
+            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception {
+                Handle handle = handleSupplier.getHandle();
+                try (Query query = handle.createQuery("select id, name from something where id = :id")) {
+                    return query.bind("id", args[0])
+                            .map(new SomethingMapper())
+                            .one();
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/internal/TestJdbiClassUtils.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/TestJdbiClassUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.internal;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestJdbiClassUtils {
+
+    @Test
+    void testVarargs() {
+        VarargsThing varargsThing = new VarargsThing();
+
+        assertThat(varargsThing.varargs()).isInstanceOf(Object[].class).isEmpty();
+        assertThat(varargsThing.varargs("x")).isInstanceOf(Object[].class).hasSize(1);
+        assertThat(varargsThing.varargs("x", "y")).isInstanceOf(Object[].class).hasSize(2);
+        assertThat(varargsThing.varargs((Object) null)).isInstanceOf(Object[].class).hasSize(1);
+        assertThat(varargsThing.varargs((Object[]) null)).isNull();
+    }
+
+    @Test
+    void testSafeVarargs() {
+        VarargsThing varargsThing = new VarargsThing();
+
+        assertThat(varargsThing.safeVarargs()).isInstanceOf(Object[].class).isEmpty();
+        assertThat(varargsThing.safeVarargs("x")).isInstanceOf(Object[].class).hasSize(1);
+        assertThat(varargsThing.safeVarargs("x", "y")).isInstanceOf(Object[].class).hasSize(2);
+        assertThat(varargsThing.safeVarargs((Object) null)).isInstanceOf(Object[].class).hasSize(1);
+        assertThat(varargsThing.safeVarargs((Object[]) null)).isInstanceOf(Object[].class).isEmpty();
+    }
+
+    @Test
+    void testVarargsProxyMethod() throws Exception {
+
+        VarargsThing varargsThing = new VarargsThing();
+
+        Method varargsMethod = VarargsThing.class.getMethod("varargs", Object[].class);
+        Method safeVarargsMethod = VarargsThing.class.getMethod("safeVarargs", Object[].class);
+
+        VarargsInterface thing = (VarargsInterface) Proxy.newProxyInstance(this.getClass().getClassLoader(),
+                new Class[] {VarargsInterface.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("varargs")) {
+                        return varargsMethod.invoke(varargsThing, args[0]);
+                    } else if (method.getName().equals("safeVarargs")) {
+                        return safeVarargsMethod.invoke(varargsThing, args[0]);
+                    }
+                    throw new IllegalStateException();
+                });
+
+        assertThat(thing.varargs()).isInstanceOf(Object[].class).isEmpty();
+        assertThat(thing.varargs("x")).isInstanceOf(Object[].class).hasSize(1);
+        assertThat(thing.varargs("x", "y")).isInstanceOf(Object[].class).hasSize(2);
+        assertThat(thing.varargs((Object) null)).isInstanceOf(Object[].class).hasSize(1);
+        assertThat(thing.varargs((Object[]) null)).isNull();
+
+        assertThat(thing.safeVarargs()).isInstanceOf(Object[].class).isEmpty();
+        assertThat(thing.safeVarargs("x")).isInstanceOf(Object[].class).hasSize(1);
+        assertThat(thing.safeVarargs("x", "y")).isInstanceOf(Object[].class).hasSize(2);
+        assertThat(thing.safeVarargs((Object) null)).isInstanceOf(Object[].class).hasSize(1);
+        assertThat(thing.safeVarargs((Object[]) null)).isInstanceOf(Object[].class).isEmpty();
+    }
+
+    static class VarargsThing {
+
+        VarargsThing() {}
+
+        public Object[] varargs(Object... args) {
+            return args;
+        }
+
+        public Object[] safeVarargs(Object... args) {
+            return JdbiClassUtils.safeVarargs(args);
+        }
+    }
+
+    interface VarargsInterface {
+
+        Object[] varargs(Object... args);
+
+        Object[] safeVarargs(Object... args);
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GeneratorSqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GeneratorSqlObjectFactory.java
@@ -13,7 +13,9 @@
  */
 package org.jdbi.v3.sqlobject;
 
+import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -34,6 +36,11 @@ public final class GeneratorSqlObjectFactory implements ExtensionFactory, OnDema
     @Override
     public boolean accepts(Class<?> extensionType) {
         return SqlObjectInitData.isConcrete(extensionType);
+    }
+
+    @Override
+    public Set<FactoryFlag> getFactoryFlags() {
+        return EnumSet.of(FactoryFlag.CLASSES_ARE_SUPPORTED);
     }
 
     /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectFactory.java
@@ -15,8 +15,10 @@ package org.jdbi.v3.sqlobject;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -57,6 +59,11 @@ public class SqlObjectFactory implements ExtensionFactory {
         return Stream.of(extensionType.getMethods())
                 .flatMap(m -> Stream.of(m.getAnnotations()))
                 .anyMatch(a -> a.annotationType().isAnnotationPresent(SqlOperation.class));
+    }
+
+    @Override
+    public Set<FactoryFlag> getFactoryFlags() {
+        return EnumSet.of(FactoryFlag.CLASSES_ARE_SUPPORTED);
     }
 
     /**


### PR DESCRIPTION
The current extension framework is relatively simple. It supports attaching an extension interface which looks up a factory that then has the responsibility of either looking up an implementation class or create a proxy to execute code for each method.

Due to that simple structure, there are a number of inconsistencies, especially around the extension context and wrapping each method from an interface.

The main reason for this is that most of the interesting functionality for the extension code is not actually in the core/extension package but in sqlobject. Extension is little more than just a scaffold that was designed with sqlobject in mind.

There is nothing wrong with this. However, it is possible to move a lot of the "interesting" functionality from the sqlobject code into the core package without losing backwards compatibility and then making it possible to implement additional  functionality using extensions.

## How SQL Objects works

SQL Objects uses three concepts:

* Handlers. These are code pieces that are executed when an extension method is called. This is the code for SQLUpdate, SQLQuery etc.
* HandlerDecorators. These code pieces change the behavior of a handler. Transactions are implemented as a decorator.
* Configurers. These code pieces add or change the configuration for a method before it is called. This configuration is then spliced into the Handle through the ExtensionContext so that all code that runs within the Handler method uses that modified configuration. Configurers are used for the "Use..." annotations.

None of these concepts is SQLObject specific. This is generic code that can be used for any extension. But by being split out of the core and part of the sqlobject module, it is not available to any other extension or has to be copied and pasted.

## Rewriting the extension framework

While the change looks big, it is mostly moving existing code around and cleaning it up. It introduces three new concepts to the core:

### ExtensionHandler

`ExtensionHandler` - This is equivalent to the SqlObject Handler class.

`ExtensionHandler.Factory` - SqlObject HandlerFactory, but with the `accepts / build` pattern.

`@UseExtensionHandler` annotation - equivalent to `@SqlOperation`. It also provides an `id` attribute to allow multiple extensions to differentiate between `@UseExtensionHandler` instances intended for them or for another extension.

### ExtensionHandlerCustomizer

`ExtensionHandlerCustomizer` - This is the equivalent of the SqlObject `HandleDecorator`

`@UseExtensionCustomizer` - This is the equivalent of the SqlObject `@SqlMethodDecoratingAnnotation` annotation.

`@ExtensionCustomizationOrder` - This is the equivalent of the SqlObject `@DecoratorOrder` annotation.

### ExtensionConfigurer

`ExtensionConfigurer` - This is the equivalent of SqlObject `Configurer`. Literally.

`ConfigCustomizer`           - This is an explicit interface where the
SqlObject code uses `Consumer<ConfigRegistry>`. We are not consuming the
registry, but customizing it. Makes code more readable.

`ConfigCustomizerFactory`    - A factory class that creates a collection
of `ConfigCustomizer` elements for an extension type or an extension
type method. That concept existed sprawled out in the
`SqlObjectInitData` class but was not pluggable and hardcoded to the
`Configurer` interface.

`@UseExtensionCustomizer` - This is the equivalent of the SqlObject `@ConfiguringAnnotation`

## Major changes to existing classes

`ExtensionFactory` gets a lot of new things, all of them with defaults that match the current code.
* a set of flags to control extension factory behavior
* bunch of getters for custom ExtensionHandlerFactories, ExtensionHandlerCustomizers and ExtensionConfigurerFactories

The `Extensions` configuration gets some new things:
* methods to register ExtensionHandlerFactories, ExtensionHandlerCustomizers and ExtensionConfigurerFactories globally
* a method to retrieve metadata for a given extension type

## Major additions

`ExtensionHandlerInvoker` takes the role of `InContextInvoker`. All invokers are managed by the `ExtensionMetadata` class

`ExtensionMetadata` takes the role of `SqlObjectInitData`. It contains all of the discovered functionality from an extension type. It builds a map of `ExtensionHandler` objects that can be wrapped into an `ExtensionInvoker` with all customizers and configurers added. Those `ExtensionInvoker` classes are called through the Proxy when a method is invoked.

`ExtensionFactoryDelegate` wraps the functionality of the old SqlObjectFactory code. It may simply delegate to the actual factory generated object or create the map of ExtensionHandlers with corresponding ExtensionHandlerInvokers and wrap them into a proxy object.

Similar to the SqlObject code, a number of "glue"
`ExtensionHandlerFactory` instances are used to create method handlers that are not managed by the extension specific code:

* bridge methods
* interface default methods
* direct method invocations if the factory provides an actual object to attach to