### PR TITLE
fix(sec): upgrade org.xerial:sqlite-jdbc to 3.41.2.2

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -111,7 +111,7 @@
         <dep.postgresql.version>42.6.0</dep.postgresql.version>
         <dep.slf4j.version>1.7.36</dep.slf4j.version>
         <dep.spring.version>5.3.27</dep.spring.version>
-        <dep.sqlite.version>3.41.2.1</dep.sqlite.version>
+        <dep.sqlite.version>3.41.2.2</dep.sqlite.version>
         <dep.stringtemplate4.version>4.3.4</dep.stringtemplate4.version>
         <dep.testcontainers.version>1.18.0</dep.testcontainers.version>
         <dep.vavr.version>0.9.3</dep.vavr.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.xerial:sqlite-jdbc 3.41.2.1
- [CVE-2023-32697](https://www.oscs1024.com/hd/CVE-2023-32697)


### What did I do？
Upgrade org.xerial:sqlite-jdbc from 3.41.2.1 to 3.41.2.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS