### PR TITLE
Turn off lombok for jdk 21

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -97,7 +97,7 @@
         <dep.jts.version>1.19.0</dep.jts.version>
         <dep.junit5.version>5.9.3</dep.junit5.version>
         <dep.kotlin.version>1.5.32</dep.kotlin.version>
-        <dep.lombok.version>1.18.26</dep.lombok.version>
+        <dep.lombok.version>1.18.28</dep.lombok.version>
         <!-- leave mockito on 4.x for jdk8 compatibility -->
         <dep.mockito.version>4.11.0</dep.mockito.version>
         <dep.pg-embedded.version>5.0</dep.pg-embedded.version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
         <module>benchmark</module>
         <module>docs</module>
         <module>examples</module>
-        <module>lombok</module>
         <module>noparameters</module>
     </modules>
 
@@ -102,6 +101,17 @@
             </activation>
             <modules>
                 <module>java17</module>
+            </modules>
+        </profile>
+
+        <!-- lombok currently does not even compile on java 21 ... -->
+        <profile>
+            <id>not-java21</id>
+            <activation>
+                <jdk>[,21)</jdk>
+            </activation>
+            <modules>
+                <module>lombok</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
Current lombok does not compile with JDK 21
