### PR TITLE
Implement `@RegisterCollector`

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterCollector.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterCollector.java
@@ -1,0 +1,27 @@
+package org.jdbi.v3.sqlobject.config;
+
+import org.jdbi.v3.core.extension.annotation.UseExtensionConfigurer;
+import org.jdbi.v3.sqlobject.config.internal.RegisterCollectorImpl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.stream.Collector;
+
+/**
+ * Registers specifically one collector for a sql object type
+ */
+@UseExtensionConfigurer(RegisterCollectorImpl.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface RegisterCollector {
+
+    /**
+     * The collector instance to register
+     *
+     * @return the collector instance
+     */
+    Class<? extends Collector<?, ?, ?>> value();
+
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorImpl.java
@@ -1,0 +1,24 @@
+package org.jdbi.v3.sqlobject.config.internal;
+
+import org.jdbi.v3.core.collector.JdbiCollectors;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.sqlobject.config.RegisterCollector;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+
+public class RegisterCollectorImpl extends SimpleExtensionConfigurer {
+    @Override
+    public void configure(ConfigRegistry config, Annotation annotation, Class<?> extensionType) {
+        RegisterCollector registerCollector = (RegisterCollector) annotation;
+        JdbiCollectors mappers = config.get(JdbiCollectors.class);
+        try {
+            Class<?> type = (Class<?>) ((ParameterizedType) getClass()
+                .getGenericSuperclass()).getActualTypeArguments()[2]; //gets resultant type of collector
+            mappers.registerCollector(type.getGenericSuperclass(), registerCollector.value().getConstructor().newInstance());
+        } catch (ReflectiveOperationException | SecurityException e) {
+            throw new IllegalStateException("Unable to instantiate collector class " + registerCollector.value(), e);
+        }
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorImpl.java
@@ -18,7 +18,8 @@ public class RegisterCollectorImpl extends SimpleExtensionConfigurer {
         try {
             Type type = null; //resultant type
             for(Type t : registerCollector.value().getGenericInterfaces()) {
-                if(t instanceof ParameterizedType pt) {
+                if(t instanceof ParameterizedType) {
+                    ParameterizedType pt = (ParameterizedType) t;
                     if(pt.getRawType().toString().equals("interface Collector")) {
                         type = pt.getActualTypeArguments()[2];
                         break;


### PR DESCRIPTION
Adds an annotation call to `JdbiCollectors#registerCollector(Type, Collector)`, allowing for QoL complex collectors as an alternative to making a `CollectorFactory` for use in interface DAOs. 
This could probably use some tests though