### PR TITLE
Add reset() method to LocalTransactionHandler

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
@@ -86,6 +86,10 @@ public class LocalTransactionHandler implements TransactionHandler {
         return new BindingLocalTransactionHandler();
     }
 
+    public void reset(Handle handle) {
+        bound.remove(handle);
+    }
+
     static class BindingLocalTransactionHandler extends LocalTransactionHandler {
         @Override
         public TransactionHandler specialize(Handle handle) throws SQLException {


### PR DESCRIPTION
We need a way to clear the cached BoundLocalTransactionHandler. We copied LocalTransactionHandler to do this so it would be nice if the library version had a reset() method.