### PR TITLE
Handle: unconditionally close Connection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+# Unreleased
+  - Handle: fix potential Connection leak if connection is closed early
+
 # 3.40.0
 
   - add extension point to decorate withHandle and friends (#2448)

--- a/core/src/main/java/org/jdbi/v3/core/ConnectionFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/ConnectionFactory.java
@@ -45,6 +45,7 @@ public interface ConnectionFactory {
 
     /**
      * Returns a {@link Cleanable} that will close the connection and release all necessary resources.
+     * Like {@link Connection#close()}, the Cleanable should no-op if called more than once.
      *
      * @param conn A {@link Connection} object.
      * @return A {@link Cleanable} instance. Calling the {@link Cleanable#close()} method will close the connection and release all resources.

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -115,12 +115,8 @@ public class Handle implements Closeable, Configurable<Handle> {
         this.transactionHandler = transactionHandler.specialize(this);
         this.forceEndTransactions = !transactionHandler.isInTransaction(this);
 
-        addCleanable(() -> {
-            // shut down statement builder
-            if (checkConnectionIsLive()) {
-                statementBuilder.close(connection);
-            }
-        });
+        addCleanable(() ->
+            statementBuilder.close(connection));
     }
 
     /**
@@ -897,51 +893,41 @@ public class Handle implements Closeable, Configurable<Handle> {
     private void cleanConnection(boolean doForceEndTransactions) {
 
         final ThrowableSuppressor throwableSuppressor = new ThrowableSuppressor();
-        final boolean connectionIsLive = checkConnectionIsLive();
 
         boolean wasInTransaction = false;
 
-        if (connectionIsLive && doForceEndTransactions) {
-            wasInTransaction = throwableSuppressor.suppressAppend(this::isInTransaction, false);
+        if (doForceEndTransactions) {
+            wasInTransaction = throwableSuppressor.suppressAppend(
+                    // if the connection was not closed, check whether it is in a transaction
+                    // if any of this throws an exception, assume that the connection was closed,
+                    // skip the transaction check and record the exception
+                    () -> !connection.isClosed() && isInTransaction(),
+                    false);
         }
 
         if (wasInTransaction) {
             throwableSuppressor.suppressAppend(this::rollback);
         }
 
-        if (connectionIsLive) {
-            try {
-                connectionCleaner.close();
-            } catch (SQLException e) {
-                CloseException ce = new CloseException("Unable to close Connection", e);
-                throwableSuppressor.attachToThrowable(ce);
-                throw ce;
-            }
-
-            throwableSuppressor.throwIfNecessary(t -> new CloseException("Failed to clear transaction status on close", t));
-
-            if (wasInTransaction) {
-                TransactionException te = new TransactionException("Improper transaction handling detected: A Handle with an open "
-                        + "transaction was closed. Transactions must be explicitly committed or rolled back "
-                        + "before closing the Handle. "
-                        + "Jdbi has rolled back this transaction automatically. "
-                        + "This check may be disabled by calling getConfig(Handles.class).setForceEndTransactions(false).");
-
-                throwableSuppressor.attachToThrowable(te); // any exception present is not the cause but just collateral.
-                throw te;
-            }
-        } else {
-            throwableSuppressor.throwIfNecessary(t -> new CloseException("Failed to clear transaction status on close", t));
-        }
-    }
-
-    private boolean checkConnectionIsLive() {
         try {
-            return !connection.isClosed();
+            connectionCleaner.close();
         } catch (SQLException e) {
-            // if the connection state can not be determined, assume that the
-            // connection is closed and ignore the exception
-            return false;
+            CloseException ce = new CloseException("Unable to close Connection", e);
+            throwableSuppressor.attachToThrowable(ce);
+            throw ce;
+        }
+
+        throwableSuppressor.throwIfNecessary(t -> new CloseException("Failed to clear transaction status on close", t));
+
+        if (wasInTransaction) {
+            TransactionException te = new TransactionException("Improper transaction handling detected: A Handle with an open "
+                    + "transaction was closed. Transactions must be explicitly committed or rolled back "
+                    + "before closing the Handle. "
+                    + "Jdbi has rolled back this transaction automatically. "
+                    + "This check may be disabled by calling getConfig(Handles.class).setForceEndTransactions(false).");
+
+            throwableSuppressor.attachToThrowable(te); // any exception present is not the cause but just collateral.
+            throw te;
         }
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/JdbiOpenLeakTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/JdbiOpenLeakTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jdbi.v3.core.statement.Cleanable;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JdbiOpenLeakTest {
+
+    Connection conn = mock(Connection.class);
+    boolean leased = false;
+    boolean handleCleaned = false;
+    Jdbi jdbi = Jdbi.create(() -> {
+        leased = true;
+        return conn;
+    });
+
+    @Test
+    void cleanupCustomizeThrows() throws Exception {
+        assertThat(leased).isFalse();
+
+        jdbi.installPlugin(new JdbiPlugin() {
+            @Override
+            public Connection customizeConnection(final Connection conn) throws SQLException {
+                throw new CosmicRayException();
+            }
+        });
+
+        assertThatThrownBy(jdbi::open)
+                .isInstanceOf(CosmicRayException.class);
+        assertThat(leased).isTrue();
+        verify(conn).close();
+    }
+
+    @Test
+    void cleanupIsClosedThrows() throws Exception {
+        when(conn.isClosed()).thenThrow(CosmicRayException.class);
+        assertThat(leased).isFalse();
+        assertThat(handleCleaned).isFalse();
+
+        try (Handle h = jdbi.open()) {
+            h.addCleanable(new Cleanable() {
+                @Override
+                public void close() throws SQLException {
+                    handleCleaned = true;
+                }
+            });
+        }
+
+        assertThat(handleCleaned).isTrue();
+        assertThat(leased).isTrue();
+        verify(conn).close();
+    }
+
+    class CosmicRayException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+    }
+}


### PR DESCRIPTION
Right now, we check if a connection is closed before closing it.

However, this isn't good enough: even if the server closed the connection, we might have borrowed this from a pool, which needs to know we've returned it.

Connection.close is specified to no-op if called more than once, so it's safe to just do it regardless.

Fixes #2446