### PR TITLE
Fix null return values for outparameters

### DIFF
--- a/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
@@ -147,6 +147,7 @@
                                 <exclude>**/ConstructorMapperPgTest.*</exclude>
                                 <exclude>**/TestArgumentBinder.*</exclude>
                                 <exclude>**/TestQueriesPG.*</exclude>
+                                <exclude>**/TestCallable.*</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/cache/noop-cache/src/it/test-noop-cache/pom.xml
+++ b/cache/noop-cache/src/it/test-noop-cache/pom.xml
@@ -147,6 +147,7 @@
                                 <exclude>**/ConstructorMapperPgTest.*</exclude>
                                 <exclude>**/TestArgumentBinder.*</exclude>
                                 <exclude>**/TestQueriesPG.*</exclude>
+                                <exclude>**/TestCallable.*</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -189,6 +189,7 @@
                                 <exclude>**/ConstructorMapperPgTest.*</exclude>
                                 <exclude>**/TestArgumentBinder.*</exclude>
                                 <exclude>**/TestQueriesPG.*</exclude>
+                                <exclude>**/TestCallable.*</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/core/src/it/test-inline-jar/pom.xml
+++ b/core/src/it/test-inline-jar/pom.xml
@@ -138,6 +138,7 @@
                                 <exclude>**/ConstructorMapperPgTest.*</exclude>
                                 <exclude>**/TestArgumentBinder.*</exclude>
                                 <exclude>**/TestQueriesPG.*</exclude>
+                                <exclude>**/TestCallable.*</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -122,7 +122,7 @@
         <jdbi.check.skip-kotlin>${basepom.check.skip-extended}</jdbi.check.skip-kotlin>
         <jdbi.check.skip-ktlint>${jdbi.check.skip-kotlin}</jdbi.check.skip-ktlint>
         <jdbi.check.skip-sortpom>${basepom.check.skip-basic}</jdbi.check.skip-sortpom>
-        <jdbi.test.pg-version>13</jdbi.test.pg-version>
+        <jdbi.test.pg-version>15</jdbi.test.pg-version>
         <kotlin.compiler.apiVersion>1.5</kotlin.compiler.apiVersion>
         <!-- remove the '1.' once we move past JDK8 compatibility -->
         <kotlin.compiler.jvmTarget>1.${project.build.targetJdk}</kotlin.compiler.jvmTarget>
@@ -1130,21 +1130,6 @@
                 <basepom.check.skip-all>true</basepom.check.skip-all>
                 <skipITs>true</skipITs>
                 <skipTests>true</skipTests>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>macos arm</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                    <arch>aarch64</arch>
-                </os>
-            </activation>
-
-            <properties>
-                <!-- the pg binaries for pg 13 do not support native mac arm64. Choose a version that does -->
-                <jdbi.test.pg-version>15</jdbi.test.pg-version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
- converted the procedure tests in TestCallable to postgres
- enabled the disabled tests (pg has outparameters)
- investigated #1813 (and added a test)

Turns out that do not correctly return null values for outparameters
(we always return the default value if an out parameter is null). Fix
that by calling #wasNull() on the statement. Add a test.
