### PR TITLE
Fix GenericType resolution in parameterized classes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  - fix `GenericType` creation in parameterized classes (#2305)
   - add `SqlStatements#setAttachAllStatementsForCleanup`. Setting this configuration flag will attach all created statements to their handles for resource cleanup. Default is `false`. (#2293, thanks @jodastephen)
   - add `SqlStatements#setAttachCallbackStatementsForCleanup`. Setting this configuration flag will attach all created statements within one of the `Jdbi` callback methods to the handle. This allows code that uses the `Jdbi` callback methods to delegate resource management fully to Jdbi. This flag is set by default. (#2293, thanks @jodastephen)
   - fix problem when using the jdbi bom in spring projects (#2295, thanks @jedvardsson)

--- a/core/src/test/java/org/jdbi/v3/core/generic/GenericTypesTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/generic/GenericTypesTest.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.generic;
 
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -75,6 +76,17 @@ public class GenericTypesTest {
             .contains(Integer.class);
         assertThat(GenericTypes.findGenericParameter(methodReturnType(Xyz.class, "sample"), Xyz.class, 2))
             .contains(Void.class);
+    }
+
+    @Test
+    void testGenericTypeWorksInParameterizedClasses() {
+        class Foo<T> {
+            Type getType() {
+                return new GenericType<List<String>>() {}.getType();
+            }
+        }
+
+        assertThat(new Foo<>().getType()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
Port the code from geantryref.TypeToken#extractType for classes passed into GenericType.

Fixes #2305