### PR TITLE
alpha/beta promotions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,23 @@
-# Unreleased
+# 3.39.0
 
   - add `Extensions#failFast()` to enable extension objects with misconfigured methods to fail at first access. Default is to fail when a misconfigured method is accessed for the first time.
   - add new `@RegisterCollector` customizing annotation (#2377)
   - correctly return null for OutParameters when the called procedure returns NULL.
+
+  - promoted from `@Beta` to stable (no functional changes, some minor doc reformatting and additions)
+    - `JdbiProperty`, `DatabaseValue`, `PropagateNull`, `GenerateSqlObject`  annotations
+    - `NamedArgumentFinder`, `SetObjectArgumentFactory`, `GetObjectColumnMapperFactory`, `GenericMapMapperFactory`, `RowViewMapper`
+    - `MapMappers` configuration object
+    - `ConfigCache` functionality
+    - `SqlStatementCustomizer#warm()` and `SqlStatementParameterCustomizer#warm()`
+    - template engines
+    - moshi json support
+
+  - promoted from `@Alpha` to `@Beta` (no functional changes, doc cleanups)
+    - Codec functionality
+    - `BaseStatement#attachToHandleForCleanup()`
+    - PostGIS support
+
 
 # 3.38.3
   - allow unknown result mappers during `ResultReturner` warmup. This restores the pre-3.38.0 behavior

--- a/core/src/main/java/org/jdbi/v3/core/annotation/JdbiProperty.java
+++ b/core/src/main/java/org/jdbi/v3/core/annotation/JdbiProperty.java
@@ -18,22 +18,21 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.jdbi.v3.meta.Beta;
-
 /**
  * Configure reflective bean and pojo property attributes.
  * Most reflective mappers, including field, method, and property mappers, try to respect this.
  */
-@Beta
 @Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface JdbiProperty {
+
     /**
      * Returns true if the property is mapped in a result. The property will be read from the database into a result.
      *
      * @return true if the property is unmappable
      */
     boolean map() default true;
+
     /**
      * Returns true if the property is bound as an argument. Property will be bound as an argument.
      *

--- a/core/src/main/java/org/jdbi/v3/core/argument/NamedArgumentFinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/NamedArgumentFinder.java
@@ -18,13 +18,13 @@ import java.util.Collections;
 import java.util.Optional;
 
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Returns an Argument based on a name. Used to lookup multiple properties e.g. in a Bean or a Map.
  */
 @FunctionalInterface
 public interface NamedArgumentFinder {
+
     Optional<Argument> find(String name, StatementContext ctx);
 
     /**
@@ -32,7 +32,6 @@ public interface NamedArgumentFinder {
      *
      * @return the names this named argument finder can find. Returns an empty collection otherwise.
      */
-    @Beta
     default Collection<String> getNames() {
         return Collections.emptySet();
     }

--- a/core/src/main/java/org/jdbi/v3/core/argument/SetObjectArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/SetObjectArgumentFactory.java
@@ -21,13 +21,12 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Factory that uses {@link java.sql.PreparedStatement#setObject(int, Object, int)} to bind values.
  */
-@Beta
 public class SetObjectArgumentFactory implements ArgumentFactory.Preparable {
+
     private final Map<Class<?>, Integer> supportedTypes;
 
     protected SetObjectArgumentFactory(Map<Class<?>, Integer> types) {
@@ -47,10 +46,10 @@ public class SetObjectArgumentFactory implements ArgumentFactory.Preparable {
     @Override
     public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
         return Optional.of(type)
-                .filter(Class.class::isInstance)
-                .map(Class.class::cast)
-                .map(supportedTypes::get)
-                .map(sqlType -> value -> ObjectArgument.of(value, sqlType));
+            .filter(Class.class::isInstance)
+            .map(Class.class::cast)
+            .map(supportedTypes::get)
+            .map(sqlType -> value -> ObjectArgument.of(value, sqlType));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/codec/Codec.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/Codec.java
@@ -18,16 +18,16 @@ import java.util.function.Function;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.mapper.ColumnMapper;
-import org.jdbi.v3.meta.Alpha;
+import org.jdbi.v3.meta.Beta;
 
 /**
  * A Codec provides a convenient way for a bidirectional mapping of an attribute to a database column.
  * <p>
  * Groups a {@link ColumnMapper} and an {@link org.jdbi.v3.core.argument.Argument} mapping function for a given type.
- *
- * <p><i>Alpha: this interface is still evolving!  It might eventually replace the existing Mappers and Arguments.</i>
+ * <p>
+ * Codec instances can replace existing Mapper and Argument pairs.
  */
-@Alpha
+@Beta
 public interface Codec<T> {
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
@@ -33,7 +33,7 @@ import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.QualifiedColumnMapperFactory;
 import org.jdbi.v3.core.qualifier.QualifiedType;
-import org.jdbi.v3.meta.Alpha;
+import org.jdbi.v3.meta.Beta;
 
 import static java.util.Objects.requireNonNull;
 
@@ -45,12 +45,12 @@ import static java.util.Objects.requireNonNull;
  * to make the new public API as small as possible</i>
  */
 @ThreadSafe
-@Alpha
+@Beta
 public class CodecFactory implements QualifiedColumnMapperFactory, QualifiedArgumentFactory.Preparable {
 
     /**
      * Map of all known codecs in this factory.
-     *
+     * <p>
      * ALPHA: the fact that this is a Map from type to Codec makes it hard to implement Codecs that target wildcard
      * or varying types e.g. mapping both {@code Sub<T>} and {@code Super<T>} with one codec.
      * It might be nice to re-imagine this as itself a JdbiPlugin and have it do all registration through the existing flows.
@@ -114,7 +114,7 @@ public class CodecFactory implements QualifiedColumnMapperFactory, QualifiedArgu
      * Fluent Builder for {@link CodecFactory}.
      */
     @NotThreadSafe
-    @Alpha
+    @Beta
     public static final class Builder {
 
         private final Map<QualifiedType<?>, Codec<?>> codecMap = new HashMap<>();

--- a/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
@@ -46,7 +46,7 @@ import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.core.statement.StatementCustomizer;
 import org.jdbi.v3.core.statement.TemplateEngine;
 import org.jdbi.v3.core.statement.TimingCollector;
-import org.jdbi.v3.meta.Alpha;
+import org.jdbi.v3.meta.Beta;
 
 /**
  * A type with access to access and modify arbitrary Jdbi configuration.
@@ -54,6 +54,7 @@ import org.jdbi.v3.meta.Alpha;
  * @param <This> The subtype that implements this interface.
  */
 public interface Configurable<This> {
+
     /**
      * Returns the configuration registry associated with this object.
      *
@@ -109,9 +110,9 @@ public interface Configurable<This> {
     /**
      * Convenience method for {@code getConfig(SqlStatements.class).setTimingCollector(collector)}
      *
-     * @deprecated use {@link #setSqlLogger} instead
      * @param collector timing collector
      * @return this
+     * @deprecated use {@link #setSqlLogger} instead
      */
     @Deprecated
     default This setTimingCollector(TimingCollector collector) {
@@ -203,8 +204,8 @@ public interface Configurable<This> {
      *
      * @param elementType element raw type
      * @param sqlTypeName SQL type name
-     * @param conversion the function to convert to database representation
-     * @param <T> element type
+     * @param conversion  the function to convert to database representation
+     * @param <T>         element type
      * @return this
      */
     default <T> This registerArrayType(Class<T> elementType, String sqlTypeName, Function<T, ?> conversion) {
@@ -235,7 +236,7 @@ public interface Configurable<This> {
      * Convenience method for {@code getConfig(JdbiCollectors.class).register(CollectorFactory.collectorFactory(collectionType, collector))}
      *
      * @param collectionType collector type to register the collector for
-     * @param collector the Collector to use to build the resulting collection
+     * @param collector      the Collector to use to build the resulting collection
      * @return this
      * @since 3.38.0
      */
@@ -266,8 +267,8 @@ public interface Configurable<This> {
     /**
      * Convenience method for {@code getConfig(ColumnMappers.class).register(type, mapper)}
      *
-     * @param <T> the type
-     * @param type the generic type to register
+     * @param <T>    the type
+     * @param type   the generic type to register
      * @param mapper the mapper to use on that type
      * @return this
      */
@@ -278,7 +279,7 @@ public interface Configurable<This> {
     /**
      * Convenience method for {@code getConfig(ColumnMappers.class).register(type, mapper)}
      *
-     * @param type the type to register
+     * @param type   the type to register
      * @param mapper the mapper to use on that type
      * @return this
      */
@@ -289,7 +290,7 @@ public interface Configurable<This> {
     /**
      * Convenience method for {@code getConfig(ColumnMappers.class).register(type, mapper)}
      *
-     * @param type the type to register
+     * @param type   the type to register
      * @param mapper the mapper to use on that type
      * @return this
      */
@@ -340,8 +341,8 @@ public interface Configurable<This> {
     /**
      * Convenience method for {@code getConfig(RowMappers.class).register(type, mapper)}
      *
-     * @param <T> the type
-     * @param type to match
+     * @param <T>    the type
+     * @param type   to match
      * @param mapper row mapper
      * @return this
      */
@@ -352,7 +353,7 @@ public interface Configurable<This> {
     /**
      * Convenience method for {@code getConfig(RowMappers.class).register(type, mapper)}
      *
-     * @param type to match
+     * @param type   to match
      * @param mapper row mapper
      * @return this
      */
@@ -376,7 +377,7 @@ public interface Configurable<This> {
      * @param codecFactory codec factory
      * @return this
      */
-    @Alpha
+    @Beta
     default This registerCodecFactory(CodecFactory codecFactory) {
         registerColumnMapper(codecFactory);
         return registerArgument(codecFactory);

--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCache.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCache.java
@@ -16,14 +16,14 @@ package org.jdbi.v3.core.config.internal;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.Configurable;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Simple cache interface.
+ *
  * @see ConfigCaches
  */
-@Beta
 public interface ConfigCache<K, V> {
+
     V get(K key, ConfigRegistry config);
 
     default V get(K key, Configurable<?> configurable) {

--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Hold metadata caches which maps various JVM constants into pre-parsed forms.
@@ -31,8 +30,8 @@ import org.jdbi.v3.meta.Beta;
  * references to JVM constant pool entries.
  * <b>This makes it unsuitable as a general-purpose shared cache.</b>
  */
-@Beta
 public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
+
     private final Map<ConfigCache<?, ?>, Map<Object, Object>> caches = new ConcurrentHashMap<>();
 
     /**
@@ -61,8 +60,8 @@ public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
             @Override
             public V get(K key, ConfigRegistry config) {
                 return (V) config.get(ConfigCaches.class).caches
-                        .computeIfAbsent(this, x -> new ConcurrentHashMap<>())
-                        .computeIfAbsent(keyNormalizer.apply(key), x -> computer.apply(config, key));
+                    .computeIfAbsent(this, x -> new ConcurrentHashMap<>())
+                    .computeIfAbsent(keyNormalizer.apply(key), x -> computer.apply(config, key));
             }
         };
     }

--- a/core/src/main/java/org/jdbi/v3/core/enums/DatabaseValue.java
+++ b/core/src/main/java/org/jdbi/v3/core/enums/DatabaseValue.java
@@ -18,11 +18,17 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.jdbi.v3.meta.Beta;
-
+/**
+ * Map a value from the database column directly onto an enum value.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-@Beta
 public @interface DatabaseValue {
+
+    /**
+     * The database value that this annotation represents.
+     *
+     * @return the database value
+     */
     String value();
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/GenericMapMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/GenericMapMapperFactory.java
@@ -32,31 +32,26 @@ import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.result.ResultBearing;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Factory for a RowMapper that can map resultset rows to column name/generic value {@link Map}s.
- *
+ * <p>
  * Each row in the resultset becomes a distinct {@link Map}, in which the keys are all distinct column names and the values are the corresponding cell contents.
  * All values are mapped to the same generic type {@code T} (e.g. {@link java.math.BigDecimal}) by a {@link ColumnMapper} from the {@link ConfigRegistry}.
- *
+ * <p>
  * This differs from {@link MapMapper} by supporting a concrete type instead of only {@link Object}, and from {@code collecting} into a {@link Map}
  * in that the latter maps an entire resultset to a single {@link Map} and can only keep 1 key and 1 value from each row.
- *
+ * <p>
  * Use cases for this are mainly single-row results like numeric reports (e.g. the price components,
  * taxes, etc of a product for sale, or a set of possible labeled values for a user setting), and matrices.
  *
  * @see ResultBearing#mapToMap(GenericType)
- *
  * @see MapMapper
  * @see ResultBearing#mapToMap()
- *
  * @see ResultBearing#collectInto(GenericType)
  */
-@Beta
-// TODO jdbi4: integrate with MapMapper? check if registering by default is compatible with other Map-mapping features
 public class GenericMapMapperFactory implements RowMapperFactory {
-    // invoked by sqlobject
+
     @Override
     public Optional<RowMapper<?>> build(Type mapType, ConfigRegistry config) {
         return Optional.of(mapType)
@@ -70,8 +65,14 @@ public class GenericMapMapperFactory implements RowMapperFactory {
             .map(GenericMapMapper::new);
     }
 
-    // invoked manually or by fluent api
-    @Beta
+    /**
+     * Returns a {@link RowMapper} for a map with the given value type. The key type is {@link String}.
+     *
+     * @param valueType A {@link Class} instance representing the value type for the {@link Map}
+     * @param config    A {@link ConfigRegistry} instance
+     * @param <T>       The value type
+     * @return A {@link RowMapper} for a map from string to the given value type
+     */
     public static <T> RowMapper<Map<String, T>> getMapperForValueType(Class<T> valueType, ConfigRegistry config) {
         return config.get(ColumnMappers.class)
             .findFor(valueType)
@@ -79,8 +80,14 @@ public class GenericMapMapperFactory implements RowMapperFactory {
             .orElseThrow(() -> new RuntimeException("no column mapper found for type " + valueType));
     }
 
-    // invoked manually or by fluent api
-    @Beta
+    /**
+     * Returns a {@link RowMapper} for a map with the given value type. The key type is {@link String}.
+     *
+     * @param valueType A {@link Class} instance representing the value type for the {@link Map}
+     * @param config    A {@link ConfigRegistry} instance
+     * @param <T>       The value type
+     * @return A {@link RowMapper} for a map from string to the given value type
+     */
     public static <T> RowMapper<Map<String, T>> getMapperForValueType(GenericType<T> valueType, ConfigRegistry config) {
         return config.get(ColumnMappers.class)
             .findFor(valueType)
@@ -89,6 +96,7 @@ public class GenericMapMapperFactory implements RowMapperFactory {
     }
 
     private static class GenericMapMapper<T> implements RowMapper<Map<String, T>> {
+
         private final ColumnMapper<T> mapper;
 
         private GenericMapMapper(ColumnMapper<T> mapper) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/GetObjectColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/GetObjectColumnMapperFactory.java
@@ -24,13 +24,12 @@ import java.util.Set;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Factory that uses {@link java.sql.ResultSet#getObject(int, Class)} to fetch values.
  */
-@Beta
 public class GetObjectColumnMapperFactory implements ColumnMapperFactory {
+
     private final Set<Class<?>> supportedTypes;
 
     protected GetObjectColumnMapperFactory(Class<?>... types) {
@@ -38,13 +37,25 @@ public class GetObjectColumnMapperFactory implements ColumnMapperFactory {
     }
 
     protected GetObjectColumnMapperFactory(Collection<Class<?>> types) {
-        supportedTypes = new HashSet<>(types);
+        this.supportedTypes = new HashSet<>(types);
     }
 
+    /**
+     * Creates a {@link ColumnMapperFactory} that accepts multiple types and maps them by calling {@link ResultSet#getObject(int, Class)}.
+     *
+     * @param types One or more types that should be mapped by this factory
+     * @return A {@link ColumnMapperFactory}
+     */
     public static ColumnMapperFactory forClasses(Class<?>... types) {
         return new GetObjectColumnMapperFactory(Arrays.asList(types));
     }
 
+    /**
+     * Creates a {@link ColumnMapperFactory} that accepts multiple types and maps them by calling {@link ResultSet#getObject(int, Class)}.
+     *
+     * @param types One or more types that should be mapped by this factory
+     * @return A {@link ColumnMapperFactory}
+     */
     public static ColumnMapperFactory forClasses(Set<Class<?>> types) {
         return new GetObjectColumnMapperFactory(types);
     }
@@ -59,6 +70,7 @@ public class GetObjectColumnMapperFactory implements ColumnMapperFactory {
     }
 
     private static class GetObjectColumnMapper<T> implements ColumnMapper<T> {
+
         private final Class<T> clazz;
 
         private GetObjectColumnMapper(Class<T> clazz) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/MapMappers.java
@@ -16,9 +16,7 @@ package org.jdbi.v3.core.mapper;
 import java.util.function.UnaryOperator;
 
 import org.jdbi.v3.core.config.JdbiConfig;
-import org.jdbi.v3.meta.Beta;
 
-@Beta
 public class MapMappers implements JdbiConfig<MapMappers> {
 
     private UnaryOperator<String> caseChange;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/PropagateNull.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/PropagateNull.java
@@ -16,8 +16,6 @@ package org.jdbi.v3.core.mapper;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import org.jdbi.v3.meta.Beta;
-
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -32,11 +30,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Retention(RUNTIME)
 @Target({PARAMETER, FIELD, METHOD, TYPE})
-@Beta
 public @interface PropagateNull {
+
     /**
      * When annotating a type, the {@code value} is the column name to check for null.
      * When annotating a property, the {@code value} is unused: instead, the property value is tested against null.
+     *
      * @return the column name whose null-ness shall be propagated
      */
     String value() default "";

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowViewMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowViewMapper.java
@@ -19,16 +19,16 @@ import java.sql.SQLException;
 import org.jdbi.v3.core.result.RowView;
 import org.jdbi.v3.core.result.internal.RowViewImpl;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Higher level cousin of {@link RowMapper} that operates over {@link RowView}s rather than
  * the bare {@link ResultSet}.
+ *
  * @param <T> the mapped type.
  */
 @FunctionalInterface
-@Beta
 public interface RowViewMapper<T> extends RowMapper<T> {
+
     @Override
     default T map(ResultSet rs, StatementContext ctx) throws SQLException {
         return map(new RowViewImpl(rs, ctx));
@@ -42,6 +42,7 @@ public interface RowViewMapper<T> extends RowMapper<T> {
 
     /**
      * Produce a single result item from the current row of a {@link RowView}.
+     *
      * @param rowView the view into the current row of the ResultSet
      * @return the produced result
      * @throws SQLException something went wrong

--- a/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/BaseStatement.java
@@ -21,9 +21,10 @@ import org.jdbi.v3.core.CloseException;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.Configurable;
-import org.jdbi.v3.meta.Alpha;
+import org.jdbi.v3.meta.Beta;
 
 abstract class BaseStatement<This> implements Closeable, Configurable<This> {
+
     @SuppressWarnings("unchecked")
     final This typedThis = (This) this;
 
@@ -67,7 +68,7 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This> {
      *
      * @since 3.35.0
      */
-    @Alpha
+    @Beta
     public final This attachToHandleForCleanup() {
         attachToHandleForCleanup(this.handle, this.ctx);
 
@@ -127,6 +128,7 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This> {
 
     @FunctionalInterface
     interface StatementCustomizerInvocation {
+
         void call(StatementCustomizer t) throws SQLException;
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/TemplateEngine.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/TemplateEngine.java
@@ -17,11 +17,10 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Renders an SQL statement from a template.
- *
+ * <p>
  * Note for implementors: define a suitable public constructor for SqlObject's {@code UseTemplateEngine} annotation, and/or create your own custom annotation in case your {@link TemplateEngine} has configuration parameters! Suitable constructors are the no-arg constructor, one that takes a {@link java.lang.Class}, and one that takes both a {@link java.lang.Class} and a {@link java.lang.reflect.Method}.
  *
  * @see DefinedAttributeTemplateEngine
@@ -29,6 +28,7 @@ import org.jdbi.v3.meta.Beta;
 @FunctionalInterface
 @SuppressWarnings("FunctionalInterfaceMethodChanged") // this is a false positive b/c a lambda can only be casted to TemplateEngine or Parsing, not both
 public interface TemplateEngine {
+
     /**
      * Convenience constant that returns the input template.
      */
@@ -48,23 +48,23 @@ public interface TemplateEngine {
     /**
      * Parse a SQL template and return a parsed representation ready to apply to a statement.
      * This allows the parsed representation to be cached and reused.
+     *
      * @param template the sql template to parse
-     * @param config the Jdbi configuration at prepare time
+     * @param config   the Jdbi configuration at prepare time
      * @return a parsed representation, if available
      */
-    @Beta
     default Optional<Function<StatementContext, String>> parse(String template, ConfigRegistry config) {
         return Optional.empty();
     }
 
     @FunctionalInterface
-    @Beta
     interface Parsing extends TemplateEngine {
+
         @Override
         default String render(String template, StatementContext ctx) {
             return parse(template, ctx.getConfig())
-                    .orElseThrow(() -> new UnableToCreateStatementException("Caching template engine did not prepare"))
-                    .apply(ctx);
+                .orElseThrow(() -> new UnableToCreateStatementException("Caching template engine did not prepare"))
+                .apply(ctx);
         }
 
         @Override

--- a/guava/src/main/java/org/jdbi/v3/guava/codec/TypeResolvingCodecFactory.java
+++ b/guava/src/main/java/org/jdbi/v3/guava/codec/TypeResolvingCodecFactory.java
@@ -24,7 +24,7 @@ import com.google.common.reflect.TypeToken.TypeSet;
 import org.jdbi.v3.core.codec.Codec;
 import org.jdbi.v3.core.codec.CodecFactory;
 import org.jdbi.v3.core.qualifier.QualifiedType;
-import org.jdbi.v3.meta.Alpha;
+import org.jdbi.v3.meta.Beta;
 
 /**
  * An extended {@link CodecFactory} which can resolve Codecs for subtypes. This allows registering e.g. a codec for <code>Set&lt;String&gt;</code> and using any
@@ -32,7 +32,7 @@ import org.jdbi.v3.meta.Alpha;
  * <p>
  * This is an experimental feature which relies on {@link TypeToken} from the Guava library.
  */
-@Alpha
+@Beta
 @ThreadSafe
 public class TypeResolvingCodecFactory extends CodecFactory {
 

--- a/moshi/src/main/java/org/jdbi/v3/moshi/MoshiConfig.java
+++ b/moshi/src/main/java/org/jdbi/v3/moshi/MoshiConfig.java
@@ -15,13 +15,12 @@ package org.jdbi.v3.moshi;
 
 import com.squareup.moshi.Moshi;
 import org.jdbi.v3.core.config.JdbiConfig;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Configuration class for Moshi integration.
  */
-@Beta
 public class MoshiConfig implements JdbiConfig<MoshiConfig> {
+
     private Moshi moshi;
 
     public MoshiConfig() {
@@ -34,6 +33,7 @@ public class MoshiConfig implements JdbiConfig<MoshiConfig> {
 
     /**
      * Set the {@link Moshi} to use for json conversion.
+     *
      * @param moshi the mapper to use
      * @return this
      */

--- a/moshi/src/main/java/org/jdbi/v3/moshi/MoshiPlugin.java
+++ b/moshi/src/main/java/org/jdbi/v3/moshi/MoshiPlugin.java
@@ -17,17 +17,16 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 import org.jdbi.v3.json.JsonConfig;
 import org.jdbi.v3.json.JsonPlugin;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Moshi integration plugin.
- *
+ * <p>
  * Adds support for {@code @Json} qualifying annotation via {@link com.squareup.moshi.Moshi}.
  *
  * @see org.jdbi.v3.json.Json
  */
-@Beta
 public class MoshiPlugin extends JdbiPlugin.Singleton {
+
     @Override
     public void customizeJdbi(Jdbi jdbi) {
         jdbi.installPlugin(new JsonPlugin());

--- a/postgis/src/main/java/org/jdbi/v3/postgis/PostgisCodec.java
+++ b/postgis/src/main/java/org/jdbi/v3/postgis/PostgisCodec.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.codec.Codec;
 import org.jdbi.v3.core.mapper.ColumnMapper;
-import org.jdbi.v3.meta.Alpha;
+import org.jdbi.v3.meta.Beta;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.io.ParseException;
@@ -27,7 +27,7 @@ import org.locationtech.jts.io.WKBWriter;
 
 import static org.locationtech.jts.io.WKBConstants.wkbNDR;
 
-@Alpha
+@Beta
 final class PostgisCodec implements Codec<Geometry> {
 
     @Override

--- a/postgis/src/main/java/org/jdbi/v3/postgis/PostgisPlugin.java
+++ b/postgis/src/main/java/org/jdbi/v3/postgis/PostgisPlugin.java
@@ -18,7 +18,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.codec.Codec;
 import org.jdbi.v3.core.codec.CodecFactory;
 import org.jdbi.v3.core.spi.JdbiPlugin;
-import org.jdbi.v3.meta.Alpha;
+import org.jdbi.v3.meta.Beta;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.LineString;
@@ -44,7 +44,7 @@ import org.locationtech.jts.geom.Polygon;
  * <li>{@link org.locationtech.jts.geom.Geometry}</li>
  * </ul>
  */
-@Alpha
+@Beta
 public class PostgisPlugin extends JdbiPlugin.Singleton {
 
     @Override

--- a/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/v3/postgres/PostgresPlugin.java
@@ -51,14 +51,8 @@ import org.postgresql.util.PGmoney;
  * <li>{@link java.util.Map Map&lt;String, String&gt;} (for {@code HSTORE} columns)</li>
  * <li>{@link java.util.UUID}</li>
  * <li>{@link java.io.InputStream} and {@link java.io.Reader} from {@code oid} large object columns</li>
- * </ul>
- *
- * <p>
- * The following qualified types have {@link org.jdbi.v3.meta.Beta} support for binding and mapping:
- *
- * <ul>
- * <li>{@link MacAddr @MacAddr java.lang.String} (for MACADDR columns)</li>
- * <li>{@link HStore @HStore Map&lt;String, String&gt;} (for HSTORE columns)</li>
+ * <li>@MacAddr {@link java.lang.String} (for {@code MACADDR} columns)</li>
+ * <li>@HStore {@link Map} (for {@code HSTORE} columns)</li>
  * </ul>
  *
  * <p>

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GenerateSqlObject.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/GenerateSqlObject.java
@@ -18,13 +18,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.jdbi.v3.meta.Beta;
-
 /**
  * Decorate a SqlObject type to instruct the {@code jdbi3-generator} annotation processor
  * to create a compiled implementation.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@Beta
 public @interface GenerateSqlObject {}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementCustomizer.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementCustomizer.java
@@ -17,7 +17,6 @@ import java.sql.SQLException;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.SqlStatement;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Used with {@link SqlStatementCustomizerFactory} to
@@ -25,8 +24,10 @@ import org.jdbi.v3.meta.Beta;
  */
 @FunctionalInterface
 public interface SqlStatementCustomizer {
+
     /**
      * Invoked to customize the sql statement
+     *
      * @param q the statement being customized
      * @throws SQLException will abort statement creation
      */
@@ -35,8 +36,8 @@ public interface SqlStatementCustomizer {
     /**
      * Called after the customizer is instantiated but before any statement is available,
      * to pre-initialize any configuration data structures.
+     *
      * @param config the configuration registry to warm
      */
-    @Beta
     default void warm(ConfigRegistry config) {}
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementParameterCustomizer.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementParameterCustomizer.java
@@ -17,16 +17,17 @@ import java.sql.SQLException;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.SqlStatement;
-import org.jdbi.v3.meta.Beta;
 
 /**
  * Customize a {@link SqlStatement} according to the value of an annotated parameter.
  */
 public interface SqlStatementParameterCustomizer {
+
     /**
      * Applies the customization to the SQL statement using the argument passed to the method.
+     *
      * @param stmt the statement being customized
-     * @param arg the argument passed to the method
+     * @param arg  the argument passed to the method
      * @throws SQLException will abort statement creation
      */
     void apply(SqlStatement<?> stmt, Object arg) throws SQLException;
@@ -34,8 +35,8 @@ public interface SqlStatementParameterCustomizer {
     /**
      * Called after the customizer is instantiated but before any statement is available,
      * to pre-initialize any configuration data structures.
+     *
      * @param config the configuration registry to warm
      */
-    @Beta
     default void warm(ConfigRegistry config) {}
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/TimestampedFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/TimestampedFactory.java
@@ -20,13 +20,13 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.function.Function;
 
-import org.jdbi.v3.meta.Beta;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizer;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
 import org.jdbi.v3.sqlobject.customizer.Timestamped;
 import org.jdbi.v3.sqlobject.customizer.TimestampedConfig;
 
 public class TimestampedFactory implements SqlStatementCustomizerFactory {
+
     private static Function<ZoneId, Clock> timeSource = Clock::system;
 
     @Override
@@ -42,7 +42,6 @@ public class TimestampedFactory implements SqlStatementCustomizerFactory {
     /**
      * for testing purposes only
      */
-    @Beta
     static void setTimeSource(Function<ZoneId, Clock> timeSource) {
         TimestampedFactory.timeSource = timeSource;
     }


### PR DESCRIPTION
  - promoted from `@Beta` to stable (no functional changes, some minor doc reformatting and additions)
    - `JdbiProperty`, `DatabaseValue`, `PropagateNull`, `GenerateSqlObject`  annotations
    - `NamedArgumentFinder`, `SetObjectArgumentFactory`, `GetObjectColumnMapperFactory`, `GenericMapMapperFactory`, `RowViewMapper`
    - `MapMappers` configuration object
    - `ConfigCache` functionality
    - `SqlStatementCustomizer#warm()` and `SqlStatementParameterCustomizer#warm()`
    - template engines
    - moshi json support

  - promoted from `@Alpha` to `@Beta` (no functional changes, doc cleanups)
    - Codec functionality
    - `BaseStatement#attachToHandleForCleanup()`
    - PostGIS support
