### PR TITLE
Improve config customizer performance

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/extension/UseAnnotationConfigCustomizerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UseAnnotationConfigCustomizerFactory.java
@@ -18,6 +18,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -25,6 +26,7 @@ import org.jdbi.v3.core.config.ConfigCustomizer;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.annotation.UseExtensionConfigurer;
 import org.jdbi.v3.core.internal.JdbiClassUtils;
+import org.jdbi.v3.core.internal.exceptions.CheckedCallable;
 
 import static java.lang.String.format;
 
@@ -41,32 +43,47 @@ final class UseAnnotationConfigCustomizerFactory implements ConfigCustomizerFact
         final ConfigurerMethod forType = (configurer, config, annotation) -> configurer.configureForType(config, annotation, extensionType);
 
         // build a configurer for the type and all supertypes. This processes all annotations on classes and interfaces
-        return buildConfigCustomizer(Stream.concat(JdbiClassUtils.superTypes(extensionType), Stream.of(extensionType)), forType);
+        return buildConfigCustomizer(extensionType, Stream.concat(JdbiClassUtils.superTypes(extensionType), Stream.of(extensionType)), forType);
     }
 
     @Override
     public Collection<ConfigCustomizer> forExtensionMethod(Class<?> extensionType, Method method) {
         final ConfigurerMethod forMethod = (configurer, config, annotation) -> configurer.configureForMethod(config, annotation, extensionType, method);
         // build a configurer that processes all annotations on the method itself.
-        return buildConfigCustomizer(Stream.of(method), forMethod);
+        return buildConfigCustomizer(extensionType, Stream.of(method), forMethod);
     }
 
-    private static Collection<ConfigCustomizer> buildConfigCustomizer(Stream<AnnotatedElement> elements, ConfigurerMethod consumer) {
+    private static Collection<ConfigCustomizer> buildConfigCustomizer(Class<?> extensionType, Stream<AnnotatedElement> elements, ConfigurerMethod consumer) {
         return elements.flatMap(ae -> Arrays.stream(ae.getAnnotations()))
                 .filter(a -> a.annotationType().isAnnotationPresent(UseExtensionConfigurer.class))
                 .map(a -> {
                     UseExtensionConfigurer meta = a.annotationType().getAnnotation(UseExtensionConfigurer.class);
                     Class<? extends ExtensionConfigurer> klass = meta.value();
 
-                    try {
-                        ExtensionConfigurer configurer = klass.getConstructor().newInstance();
-                        return (ConfigCustomizer) config -> consumer.configure(configurer, config, a);
-                    } catch (ReflectiveOperationException | SecurityException e) {
-                        throw new IllegalStateException(format("Unable to instantiate class %s", klass), e);
-                    }
+                    ExtensionConfigurer configurer = createConfigurer(klass, extensionType, a);
+                    return (ConfigCustomizer) config -> consumer.configure(configurer, config, a);
 
                 })
                 .collect(Collectors.toList());
+    }
+
+    private static ExtensionConfigurer createConfigurer(Class<? extends ExtensionConfigurer> configurerType, Class<?> extensionType, Annotation annotation) {
+
+        CheckedCallable[] callables = {
+            () -> configurerType.getConstructor().newInstance(),
+            () -> configurerType.getConstructor(Annotation.class).newInstance(annotation),
+            () -> configurerType.getConstructor(Annotation.class, Class.class).newInstance(annotation, extensionType)
+        };
+
+        for (CheckedCallable<ExtensionConfigurer> callable : callables) {
+            Optional<ExtensionConfigurer> handler = JdbiClassUtils.createInstanceIfPossible(callable);
+            if (handler.isPresent()) {
+                return handler.get();
+            }
+        }
+
+        throw new IllegalStateException(format("ExtensionConfigurer class %s cannot be instantiated. "
+            + "Expected a constructor with parameters (Annotation) or ().", configurerType));
     }
 
     private interface ConfigurerMethod {


### PR DESCRIPTION
Allow config customizers that do not need the config object itself to
create internal state at metadata creation time and cache that state as
part of the extension type metadata. This moves the creation of a
class (and potentially other expensive operations) away from the
invocation of extension methods.
