### PR TITLE
Make caches for row and column mappers smarter

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
@@ -155,7 +155,8 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
      */
     public ColumnMappers register(QualifiedColumnMapperFactory factory) {
         factories.add(0, factory);
-        cache.clear();
+        factory.getType().ifPresentOrElse(cache::remove, cache::clear);
+
         return this;
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/InferredColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/InferredColumnMapperFactory.java
@@ -47,4 +47,9 @@ class InferredColumnMapperFactory implements QualifiedColumnMapperFactory {
                 ? Optional.of(mapper)
                 : Optional.empty();
     }
+
+    @Override
+    public Optional<QualifiedType<?>> getType() {
+        return Optional.of(maps);
+    }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/InferredRowMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/InferredRowMapperFactory.java
@@ -49,4 +49,9 @@ class InferredRowMapperFactory implements RowMapperFactory {
                 ? Optional.of(mapper)
                 : Optional.empty();
     }
+
+    @Override
+    public Optional<Type> getType() {
+        return Optional.of(maps);
+    }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/QualifiedColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/QualifiedColumnMapperFactory.java
@@ -36,6 +36,10 @@ public interface QualifiedColumnMapperFactory {
      */
     Optional<ColumnMapper<?>> build(QualifiedType<?> type, ConfigRegistry config);
 
+    default Optional<QualifiedType<?>> getType() {
+        return Optional.empty();
+    }
+
     /**
      * Adapts a {@link ColumnMapperFactory} into a QualifiedColumnMapperFactory. The returned
      * factory only matches qualified types with zero qualifiers.
@@ -59,6 +63,18 @@ public interface QualifiedColumnMapperFactory {
      * @return A {@link QualifiedColumnMapperFactory}
      */
     static <T> QualifiedColumnMapperFactory of(QualifiedType<T> type, ColumnMapper<T> mapper) {
-        return (t, config) -> t.equals(type) ? Optional.of(mapper) : Optional.empty();
+        return new QualifiedColumnMapperFactory() {
+            @Override
+            public Optional<ColumnMapper<?>> build(QualifiedType<?> t, ConfigRegistry config) {
+                return t.equals(type)
+                    ? Optional.of(mapper)
+                    : Optional.empty();
+            }
+
+            @Override
+            public Optional<QualifiedType<?>> getType() {
+                return Optional.of(type);
+            }
+        };
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapper.java
@@ -13,8 +13,10 @@
  */
 package org.jdbi.v3.core.mapper;
 
+import java.lang.reflect.Type;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -71,4 +73,8 @@ public interface RowMapper<T> {
      * @param registry A reference to the {@link ConfigRegistry} that this instance belongs to.
      */
     default void init(ConfigRegistry registry) {}
+
+    default Optional<Type> getType() {
+        return Optional.empty();
+    }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMapperFactory.java
@@ -33,6 +33,10 @@ public interface RowMapperFactory {
      */
     Optional<RowMapper<?>> build(Type type, ConfigRegistry config);
 
+    default Optional<Type> getType() {
+        return Optional.empty();
+    }
+
     /**
      * Create a RowMapperFactory from a given {@link RowMapper} that matches
      * a {@link Type} exactly.
@@ -43,8 +47,18 @@ public interface RowMapperFactory {
      * @return the factory
      */
     static RowMapperFactory of(Type type, RowMapper<?> mapper) {
-        return (t, ctx) -> t.equals(type)
-                ? Optional.of(mapper)
-                : Optional.empty();
+        return new RowMapperFactory() {
+            @Override
+            public Optional<RowMapper<?>> build(Type t, ConfigRegistry ctx) {
+                return t.equals(type)
+                    ? Optional.of(mapper)
+                    : Optional.empty();
+            }
+
+            @Override
+            public Optional<Type> getType() {
+                return Optional.of(type);
+            }
+        };
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMappers.java
@@ -120,7 +120,8 @@ public class RowMappers implements JdbiConfig<RowMappers> {
      */
     public RowMappers register(RowMapperFactory factory) {
         factories.add(0, factory);
-        cache.clear();
+        factory.getType().ifPresentOrElse(cache::remove, cache::clear);
+
         return this;
     }
 


### PR DESCRIPTION
If a mapper factory can report a type that it supports (the inferred
factories and the static `...of()` mappers do as well), only invalidate
a single cache entry, not the whole cache.

This preserves elements that have been registered on the handle or the
jdbi ifself when using with sqlobject @RegisterColumnMapper and
@RegisterRowMapper annotations

Self-rolled factories can implement the `getType()` method on the
RowMapper and ColumnMapper interfaces to benefit from this as well.
