### PR TITLE
Fix transactions for non-autocommitting handles

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
   - Deprecate the `otjPostgres` support in jdbi-testing. This will be undeprecated if they ship a version that provides an automatic module name for JPMS, otherwise it will be removed when Jdbi ships with full JPMS support.
+  - Restore pre-3.41.0 behavior for handles using auto-commit == false where transactions don't need `Handle#begin()` before `Handle#commit()` (#2491, thanks @grigorem)
 
 
 # 3.41.1

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -114,7 +114,7 @@ public class Handle implements Closeable, Configurable<Handle> {
 
         // both of these methods are bad because they leak a reference to this handle before the c'tor finished.
         this.transactionHandler = transactionHandler.specialize(this);
-        this.forceEndTransactions = !transactionHandler.isInTransaction(this);
+        this.forceEndTransactions = !this.transactionHandler.isInTransaction(this);
 
         addCleanable(() ->
             statementBuilder.close(connection));

--- a/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
@@ -108,10 +108,11 @@ public class LocalTransactionHandler implements TransactionHandler {
         }
         private final Map<String, Savepoint> savepoints = new HashMap<>();
         private boolean initialAutocommit;
-        private State handlerState = State.OUTSIDE_TRANSACTION;
+        private State handlerState;
 
         BoundLocalTransactionHandler(Handle handle) throws SQLException {
             this.initialAutocommit = handle.getConnection().getAutoCommit();
+            this.handlerState = initialAutocommit ? State.OUTSIDE_TRANSACTION : State.AFTER_BEGIN;
         }
 
         @Override
@@ -253,8 +254,9 @@ public class LocalTransactionHandler implements TransactionHandler {
 
         private void restoreAutoCommitState(Handle handle) {
             try {
+                handle.getConnection().setAutoCommit(initialAutocommit);
+
                 if (initialAutocommit) {
-                    handle.getConnection().setAutoCommit(initialAutocommit);
                     savepoints.clear();
                 }
             } catch (SQLException e) {


### PR DESCRIPTION
If a handle is by default using autocommit == false, then transactions
could be commited (or rolled back) without having to call
Handle#begin() first. This broke in 3.41.1.

Restore the old behavior. Fixes #2491
