### PR TITLE
Fix javadoc generation

### DIFF
--- a/JPMS-SUPPORT.md
+++ b/JPMS-SUPPORT.md
@@ -30,34 +30,23 @@ forever. Those are annoying but not critical.
 
 ## Javadocs
 
-The most pressing issue right now is the generation of Javadocs. The
-current build uses a hardcoded version of "8" to build non-modularized
-javadocs. With the introduction of Java 9+ code, warnings like `as of
-release 10, 'var' is a restricted type name and cannot be used for
-type declarations or as the element type of an array` have started
-popping up.
+With the release of maven-javadoc-plugin 3.6.0, we can build non-JPMS
+javadocs again that use Java 11 (our release version) and no longer
+report warnings.
 
-While it is possible to build per-maven module javadocs that are
-structured like java 9+ javadocs, building an aggregation (all
-javadocs in one place) has consistently failed.
+Going forward, while it is possible to build per-maven module javadocs
+that are structured like java 9+ javadocs, building an aggregation
+(all javadocs in one place) has consistently failed.
 
 For aggregated jars, the way the maven-javadoc plugin calls the
 javadoc tool does not work ("too many patched modules") or limitations
 of the maven-javadoc-plugin
-(https://issues.apache.org/jira/browse/MJAVADOC-767, fix merged;
-https://issues.apache.org/jira/browse/MJAVADOC-768, unresolved;
-https://issues.apache.org/jira/browse/MJAVADOC-769, fix proposed).
+( see https://issues.apache.org/jira/browse/MJAVADOC-768, unresolved)
 
 In addition, the javadoc tool itself does not work well with automatic
 modules (the --module-source-path option only works with module
 descriptors, so patching the module with the source code is the only
 viable option).
-
-A change to the javadoc plugin has been proposed
-(https://issues.apache.org/jira/browse/MJAVADOC-770) which would allow
-building the javadocs as is but using a newer release version. This
-might be our best bet for now.
-
 
 ## Full modularization
 

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -110,6 +110,7 @@
         <dep.plugin.dokka.version>1.9.0</dep.plugin.dokka.version>
         <dep.plugin.flatten.version>1.5.0</dep.plugin.flatten.version>
         <dep.plugin.inline.version>1.1.0</dep.plugin.inline.version>
+        <dep.plugin.javadoc.version>3.6.0</dep.plugin.javadoc.version>
         <dep.plugin.kotlin.version>1.9.10</dep.plugin.kotlin.version>
         <dep.plugin.ktlint.version>2.0.0</dep.plugin.ktlint.version>
         <dep.plugin.sortpom.version>3.3.0</dep.plugin.sortpom.version>
@@ -603,17 +604,15 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
                         <outputDirectory>${project.build.directory}/apidocs</outputDirectory>
-                        <!-- Build Java 8 style javadocs for now, see #2401 -->
-                        <release>8</release>
-                        <!-- manual 11 link, otherwise this would be JDK 8 -->
-                        <detectJavaApiLink>false</detectJavaApiLink>
+                        <legacyMode>true</legacyMode>
+                        <release>${project.build.targetJdk}</release>
                         <links>
-                            <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
                             <link>https://google.github.io/guice/api-docs/${dep.guice.version}/javadoc/</link>
                             <link>https://javaee.github.io/javaee-spec/javadocs/</link>
                             <link>https://junit.org/junit5/docs/${dep.junit5.version}/api/</link>
                             <link>https://javadoc.io/doc/org.testcontainers/jdbc/${dep.testcontainers.version}/</link>
                         </links>
+                        <detectOfflineLinks>false</detectOfflineLinks>
                         <nodeprecated>false</nodeprecated>
                         <author>false</author>
                         <nohelp>true</nohelp>


### PR DESCRIPTION
Use a post-3.5.1 maven-javadoc-plugin with MJAVADOC-769 and
MJAVADOC-770 fixes applied.
