### PR TITLE
Remove spring-jcl exclusion from bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -148,13 +148,6 @@
                 <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-spring5</artifactId>
                 <version>${dep.jdbi3.version}</version>
-                <!--- it is always spring. always. -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.springframework</groupId>
-                        <artifactId>spring-jcl</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -30,6 +30,9 @@
         <!-- Javadocs refer to jars without actual code references -->
         <basepom.check.skip-dependency>true</basepom.check.skip-dependency>
         <basepom.check.skip-license>true</basepom.check.skip-license>
+
+        <!-- workaround because spring5 needs an exclusion. -->
+        <basepom.dependency-management.allow-exclusions>true</basepom.dependency-management.allow-exclusions>
         <basepom.deploy.skip>true</basepom.deploy.skip>
         <basepom.site.scm.branch>master</basepom.site.scm.branch>
         <basepom.site.scm.checkout-directory>${java.io.tmpdir}/gh-pages-publish/jdbi-docs</basepom.site.scm.checkout-directory>
@@ -120,6 +123,13 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-spring5</artifactId>
+            <!--- it is always spring. always. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>


### PR DESCRIPTION
Turns out that this actually makes using the jdbi bom in spring projects harder.

Fixes #2295