### PR TITLE
Adds `setAttachAllStatementsForCleanup` flag

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 3.38.0
+  - add `SqlStatements#setAttachAllStatementsForCleanup`. Setting this configuration flag will attach all created statements to their handles for resource cleanup. Default is `false`.
+  - add `SqlStatements#setAttachCallbackStatementsForCleanup`. Setting this configuration flag will attach all created statements within one of the `Jdbi` callback methods to the handle. This allows code that uses the `Jdbi` callback methods to delegate resource management fully to Jdbi. This flag is set by default.
+
 # 3.37.1
   - fix deadlock in default Jdbi cache (#2274)
 

--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -36,6 +36,7 @@ import org.jdbi.v3.core.internal.OnDemandExtensions;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 import org.jdbi.v3.core.statement.DefaultStatementBuilder;
+import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.core.statement.StatementBuilder;
 import org.jdbi.v3.core.statement.StatementBuilderFactory;
 import org.jdbi.v3.core.transaction.LocalTransactionHandler;
@@ -362,6 +363,9 @@ public class Jdbi implements Configurable<Jdbi> {
         }
 
         try (Handle h = this.open()) {
+            SqlStatements sqlStatements = h.getConfig(SqlStatements.class);
+            sqlStatements.setAttachAllStatementsForCleanup(sqlStatements.isAttachCallbackStatementsForCleanup());
+
             handleSupplier = ConstantHandleSupplier.of(h);
             threadHandleSupplier.set(handleSupplier);
             return callback.withHandle(h);
@@ -398,7 +402,7 @@ public class Jdbi implements Configurable<Jdbi> {
      * @throws X any exception thrown by the callback
      */
     public <R, X extends Exception> R inTransaction(final HandleCallback<R, X> callback) throws X {
-        return withHandle(handle -> handle.<R, X>inTransaction(callback));
+        return withHandle(handle -> handle.inTransaction(callback));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
@@ -32,7 +32,12 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This> {
 
     BaseStatement(Handle handle) {
         this.handle = handle;
-        this.ctx = StatementContext.create(handle.getConfig().createCopy(), handle.getExtensionMethod());
+        final ConfigRegistry config = handle.getConfig().createCopy();
+        this.ctx = StatementContext.create(config, handle.getExtensionMethod());
+
+        if (config.get(SqlStatements.class).isAttachAllStatementsForCleanup()) {
+            attachToHandleForCleanup(this.handle, this.ctx);
+        }
     }
 
     public final Handle getHandle() {

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -29,6 +29,8 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.cache.JdbiCache;
 import org.jdbi.v3.core.cache.JdbiCacheBuilder;
 import org.jdbi.v3.core.cache.JdbiCacheLoader;
@@ -52,6 +54,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     private Integer queryTimeout;
     private boolean allowUnusedBindings;
     private boolean attachAllStatementsForCleanup;
+    private boolean attachCallbackStatementsForCleanup = true;
     private final Collection<StatementCustomizer> customizers = new CopyOnWriteArrayList<>();
 
     private final Collection<StatementContextListener> contextListeners = new CopyOnWriteArraySet<>();
@@ -73,6 +76,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
         this.queryTimeout = that.queryTimeout;
         this.allowUnusedBindings = that.allowUnusedBindings;
         this.attachAllStatementsForCleanup = that.attachAllStatementsForCleanup;
+        this.attachCallbackStatementsForCleanup = that.attachCallbackStatementsForCleanup;
         this.customizers.addAll(that.customizers);
         this.contextListeners.addAll(that.contextListeners);
         this.templateCache = that.templateCache;
@@ -270,22 +274,54 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
         return this;
     }
 
+    /**
+     * If true, all statements created within {@link Jdbi#withHandle}, {@link Jdbi#useHandle}, {@link Jdbi#inTransaction} and {@link Jdbi#useTransaction}
+     * are attached to the {@link Handle} object for cleanup.
+     *
+     * @return True if statements are attached to their handle for cleanup
+     *
+     * @since 3.38.0
+     */
     public boolean isAttachAllStatementsForCleanup() {
         return attachAllStatementsForCleanup;
     }
 
     /**
-     * Sets whether all statements created will automatically attached to the corresponding {@link org.jdbi.v3.core.Handle} object automatically.
+     * Sets whether all statements created will automatically attached to the corresponding {@link Handle} object automatically.
      * This can be useful when mostly short-lived handles are used because closing the handle will now clean up all outstanding resources from
-     * any statement.
+     * any statement. The default is false.
      *
-     * @param attachAllStatementsForCleanup If true, all statements are automatically attached to the Handle.
+     * @param attachAllStatementsForCleanup If true, all statements are automatically attached to the Handle
      *
      * @since 3.38.0
      */
     @Beta
     public void setAttachAllStatementsForCleanup(boolean attachAllStatementsForCleanup) {
         this.attachAllStatementsForCleanup = attachAllStatementsForCleanup;
+    }
+
+    /**
+     * If true, statements created within {@link Jdbi#withHandle}, {@link Jdbi#useHandle}, {@link Jdbi#inTransaction} and {@link Jdbi#useTransaction}
+     * will be attached to the {@link Handle} object in the callback for cleanup.
+     *
+     * @return True if statements are attached to their handle within Jdbi callbacks
+     *
+     * @since 3.38.0
+     */
+    public boolean isAttachCallbackStatementsForCleanup() {
+        return attachCallbackStatementsForCleanup;
+    }
+
+    /**
+     * Sets whether statements created within the {@link Jdbi#withHandle}, {@link Jdbi#useHandle}, {@link Jdbi#inTransaction} and {@link Jdbi#useTransaction}
+     * callback methods will automatically attached to the {@link Handle} object and therefore cleaned up when the callback ends. The default is true.
+
+     * @param attachCallbackStatementsForCleanup If true, statements created within the Jdbi callbacks are attached to the handle
+     *
+     * @since 3.38.0
+     */
+    public void setAttachCallbackStatementsForCleanup(boolean attachCallbackStatementsForCleanup) {
+        this.attachCallbackStatementsForCleanup = attachCallbackStatementsForCleanup;
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -51,6 +51,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     private SqlLogger sqlLogger;
     private Integer queryTimeout;
     private boolean allowUnusedBindings;
+    private boolean attachAllStatementsForCleanup;
     private final Collection<StatementCustomizer> customizers = new CopyOnWriteArrayList<>();
 
     private final Collection<StatementContextListener> contextListeners = new CopyOnWriteArraySet<>();
@@ -71,6 +72,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
         this.sqlLogger = that.sqlLogger;
         this.queryTimeout = that.queryTimeout;
         this.allowUnusedBindings = that.allowUnusedBindings;
+        this.attachAllStatementsForCleanup = that.attachAllStatementsForCleanup;
         this.customizers.addAll(that.customizers);
         this.contextListeners.addAll(that.contextListeners);
         this.templateCache = that.templateCache;
@@ -266,6 +268,24 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     public SqlStatements setUnusedBindingAllowed(boolean unusedBindingAllowed) {
         this.allowUnusedBindings = unusedBindingAllowed;
         return this;
+    }
+
+    public boolean isAttachAllStatementsForCleanup() {
+        return attachAllStatementsForCleanup;
+    }
+
+    /**
+     * Sets whether all statements created will automatically attached to the corresponding {@link org.jdbi.v3.core.Handle} object automatically.
+     * This can be useful when mostly short-lived handles are used because closing the handle will now clean up all outstanding resources from
+     * any statement.
+     *
+     * @param attachAllStatementsForCleanup If true, all statements are automatically attached to the Handle.
+     *
+     * @since 3.38.0
+     */
+    @Beta
+    public void setAttachAllStatementsForCleanup(boolean attachAllStatementsForCleanup) {
+        this.attachAllStatementsForCleanup = attachAllStatementsForCleanup;
     }
 
     /**

--- a/core/src/test/java/org/jdbi/v3/core/statement/LeakTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/LeakTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.junit5.H2DatabaseExtension;
 import org.jdbi.v3.core.result.ResultIterator;
 import org.junit.jupiter.api.BeforeEach;
@@ -142,6 +143,18 @@ public class LeakTest {
                     .stream().findFirst();
             assertThat(userName).isPresent();
         }
+    }
+
+    @Test
+    void testStatementStreamCallbackCleanup() {
+        final Jdbi jdbi = h2Extension.getJdbi();
+
+        Optional<String> userName = jdbi.withHandle(h ->
+                h.createQuery("SELECT name from users")
+                        .mapTo(String.class)
+                        .stream().findFirst());
+
+        assertThat(userName).isPresent();
     }
 
     @Test

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -981,7 +981,7 @@ Create, execute and release 100,000 update statements:
 
 [source,java,indent=0]
 ----
-jdbi.useHandle(handle -> {
+try (Handle handle = jdbi.open()) {
     for (int i = 0; i < 100_000; i++) {
         try (Update update = handle.createUpdate("INSERT INTO users (id, name) VALUES (:id, :name)")) {
             update.bind("id", i)
@@ -989,14 +989,14 @@ jdbi.useHandle(handle -> {
                   .execute();
         }
     }
-});
+}
 ----
 
 It is not necessary to use a _try-with-resources_ block, the close() method can be called manually as well:
 
 [source,java,indent=0]
 ----
-jdbi.useHandle(handle -> {
+try (Handle handle = jdbi.open()) {
     for (int i = 0; i < 100_000; i++) {
         Update update = handle.createUpdate("INSERT INTO users (id, name) VALUES (:id, :name)");
         try {
@@ -1007,7 +1007,7 @@ jdbi.useHandle(handle -> {
             update.close();
         }
     }
-});
+}
 ----
 
 Explicit statement resource management, while a bit more involved ensures that all resources are always correctly released, especially when there are exceptions thrown during statement execution. While many examples and demo code omit managing the <<Statement types, statement types>>, it is strongly recommended to do so.
@@ -1079,14 +1079,33 @@ try (Handle handle = jdbi.open()) {
 
 The same pattern applies to a result iterator.
 
-ResultIterable also offers callbacks (link:{jdbidocs}/core/result/ResultIterable.html#withIterator(org.jdbi.v3.core.result.IteratorCallback)[withIterator()^], link:{jdbidocs}/core/result/ResultIterable.html#useIterator(org.jdbi.v3.core.result.IteratorConsumer)[useIterator()^], link:{jdbidocs}/core/result/ResultIterable.html#withStream(org.jdbi.v3.core.result.StreamCallback)[withStream()^], link:{jdbidocs}/core/result/ResultIterable.htmll#useStream(org.jdbi.v3.core.result.StreamConsumer)[useStream()^]) that manage the iterator / stream through Jdbi:
+Streams and iterators are "live" objects. They require an active statement and result set. Any operation that closes and releases these resources will cause future operations on the stream or iterator to fail.
+
+The following code *does not work*:
+
+[source,java,indent=0]
+----
+Stream<User> userStream = jdbi.withHandle(handle ->
+    handle.createQuery("SELECT * from users")
+        .mapTo(User.class)
+        .stream();  <1>
+    });  <2>
+
+Optional<User> user = stream.findFirst(); <3>
+----
+
+<1> Creates a live stream object backed by the open result set of the query
+<2> leaving the callback closes the handle and releases all resources including the result set
+<3> throws an exception because the result set has already been closed
+
+This can be avoided by using one of the callback methods that ResultIterable offers: link:{jdbidocs}/core/result/ResultIterable.html#withIterator(org.jdbi.v3.core.result.IteratorCallback)[withIterator()^], link:{jdbidocs}/core/result/ResultIterable.html#useIterator(org.jdbi.v3.core.result.IteratorConsumer)[useIterator()^], link:{jdbidocs}/core/result/ResultIterable.html#withStream(org.jdbi.v3.core.result.StreamCallback)[withStream()^], link:{jdbidocs}/core/result/ResultIterable.htmll#useStream(org.jdbi.v3.core.result.StreamConsumer)[useStream()^]. Each of these methods manages the iterator / stream through Jdbi and allow consumption of its contents within a callback:
 
 [source,java,indent=0]
 ----
 try (Handle handle = jdbi.open()) {
-    try (Query query = handle.createQuery("SELECT * from users")) { // <1>
+    try (Query query = handle.createQuery("SELECT * from users")) {
         query.mapTo(User.class).useIterator(it -> {
-            // consume the iterator
+            // consume the iterator contents
         });
     }
 }
@@ -1094,43 +1113,106 @@ try (Handle handle = jdbi.open()) {
 
 While it is not strictly necessary to execute the query in a _try-with-resources_ block because the link:{jdbidocs}/core/result/ResultIterable.html#useIterator(org.jdbi.v3.core.result.IteratorConsumer)[useIterator()^] method will close the iterator and release all resources from the query, it is good practice and guards against possible errors that may happen between the creation of the query and the callback execution.
 
+Using a jdbi callback allows fully automated resource management:
+
+[source,java,indent=0]
+----
+jdbi.useHandle(handle -> {
+    handle.createQuery("SELECT * from users")
+        .mapTo(User.class)
+        .useIterator(it -> {
+            // consume the iterator contents
+        });
+    });
+----
+
 
 ==== Attaching statements to the handle lifecycle
 
 An elegant way to manage resources is attaching the statement to the handle lifecycle. Calling the `attachToHandleForCleanup()` method, which is available on <<Statement types, SQL statements>>, associates the statement with the handle. When the handle is closed, all attached statements that have not been cleaned up yet, will also be released.
 
-This works best for short-lived handles with a few statement operations. As the resources may not be released until the handle is closed, running a large number of SQL statements that all may need cleaning up could lead to resource exhaustion. When in doubt, prefer the _try-with-resources_ construct over attaching a SQL statements to the handle.
-
-Methods on the Jdbi object that take a callback (link:{jdbidocs}/core/Jdbi.html#withHandle(org.jdbi.v3.core.HandleCallback)[withHandle^], link:{jdbidocs}/core/Jdbi.html#useHandle(org.jdbi.v3.core.HandleConsumer)[useHandle^], link:{jdbidocs}/core/Jdbi.html#inTransaction(org.jdbi.v3.core.HandleCallback)[inTransaction^], link:{jdbidocs}/core/Jdbi.html#useTransaction(org.jdbi.v3.core.HandleConsumer)[useTransaction^]) can use this to attach statements to the handle passed into the callback. These handles are fully managed and will be closed when the callback exits.
-
 [source,java,indent=0]
 ----
-User user = jdbi.withHandle(handle ->
-    handle.createQuery("SELECT * FROM users WHERE id = :id")
-        .attachToHandleForCleanup() // <1>
+Optional<User> user = handle.createQuery("SELECT * FROM users WHERE id = :id")
+        .attachToHandleForCleanup() <1>
         .bind("id", id)
         .mapTo(User.class)
-        .one());
+        .stream()
+        .findAny();
 ----
 
 <1> By attaching the statement to the handle, all resources are now managed by Jdbi and released even if the operation throws an exception.
 
-It is possible to attach all created statements by default to the handle by calling link:{jdbidocs}/core/statement/SqlStatements.html#setAttachAllStatementsForCleanup(boolean)[setAttachAllStatementsForCleanup(true)^] on the SqlStatements config object:
+This works best for short-lived handles with a few statement operations. As the resources may not be released until the handle is closed, executing a large number of SQL statements that all may need cleaning up could lead to resource exhaustion. When in doubt, prefer the _try-with-resources_ construct over attaching a SQL statements to the handle.
+
+It is possible to attach all created statements by default to a handle by calling link:{jdbidocs}/core/statement/SqlStatements.html#setAttachAllStatementsForCleanup(boolean)[setAttachAllStatementsForCleanup(true)^] on the SqlStatements config object:
 
 [source,java,indent=0]
 ----
 jdbi.getConfig(SqlStatements.class)
     .setAttachAllStatementsForCleanup(true);
 
+try (Handle handle = jdbi.open()) {
+    Optional<User> user = handle.createQuery("SELECT * FROM users WHERE id = :id")
+        .bind("id", id)
+        .mapTo(User.class)
+        .stream()
+        .findAny();
+}
+----
+
+This setting can be controlled either per Jdbi object or per Handle.
+
+[source,java,indent=0]
+----
+try (Handle handle = jdbi.open()) {
+    handle.getConfig(SqlStatements.class)
+        .setAttachAllStatementsForCleanup(true);
+
+    Optional<User> user = handle.createQuery("SELECT * FROM users WHERE id = :id")
+        .bind("id", id)
+        .mapTo(User.class)
+        .stream()
+        .findAny();
+}
+----
+
+
+As a special case, any method on the Jdbi object that takes a callback (link:{jdbidocs}/core/Jdbi.html#withHandle(org.jdbi.v3.core.HandleCallback)[withHandle^], link:{jdbidocs}/core/Jdbi.html#useHandle(org.jdbi.v3.core.HandleConsumer)[useHandle^], link:{jdbidocs}/core/Jdbi.html#inTransaction(org.jdbi.v3.core.HandleCallback)[inTransaction^], link:{jdbidocs}/core/Jdbi.html#useTransaction(org.jdbi.v3.core.HandleConsumer)[useTransaction^]) attaches statements created in the callback by default to the handle passed into the callback. These handles are fully managed and will be closed when the callback exits.
+
+[source,java,indent=0]
+----
 User user = jdbi.withHandle(handle ->
     handle.createQuery("SELECT * FROM users WHERE id = :id")
         .bind("id", id)
         .mapTo(User.class)
-        .stream()
-        .findAny());
+        .one());
 ----
 
-This setting can be per Jdbi object or per Handle.
+This behavior can be controlled through the link:{jdbidocs}/core/statement/SqlStatements.html#setAttachCallbackStatementsForCleanup(boolean)[setAttachCallbackStatementsForCleanup()^] method.
+If a callback executes a huge number of statements, it may be preferable to manage resources manually:
+
+[source,java,indent=0]
+----
+jdbi.useHandle(handle -> {
+    handle.getConfig(SqlStatements.class).setAttachCallbackStatementsForCleanup(false); <1>
+
+    for (int i = 0; i < 100_000; i++) {
+        try (Update update = handle.createUpdate("INSERT INTO users (id, name) VALUES (:id, :name)")) {
+            update.bind("id", i)
+                  .bind("name", "user_" + i)
+                  .execute();
+        }
+    }
+});
+----
+
+<1> Turn off automatic attachment of statements to the handle because the callback creates a large number of statements. Modifying this value only changes the setting for the current handle; it does not affect the global setting associated with the Jdbi object that created the handle.
+
+
+[NOTE]
+While the `attachAllStatementsForCleanup` setting affects all statements created *outside* a Jdbi callback (link:{jdbidocs}/core/Jdbi.html#withHandle(org.jdbi.v3.core.HandleCallback)[withHandle^], link:{jdbidocs}/core/Jdbi.html#useHandle(org.jdbi.v3.core.HandleConsumer)[useHandle^], link:{jdbidocs}/core/Jdbi.html#inTransaction(org.jdbi.v3.core.HandleCallback)[inTransaction^], link:{jdbidocs}/core/Jdbi.html#useTransaction(org.jdbi.v3.core.HandleConsumer)[useTransaction^]), *inside* these callbacks, the behavior is controlled by the `attachCallbackStatementsForCleanup` setting.
+The default value for the `attachAllStatementsForCleanup` is `false` while the default value for `attachCallbackStatementsForCleanup` is `true`.
 
 == Arguments
 

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -1105,15 +1105,32 @@ Methods on the Jdbi object that take a callback (link:{jdbidocs}/core/Jdbi.html#
 
 [source,java,indent=0]
 ----
-User user = jdbi.withHandle(handle -> handle.createQuery("SELECT * FROM users WHERE id = :id")
-    .attachToHandleForCleanup() // <1>
-    .bind("id", id)
-    .mapTo(User.class)
-    .one());
+User user = jdbi.withHandle(handle ->
+    handle.createQuery("SELECT * FROM users WHERE id = :id")
+        .attachToHandleForCleanup() // <1>
+        .bind("id", id)
+        .mapTo(User.class)
+        .one());
 ----
 
 <1> By attaching the statement to the handle, all resources are now managed by Jdbi and released even if the operation throws an exception.
 
+It is possible to attach all created statements by default to the handle by calling link:{jdbidocs}/core/statement/SqlStatements.html#setAttachAllStatementsForCleanup(boolean)[setAttachAllStatementsForCleanup(true)^] on the SqlStatements config object:
+
+[source,java,indent=0]
+----
+jdbi.getConfig(SqlStatements.class)
+    .setAttachAllStatementsForCleanup(true);
+
+User user = jdbi.withHandle(handle ->
+    handle.createQuery("SELECT * FROM users WHERE id = :id")
+        .bind("id", id)
+        .mapTo(User.class)
+        .stream()
+        .findAny());
+----
+
+This setting can be per Jdbi object or per Handle.
 
 == Arguments
 


### PR DESCRIPTION
Allows all statements to be attached to their handle by default and cleaned up when the handle closes.

Addresses #2293.

@jodastephen would that work for your use case?