### PR TITLE
RowMapper, ColumnMapper.findFor: reduce Stream usage in hot path

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # unreleased
 
-- fix `PreparedBatch` c'tor problem where the binding context was not set correctly.
+  - fix `PreparedBatch` c'tor problem where the binding context was not set correctly.
+  - Slight memory optimization on RowMappers and ColumnMappers findFor
 
 # 3.39.1
 


### PR DESCRIPTION
This showed up as an allocation hotspot in our app since finding mappers is one of the most common Jdbi ops