### PR TITLE
Enforce single Consumer argument

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
@@ -95,13 +95,19 @@ abstract class ResultReturner {
      * @return a ResultReturner that invokes the consumer and does not return a value
      */
     static Optional<ResultReturner> findConsumer(Method method) {
+        Optional<ResultReturner> result = Optional.empty();
+
         final Class<?>[] paramTypes = method.getParameterTypes();
         for (int i = 0; i < paramTypes.length; i++) {
             if (paramTypes[i] == Consumer.class) {
-                return Optional.of(ConsumerResultReturner.of(method, i));
+                if (result.isPresent()) {
+                    throw new IllegalArgumentException(format("Method %s has multiple consumer arguments!", method));
+                }
+                result = Optional.of(ConsumerResultReturner.of(method, i));
             }
         }
-        return Optional.empty();
+
+        return result;
     }
 
     protected abstract Object mappedResult(ResultIterable<?> iterable, StatementContext ctx);

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConsumer.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestConsumer.java
@@ -81,6 +81,13 @@ public class TestConsumer {
     }
 
     @Test
+    public void consumeMultiStream() {
+        assertThatThrownBy(() -> h2Extension.getSharedHandle().attach(MultiConsumerDao.class))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+    @Test
     public void testIteratorPartialConsumeOk() {
         final List<Something> results = new ArrayList<>();
         dao.consumeIterator(iter -> results.add(iter.next()));
@@ -135,17 +142,27 @@ public class TestConsumer {
     public interface SomethingStream extends Stream<Something> {}
 
     public interface SomethingStreamDao {
+
         @SqlQuery("select id, name from something order by id desc")
         @RegisterRowMapper(SomethingMapper.class)
         void consumeStream(Consumer<SomethingStream> consumer);
 
     }
+
     public interface SpecialStream<T> extends Stream<T> {}
 
     public interface SpecialStreamDao {
+
         @SqlQuery("select id, name from something order by id desc")
         @RegisterRowMapper(SomethingMapper.class)
         void consumeStream(Consumer<SpecialStream<Something>> consumer);
 
+    }
+
+    public interface MultiConsumerDao {
+
+        @SqlQuery("select id, name from something order by id desc")
+        @RegisterRowMapper(SomethingMapper.class)
+        void consumeMultiStream(Consumer<Stream<Something>> stream, Consumer<Iterator<Something>> iterator);
     }
 }


### PR DESCRIPTION
Make sure that there can not be multiple consumer arguments for a SQL object method.