### PR TITLE
Make object creation more efficient

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/config/ConfigRegistry.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/ConfigRegistry.java
@@ -13,9 +13,6 @@
  */
 package org.jdbi.v3.core.config;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -24,7 +21,7 @@ import java.util.function.Function;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.config.internal.ConfigCaches;
-import org.jdbi.v3.core.internal.exceptions.Unchecked;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.core.mapper.Mappers;
 import org.jdbi.v3.core.mapper.RowMappers;
@@ -36,6 +33,9 @@ import org.jdbi.v3.core.statement.SqlStatements;
  * @see Configurable
  */
 public final class ConfigRegistry {
+
+    private static final Class<?>[] JDBI_CONFIG_TYPES = {ConfigRegistry.class};
+
     private final Map<Class<? extends JdbiConfig<?>>, JdbiConfig<?>> configs = new ConcurrentHashMap<>(32);
     private final Map<Class<? extends JdbiConfig<?>>, Function<ConfigRegistry, JdbiConfig<?>>> configFactories;
 
@@ -81,34 +81,12 @@ public final class ConfigRegistry {
     }
 
     private Function<ConfigRegistry, JdbiConfig<?>> configFactory(Class<? extends JdbiConfig<?>> configClass) {
-        return configFactories.computeIfAbsent(configClass, klass -> {
-            final Exception notFound;
-            try {
-                MethodHandle mh = MethodHandles.lookup().findConstructor(klass,
-                        MethodType.methodType(void.class, ConfigRegistry.class))
-                    .asType(MethodType.methodType(JdbiConfig.class, ConfigRegistry.class));
-                return Unchecked.function(registry -> (JdbiConfig<?>) mh.invokeExact(registry));
-            } catch (NoSuchMethodException e) {
-                notFound = e;
-            } catch (ReflectiveOperationException e) {
-                throw new IllegalStateException("Unable to use constructor taking ConfigRegistry to create " + configClass, e);
-            }
-            try {
-                MethodHandle mh = MethodHandles.lookup().findConstructor(klass,
-                        MethodType.methodType(void.class))
-                    .asType(MethodType.methodType(JdbiConfig.class));
-                return Unchecked.function(registry -> {
-                    JdbiConfig<?> result = (JdbiConfig<?>) mh.invokeExact();
-                    result.setRegistry(registry);
-                    return result;
+        return configFactories.computeIfAbsent(configClass, klass ->
+                registry -> {
+                    var config = JdbiClassUtils.findConstructorAndCreateInstance(klass, JDBI_CONFIG_TYPES, registry);
+                    config.setRegistry(registry);
+                    return config;
                 });
-            } catch (ReflectiveOperationException e) {
-                IllegalStateException failure = new IllegalStateException("Unable to instantiate config class " + configClass
-                        + ". Is there a public no-arg constructor?", e);
-                failure.addSuppressed(notFound);
-                throw failure;
-            }
-        });
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandlerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandlerFactory.java
@@ -16,9 +16,12 @@ package org.jdbi.v3.core.extension;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
+import org.jdbi.v3.meta.Alpha;
+
 /**
  * A factory to create {@link ExtensionHandler} instances.
  */
+@Alpha
 public interface ExtensionHandlerFactory {
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/extension/UseAnnotationConfigCustomizerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UseAnnotationConfigCustomizerFactory.java
@@ -18,7 +18,6 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -26,15 +25,14 @@ import org.jdbi.v3.core.config.ConfigCustomizer;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.annotation.UseExtensionConfigurer;
 import org.jdbi.v3.core.internal.JdbiClassUtils;
-import org.jdbi.v3.core.internal.exceptions.CheckedCallable;
-
-import static java.lang.String.format;
 
 /**
  * Applies configuration customizers according to {@link UseExtensionConfigurer} decorating annotations.
  * present on the method.
  */
 final class UseAnnotationConfigCustomizerFactory implements ConfigCustomizerFactory {
+
+    private static final Class<?>[] EXTENSION_CONFIGURER_TYPES = {Annotation.class, Class.class, Method.class};
 
     static final ConfigCustomizerFactory INSTANCE = new UseAnnotationConfigCustomizerFactory();
 
@@ -53,38 +51,22 @@ final class UseAnnotationConfigCustomizerFactory implements ConfigCustomizerFact
         return buildConfigCustomizer(extensionType, method, Stream.of(method), forMethod);
     }
 
-    private static Collection<ConfigCustomizer> buildConfigCustomizer(Class<?> extensionType, Method method, Stream<AnnotatedElement> elements, ConfigurerMethod consumer) {
+    private static Collection<ConfigCustomizer> buildConfigCustomizer(Class<?> extensionType,
+            Method method,
+            Stream<AnnotatedElement> elements,
+            ConfigurerMethod consumer) {
         return elements.flatMap(ae -> Arrays.stream(ae.getAnnotations()))
                 .filter(a -> a.annotationType().isAnnotationPresent(UseExtensionConfigurer.class))
                 .map(a -> {
                     UseExtensionConfigurer meta = a.annotationType().getAnnotation(UseExtensionConfigurer.class);
                     Class<? extends ExtensionConfigurer> klass = meta.value();
+                    ExtensionConfigurer configurer =
+                            JdbiClassUtils.findConstructorAndCreateInstance(klass, EXTENSION_CONFIGURER_TYPES, a, extensionType, method);
 
-                    ExtensionConfigurer configurer = createConfigurer(klass, method, extensionType, a);
                     return (ConfigCustomizer) config -> consumer.configure(configurer, config, a);
 
                 })
                 .collect(Collectors.toList());
-    }
-
-    private static ExtensionConfigurer createConfigurer(Class<? extends ExtensionConfigurer> configurerType, Method method, Class<?> extensionType, Annotation annotation) {
-
-        CheckedCallable[] callables = {
-            () -> configurerType.getConstructor(Annotation.class, Class.class, Method.class).newInstance(annotation, extensionType, method),
-            () -> configurerType.getConstructor(Annotation.class, Class.class).newInstance(annotation, extensionType),
-            () -> configurerType.getConstructor(Annotation.class).newInstance(annotation),
-            () -> configurerType.getConstructor().newInstance()
-        };
-
-        for (CheckedCallable<ExtensionConfigurer> callable : callables) {
-            Optional<ExtensionConfigurer> handler = JdbiClassUtils.createInstanceIfPossible(callable);
-            if (handler.isPresent()) {
-                return handler.get();
-            }
-        }
-
-        throw new IllegalStateException(format("ExtensionConfigurer class %s cannot be instantiated. "
-            + "Expected a constructor with parameters (Annotation) or ().", configurerType));
     }
 
     private interface ConfigurerMethod {

--- a/core/src/main/java/org/jdbi/v3/core/internal/JdbiClassUtils.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/JdbiClassUtils.java
@@ -18,11 +18,12 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jdbi.v3.core.internal.exceptions.CheckedCallable;
-import org.jdbi.v3.core.internal.exceptions.Sneaky;
+import org.jdbi.v3.core.statement.UnableToCreateStatementException;
+import org.jdbi.v3.meta.Alpha;
 
 import static java.lang.String.format;
 
@@ -47,6 +48,7 @@ public final class JdbiClassUtils {
 
     /**
      * Returns true if a specific class can be loaded.
+     *
      * @param klass The class
      * @return True if it can be loaded, false otherwise
      */
@@ -62,8 +64,9 @@ public final class JdbiClassUtils {
     /**
      * Lookup a specific method name related to a class. This helper tries {@link Class#getMethod(String, Class[])} first, then
      * falls back to {@link Class#getDeclaredMethod(String, Class[])}.
-     * @param klass A class
-     * @param methodName A method name
+     *
+     * @param klass          A class
+     * @param methodName     A method name
      * @param parameterTypes All parameter types for the method
      * @return A {@link Method} object
      * @throws IllegalStateException If the method could not be found
@@ -84,8 +87,9 @@ public final class JdbiClassUtils {
     /**
      * Lookup a specific method name related to a class. This helper tries {@link Class#getMethod(String, Class[])} first, then
      * falls back to {@link Class#getDeclaredMethod(String, Class[])}.
-     * @param klass A class
-     * @param methodName A method name
+     *
+     * @param klass          A class
+     * @param methodName     A method name
      * @param parameterTypes All parameter types for the method
      * @return A {@link Method} object wrapped in an {@link Optional} if the method could be found, {@link Optional#empty()} otherwise
      */
@@ -102,31 +106,8 @@ public final class JdbiClassUtils {
     }
 
     /**
-     * Creates a new instance from a {@link CheckedCallable} instance if possible.
-     *
-     * @param creator A {@link CheckedCallable} instance which returns
-     *                a new instance or throws any of the exceptions out
-     *                of {@link Class#getConstructor(Class[])} or
-     *                {@link java.lang.reflect.Constructor#newInstance(Object...)}
-     * @return A new instance wrapped in an {@link Optional} or {@link Optional#empty()}
-     * if a {@link ReflectiveOperationException} or {@link SecurityException} occured
-     * @param <T> The type of the new instance
-     */
-    @SuppressWarnings("PMD.PreserveStackTrace")
-    public static <T> Optional<T> createInstanceIfPossible(CheckedCallable<T> creator) {
-        try {
-            return Optional.of(creator.call());
-        } catch (InvocationTargetException e) {
-            throw Sneaky.throwAnyway(e.getCause());
-        } catch (ReflectiveOperationException | SecurityException ignored) {
-            return Optional.empty();
-        } catch (Throwable t) {
-            throw Sneaky.throwAnyway(t);
-        }
-    }
-
-    /**
      * Returns all supertypes to a given type.
+     *
      * @param type A type
      * @return A {@link Stream} of {@link Class} objects
      */
@@ -135,8 +116,8 @@ public final class JdbiClassUtils {
         // collect into a set to deduplicate the classes found.
         // this can happen if e.g. a extends b and both implement c.
         Set<Class<?>> result = Stream.concat(
-                Arrays.stream(interfaces).flatMap(JdbiClassUtils::superTypes),
-                Arrays.stream(interfaces))
+                        Arrays.stream(interfaces).flatMap(JdbiClassUtils::superTypes),
+                        Arrays.stream(interfaces))
                 .collect(Collectors.toSet());
 
         return result.stream();
@@ -146,10 +127,110 @@ public final class JdbiClassUtils {
 
     /**
      * Safely move arguments passed from from a varargs call to a call that expects an array of objects.
+     *
      * @param args A list of objects. May be null or empty
      * @return Returns an Array of objects. If the input was null, returns an empty array, otherwise all arguments as an array
      */
     public static Object[] safeVarargs(Object... args) {
         return (args == null) ? NO_ARGS : args;
+    }
+
+    private static final BiFunction<Class<?>, Throwable, RuntimeException> UNABLE_TO_CREATE_STATEMENT_HANDLER = (t, e) ->
+            new UnableToCreateStatementException(format("Unable to instantiate '%s':", t.getName()), e);
+
+    private static final Class<?>[] NO_PARAMS = new Class[0];
+
+    /**
+     * Create a new instance for a type with a no-args constructor.
+     *
+     * @param type The type to create.
+     * @return An instance of the type, created by the no-args constructor.
+     * @throws UnableToCreateStatementException If the type could not be instantiated.
+     */
+    @Alpha
+    public static <T> T checkedCreateInstance(Class<T> type) {
+        return checkedCreateInstance(type, NO_PARAMS, UNABLE_TO_CREATE_STATEMENT_HANDLER);
+    }
+
+    /**
+     * Create a new instance for a type.
+     *
+     * @param type       The type to create.
+     * @param parameters The type parameters for the constructor.
+     * @param f          An error function. If creating the instance throws a Throwable, process it and return a runtime exception for reporting.
+     * @param values     Type values for the constructor. The number of values must match the number of type parameters.
+     * @return AN instance of the type.
+     */
+    @Alpha
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    private static <T> T checkedCreateInstance(Class<T> type, Class<?>[] parameters, BiFunction<Class<?>, Throwable, RuntimeException> f, Object... values) {
+        try {
+            return type.getConstructor(parameters).newInstance(values);
+        } catch (InvocationTargetException e) {
+            throw f.apply(type, e.getCause());
+        } catch (ReflectiveOperationException | SecurityException e) {
+            throw f.apply(type, e);
+        }
+    }
+
+    private static final BiFunction<Class<?>, Throwable, RuntimeException> DEFAULT_EXCEPTION_HANDLER = (t, e) ->
+             e instanceof RuntimeException
+                     ? (RuntimeException) e
+                     : new IllegalStateException(format("Unable to instantiate '%s':", t.getName()), e);
+
+    /**
+     * Inspect a type, find a matching constructor and return an instance. The method tries to match as many parameters as possible
+     * to the available constructors, cutting off parameters from the end one-by-one until a matching constructor is found.
+     *
+     * @param type       The type that should be instantiated.
+     * @param types      Array of parameter types.
+     * @param parameters Parameters for the constructor.
+     * @return An {@link Optional} wrapping the instantiated type or {@link Optional#empty()} if no matching constructor was found.
+     */
+    @Alpha
+    public static <T> T findConstructorAndCreateInstance(Class<T> type, Class<?>[] types, Object... parameters) {
+        return findConstructorAndCreateInstance(type, types, DEFAULT_EXCEPTION_HANDLER, parameters);
+    }
+
+    @Alpha
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    private static <T> T findConstructorAndCreateInstance(Class<T> type,
+            Class<?>[] types,
+            BiFunction<Class<?>, Throwable, RuntimeException> f,
+            Object... parameters) {
+        if (types.length != parameters.length) {
+            throw new IllegalArgumentException(format("%d types but %d parameters. Can not create instance!", types.length, parameters.length));
+        }
+
+        var constructors = type.getConstructors();
+
+        for (int argCount = types.length; argCount >= 0; argCount--) {
+            for (var constructor : constructors) {
+                if (constructor.getParameterCount() != argCount) {
+                    continue; // for
+                }
+
+                boolean match = true;
+                for (int i = 0; i < argCount; i++) {
+                    if (!constructor.getParameterTypes()[i].isAssignableFrom(types[i])) {
+                        match = false;
+                        break; // for(int i = 0; ...
+                    }
+                }
+                if (!match) {
+                    continue; // for(Constructor...
+                }
+
+                try {
+                    return type.cast(constructor.newInstance(Arrays.copyOf(parameters, argCount)));
+                } catch (InvocationTargetException e) {
+                    throw f.apply(type, e.getCause());
+                } catch (ReflectiveOperationException | SecurityException e) {
+                    throw f.apply(type, e);
+                }
+            }
+        }
+
+        throw f.apply(type, null);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/config/TestConfigRegistry.java
+++ b/core/src/test/java/org/jdbi/v3/core/config/TestConfigRegistry.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class TestConfigRegistry {
+public class TestConfigRegistry {
 
     private ConfigRegistry parent;
     private ConfigRegistry child1;
@@ -205,7 +205,7 @@ class TestConfigRegistry {
         private final Set<String> set;
         private final Map<String, String> map;
 
-        TestConfig() {
+        public TestConfig() {
             this.list = new CopyOnWriteArrayList<>();
             this.set = new CopyOnWriteArraySet<>();
             this.map = new ConcurrentHashMap<>();

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -8216,7 +8216,7 @@ link:{jdkdocs}/java/lang/annotation/Target.html[@Target({ElementType.METHOD})^] 
 The extension framework processes all annotations that use this meta-annotation. It will instantiate the extension handler by locating
 
 - a constructor that takes both the extension type and a method object
-- a constructor that takes only a method object
+- a constructor that takes only the extension type
 - a no-argument constructor
 
 If none of those can be found, an exception will be thrown.
@@ -8290,7 +8290,7 @@ be placed on a method or the extension type itself.
 The extension framework processes all annotations that use this meta-annotation. It will instantiate the extension handler customizer by locating
 
 - a constructor that takes both the extension type and a method object
-- a constructor that takes only a method object
+- a constructor that takes only the extension type
 - a no-argument constructor
 
 If none of those can be found, an exception will be thrown.

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotatedHandlerDecorator.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlMethodAnnotatedHandlerDecorator.java
@@ -21,6 +21,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.jdbi.v3.core.internal.JdbiClassUtils;
+
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -48,7 +50,7 @@ class SqlMethodAnnotatedHandlerDecorator implements HandlerDecorator {
 
         List<HandlerDecorator> decorators = annotationTypes.stream()
                 .map(type -> type.getAnnotation(SqlMethodDecoratingAnnotation.class))
-                .map(a -> buildDecorator(a.value()))
+                .map(a -> JdbiClassUtils.checkedCreateInstance(a.value()))
                 .collect(toList());
 
         for (HandlerDecorator decorator : decorators) {
@@ -66,13 +68,4 @@ class SqlMethodAnnotatedHandlerDecorator implements HandlerDecorator {
             return index == -1 ? ordering.size() : index;
         });
     }
-
-    private static HandlerDecorator buildDecorator(Class<? extends HandlerDecorator> decoratorClass) {
-        try {
-            return decoratorClass.getConstructor().newInstance();
-        } catch (ReflectiveOperationException | SecurityException e) {
-            throw new IllegalStateException("Decorator class " + decoratorClass + "cannot be instantiated", e);
-        }
-    }
-
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectCustomizerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/SqlObjectCustomizerFactory.java
@@ -28,8 +28,6 @@ import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.sqlobject.config.Configurer;
 import org.jdbi.v3.sqlobject.config.ConfiguringAnnotation;
 
-import static java.lang.String.format;
-
 class SqlObjectCustomizerFactory implements ConfigCustomizerFactory {
 
     static final ConfigCustomizerFactory FACTORY = new SqlObjectCustomizerFactory();
@@ -55,15 +53,8 @@ class SqlObjectCustomizerFactory implements ConfigCustomizerFactory {
                 .filter(a -> a.annotationType().isAnnotationPresent(ConfiguringAnnotation.class))
                 .map(a -> {
                     ConfiguringAnnotation meta = a.annotationType().getAnnotation(ConfiguringAnnotation.class);
-                    Class<? extends Configurer> klass = meta.value();
-
-                    try {
-                        Configurer configurer = klass.getConstructor().newInstance();
-                        return (ConfigCustomizer) config -> consumer.configure(configurer, config, a);
-                    } catch (ReflectiveOperationException | SecurityException e) {
-                        throw new IllegalStateException(format("Unable to instantiate class %s", klass), e);
-                    }
-
+                    Configurer configurer = JdbiClassUtils.checkedCreateInstance(meta.value());
+                    return (ConfigCustomizer) config -> consumer.configure(configurer, config, a);
                 })
                 .collect(Collectors.toList());
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterArgumentFactoriesImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterArgumentFactoriesImpl.java
@@ -21,6 +21,7 @@ import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactories;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 
@@ -33,13 +34,7 @@ public class RegisterArgumentFactoriesImpl extends SimpleExtensionConfigurer {
         this.argumentFactories = new ArrayList<>(registerArgumentFactories.value().length);
 
         for (RegisterArgumentFactory registerArgumentFactory : registerArgumentFactories.value()) {
-            final Class<? extends ArgumentFactory> klass = registerArgumentFactory.value();
-
-            try {
-                argumentFactories.add(klass.getConstructor().newInstance());
-            } catch (ReflectiveOperationException | SecurityException e) {
-                throw new IllegalStateException("Unable to instantiate column mapper class " + klass, e);
-            }
+            argumentFactories.add(JdbiClassUtils.checkedCreateInstance(registerArgumentFactory.value()));
         }
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterArgumentFactoryImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterArgumentFactoryImpl.java
@@ -19,6 +19,7 @@ import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 
 public class RegisterArgumentFactoryImpl extends SimpleExtensionConfigurer {
@@ -27,13 +28,8 @@ public class RegisterArgumentFactoryImpl extends SimpleExtensionConfigurer {
 
     public RegisterArgumentFactoryImpl(Annotation annotation) {
         RegisterArgumentFactory registerArgumentFactory = (RegisterArgumentFactory) annotation;
-        final Class<? extends ArgumentFactory> klass = registerArgumentFactory.value();
 
-        try {
-            this.argumentFactory = klass.getConstructor().newInstance();
-        } catch (ReflectiveOperationException | SecurityException e) {
-            throw new IllegalStateException("Unable to instantiate column mapper class " + klass, e);
-        }
+        this.argumentFactory = JdbiClassUtils.checkedCreateInstance(registerArgumentFactory.value());
     }
 
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorFactoryImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorFactoryImpl.java
@@ -19,6 +19,7 @@ import org.jdbi.v3.core.collector.CollectorFactory;
 import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.sqlobject.config.RegisterCollectorFactory;
 
 public class RegisterCollectorFactoryImpl extends SimpleExtensionConfigurer {
@@ -27,12 +28,8 @@ public class RegisterCollectorFactoryImpl extends SimpleExtensionConfigurer {
 
     public RegisterCollectorFactoryImpl(Annotation annotation) {
         RegisterCollectorFactory registerCollectorFactory = (RegisterCollectorFactory) annotation;
-        Class<? extends CollectorFactory> type = registerCollectorFactory.value();
-        try {
-            collectorFactory = type.getConstructor().newInstance();
-        } catch (ReflectiveOperationException | SecurityException e) {
-            throw new IllegalStateException("Unable to instantiate collector factory class " + registerCollectorFactory.value(), e);
-        }
+
+        this.collectorFactory = JdbiClassUtils.checkedCreateInstance(registerCollectorFactory.value());
     }
 
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterCollectorImpl.java
@@ -21,6 +21,7 @@ import org.jdbi.v3.core.collector.JdbiCollectors;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
 import org.jdbi.v3.core.generic.GenericTypes;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.sqlobject.config.RegisterCollector;
 
 public class RegisterCollectorImpl extends SimpleExtensionConfigurer {
@@ -30,15 +31,11 @@ public class RegisterCollectorImpl extends SimpleExtensionConfigurer {
 
     public RegisterCollectorImpl(Annotation annotation) {
         final RegisterCollector registerCollector = (RegisterCollector) annotation;
-        final Class<? extends Collector<?, ?, ?>> collectorClass = registerCollector.value();
+        final Class<? extends Collector<?, ?, ?>> klass = registerCollector.value();
 
-        try {
-            this.resultType = GenericTypes.findGenericParameter(collectorClass, Collector.class, 2)
+        this.resultType = GenericTypes.findGenericParameter(klass, Collector.class, 2)
                 .orElseThrow(() -> new IllegalArgumentException("Tried to pass non-collector object to @RegisterCollector"));
-            this.collector = collectorClass.getConstructor().newInstance();
-        } catch (ReflectiveOperationException | SecurityException e) {
-            throw new IllegalStateException("Unable to instantiate collector class " + collectorClass, e);
-        }
+        this.collector = JdbiClassUtils.checkedCreateInstance(klass);
     }
 
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMapperFactoriesImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMapperFactoriesImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapperFactories;
@@ -33,13 +34,7 @@ public class RegisterColumnMapperFactoriesImpl extends SimpleExtensionConfigurer
         this.columnMapperFactories = new ArrayList<>(registerColumnMapperFactories.value().length);
 
         for (RegisterColumnMapperFactory registerColumnMapperFactory : registerColumnMapperFactories.value()) {
-            final Class<? extends ColumnMapperFactory> klass = registerColumnMapperFactory.value();
-
-            try {
-                columnMapperFactories.add(klass.getConstructor().newInstance());
-            } catch (ReflectiveOperationException | SecurityException e) {
-                throw new IllegalStateException("Unable to instantiate row mapper factory class " + klass, e);
-            }
+            this.columnMapperFactories.add(JdbiClassUtils.checkedCreateInstance(registerColumnMapperFactory.value()));
         }
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMapperFactoryImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMapperFactoryImpl.java
@@ -17,6 +17,7 @@ import java.lang.annotation.Annotation;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.ColumnMapperFactory;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapperFactory;
@@ -27,13 +28,8 @@ public class RegisterColumnMapperFactoryImpl extends SimpleExtensionConfigurer {
 
     public RegisterColumnMapperFactoryImpl(Annotation annotation) {
         final RegisterColumnMapperFactory registerColumnMapperFactory = (RegisterColumnMapperFactory) annotation;
-        final Class<? extends ColumnMapperFactory> klass = registerColumnMapperFactory.value();
 
-        try {
-            this.columnMapperFactory = klass.getConstructor().newInstance();
-        } catch (ReflectiveOperationException | SecurityException e) {
-            throw new IllegalStateException("Unable to instantiate column mapper factory class " + klass, e);
-        }
+        this.columnMapperFactory = JdbiClassUtils.checkedCreateInstance(registerColumnMapperFactory.value());
     }
 
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMapperImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMapperImpl.java
@@ -17,6 +17,7 @@ import java.lang.annotation.Annotation;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
@@ -27,13 +28,8 @@ public class RegisterColumnMapperImpl extends SimpleExtensionConfigurer {
 
     public RegisterColumnMapperImpl(Annotation annotation) {
         RegisterColumnMapper registerColumnMapper = (RegisterColumnMapper) annotation;
-        final Class<? extends ColumnMapper<?>> klass = registerColumnMapper.value();
 
-        try {
-            this.columnMapper = klass.getConstructor().newInstance();
-        } catch (ReflectiveOperationException | SecurityException e) {
-            throw new IllegalStateException("Unable to instantiate column mapper class " + klass, e);
-        }
+        this.columnMapper = JdbiClassUtils.checkedCreateInstance(registerColumnMapper.value());
     }
 
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMappersImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterColumnMappersImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
@@ -33,13 +34,7 @@ public class RegisterColumnMappersImpl extends SimpleExtensionConfigurer {
         this.columnMappers = new ArrayList<>(registerColumnMappers.value().length);
 
         for (RegisterColumnMapper registerColumnMapper : registerColumnMappers.value()) {
-            final Class<? extends ColumnMapper<?>> klass = registerColumnMapper.value();
-
-            try {
-                columnMappers.add(klass.getConstructor().newInstance());
-            } catch (ReflectiveOperationException | SecurityException e) {
-                throw new IllegalStateException("Unable to instantiate column mapper class " + klass, e);
-            }
+            columnMappers.add(JdbiClassUtils.checkedCreateInstance(registerColumnMapper.value()));
         }
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMapperFactoriesImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMapperFactoriesImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.RowMappers;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapperFactories;
@@ -33,13 +34,8 @@ public class RegisterRowMapperFactoriesImpl extends SimpleExtensionConfigurer {
         this.rowMapperFactories = new ArrayList<>(registerRowMapperFactories.value().length);
 
         for (RegisterRowMapperFactory registerRowMapperFactory : registerRowMapperFactories.value()) {
-            final Class<? extends RowMapperFactory> klass = registerRowMapperFactory.value();
 
-            try {
-                rowMapperFactories.add(klass.getConstructor().newInstance());
-            } catch (ReflectiveOperationException | SecurityException e) {
-                throw new IllegalStateException("Unable to instantiate row mapper factory class " + klass, e);
-            }
+            rowMapperFactories.add(JdbiClassUtils.checkedCreateInstance(registerRowMapperFactory.value()));
         }
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMapperFactoryImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMapperFactoryImpl.java
@@ -17,6 +17,7 @@ import java.lang.annotation.Annotation;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.RowMappers;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapperFactory;
@@ -27,13 +28,8 @@ public class RegisterRowMapperFactoryImpl extends SimpleExtensionConfigurer {
 
     public RegisterRowMapperFactoryImpl(Annotation annotation) {
         final RegisterRowMapperFactory registerRowMapperFactory = (RegisterRowMapperFactory) annotation;
-        final Class<? extends RowMapperFactory> klass = registerRowMapperFactory.value();
 
-        try {
-            this.rowMapperFactory = klass.getConstructor().newInstance();
-        } catch (ReflectiveOperationException | SecurityException e) {
-            throw new IllegalStateException("Unable to instantiate row mapper factory class " + klass, e);
-        }
+        this.rowMapperFactory = JdbiClassUtils.checkedCreateInstance(registerRowMapperFactory.value());
     }
 
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMapperImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMapperImpl.java
@@ -17,6 +17,7 @@ import java.lang.annotation.Annotation;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMappers;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -27,13 +28,7 @@ public class RegisterRowMapperImpl extends SimpleExtensionConfigurer {
 
     public RegisterRowMapperImpl(Annotation annotation) {
         RegisterRowMapper registerRowMapper = (RegisterRowMapper) annotation;
-        final Class<? extends RowMapper<?>> klass = registerRowMapper.value();
-
-        try {
-            this.rowMapper = klass.getConstructor().newInstance();
-        } catch (ReflectiveOperationException | SecurityException e) {
-            throw new IllegalStateException("Unable to instantiate row mapper class " + klass, e);
-        }
+        this.rowMapper = JdbiClassUtils.checkedCreateInstance(registerRowMapper.value());
     }
 
     @Override

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMappersImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterRowMappersImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMappers;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -33,13 +34,7 @@ public class RegisterRowMappersImpl extends SimpleExtensionConfigurer {
         this.rowMappers = new ArrayList<>(registerRowMappers.value().length);
 
         for (RegisterRowMapper registerRowMapper : registerRowMappers.value()) {
-            final Class<? extends RowMapper<?>> klass = registerRowMapper.value();
-
-            try {
-                rowMappers.add(klass.getConstructor().newInstance());
-            } catch (ReflectiveOperationException | SecurityException e) {
-                throw new IllegalStateException("Unable to instantiate row mapper class " + klass, e);
-            }
+            rowMappers.add(JdbiClassUtils.checkedCreateInstance(registerRowMapper.value()));
         }
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseTemplateEngineImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/UseTemplateEngineImpl.java
@@ -14,56 +14,30 @@
 package org.jdbi.v3.sqlobject.config.internal;
 
 import java.lang.annotation.Annotation;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
-import org.jdbi.v3.core.internal.exceptions.Sneaky;
+import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.core.statement.TemplateEngine;
 import org.jdbi.v3.sqlobject.config.UseTemplateEngine;
 
 public class UseTemplateEngineImpl extends SimpleExtensionConfigurer {
 
+    private static final Class<?>[] TEMPLATE_ENGINE_PARAMETERS = {Class.class, Method.class};
+
     private final TemplateEngine templateEngine;
 
     public UseTemplateEngineImpl(Annotation annotation, Class<?> sqlObjectType, @Nullable Method method) {
         UseTemplateEngine useTemplateEngine = (UseTemplateEngine) annotation;
-        this.templateEngine = instantiate(useTemplateEngine.value(), sqlObjectType, method);
+        Class<? extends TemplateEngine> engineClass = useTemplateEngine.value();
+        this.templateEngine = JdbiClassUtils.findConstructorAndCreateInstance(engineClass, TEMPLATE_ENGINE_PARAMETERS, sqlObjectType, method);
     }
 
     @Override
     public void configure(ConfigRegistry config, Annotation annotation, Class<?> sqlObjectType) {
         config.get(SqlStatements.class).setTemplateEngine(templateEngine);
-    }
-
-    private static TemplateEngine instantiate(Class<? extends TemplateEngine> engineClass, Class<?> sqlObjectType, @Nullable Method method) {
-        return Stream.of(tryConstructor(engineClass), tryConstructor(engineClass, sqlObjectType), tryConstructor(engineClass, sqlObjectType, method))
-            .map(Supplier::get)
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException("Unable to instantiate, no viable constructor for " + engineClass.getName()));
-    }
-
-    private static <T extends TemplateEngine> Supplier<T> tryConstructor(Class<T> clazz, Object... args) {
-        return () -> {
-            try {
-                Object[] nonNullArgs = Arrays.stream(args).filter(Objects::nonNull).toArray(Object[]::new);
-                Class[] argClasses = Arrays.stream(nonNullArgs).map(Object::getClass).toArray(Class[]::new);
-                MethodType type = MethodType.methodType(void.class, argClasses);
-                return (T) MethodHandles.lookup().findConstructor(clazz, type).invokeWithArguments(nonNullArgs);
-            } catch (NoSuchMethodException ignored) {
-                return null;
-            } catch (Throwable t) {
-                throw Sneaky.throwAnyway(t);
-            }
-        };
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/CreateSqlObjectHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/internal/CreateSqlObjectHandler.java
@@ -27,7 +27,7 @@ import org.jdbi.v3.sqlobject.SqlObjectFactory;
 public class CreateSqlObjectHandler implements ExtensionHandler {
     private final Method method;
 
-    public CreateSqlObjectHandler(Method method) {
+    public CreateSqlObjectHandler(Class<?> sqlObjectType, Method method) {
         this.method = method;
     }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/TestMaxRows.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/customizer/TestMaxRows.java
@@ -109,7 +109,7 @@ public class TestMaxRows {
     public void testMethodNonsense() {
         assertThatThrownBy(() -> handle.attach(FooMethodNonsenseValue.class))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("is 0, which is negative or 0");
+                .hasMessageContaining("is 0, which is negative or 0");
     }
 
     @Test


### PR DESCRIPTION
Centralize c'tor lookup algorithms and object instantiation, choose
c'tor explicitly, not by try-and-exception.

Removes a large amount of reflection-related code from all over core
and sqlobject.
