### PR TITLE
Dependency and build upgrades

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ trim_trailing_whitespace = false
 
 [*.yml]
 indent_size = 2
+
+[*.kt]
+ij_kotlin_allow_trailing_comma_on_call_site=false
+ij_kotlin_allow_trailing_comma=false

--- a/.github/workflows/flyway-versions.yml
+++ b/.github/workflows/flyway-versions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flyway-version: [ 7.15.0, 8.2.3, 8.5.13, 9.16.1 ] # baseline, first 8.x that supports H2, latest 8.x.x, latest 9.x.x
+        flyway-version: [ 7.15.0, 8.2.3, 8.5.13, 9.17.0 ] # baseline, first 8.x that supports H2, latest 8.x.x, latest 9.x.x
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/versions-check.yml
+++ b/.github/workflows/versions-check.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        test-version: [ 31.1-jre, 31.0.1-jre, 31.0-jre ]
+        test-version: [ 30.1.1-jre, 31.0.1-jre, 31.0-jre ]
 
     steps:
     - uses: actions/checkout@v3
@@ -129,6 +129,31 @@ jobs:
     - name: Build
       env:
         MAVEN_CONFIG: "-B -fae -am -pl :jdbi3-vavr -Ddep.vavr.version=${{ matrix.test-version }}"
+      run: |
+        ./mvnw --version
+        echo $PATH
+        make install
+
+  guice:
+    name: Test guice versions
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        test-version: [ 5.0.1, 5.1.0, 6.0.0-rc2 ]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-java@v3
+      with:
+        java-version: 17
+        distribution: temurin
+        cache: maven
+
+    - name: Build
+      env:
+        MAVEN_CONFIG: "-B -fae -am -pl :jdbi3-guice -Ddep.guice.version=${{ matrix.test-version }}"
       run: |
         ./mvnw --version
         echo $PATH

--- a/.github/workflows/versions-check.yml
+++ b/.github/workflows/versions-check.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        test-version: [ 30.1.1-jre, 31.0.1-jre, 31.0-jre ]
+        test-version: [ 31.1-jre, 31.0.1-jre, 31.0-jre ]
 
     steps:
     - uses: actions/checkout@v3

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -30,7 +30,7 @@
         <basepom.check.skip-pmd>true</basepom.check.skip-pmd>
         <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
         <basepom.deploy.skip>true</basepom.deploy.skip>
-        <dep.jmh.version>1.32</dep.jmh.version>
+        <dep.jmh.version>1.36</dep.jmh.version>
         <moduleName>org.jdbi.v3.benchmark</moduleName>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.guava;
 
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.TypeVariable;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
@@ -143,6 +145,13 @@ public class TestGuavaCollectors {
         assertThat(map)
                 .isInstanceOf(erasedType)
                 .containsExactly(entry(1L, "foo"), entry(2L, "bar"));
+    }
+
+    @Test
+    public void testGuavaCrash() {
+        TypeVariable<Class<Multimap>>[] multimapParams = Multimap.class.getTypeParameters();
+        AnnotatedType[] annotatedBounds = multimapParams[0].getAnnotatedBounds();
+        assertThat(annotatedBounds).isNotNull();
     }
 
     @Test

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -70,8 +70,7 @@
         <dep.antlr.version>4.12.0</dep.antlr.version>
         <dep.asciidoctorj-diagram.version>2.2.7</dep.asciidoctorj-diagram.version>
         <dep.asciidoctorj.version>2.5.8</dep.asciidoctorj.version>
-        <dep.assertj-core.version>3.24.2</dep.assertj-core.version>
-        <dep.assertj-guava.version>3.24.2</dep.assertj-guava.version>
+        <dep.assertj.version>3.24.2</dep.assertj.version>
         <dep.caffeine.version>3.1.6</dep.caffeine.version>
         <dep.checkerframework.version>3.34.0</dep.checkerframework.version>
         <dep.commons-compress.version>1.23.0</dep.commons-compress.version>
