### PR TITLE
Allow user defined message rendering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  - allow user defined functions for message rendering (#2311)
   - fix `GenericType` creation in parameterized classes (#2305)
   - add `SqlStatements#setAttachAllStatementsForCleanup`. Setting this configuration flag will attach all created statements to their handles for resource cleanup. Default is `false`. (#2293, thanks @jodastephen)
   - add `SqlStatements#setAttachCallbackStatementsForCleanup`. Setting this configuration flag will attach all created statements within one of the `Jdbi` callback methods to the handle. This allows code that uses the `Jdbi` callback methods to delegate resource management fully to Jdbi. This flag is set by default. (#2293, thanks @jodastephen)

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementExceptions.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementExceptions.java
@@ -24,7 +24,7 @@ import org.jdbi.v3.meta.Beta;
 @Beta
 public class StatementExceptions implements JdbiConfig<StatementExceptions> {
 
-    private MessageRendering messageRendering = MessageRendering.SHORT_STATEMENT;
+    private Function<StatementException, String> messageRendering = MessageRendering.SHORT_STATEMENT;
     private int lengthLimit = 1024;
 
     public StatementExceptions() {}
@@ -57,8 +57,9 @@ public class StatementExceptions implements JdbiConfig<StatementExceptions> {
      * Returns the statement exception message rendering strategy.
      *
      * @return the statement exception message rendering strategy.
+     * @see MessageRendering
      */
-    public MessageRendering getMessageRendering() {
+    public Function<StatementException, String> getMessageRendering() {
         return messageRendering;
     }
 
@@ -66,8 +67,9 @@ public class StatementExceptions implements JdbiConfig<StatementExceptions> {
      * Configure exception statement message generation.
      * @param messageRendering the message rendering strategy to use
      * @return this
+     * @see MessageRendering
      */
-    public StatementExceptions setMessageRendering(MessageRendering messageRendering) {
+    public StatementExceptions setMessageRendering(Function<StatementException, String> messageRendering) {
         this.messageRendering = messageRendering;
         return this;
     }


### PR DESCRIPTION
Make the StatementExceptions#setMessageRendering and getMessageRendering methods operate on Function objects, not the MessageRendering implementations. This allows users to plug in their own implementations, not limit them to the provided implementations