### PR TITLE
Revise the HandleCallback decorator code

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/HandleCallbackDecorator.java
+++ b/core/src/main/java/org/jdbi/v3/core/HandleCallbackDecorator.java
@@ -13,8 +13,15 @@
  */
 package org.jdbi.v3.core;
 
-public interface Handler {
-    Handler STANDARD_HANDLER = new Handler() {
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Decorates the {@link HandleCallback} instance for {@link Jdbi#useHandle(HandleConsumer)}, {@link Jdbi#withHandle(HandleCallback)},
+ * {@link Jdbi#inTransaction(HandleCallback)} and {@link Jdbi#useTransaction(HandleConsumer)}.
+ */
+@Alpha
+public interface HandleCallbackDecorator {
+    HandleCallbackDecorator STANDARD_HANDLE_CALLBACK_DECORATOR = new HandleCallbackDecorator() {
         @Override
         public <R, X extends Exception> HandleCallback<R, X> decorate(HandleCallback<R, X> callback) {
             return callback;
@@ -22,12 +29,10 @@ public interface Handler {
     };
 
     /**
-     * Decorate the given Handle callback
+     * Decorate the given {@link HandleCallback} instance.
      *
      * @param callback a callback which will receive the open handle
-     *
      * @return the callback decorated as needed
-     *
      * @see Jdbi#withHandle(HandleCallback)
      */
     <R, X extends Exception> HandleCallback<R, X> decorate(HandleCallback<R, X> callback);

--- a/core/src/test/java/org/jdbi/v3/core/TestHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestHandle.java
@@ -217,10 +217,11 @@ public class TestHandle {
     }
 
     @Test
-    public void testCustomHandler() {
+    public void testHandleCallbackDecorator() {
         AtomicReference<HandleCallback<?, ?>> overrideCallback = new AtomicReference<>();
         AtomicBoolean gotCalled = new AtomicBoolean();
-        Handler testHandler = new Handler() {
+
+        var handleCallbackDecorator = new HandleCallbackDecorator() {
             @SuppressWarnings("unchecked")
             @Override
             public <R, X extends Exception> HandleCallback<R, X> decorate(HandleCallback<R, X> callback) {
@@ -234,8 +235,10 @@ public class TestHandle {
         };
 
         Jdbi jdbi = h2Extension.getJdbi();
-        Handler saveHandler = jdbi.getHandler();
-        jdbi.setHandler(testHandler);
+
+        HandleCallbackDecorator saveHandleDecorator = jdbi.getHandleCallbackDecorator();
+        jdbi.setHandleCallbackDecorator(handleCallbackDecorator);
+
         try {
             String result = jdbi.withHandle(handle -> "hey");
             assertThat(result).isEqualTo("hey");
@@ -261,7 +264,7 @@ public class TestHandle {
             gotCalled.set(false);
             overrideCallback.set(null);
         } finally {
-            jdbi.setHandler(saveHandler);
+            jdbi.setHandleCallbackDecorator(saveHandleDecorator);
         }
     }
 


### PR DESCRIPTION
- Rename "Handler" to "HandleCallbackDecorator". "Handler" is a way too generic name and there is potential for confusion with "Handle" which is a main concept in Jdbi while this change introduces a minor feature.
- Mark the added code with `@Alpha` annotation, as the API should not have been set in stone.