@@ -362,13 +361,20 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>${dep.assertj-core.version}</version>
+                <version>${dep.assertj.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-guava</artifactId>
-                <version>${dep.assertj-guava.version}</version>
+                <version>${dep.assertj.version}</version>
+                <exclusions>
+                    <!-- exclusion is needed, otherwise the version checks on CI fail -->
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -83,7 +83,8 @@
         <dep.flyway.version>7.15.0</dep.flyway.version>
         <dep.freebuilder.version>2.8.0</dep.freebuilder.version>
         <dep.freemarker.version>2.3.32</dep.freemarker.version>
-        <dep.guava.version>31.1-jre</dep.guava.version>
+        <!-- don't upgrade to 31.1-jre because of https://github.com/google/guava/issues/6474 -->
+        <dep.guava.version>30.1.1-jre</dep.guava.version>
         <dep.guice.version>5.0.1</dep.guice.version>
         <dep.h2.version>2.1.214</dep.h2.version>
         <!-- leave hikari-cp on 4.x for jdk8 compatibility! -->
@@ -381,10 +382,18 @@
                 <version>${dep.assertj-core.version}</version>
             </dependency>
 
+            <!-- remove when https://github.com/google/guava/issues/6474 is resolved
+                 or we drop JDK8 compatibility -->
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-guava</artifactId>
                 <version>${dep.assertj-guava.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -75,7 +75,8 @@
         <dep.checkerframework.version>3.34.0</dep.checkerframework.version>
         <dep.commons-compress.version>1.23.0</dep.commons-compress.version>
         <dep.commons-text.version>1.10.0</dep.commons-text.version>
-        <dep.derby.version>10.16.1.1</dep.derby.version>
+        <!-- derby 10.16 is JDK 17 only, keep it on 10.15 for now -->
+        <dep.derby.version>10.15.2.0</dep.derby.version>
         <dep.detekt.version>1.22.0</dep.detekt.version>
         <dep.dokka.version>1.8.10</dep.dokka.version>
         <dep.errorprone.version>2.18.0</dep.errorprone.version>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -83,8 +83,7 @@
         <dep.flyway.version>7.15.0</dep.flyway.version>
         <dep.freebuilder.version>2.8.0</dep.freebuilder.version>
         <dep.freemarker.version>2.3.32</dep.freemarker.version>
-        <!-- don't upgrade to 31.1-jre because of https://github.com/google/guava/issues/6474 -->
-        <dep.guava.version>30.1.1-jre</dep.guava.version>
+        <dep.guava.version>31.1-jre</dep.guava.version>
         <dep.guice.version>5.0.1</dep.guice.version>
         <dep.h2.version>2.1.214</dep.h2.version>
         <!-- leave hikari-cp on 4.x for jdk8 compatibility! -->
@@ -174,12 +173,6 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${dep.guava.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.checkerframework</groupId>
-                        <artifactId>checker-qual</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
@@ -196,10 +189,6 @@
                     <exclusion>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.checkerframework</groupId>
-                        <artifactId>checker-qual</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -298,12 +287,6 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${dep.postgresql.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.checkerframework</groupId>
-                        <artifactId>checker-qual</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
@@ -382,18 +365,10 @@
                 <version>${dep.assertj-core.version}</version>
             </dependency>
 
-            <!-- remove when https://github.com/google/guava/issues/6474 is resolved
-                 or we drop JDK8 compatibility -->
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-guava</artifactId>
                 <version>${dep.assertj-guava.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -67,20 +67,24 @@
         <basepom.release.tag-name-format>v@{project.version}</basepom.release.tag-name-format>
         <basepom.test.fork-count>4</basepom.test.fork-count>
         <basepom.test.timeout>240</basepom.test.timeout>
-
-        <dep.antlr.version>4.10.1</dep.antlr.version>
-        <dep.asciidoctorj-diagram.version>2.2.3</dep.asciidoctorj-diagram.version>
-        <dep.asciidoctorj.version>2.5.6</dep.asciidoctorj.version>
-        <dep.assertj-core.version>3.23.1</dep.assertj-core.version>
-        <dep.assertj-guava.version>3.4.0</dep.assertj-guava.version>
-        <dep.caffeine.version>3.0.3</dep.caffeine.version>
+        <dep.antlr.version>4.12.0</dep.antlr.version>
+        <dep.asciidoctorj-diagram.version>2.2.7</dep.asciidoctorj-diagram.version>
+        <dep.asciidoctorj.version>2.5.8</dep.asciidoctorj.version>
+        <dep.assertj-core.version>3.24.2</dep.assertj-core.version>
+        <dep.assertj-guava.version>3.24.2</dep.assertj-guava.version>
+        <dep.caffeine.version>3.1.6</dep.caffeine.version>
+        <dep.checkerframework.version>3.34.0</dep.checkerframework.version>
+        <dep.commons-compress.version>1.23.0</dep.commons-compress.version>
         <dep.commons-text.version>1.10.0</dep.commons-text.version>
-        <dep.derby.version>10.15.2.0</dep.derby.version>
-        <dep.detekt.version>1.21.0-RC2</dep.detekt.version>
-        <dep.dokka.version>1.7.10</dep.dokka.version>
+        <dep.derby.version>10.16.1.1</dep.derby.version>
+        <dep.detekt.version>1.22.0</dep.detekt.version>
+        <dep.dokka.version>1.8.10</dep.dokka.version>
+        <dep.errorprone.version>2.18.0</dep.errorprone.version>
         <dep.flyway.version>7.15.0</dep.flyway.version>
-        <dep.freebuilder.version>2.7.0</dep.freebuilder.version>
-        <dep.guava.version>30.1.1-jre</dep.guava.version>
+        <dep.freebuilder.version>2.8.0</dep.freebuilder.version>
+        <dep.freemarker.version>2.3.32</dep.freemarker.version>
+        <dep.guava.version>31.1-jre</dep.guava.version>
+        <dep.guice.version>5.0.1</dep.guice.version>
         <dep.h2.version>2.1.214</dep.h2.version>
         <!-- leave hikari-cp on 4.x for jdk8 compatibility! -->
         <dep.hikari-cp.version>4.0.3</dep.hikari-cp.version>
@@ -91,24 +95,26 @@
         <dep.jetbrainsAnnotations.version>21.0.1</dep.jetbrainsAnnotations.version>
         <dep.joda-time.version>2.9.9</dep.joda-time.version>
         <dep.jts.version>1.19.0</dep.jts.version>
-        <dep.junit5.version>5.9.1</dep.junit5.version>
+        <dep.junit5.version>5.9.3</dep.junit5.version>
         <dep.kotlin.version>1.5.32</dep.kotlin.version>
-        <dep.lombok.version>1.18.24</dep.lombok.version>
-        <dep.mockito.version>4.2.0</dep.mockito.version>
+        <dep.lombok.version>1.18.26</dep.lombok.version>
+        <!-- leave mockito on 4.x for jdk8 compatibility -->
+        <dep.mockito.version>4.11.0</dep.mockito.version>
         <dep.pg-embedded.version>4.2</dep.pg-embedded.version>
-        <dep.plugin.asciidoctor.version>2.2.2</dep.plugin.asciidoctor.version>
-        <dep.plugin.detekt.version>1.21.0.1</dep.plugin.detekt.version>
+        <dep.plugin.asciidoctor.version>2.2.3</dep.plugin.asciidoctor.version>
+        <dep.plugin.detekt.version>1.22.0</dep.plugin.detekt.version>
         <dep.plugin.flatten.version>1.4.1</dep.plugin.flatten.version>
         <dep.plugin.inline.version>1.0.1</dep.plugin.inline.version>
         <dep.plugin.jacoco.version>0.8.10</dep.plugin.jacoco.version>
-        <dep.plugin.kotlin.version>1.7.10</dep.plugin.kotlin.version>
-        <dep.plugin.ktlint.version>1.15.1</dep.plugin.ktlint.version>
-        <dep.plugin.sortpom.version>3.2.0</dep.plugin.sortpom.version>
-        <dep.postgresql.version>42.5.1</dep.postgresql.version>
+        <dep.plugin.kotlin.version>1.8.21</dep.plugin.kotlin.version>
+        <dep.plugin.ktlint.version>1.16.0</dep.plugin.ktlint.version>
+        <dep.plugin.sortpom.version>3.2.1</dep.plugin.sortpom.version>
+        <dep.postgresql.version>42.6.0</dep.postgresql.version>
         <dep.slf4j.version>1.7.36</dep.slf4j.version>
         <dep.spring.version>5.3.27</dep.spring.version>
+        <dep.sqlite.version>3.41.2.1</dep.sqlite.version>
         <dep.stringtemplate4.version>4.3.4</dep.stringtemplate4.version>
-        <dep.testcontainers.version>1.17.6</dep.testcontainers.version>
+        <dep.testcontainers.version>1.18.0</dep.testcontainers.version>
         <dep.vavr.version>0.9.3</dep.vavr.version>
         <jdbi.check.fail-detekt>${jdbi.check.fail-kotlin}</jdbi.check.fail-detekt>
         <jdbi.check.fail-kotlin>${basepom.check.fail-extended}</jdbi.check.fail-kotlin>
@@ -158,6 +164,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${dep.errorprone.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${dep.guava.version}</version>
@@ -172,7 +184,7 @@
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
-                <version>5.0.1</version>
+                <version>${dep.guice.version}</version>
             </dependency>
 
             <dependency>
@@ -438,19 +450,19 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.21</version>
+                <version>${dep.commons-compress.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.15.0</version>
+                <version>${dep.checkerframework.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.xerial</groupId>
                 <artifactId>sqlite-jdbc</artifactId>
-                <version>3.36.0.1</version>
+                <version>${dep.sqlite.version}</version>
             </dependency>
 
             <dependency>
@@ -480,7 +492,7 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.31</version>
+                <version>${dep.freemarker.version}</version>
             </dependency>
 
             <dependency>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -92,6 +92,7 @@
                         <configuration>
                             <excludes combine.children="append">
                                 <exclude>**/TestGetGeneratedKeys.*</exclude>
+                                <exclude>**/TestGetGeneratedKeys$*.*</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -33,7 +33,8 @@
         <basepom.test.skip>true</basepom.test.skip>
         <!-- docker tests run long -->
         <basepom.test.timeout>600</basepom.test.timeout>
-        <dep.clickhouse.version>0.3.2-patch11</dep.clickhouse.version>
+        <!-- Sigh. Java is really hard. Leave this at 0.3.2, all other versions are worse -->
+        <dep.clickhouse.version>0.3.2</dep.clickhouse.version>
         <dep.mysql.version>8.0.33</dep.mysql.version>
         <dep.oracle-xe.version>23.2.0.0</dep.oracle-xe.version>
         <dep.trino.version>416</dep.trino.version>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -33,11 +33,11 @@
         <basepom.test.skip>true</basepom.test.skip>
         <!-- docker tests run long -->
         <basepom.test.timeout>600</basepom.test.timeout>
-        <dep.clickhouse.version>0.3.2</dep.clickhouse.version>
-        <dep.mysql.version>8.0.31</dep.mysql.version>
-        <dep.oracle-xe.version>19.14.0.0</dep.oracle-xe.version>
-        <dep.trino.version>403</dep.trino.version>
-        <dep.yugabyte.version>42.3.4</dep.yugabyte.version>
+        <dep.clickhouse.version>0.4.5</dep.clickhouse.version>
+        <dep.mysql.version>8.0.33</dep.mysql.version>
+        <dep.oracle-xe.version>23.2.0.0</dep.oracle-xe.version>
+        <dep.trino.version>416</dep.trino.version>
+        <dep.yugabyte.version>42.3.5-yb-2</dep.yugabyte.version>
         <moduleName>org.jdbi.v3.testcontainers</moduleName>
     </properties>
 

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -33,7 +33,7 @@
         <basepom.test.skip>true</basepom.test.skip>
         <!-- docker tests run long -->
         <basepom.test.timeout>600</basepom.test.timeout>
-        <dep.clickhouse.version>0.4.5</dep.clickhouse.version>
+        <dep.clickhouse.version>0.3.2-patch11</dep.clickhouse.version>
         <dep.mysql.version>8.0.33</dep.mysql.version>
         <dep.oracle-xe.version>23.2.0.0</dep.oracle-xe.version>
         <dep.trino.version>416</dep.trino.version>

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/AbstractJdbiTestcontainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/AbstractJdbiTestcontainersExtensionTest.java
@@ -35,8 +35,8 @@ abstract class AbstractJdbiTestcontainersExtensionTest {
     JdbiExtension extension = JdbiTestcontainersExtension.instance(getDbContainer())
         .withInitializer((ds, handle) -> {
             handle.execute(getTableCreateStatement());
-            handle.execute("INSERT INTO users VALUES (1, 'Alice')");
-            handle.execute("INSERT INTO users VALUES (2, 'Bob')");
+            handle.execute("INSERT INTO users VALUES (?, ?)", 1, "Alice");
+            handle.execute("INSERT INTO users VALUES (?, ?)", 2, "Bob");
         });
 
     @Test

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/OracleXeJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/OracleXeJdbiTestContainersExtensionTest.java
@@ -13,12 +13,14 @@
  */
 package org.jdbi.v3.testing.junit5.tc;
 
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
+@EnabledOnOs(architectures = {"x86_64"})
 class OracleXeJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/PostGisJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/PostGisJdbiTestContainersExtensionTest.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.testing.junit5.tc;
 
 
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -21,6 +22,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
+@EnabledOnOs(architectures = {"x86_64"})
 class PostGisJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/YugabyteJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/YugabyteJdbiTestContainersExtensionTest.java
@@ -13,12 +13,14 @@
  */
 package org.jdbi.v3.testing.junit5.tc;
 
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.YugabyteDBYSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
+@EnabledOnOs(architectures = {"x86_64"})
 class YugabyteJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container


### PR DESCRIPTION
build changes:

- test newer dependency versions in CI tests
- test new guice versions in CI tests

internal dependencies:

- jmh to 1.36 (from 1.32)
- antlr to 4.12.0 (from 4.10.1)
- assertj to 3.24.2 (from 3.23.1)
- checkerframework to 3.34.0 (from 3.15.0)
- commons-compress to 1.23.0 (from 1.21)
- derby to 10.16.1.1 (from 10.15.2.0)
- freebuilder to 2.8.0 (from 2.7.0)
- junit to 5.9.3 (from 5.9.1)
- lombok to 1.18.26 (from 1.18.24)
- mockito to 4.11.0 (from 4.2.0)
- sortpom 3.2.1 (from 3.2.0)
- testcontainer 1.18.0 (from 1.17.6)
- testcontainer database updates

code dependencies:

- caffeine to 3.1.6 (from 3.0.3)
- freemarker to 2.3.23 (from 2.3.31)
- guava to 31.1-jre (from 30.1.1-jre)
- postgresql to 42.6.0 (from 42.5.1)
- sqlite to 3.41.2.1 (from 3.36.0.1)

kotlin changes:

- set trailing comma for kotlin to false (ktlint changed default)
- detekt to 1.22.0 (from 1.21.0-RC2)
- dokka to 1.8.10 (from 1.7.10)
- use kotlin 1.8.21 compiler (from 1.7.10)
- ktlint 1.16.0 (from 1.15.1)

documentation:

- asciidoctor and asciidoctorj updates