### PR TITLE
Support custom callback handlers

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handler.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handler.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+public interface Handler {
+    Handler STANDARD_HANDLER = new Handler() {
+        @Override
+        public <R, X extends Exception> HandleCallback<R, X> decorate(HandleCallback<R, X> callback) {
+            return callback;
+        }
+    };
+
+    /**
+     * Decorate the given Handle callback
+     *
+     * @param callback a callback which will receive the open handle
+     *
+     * @return the callback decorated as needed
+     *
+     * @see Jdbi#withHandle(HandleCallback)
+     */
+    <R, X extends Exception> HandleCallback<R, X> decorate(HandleCallback<R, X> callback);
+}


### PR DESCRIPTION
Currently, it is very simple to add global custom handling for
transaction callbacks using JDBI's `TransactionHandler`. 
Specialized behavior can be added for an app's entire JDBI usage
without project devs needing to do anything special. This is very
useful when introducing protocols such as custom retry behavior,
custom connection management, etc.

Introduce new interface that is an analog of `TransactionHandler`
but for all callbacks, not just transactions. This interface,
`Handler` is used to invoke the callback passed to JDBI's
`useHandle`, `withHandle`, `inTransaction` and `withTransaction`.
This gives users a chance to global patch callbacks for all
JDBI uses not just transactions.
