### PR TITLE
Ignore unknown mappers when warming DAO classes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 # Unreleased
+
+  - allow unknown result mappers during `ResultReturner` warmup. This restores the pre-3.38.0 behavior
+    where SQLObject classes with invalid methods could be used unless a method is explicitly called (#2342)
   - document vavr incompatibility between 0.10.x and 1.0.0-alpha (#2350)
   - Handle.inTransaction: improve exception thrown when restoring transaction isolation #2343
   - add support for Guice 6.x (using javax.inject annotations) and guice 7.x (using jakarta.inject annotations)

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapEntryMapper.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
 
+import static java.lang.String.format;
+
 import static org.jdbi.v3.core.generic.GenericTypes.getErasedType;
 import static org.jdbi.v3.core.generic.GenericTypes.resolveType;
 
@@ -69,12 +71,12 @@ public class MapEntryMapper<K, V> implements RowMapper<Map.Entry<K, V>> {
         if (column == null) {
             return config.get(RowMappers.class)
                     .findFor(keyType)
-                    .orElseThrow(() -> new NoSuchMapperException("No row mapper registered for map key " + keyType));
+                    .orElseThrow(() -> new NoSuchMapperException(format("Map key column is not declared (missing @KeyColumn annotation?) and no row mapper for key type '%s' is registered!", keyType)));
         } else {
             return config.get(ColumnMappers.class)
                     .findFor(keyType)
                     .map(mapper -> new SingleColumnMapper<>(mapper, column))
-                    .orElseThrow(() -> new NoSuchMapperException("No column mapper registered for map key " + keyType + " in column " + column));
+                    .orElseThrow(() -> new NoSuchMapperException(format("Type '%s' for map key column '%s' has no column mapper registered!", keyType, column)));
         }
     }
 
@@ -83,12 +85,12 @@ public class MapEntryMapper<K, V> implements RowMapper<Map.Entry<K, V>> {
         if (column == null) {
             return config.get(RowMappers.class)
                     .findFor(valueType)
-                    .orElseThrow(() -> new NoSuchMapperException("No row mapper registered for map value " + valueType));
+                    .orElseThrow(() -> new NoSuchMapperException(format("Map value column is not declared (missing @ValueColumn annotation?) and no row mapper for value type '%s' is registered!", valueType)));
         } else {
             return config.get(ColumnMappers.class)
                     .findFor(valueType)
                     .map(mapper -> new SingleColumnMapper<>(mapper, column))
-                    .orElseThrow(() -> new NoSuchMapperException("No column mapper registered for map value " + valueType + " in column " + column));
+                    .orElseThrow(() -> new NoSuchMapperException(format("Type '%s' for map value column '%s' has no column mapper registered!", valueType, column)));
         }
     }
 

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -132,14 +132,15 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes combine.children="append">
-                                <exclude>**/TestReadOnly.*</exclude>
-                                <exclude>**/TestSqlLocator.*</exclude>
-                                <exclude>**/TestPostgresBugs.*</exclude>
-                                <exclude>**/TestPostgresRefcursorProc.*</exclude>
-                                <exclude>**/TestOutParameterAnnotation.*</exclude>
+                                <exclude>**/MapResultTest.*</exclude>
                                 <exclude>**/TestGetGeneratedKeysPostgres$*.*</exclude>
                                 <exclude>**/TestGetGeneratedKeysPostgres.*</exclude>
+                                <exclude>**/TestOutParameterAnnotation.*</exclude>
+                                <exclude>**/TestPostgresBugs.*</exclude>
+                                <exclude>**/TestPostgresRefcursorProc.*</exclude>
+                                <exclude>**/TestReadOnly.*</exclude>
                                 <exclude>**/TestRegisterJoinRowMapper.*</exclude>
+                                <exclude>**/TestSqlLocator.*</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
@@ -25,6 +25,7 @@ import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.mapper.Mappers;
+import org.jdbi.v3.core.mapper.NoSuchMapperException;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.qualifier.Qualifiers;
 import org.jdbi.v3.core.result.ResultIterable;
@@ -117,8 +118,13 @@ abstract class ResultReturner {
     protected abstract QualifiedType<?> elementType(ConfigRegistry config);
 
     protected void warm(ConfigRegistry config) {
-        Optional.ofNullable(elementType(config))
-                .ifPresent(config.get(Mappers.class)::findFor);
+        try {
+            Optional.ofNullable(elementType(config))
+                    .ifPresent(config.get(Mappers.class)::findFor);
+        } catch (NoSuchMapperException ignore) {
+            // if the result mapper is not available during warming up,
+            // simply ignore it.
+        }
     }
 
     private static Object checkResult(Object result, QualifiedType<?> type) {

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/MapResultTest.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/MapResultTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.customizer;
+
+import java.util.Map;
+import java.util.UUID;
+
+import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
+import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.config.KeyColumn;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MapResultTest {
+
+    @RegisterExtension
+    public static EmbeddedPgExtension pg = MultiDatabaseBuilder.instanceWithDefaults().build();
+
+    @RegisterExtension
+    JdbiExtension pgExtension = JdbiExtension.postgres(pg)
+            .withPlugins(new SqlObjectPlugin());
+
+    Jdbi jdbi;
+    UUID content;
+
+    @BeforeEach
+    void setUp() {
+        this.jdbi = pgExtension.getJdbi();
+
+        jdbi.registerRowMapper(JsonBean.class, ConstructorMapper.of(JsonBean.class));
+
+        jdbi.useHandle(handle -> handle.execute("CREATE TABLE json_data (id INTEGER PRIMARY KEY, key VARCHAR, value UUID)"));
+
+        this.content = UUID.randomUUID();
+        jdbi.withHandle(handle -> handle.execute("INSERT INTO json_data (id, key, value) VALUES (?, ?, ?)", 1, "test", content));
+    }
+
+    @Test
+    public void testMapResult() {
+        Map<String, JsonBean> result = jdbi.withExtension(MapDao.class, dao -> dao.getValues(1));
+
+        assertThat(result).isNotNull().hasSize(1);
+
+        JsonBean bean = result.get("test");
+        assertThat(bean).isNotNull().extracting("id").isEqualTo(1);
+        assertThat(bean).extracting("key").isEqualTo("test");
+        assertThat(bean).extracting("value").isEqualTo(content);
+    }
+
+    @Test
+    public void testNoKeyColumn() {
+        assertThatThrownBy(() -> jdbi.withExtension(MapDao.class, dao -> dao.getValuesMissingAnnotation(1)))
+                .hasMessageContaining(
+                        "Map key column is not declared (missing @KeyColumn annotation?) and no row mapper for key type 'class java.lang.String' is registered!");
+    }
+
+
+    public static final class JsonBean {
+
+        private final int id;
+        private final String key;
+        private final UUID value;
+
+        public JsonBean(int id, String key, UUID value) {
+            this.id = id;
+            this.key = key;
+            this.value = value;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public UUID getValue() {
+            return value;
+        }
+    }
+
+    public interface MapDao {
+
+        @SqlQuery("SELECT * FROM json_data WHERE id = :id")
+        @KeyColumn("key")
+        Map<String, JsonBean> getValues(int id);
+
+        @SqlQuery("SELECT * FROM json_data WHERE id = :id")
+        Map<String, JsonBean> getValuesMissingAnnotation(int id);
+    }
+}


### PR DESCRIPTION
Restore the pre-3.38.0 behavior where errors during warming were only thrown when a method was called for the first time. The 3.38.0 changes made warming up much more aggressive which resulted in errors being reported for extension methods that were not in use (but present on the extension class).

Add some clarification to the error messages as well. 

This addresses #2342 