### PR TITLE
deprecated otj-postgres support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  - Deprecate the `otjPostgres` support in jdbi-testing. This will be undeprecated if they ship a version that provides an automatic module name for JPMS, otherwise it will be removed when Jdbi ships with full JPMS support.
+
 
 # 3.41.1
 

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExtension.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExtension.java
@@ -144,7 +144,13 @@ public abstract class JdbiExtension implements BeforeAllCallback, AfterAllCallba
      *
      * @return A {@link JdbiExtension} connected to a managed postgres data source.
      * @see JdbiOtjPostgresExtension
+     * @deprecated The <a href="https://github.com/opentable/otj-pg-embedded/">OtjPostgres project</a> ships its artifact as an automatic module with filename
+     * based module name. It is strongly discouraged to ship any JPMS enabled project that depends on automatic modules with filename based module names. We
+     * have reached out to the OtjPostgres project and <a href="https://github.com/opentable/otj-pg-embedded/pull/184">proposed a change that would fix this</a>.
+     * If they ship a version that fixes this before we are ready to move to full JPMS support, we will un-deprecate this class, otherwise it will be removed
+     * with our switch to JPMS.
      */
+    @Deprecated(since = "3.42.0", forRemoval = true) // intellij users need to change the "Usage of API marked for removal" inspection from error to warning
     public static JdbiOtjPostgresExtension otjEmbeddedPostgres() {
         return JdbiOtjPostgresExtension.instance();
     }

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtension.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtension.java
@@ -54,7 +54,14 @@ import com.opentable.db.postgres.embedded.EmbeddedPostgres;
  *     }
  * }
  * }</pre>
+ *
+ * @deprecated The <a href="https://github.com/opentable/otj-pg-embedded/">OtjPostgres project</a> ships its artifact as an automatic module with filename
+ * based module name. It is strongly discouraged to ship any JPMS enabled project that depends on automatic modules with filename based module names. We
+ * have reached out to the OtjPostgres project and <a href="https://github.com/opentable/otj-pg-embedded/pull/184">proposed a change that would fix this</a>.
+ * If they ship a version that fixes this before we are ready to move to full JPMS support, we will un-deprecate this class, otherwise it will be removed
+ * with our switch to JPMS.
  */
+@Deprecated(since = "3.42.0", forRemoval = true) // intellij users need to change the "Usage of API marked for removal" inspection from error to warning
 public class JdbiOtjPostgresExtension extends JdbiExtension {
 
     private volatile EmbeddedPostgres epg;


### PR DESCRIPTION
The OtjPostgres project ships its artifact as an automatic module with
filename based module name. It is strongly discouraged to ship any JPMS
enabled project that depends on automatic modules with filename based
module names. We have reached out to the OtjPostgres project and
proposed a change that would fix this.

If they ship a version that fixes this before we are ready to move to
full JPMS support, we will un-deprecate this class, otherwise it will be
removed with our switch to JPMS.
