### PR TITLE
Start a mysql module

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -104,6 +104,7 @@
         <dep.lombok.version>1.18.28</dep.lombok.version>
         <dep.mockito.version>5.5.0</dep.mockito.version>
         <dep.moshi.version>1.15.0</dep.moshi.version>
+        <dep.mysql.version>8.1.0</dep.mysql.version>
         <dep.pg-embedded.version>5.0</dep.pg-embedded.version>
         <dep.plugin.asciidoctor.version>2.2.4</dep.plugin.asciidoctor.version>
         <dep.plugin.detekt.version>1.23.1</dep.plugin.detekt.version>
@@ -304,6 +305,12 @@
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
                 <version>${dep.derby.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>${dep.mysql.version}</version>
             </dependency>
 
             <dependency>

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jdbi.internal</groupId>
+        <artifactId>jdbi3-parent</artifactId>
+        <version>3.41.2-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.jdbi</groupId>
+    <artifactId>jdbi3-mysql</artifactId>
+
+    <name>jdbi3 mysql</name>
+    <description>Support for additional MySQL features and data types.</description>
+
+    <properties>
+        <basepom.deploy.skip>true</basepom.deploy.skip>
+        <basepom.install.skip>true</basepom.install.skip>
+        <!-- tests are slow, so run tests only if explictly asked for -->
+        <basepom.test.skip>true</basepom.test.skip>
+        <!-- docker tests run long -->
+        <basepom.test.timeout>600</basepom.test.timeout>
+        <moduleName>org.jdbi.v3.mysql</moduleName>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>no-docker</id>
+            <activation>
+                <property>
+                    <name>no-docker</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/*</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/mysql/src/test/java/org/jdbi/v3/mysql/TestMySQL.java
+++ b/mysql/src/test/java/org/jdbi/v3/mysql/TestMySQL.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.mysql;
+
+import java.util.List;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.jdbi.v3.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static java.lang.String.format;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+public class TestMySQL {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new MySQLContainer<>("mysql");
+
+    @RegisterExtension
+    JdbiExtension extension = JdbiTestcontainersExtension.instance(dbContainer)
+            .withPlugin(new SqlObjectPlugin());
+
+    @Test
+    void testIssue2402() {
+        final Handle handle = extension.getSharedHandle();
+        handle.registerRowMapper(Contact.class, ConstructorMapper.of(Contact.class));
+
+        handle.execute("CREATE TABLE contacts (contact_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT, etag VARCHAR(255))");
+
+        for (int i = 0; i < 100; i++) {
+            handle.execute(format("INSERT INTO contacts (etag) VALUES ('tag_%05d')", i));
+        }
+
+        ContactDao contactDao = handle.attach(ContactDao.class);
+
+        List<Contact> contacts = contactDao.getAllContacts();
+        assertThat(contacts).hasSize(100);
+
+        List<String> test1 = contactDao.testOne("9");
+        assertThat(test1).hasSize(10);
+
+        List<String> test2 = contactDao.testTwo("9");
+        assertThat(test2).hasSize(10);
+    }
+
+    public interface ContactDao {
+
+        @SqlQuery("SELECT * FROM contacts")
+        List<Contact> getAllContacts();
+
+        @SqlQuery("SELECT contact_id "
+                + " FROM contacts "
+                + " WHERE RIGHT(etag, 1) = RIGHT(:etag, 1)")
+        List<String> testOne(@Bind("etag") String etag);
+
+        @SqlQuery("SELECT contact_id"
+                + " FROM contacts "
+                + " WHERE etag LIKE \\'%<etagPattern>\\'")
+        List<String> testTwo(@Define("etagPattern") String etag);
+    }
+
+    public static class Contact {
+
+        private final int id;
+        private final String etag;
+
+        public Contact(@ColumnName("contact_id") int id, String etag) {
+            this.id = id;
+            this.etag = etag;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        public String etag() {
+            return etag;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>kotlin-sqlobject</module>
         <module>kotlin</module>
         <module>moshi</module>
+        <module>mysql</module>
         <module>postgis</module>
         <module>postgres</module>
         <module>spring5</module>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -36,7 +36,6 @@
         <basepom.test.timeout>600</basepom.test.timeout>
         <!-- Sigh. Java is really hard. Leave this at 0.3.2, all other versions are worse -->
         <dep.clickhouse.version>0.3.2</dep.clickhouse.version>
-        <dep.mysql.version>8.1.0</dep.mysql.version>
         <dep.oracle-xe.version>23.2.0.0</dep.oracle-xe.version>
         <dep.trino.version>426</dep.trino.version>
         <dep.yugabyte.version>42.3.5-yb-3</dep.yugabyte.version>
@@ -46,12 +45,6 @@
     <!-- we need tons of additional JDBC drivers in this one module. So we keep them all here. -->
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>com.mysql</groupId>
-                <artifactId>mysql-connector-j</artifactId>
-                <version>${dep.mysql.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>


### PR DESCRIPTION
Currently does not create an artifact, just runs tests.

Tests are disabled by default (because they use testcontainers which is
slow).

Run tests with `mvn -Dbasepom.test.skip=false -pl :jdbi3-mysql clean test`
