### PR TITLE
Remove JSR 305 annotations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
   - Slight memory optimization on RowMappers and ColumnMappers findFor
   - JsonMapper implementations now bind the Type earlier, which saves work in Jackson and Gson (#2420)
   - performance improvements for all ExtensionConfigurer implementations (#2416, #2424)
+  - Remove JSR 305 annotations from the Jdbi codebase, one small step closer to JPMS.
 
 # 3.39.1
 

--- a/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
@@ -60,6 +60,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- all the test dependencies as the -tests jar does not provide deps -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/cache/noop-cache/src/it/test-noop-cache/pom.xml
+++ b/cache/noop-cache/src/it/test-noop-cache/pom.xml
@@ -60,6 +60,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- all the test dependencies as the -tests jar does not provide deps -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,9 +55,10 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
         </dependency>
 
         <dependency>
@@ -88,6 +89,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/core/src/it/test-inline-jar/pom.xml
+++ b/core/src/it/test-inline-jar/pom.xml
@@ -68,6 +68,12 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>test</scope>

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -24,8 +24,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.annotation.concurrent.GuardedBy;
-
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.Configurable;
 import org.jdbi.v3.core.extension.ExtensionContext;

--- a/core/src/main/java/org/jdbi/v3/core/Sql.java
+++ b/core/src/main/java/org/jdbi/v3/core/Sql.java
@@ -18,8 +18,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import javax.annotation.Nonnull;
-
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jdbi.v3.meta.Beta;
 
 /**
@@ -104,7 +103,7 @@ public final class Sql implements CharSequence {
         return str.charAt(index);
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public CharSequence subSequence(int start, int end) {
         return str.subSequence(start, end);

--- a/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCache.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCache.java
@@ -18,8 +18,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import javax.annotation.concurrent.GuardedBy;
-
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.jdbi.v3.core.cache.JdbiCache;
 import org.jdbi.v3.core.cache.JdbiCacheLoader;
 

--- a/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/CodecFactory.java
@@ -23,9 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
-import javax.annotation.concurrent.NotThreadSafe;
-import javax.annotation.concurrent.ThreadSafe;
-
+import com.google.errorprone.annotations.ThreadSafe;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.QualifiedArgumentFactory;
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -113,7 +111,6 @@ public class CodecFactory implements QualifiedColumnMapperFactory, QualifiedArgu
     /**
      * Fluent Builder for {@link CodecFactory}.
      */
-    @NotThreadSafe
     @Beta
     public static final class Builder {
 

--- a/core/src/main/java/org/jdbi/v3/core/interceptor/JdbiInterceptionChainHolder.java
+++ b/core/src/main/java/org/jdbi/v3/core/interceptor/JdbiInterceptionChainHolder.java
@@ -18,9 +18,9 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jdbi.v3.meta.Alpha;
 
 import static java.util.Objects.requireNonNull;
@@ -75,7 +75,7 @@ public final class JdbiInterceptionChainHolder<S, T> {
      * @param source A source object.
      * @return A target object processed by one of the registered {@link JdbiInterceptor} instances.
      */
-    @Nonnull
+    @NonNull
     public T process(@Nullable S source) {
         ChainInstance instance = new ChainInstance(source);
         T result = instance.next();

--- a/core/src/main/java/org/jdbi/v3/core/interceptor/JdbiInterceptor.java
+++ b/core/src/main/java/org/jdbi/v3/core/interceptor/JdbiInterceptor.java
@@ -13,9 +13,8 @@
  */
 package org.jdbi.v3.core.interceptor;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
-
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jdbi.v3.meta.Alpha;
 
 /**

--- a/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Sneaky.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Sneaky.java
@@ -19,9 +19,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jdbi.v3.core.internal.UtilityClassException;
 
 public class Sneaky {
@@ -33,7 +32,7 @@ public class Sneaky {
      * Will <b>always</b> throw an exception, so the caller should also always throw the dummy return value to make sure the control flow remains clear.
      */
     @CheckReturnValue
-    @Nonnull
+    @NonNull
     public static DummyException throwAnyway(Throwable t) {
         if (t instanceof Error) {
             throw (Error) t;

--- a/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
+++ b/core/src/main/java/org/jdbi/v3/core/locator/internal/ClasspathBuilder.java
@@ -19,8 +19,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 public class ClasspathBuilder {
     private static final String DOT = ".";
@@ -42,17 +42,17 @@ public class ClasspathBuilder {
     }
 
     // org.foo.Bar$Inner -> org/foo/Bar$Inner
-    public ClasspathBuilder appendFullyQualifiedClassName(@Nonnull Class<?> clazz) {
+    public ClasspathBuilder appendFullyQualifiedClassName(@NonNull Class<?> clazz) {
         return appendDotPath(clazz.getName());
     }
 
     // com.google.guava -> com/google/guava
-    public ClasspathBuilder appendDotPath(@Nonnull String path) {
+    public ClasspathBuilder appendDotPath(@NonNull String path) {
         return appendVerbatim(path.replace(DOT, SLASH));
     }
 
     // because sometimes you just don't have fancy data structures or patterns to work on
-    public ClasspathBuilder appendVerbatim(@Nonnull String s) {
+    public ClasspathBuilder appendVerbatim(@NonNull String s) {
         return addCarefully(s);
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ColumnName.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ColumnName.java
@@ -25,7 +25,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Specify the mapping name for a property or parameter explicitly. This annotation is respected by:
  *
  * <ul>
- *     <li>BeanMapper, FieldMapper, and ConstructorMapper in core</li>
+ *     <li>{@link BeanMapper}, {@link FieldMapper}, and {@link ConstructorMapper} in core</li>
  *     <li>The Kotlin data class mapper in KotlinPlugin</li>
  *     <li>Immutables property definitions</li>
  * </ul>

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -303,15 +303,17 @@ public final class ConstructorMapper<T> implements RowMapper<T> {
     private static String paramName(Parameter[] parameters,
                                     int position,
                                     ConstructorProperties parameterNames) {
+
         final Parameter parameter = parameters[position];
-        ColumnName dbName = parameter.getAnnotation(ColumnName.class);
-        if (dbName != null) {
-            return dbName.value();
-        }
-        if (parameterNames != null) {
-            return parameterNames.value()[position];
-        }
-        return parameter.getName();
+        return Optional.ofNullable(parameter.getAnnotation(ColumnName.class))
+            .map(ColumnName::value)
+            .orElseGet(() -> {
+                if (parameterNames != null) {
+                    return parameterNames.value()[position];
+                } else {
+                    return parameter.getName();
+                }
+            });
     }
 
     private String debugName(Parameter parameter) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/InstanceFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/InstanceFactory.java
@@ -19,7 +19,7 @@ import java.lang.reflect.Parameter;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -27,8 +27,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Function;
 
-import javax.annotation.Nullable;
-
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.cache.JdbiCache;

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
@@ -32,8 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collector;
 
-import javax.annotation.Nullable;
-
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jdbi.v3.core.CloseException;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.argument.Argument;

--- a/core/src/test/java/org/jdbi/v3/core/interceptor/JdbiInterceptionChainHolderTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/interceptor/JdbiInterceptionChainHolderTest.java
@@ -16,9 +16,6 @@ package org.jdbi.v3.core.interceptor;
 import java.util.UUID;
 import java.util.function.Function;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
-
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -263,9 +260,8 @@ public class JdbiInterceptionChainHolderTest {
             return target;
         }
 
-        @CheckForNull
         @Override
-        public String intercept(@Nullable S s, JdbiInterceptionChain<String> chain) {
+        public String intercept(S s, JdbiInterceptionChain<String> chain) {
             this.source = s;
             if (doIt) {
                 return this.target;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperPropagateNullableTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperPropagateNullableTest.java
@@ -14,7 +14,7 @@
 
 package org.jdbi.v3.core.mapper.reflect;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.junit5.H2DatabaseExtension;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
@@ -15,7 +15,7 @@ package org.jdbi.v3.core.mapper.reflect;
 
 import java.beans.ConstructorProperties;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.junit5.H2DatabaseExtension;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
@@ -13,7 +13,7 @@
  */
 package org.jdbi.v3.core.mapper.reflect;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.SampleBean;

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -163,11 +163,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -16,6 +16,7 @@
 
 :jdbidocs: ./apidocs/org/jdbi/v3
 :jdkdocs: https://docs.oracle.com/javase/8/docs/api
+:jakartadocs: https://jakarta.ee/specifications/platform/10/apidocs
 
 :projecthome: https://github.com/jdbi/jdbi
 :exampledir: ../test/java/jdbi/doc
@@ -1350,12 +1351,11 @@ Out of the box, Jdbi supports the following types as SQL statement arguments:
 * java.time: `Instant`, `LocalDate`, `LocalDateTime`, `LocalTime`,
   `OffsetDateTime`, `ZonedDateTime`, and `ZoneId`
 * java.util: `Date`, link:{jdkdocs}/java/util/Optional.html[Optional^] (around any other supported type), and `UUID`
-* `java.util.Collection` and Java arrays (stored as SQL arrays). Some
-  additional setup may be required depending on the type of array element.
+* `java.util.Collection` and Java arrays (stored as SQL arrays).
+Some additional setup may be required depending on the type of array element.
 
-You can also configure Jdbi to support additional argument types. More on that
-later.
-
+You can also configure Jdbi to support additional argument types.
+More on that later.
 
 === Binding Arguments
 
@@ -2107,24 +2107,44 @@ columns to camelCase field/argument/property names.
 
 ==== Supported property annotations
 
-Reflection mappers support the following annotations. Unless otherwise noted, all annotations are supported on bean getters and setters for the `BeanMapper`, constructor parameters for the `ConstructorMapper` and bean fields for the `FieldMapper`.
+Reflection mappers support the following annotations.
+Unless otherwise noted, all annotations are supported on bean getters and setters for the `BeanMapper`, constructor parameters for the `ConstructorMapper` and bean fields for the `FieldMapper`.
 
-* `@ColumnName` allows explicit naming of the column that is mapped to
-  the specific attribute.
-* `@Nested` for nested beans. Without this annotation, any attribute is treated as mappable from a single column. This annotation creates
-  a mapper for the nested bean. There is a limitation that only one type of mapper can be nested at a time; `BeanMapper` will create
-  another `BeanMapper`, `ConstructorMapper` will create another `ConstructorMapper` etc. `@Nested` supports an optional prefix for
-  all attributes in the nested bean (`@Nested("prefix")`).
-* `@PropagateNull` on a given attribute propagates a null value for a specific attribute up. So if the attribute or column is null, the whole bean will be discarded and a null value will be used instead of the bean itself. This annotation can also be used on the bean
-  class with a column name that must be present in the result set. When used on an attribute, no value must be set.
-* `@Nullable` for `ConstructorMapper` arguments. If no column is mapped onto a specific constructor argument, don't fail but use `null` as value. Any annotation called `Nullable` is accepted.
-* `@JdbiProperty(map=false)` allows configuring whether a discovered property is mapped in results. Turn the `map` value off, and the property discovery mechanism will ignore it. This used to be called `@Unmappable`.
+* link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] allows explicit naming of the column that is mapped to the specific attribute.
+* link:{jdbidocs}/core/mapper/Nested.html[@Nested^] for nested beans.
+Without this annotation, any attribute is treated as mappable from a single column.
+This annotation creates a mapper for the nested bean.
+There is a limitation that only one type of mapper can be nested at a time; `BeanMapper` will create another `BeanMapper`, `ConstructorMapper` will create another `ConstructorMapper` etc. link:{jdbidocs}/core/mapper/Nested.html[@Nested^] supports an optional prefix for all attributes in the nested bean (`@Nested("prefix")`).
+* `@PropagateNull` on a given attribute propagates a null value for a specific attribute up.
+So if the attribute or column is null, the whole bean will be discarded and a null value will be used instead of the bean itself.
+This annotation can also be used on the bean class with a column name that must be present in the result set.
+When used on an attribute, no value must be set.
+* `@Nullable` for `ConstructorMapper` arguments.
+If no column is mapped onto a specific constructor argument, don't fail but use `null` as value.
+* `@JdbiProperty(map=false)` allows configuring whether a discovered property is mapped in results.
+Turn the `map` value off, and the property discovery mechanism will ignore it.
+This used to be called `@Unmappable`.
 
 [NOTE]
-The `@ColumnName` annotation only applies while mapping SQL data into Java
-objects. When binding object properties (e.g. with `bindBean()`), bind the
-property name (`:id`) rather than the column name (`:user_id`).
+The link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] annotation only applies while mapping SQL data into Java objects.
+When binding object properties (e.g. with `bindBean()`), bind the property name (`:id`) rather than the column name (`:user_id`).
 
+===== Using `@Nullable` annotations
+
+Jdbi accepts any annotation that is named `Nullable` to mark a field or method as nullable.
+
+These are popular choices:
+
+- `jakarta.annotation.Nullable` -- https://search.maven.org/artifact/jakarta.annotation/jakarta.annotation-api[jakarta annotation-api^]
+- `javax.annotation.Nullable` -- https://search.maven.org/artifact/com.google.code.findbugs/jsr305[findbugs jsr305^]
+- `edu.umd.cs.findbugs.annotations.Nullable` -- https://search.maven.org/artifact/com.github.spotbugs/spotbugs-annotations[Spotbugs annotations^]
+- `org.jetbrains.annotations.Nullable` -- https://search.maven.org/artifact/org.jetbrains/annotations[Jetbrains annotations^]
+- `org.checkerframework.checker.nullness.qual.Nullable` -- https://search.maven.org/artifact/org.checkerframework/checker-qual[checker framework^]
+- `org.springframework.lang.Nullable` -- https://search.maven.org/artifact/org.springframework/spring-core[Spring Framework^]
+
+[WARNING]
+To allow Jdbi to discover the `@Nullable` annotation at runtime, it must use link:{jdkdocs}/java/lang/annotation/RetentionPolicy.html#RUNTIME[RetentionPolicy.RUNTIME^].
+When in doubt, prefer the link:{jakartadocs}/jakarta/annotation/nullable[Jakarta variant^]!.
 
 ==== ConstructorMapper
 
@@ -2139,7 +2159,7 @@ these names to select columns.
 include::{exampledir}/ResultsTest.java[tags=userConstructor]
 ----
 
-Otherwise, the names can be explictly set with the `@ColumnName`
+Otherwise, the names can be explictly set with the link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^]
 annotation on each constructor parameter:
 
 [source,java,indent=0]
@@ -2203,7 +2223,7 @@ constructors, Jdbi will pick one based on these rules:
   use.
 
 For legacy column names that don't match up to property names, use the
-`@ColumnName` annotation to provide an exact column name.
+link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] annotation to provide an exact column name.
 
 [source,java,indent=0]
 ----
@@ -2213,7 +2233,7 @@ public User(@ColumnName("user_id") int id, String name) {
 }
 ----
 
-Nested constructor-injected types can be mapped using the `@Nested` annotation:
+Nested constructor-injected types can be mapped using the link:{jdbidocs}/core/mapper/Nested.html[@Nested^] annotation:
 
 [source,java,indent=0]
 ----
@@ -2245,8 +2265,7 @@ List<User> users = handle
     .list();
 ----
 
-The `@Nested` annotation has an optional `value()` attribute, which can be used
-to apply a column name prefix to each nested constructor parameter:
+The link:{jdbidocs}/core/mapper/Nested.html[@Nested^] annotation has an optional `value()` attribute, which can be used to apply a column name prefix to each nested constructor parameter:
 
 [source,java,indent=0]
 ----
@@ -2267,11 +2286,9 @@ List<User> users = handle
     .list();
 ----
 
-By default, ConstructorMapper expects the result set to contain columns to map
-every constructor parameter, and will throw an exception if any parameters
-cannot be mapped.
+By default, ConstructorMapper expects the result set to contain columns to map every constructor parameter, and will throw an exception if any parameters cannot be mapped.
 
-Parameters annotated `@Nullable` may be omitted from the result set, in which
+Parameters annotated `@Nullable` (see <<Using `@Nullable` annotations>>) may be omitted from the result set, in which
 `ConstructorMapper` will pass `null` to the constructor for that parameter.
 
 [source,java,indent=0]
@@ -2286,14 +2303,8 @@ public class User {
 }
 ----
 
-In this example, the `id` and `name` columns must be present in the result set,
-but `passwordHash` and `address` are optional. If they are present, they will
-be mapped. Otherwise,
-
-[TIP]
-Any `@Nullable` annotation from any package may be used.
-`javax.annotation.Nullable` is a good choice.
-
+In this example, the `id` and `name` columns must be present in the result set, but `passwordHash` and `address` are optional.
+If they are present, they will be mapped.
 
 ==== BeanMapper
 
@@ -2340,7 +2351,7 @@ include::{exampledir}/ResultsTest.java[tags=beanMapperPrefix]
 ----
 
 For legacy column names that don't match up to property names, use the
-`@ColumnName` annotation to provide an exact column name.
+link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] annotation to provide an exact column name.
 
 [source,java,indent=0]
 ----
@@ -2354,10 +2365,10 @@ public class User {
 }
 ----
 
-The `@ColumnName` annotation can be placed on either the getter or setter
-method. If conflicting annotations exist, then Annotations on the setter are preferred.
+The link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] annotation can be placed on either the getter or setter method.
+If conflicting annotations exist, then Annotations on the setter are preferred.
 
-Nested Java Bean types can be mapped using the `@Nested` annotation:
+Nested Java Bean types can be mapped using the link:{jdbidocs}/core/mapper/Nested.html[@Nested^] annotation:
 
 [source,java,indent=0]
 ----
@@ -2383,8 +2394,9 @@ public class Address {
     // ... (getters and setters)
 }
 ----
-<1> The `@Nested` annotation can be placed on either the getter or setter
-    method. The setter is preferred.
+
+<1> The link:{jdbidocs}/core/mapper/Nested.html[@Nested^] annotation can be placed on either the getter or setter method.
+The setter is preferred.
 
 [source,java,indent=0]
 ----
@@ -2396,8 +2408,7 @@ List<User> users = handle
     .list();
 ----
 
-The `@Nested` annotation has an optional `value()` attribute, which can be used
-to apply a column name prefix to each nested bean property:
+The link:{jdbidocs}/core/mapper/Nested.html[@Nested^] annotation has an optional `value()` attribute, which can be used to apply a column name prefix to each nested bean property:
 
 [source,java,indent=0]
 ----
@@ -2416,9 +2427,7 @@ List<User> users = handle
 ----
 
 [NOTE]
-`@Nested` properties are left unmodified (i.e. null) if the result set has no
-columns matching any properties of the nested object.
-
+link:{jdbidocs}/core/mapper/Nested.html[@Nested^] properties are left unmodified (i.e. null) if the result set has no columns matching any properties of the nested object.
 
 ==== FieldMapper
 
@@ -2465,7 +2474,7 @@ List<JoinRow> contactPhones = handle.select(
 ----
 
 For legacy column names that don't match up to field names, use the
-`@ColumnName` annotation to provide an exact column name:
+link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] annotation to provide an exact column name:
 
 [source,java,indent=0]
 ----
@@ -2477,7 +2486,7 @@ public class User {
 }
 ----
 
-Nested field-mapped types can be mapped using the `@Nested` annotation:
+Nested field-mapped types can be mapped using the link:{jdbidocs}/core/mapper/Nested.html[@Nested^] annotation:
 
 [source,java,indent=0]
 ----
@@ -2507,8 +2516,7 @@ List<User> users = handle
     .list();
 ----
 
-The `@Nested` annotation has an optional `value()` attribute, which can be used
-to apply a column name prefix to each nested field:
+The link:{jdbidocs}/core/mapper/Nested.html[@Nested^] annotation has an optional `value()` attribute, which can be used to apply a column name prefix to each nested field:
 
 [source,java,indent=0]
 ----
@@ -2532,8 +2540,7 @@ List<User> users = handle
 ----
 
 [NOTE]
-`@Nested` fields are left unmodified (i.e. null) if the result set has no
-columns matching any fields of the nested object.
+link:{jdbidocs}/core/mapper/Nested.html[@Nested^] fields are left unmodified (i.e. null) if the result set has no columns matching any fields of the nested object.
 
 ////
 ==== ReflectionMappers config class
@@ -6942,6 +6949,7 @@ To use this plugin, add a Maven dependency:
 ----
 
 Ensure the Kotlin compiler's https://kotlinlang.org/docs/reference/using-maven.html#attributes-specific-for-jvm[JVM target version^] is set to at least 11:
+
 [source,xml,indent=0,subs="specialchars"]
 ----
 <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
@@ -6954,18 +6962,15 @@ Then install the plugin into the link:{jdbidocs}/core/Jdbi.html[Jdbi^] instance:
 jdbi.installPlugin(KotlinPlugin());
 ----
 
-The Kotlin mapper also supports `@ColumnName` annotation that allows to specify
-name for a property or parameter explicitly, as well as the `@Nested` annotation
-that allows mapping nested Kotlin objects.
+The Kotlin mapper also supports link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] annotation that allows to specify name for a property or parameter explicitly, as well as the link:{jdbidocs}/core/mapper/Nested.html[@Nested^] annotation that allows mapping nested Kotlin objects.
 
 [NOTE]
 Instead of using link:{jdbidocs}/sqlobject/customizer/BindBean.html[@BindBean^], `bindBean()`, and link:{jdbidocs}/sqlobject/config/RegisterBeanMapper.html[@RegisterBeanMapper^] use `@BindKotlin`, `bindKotlin()`, and `KotlinMapper`
 for qualifiers on constrictor parameters, getter, setters, and setter parameters of Kotlin class.
 
 [NOTE]
-The `@ColumnName` annotation only applies while mapping SQL data into Java
-objects. When binding object properties (e.g. with `bindBean()`), bind the
-property name (`:id`) rather than the column name (`:user_id`).
+The link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] annotation only applies while mapping SQL data into Java objects.
+When binding object properties (e.g. with `bindBean()`), bind the property name (`:id`) rather than the column name (`:user_id`).
 
 If you load all Jdbi plugins via `Jdbi.installPlugins()` this plugin will be
 discovered and registered automatically. Otherwise, you can attach it using

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -47,11 +47,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
             <classifier>tests</classifier>

--- a/guava/src/main/java/org/jdbi/v3/guava/codec/TypeResolvingCodecFactory.java
+++ b/guava/src/main/java/org/jdbi/v3/guava/codec/TypeResolvingCodecFactory.java
@@ -17,10 +17,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import com.google.common.reflect.TypeToken;
 import com.google.common.reflect.TypeToken.TypeSet;
+import com.google.errorprone.annotations.ThreadSafe;
 import org.jdbi.v3.core.codec.Codec;
 import org.jdbi.v3.core.codec.CodecFactory;
 import org.jdbi.v3.core.qualifier.QualifiedType;

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -53,6 +53,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
             <scope>provided</scope>
@@ -64,6 +69,12 @@
             <artifactId>javax.inject</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/guice/src/main/java/org/jdbi/v3/guice/AbstractJdbiDefinitionModule.java
+++ b/guice/src/main/java/org/jdbi/v3/guice/AbstractJdbiDefinitionModule.java
@@ -15,7 +15,6 @@ package org.jdbi.v3.guice;
 
 import java.lang.annotation.Annotation;
 
-import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
 import com.google.inject.Key;
@@ -24,6 +23,7 @@ import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.Multibinder;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.guice.internal.InternalGuiceJdbiCustomizer;
 import org.jdbi.v3.guice.internal.InternalGuiceJdbiFactory;

--- a/guice/src/main/java/org/jdbi/v3/guice/internal/InternalImportBindingBuilder.java
+++ b/guice/src/main/java/org/jdbi/v3/guice/internal/InternalImportBindingBuilder.java
@@ -15,8 +15,6 @@ package org.jdbi.v3.guice.internal;
 
 import java.lang.annotation.Annotation;
 
-import javax.annotation.CheckForNull;
-
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -25,6 +23,7 @@ import com.google.inject.Scope;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.binder.ScopedBindingBuilder;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;

--- a/guice/src/main/java/org/jdbi/v3/guice/internal/InternalLooseImportBindingBuilder.java
+++ b/guice/src/main/java/org/jdbi/v3/guice/internal/InternalLooseImportBindingBuilder.java
@@ -15,9 +15,6 @@ package org.jdbi.v3.guice.internal;
 
 import java.lang.annotation.Annotation;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
-
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -26,6 +23,8 @@ import com.google.inject.Scope;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.binder.ScopedBindingBuilder;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;

--- a/guice/src/test/java/org/jdbi/v3/guice/TestImportBindingBuilder.java
+++ b/guice/src/test/java/org/jdbi/v3/guice/TestImportBindingBuilder.java
@@ -15,8 +15,9 @@ package org.jdbi.v3.guice;
 
 import java.lang.annotation.Annotation;
 
-import javax.annotation.Nullable;
 import javax.sql.DataSource;
+
+import jakarta.annotation.Nullable;
 
 import com.google.inject.Inject;
 import com.google.inject.Injector;

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -90,6 +90,7 @@
         <dep.hsqldb.version>2.7.2</dep.hsqldb.version>
         <dep.immutables.version>2.9.3</dep.immutables.version>
         <dep.jackson2.version>2.12.7</dep.jackson2.version>
+        <dep.jakarta-annotation-api.version>2.1.1</dep.jakarta-annotation-api.version>
         <dep.jakarta-inject-api.version>2.0.1</dep.jakarta-inject-api.version>
         <dep.javax-inject.version>1</dep.javax-inject.version>
         <dep.jdbi-policy.version>3.40.0-SNAPSHOT</dep.jdbi-policy.version>
@@ -164,12 +165,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_annotations</artifactId>
-                <version>${dep.errorprone.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${dep.guava.version}</version>
@@ -197,12 +192,6 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${dep.caffeine.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_annotations</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
@@ -397,12 +386,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jetbrains</groupId>
-                <artifactId>annotations</artifactId>
-                <version>${dep.jetbrainsAnnotations.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
                 <version>${dep.kotlin.version}</version>
@@ -457,12 +440,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.checkerframework</groupId>
-                <artifactId>checker-qual</artifactId>
-                <version>${dep.checkerframework.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.xerial</groupId>
                 <artifactId>sqlite-jdbc</artifactId>
                 <version>${dep.sqlite.version}</version>
@@ -512,6 +489,14 @@
             </dependency>
 
             <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>${dep.checkerframework.version}</version>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
+
+            <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>${dep.spotbugs.version}</version>
@@ -520,12 +505,29 @@
             </dependency>
 
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.2</version>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${dep.jetbrainsAnnotations.version}</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>
+
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${dep.errorprone.version}</version>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${dep.jakarta-annotation-api.version}</version>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -858,6 +860,12 @@
                                     <property>moduleName</property>
                                     <message>This module must set a moduleName.</message>
                                 </requireProperty>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>com.google.code.findbugs:jsr305</exclude>
+                                    </excludes>
+                                    <searchTransitive>false</searchTransitive>
+                                </bannedDependencies>
                             </rules>
                         </configuration>
                     </execution>

--- a/lombok/pom.xml
+++ b/lombok/pom.xml
@@ -34,11 +34,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
             <scope>test</scope>
@@ -47,6 +42,12 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lombok/src/test/java/org/jdbi/v3/lombok/LombokReflectionTest.java
+++ b/lombok/src/test/java/org/jdbi/v3/lombok/LombokReflectionTest.java
@@ -16,7 +16,7 @@ package org.jdbi.v3.lombok;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import lombok.Data;
 import lombok.Value;

--- a/postgis/pom.xml
+++ b/postgis/pom.xml
@@ -38,11 +38,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -48,11 +48,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -45,15 +45,17 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseSqlParserImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseSqlParserImpl.java
@@ -22,8 +22,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
-
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseTemplateEngineImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseTemplateEngineImpl.java
@@ -22,8 +22,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
-
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
 import org.jdbi.v3.core.internal.exceptions.Sneaky;

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -49,9 +49,10 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>

--- a/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/sqlobject/BindListTest.java
@@ -19,9 +19,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
@@ -259,10 +256,10 @@ public class BindListTest {
         // `in (null)` doesn't work on h2
         @SqlQuery("select name from something <if(name)> where name is <name> <endif>")
         @UseStringTemplateEngine
-        List<String> getForNull(@Nullable @BindList(value = "name", onEmpty = NULL_VALUE) List<String> name);
+        List<String> getForNull(@BindList(value = "name", onEmpty = NULL_VALUE) List<String> name);
 
         @SqlQuery("select name from something <if(name)> where name in (<name>) <endif>")
         @UseStringTemplateEngine
-        List<String> getForValue(@Nonnull @BindList(value = "name", onEmpty = NULL_VALUE) List<String> name);
+        List<String> getForValue(@BindList(value = "name", onEmpty = NULL_VALUE) List<String> name);
     }
 }

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -40,6 +40,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <optional>true</optional>

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExtension.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExtension.java
@@ -21,11 +21,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
 import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Handles;
 import org.jdbi.v3.core.Jdbi;
@@ -121,9 +121,9 @@ public abstract class JdbiExtension implements BeforeAllCallback, AfterAllCallba
      * @see JdbiExternalPostgresExtension
      */
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
-    public static JdbiExtension externalPostgres(@Nonnull String hostname,
+    public static JdbiExtension externalPostgres(@NonNull String hostname,
         @Nullable Integer port,
-        @Nonnull String database,
+        @NonNull String database,
         @Nullable String username,
         @Nullable String password) {
         return JdbiExternalPostgresExtension.instance(hostname, port, database, username, password);

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExternalPostgresExtension.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExternalPostgresExtension.java
@@ -13,10 +13,10 @@
  */
 package org.jdbi.v3.testing.junit5;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.postgresql.ds.PGSimpleDataSource;
 
 import static java.util.Objects.requireNonNull;
@@ -33,7 +33,7 @@ public class JdbiExternalPostgresExtension extends JdbiExtension {
 
     /**
      * Jdbi external PostgreSQL JUnit 5 rule. This class should not be used directly but through {@link JdbiExtension#externalPostgres(String, Integer, String, String, String)}.
-     *
+     * <br>
      * This class is public with a protected constructor to allow special case construction.
      *
      * <pre>{@code
@@ -46,9 +46,9 @@ public class JdbiExternalPostgresExtension extends JdbiExtension {
      *     };
      * }</pre>
      */
-    protected JdbiExternalPostgresExtension(@Nonnull String hostname,
+    protected JdbiExternalPostgresExtension(@NonNull String hostname,
         @Nullable Integer port,
-        @Nonnull String database,
+        @NonNull String database,
         @Nullable String username,
         @Nullable String password) {
 
@@ -73,9 +73,9 @@ public class JdbiExternalPostgresExtension extends JdbiExtension {
         this.jdbcUri = sb.toString();
     }
 
-    static JdbiExtension instance(@Nonnull String hostname,
+    static JdbiExtension instance(@NonNull String hostname,
         @Nullable Integer port,
-        @Nonnull String database,
+        @NonNull String database,
         @Nullable String username,
         @Nullable String password) {
         return new JdbiExternalPostgresExtension(hostname, port, database, username, password);


### PR DESCRIPTION
The findbugs jsr305 annotations jar uses annotations in the
javax.annotation namespace, which causes problems with JPMS.

Remove the annotations from the code base. The Jdbi code itself
transitions to error prone and spotbugs.

For code that uses Jdbi (and all tests), a new
annotation (org.jdbi.v3.core.mapper.reflect.Nullable) is introduced as
all candidates either do not have Runtime retention (spotbugs,
jetbrains), have problems with JPMS (jsr305), are very
specialized (spring) or obscure (checker framework).
