### PR TITLE
MapToFactory: reuse a single ResultReturner

### DIFF
--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/MapToFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/MapToFactory.java
@@ -32,6 +32,7 @@ public class MapToFactory implements SqlStatementCustomizerFactory {
                                                               Parameter param,
                                                               int index,
                                                               Type type) {
+        ResultReturner returner = ResultReturner.forMethod(sqlObjectType, method);
         return (sqlStatement, arg) -> {
             final QualifiedType<?> mapTo;
 
@@ -45,7 +46,6 @@ public class MapToFactory implements SqlStatementCustomizerFactory {
                 throw new UnsupportedOperationException("@MapTo must take a GenericType, QualifiedType, or Type, but got a " + arg.getClass().getName());
             }
 
-            ResultReturner returner = ResultReturner.forMethod(sqlObjectType, method);
             sqlStatement.getConfig(SqlObjectStatementConfiguration.class).setReturner(
                     () -> returner.mappedResult(((ResultBearing) sqlStatement).mapTo(mapTo), sqlStatement.getContext()));
         };

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/ResultReturner.java
@@ -37,6 +37,7 @@ import static java.lang.String.format;
 /**
  * Helper class used by the {@link CustomizingStatementHandler}s to assemble
  * the result Collection, Iterable, etc.
+ * The instance may be reused and should be stateless.
  */
 abstract class ResultReturner {
 


### PR DESCRIPTION
rather than re-creating it each time

Inspecting methods is relatively expensive and they don't change.