### PR TITLE
StringTemplate engine: handle st4 errors, allow configuring missing attribute as error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
   - rewrite the core extension framework, move functionality from sqlobject to core
   - rewrite sqlobject and the generator to use the new extension framework, deprecate functionality that moved to the core
   - StringTemplate engine: handle st4 errors rather than logging to stderr. Allow configuring missing attribute as a fatal error
+  - StringTemplate 4.3.3
 
 # 3.37.1
   - fix deadlock in default Jdbi cache (#2274)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
   - add `JdbiExecutor` for async Jdbi operations (#2280, thanks @leblonk)
   - rewrite the core extension framework, move functionality from sqlobject to core
   - rewrite sqlobject and the generator to use the new extension framework, deprecate functionality that moved to the core
+  - StringTemplate engine: handle st4 errors rather than logging to stderr. Allow configuring missing attribute as a fatal error
 
 # 3.37.1
   - fix deadlock in default Jdbi cache (#2274)

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -6811,6 +6811,9 @@ In this example, the SQL template will still be loaded from the file
 `com/foo/AccountDao.sql.stg` on the classpath, however the `listSorted`
 template will be used, regardless of the method name.
 
+There are some options for StringTemplateEngine on the
+link:{jdbidocs}/stringtemplate4/StringTemplates.html[StringTemplates^] configuration class,
+like whether missing attributes are considered an error or not.
 
 === Vavr
 

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -450,7 +450,7 @@
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>ST4</artifactId>
-                <version>4.3.1</version>
+                <version>4.3.4</version>
             </dependency>
 
             <dependency>

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplates.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplates.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.stringtemplate4;
+
+import org.jdbi.v3.core.config.JdbiConfig;
+
+/**
+ * Configuration options for {@link StringTemplateEngine}.
+ */
+public class StringTemplates implements JdbiConfig<StringTemplates> {
+    private boolean failOnMissingAttribute = false;
+
+    public StringTemplates() {}
+
+    StringTemplates(StringTemplates other) {
+        this.failOnMissingAttribute = other.failOnMissingAttribute;
+    }
+
+    /**
+     * @return whether missing attributes in a StringTemplate are a rendering error
+     */
+    public boolean isFailOnMissingAttribute() {
+        return failOnMissingAttribute;
+    }
+
+    /**
+     * Control whether missing attributes cause a rendering exception. Defaults to false.
+     * @param failOnMissingAttribute whether a missing attribute throws an exception
+     * @return this configuration instance
+     */
+    public StringTemplates setFailOnMissingAttribute(boolean failOnMissingAttribute) {
+        this.failOnMissingAttribute = failOnMissingAttribute;
+        return this;
+    }
+
+    @Override
+    public StringTemplates createCopy() {
+        return new StringTemplates(this);
+    }
+}

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestErrorHandling.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestErrorHandling.java
@@ -1,0 +1,69 @@
+package org.jdbi.v3.stringtemplate4;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.UnableToCreateStatementException;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestErrorHandling {
+
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2();
+
+    Handle handle;
+
+    @BeforeEach
+    void setup() {
+        handle = h2Extension.getSharedHandle();
+        handle.setTemplateEngine(new StringTemplateEngine());
+    }
+
+    @Test
+    void testSyntaxError() {
+        assertThatThrownBy(() ->
+            h2Extension.getSharedHandle().createQuery("select <a")
+                .mapTo(String.class)
+                .one())
+            .isInstanceOf(UnableToCreateStatementException.class)
+            .hasMessageContaining("Compiling StringTemplate failed", "premature EOF");
+    }
+
+    @Test
+    void testUnboundVar() {
+        assertThat(
+            h2Extension.getSharedHandle().createQuery("select <if(a)> true <else> false <endif>")
+                .mapTo(boolean.class)
+                .one())
+            .isEqualTo(false);
+    }
+
+    @Test
+    void testUnboundVarThrows() {
+        assertThatThrownBy(() ->
+            h2Extension.getSharedHandle().createQuery("select <if(a)> true <else> false <endif>")
+                    .configure(StringTemplates.class, st -> st.setFailOnMissingAttribute(true))
+                .mapTo(boolean.class)
+                .one())
+            .isInstanceOf(UnableToExecuteStatementException.class)
+            .hasMessageContaining("Executing StringTemplate failed", "attribute a isn't defined");
+    }
+}


### PR DESCRIPTION


Fixes #1556