### PR TITLE
Configure slow tests with tags

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -10,8 +10,8 @@ on:
       - master
 
 jobs:
-  containers:
-    name: Run testcontainer based tests
+  slow-tests:
+    name: Run slow tests
     runs-on: ubuntu-latest
 
     strategy:
@@ -27,14 +27,14 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: build distribution
+      - name: run tests
         env:
           MAVEN_CONFIG: "-B -fae"
         run: |
           make install-fast
 
-      - name: run container tests
+      - name: run slow tests
         env:
           MAVEN_CONFIG: "-B -fae -Ddep.testcontainers.version=${{ matrix.test-version }}"
         run: |
-          make run-tests-container
+          make run-slow-tests

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 SHELL = /bin/sh
 .SUFFIXES:
-.PHONY: help clean install install-notests install-nodocker install-fast docs tests run-tests run-tests-container run-tests-nodocker publish-docs deploy release release-docs
+.PHONY: help clean install install-notests install-nodocker install-fast docs tests run-tests run-slow-tests run-tests-nodocker publish-docs deploy release release-docs
 
 MAVEN = ./mvnw ${JDBI_MAVEN_OPTS}
 
@@ -29,7 +29,7 @@ clean:
 install:
 	${MAVEN} clean install
 
-tests: install-notests run-tests
+tests: install-fast run-tests
 
 install-notests: MAVEN_CONFIG += -Dbasepom.test.skip=true
 install-notests: install
@@ -47,12 +47,11 @@ run-tests: MAVEN_CONFIG += -Dbasepom.it.skip=false
 run-tests:
 	${MAVEN} surefire:test invoker:install invoker:integration-test invoker:verify
 
-run-tests-container: MAVEN_CONFIG += -Dbasepom.test.skip=false
-run-tests-container:
-	${MAVEN} surefire:test -pl :jdbi3-testcontainers
+run-slow-tests: MAVEN_CONFIG += -Pslow-tests
+run-slow-tests: run-tests
 
 run-tests-nodocker: MAVEN_CONFIG += -Dno-docker=true
-run-tests-nodocker: tests
+run-tests-nodocker: run-tests
 
 publish-docs: MAVEN_CONFIG += -Pfast -Dbasepom.javadoc.skip=false
 publish-docs: install

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -813,6 +813,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
+                        <!-- exclude "slow" group by default -->
+                        <groups />
+                        <excludedGroups>slow</excludedGroups>
                         <systemPropertyVariables combine.children="append">
                             <pg-embedded.postgres-version>${jdbi.test.pg-version}</pg-embedded.postgres-version>
                         </systemPropertyVariables>
@@ -1143,6 +1146,22 @@
                 <skipITs>true</skipITs>
                 <skipTests>true</skipTests>
             </properties>
+        </profile>
+        <profile>
+            <!-- profile to activate slow tests. -->
+            <id>slow-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <groups>slow</groups>
+                            <excludedGroups combine.self="override" />
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -30,8 +30,6 @@
     <properties>
         <basepom.deploy.skip>true</basepom.deploy.skip>
         <basepom.install.skip>true</basepom.install.skip>
-        <!-- tests are slow, so run tests only if explictly asked for -->
-        <basepom.test.skip>true</basepom.test.skip>
         <!-- docker tests run long -->
         <basepom.test.timeout>600</basepom.test.timeout>
         <moduleName>org.jdbi.v3.mysql</moduleName>

--- a/mysql/src/test/java/org/jdbi/v3/mysql/TestMySQL.java
+++ b/mysql/src/test/java/org/jdbi/v3/mysql/TestMySQL.java
@@ -24,6 +24,7 @@ import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -35,6 +36,7 @@ import static java.lang.String.format;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Tag("slow")
 @Testcontainers
 public class TestMySQL {
 

--- a/postgis/src/test/java/org/jdbi/v3/postgis/PostgisPluginTest.java
+++ b/postgis/src/test/java/org/jdbi/v3/postgis/PostgisPluginTest.java
@@ -21,6 +21,7 @@ import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.locationtech.jts.geom.Coordinate;
@@ -36,6 +37,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Tag("slow")
 @Testcontainers
 final class PostgisPluginTest {
 

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -30,8 +30,6 @@
     <properties>
         <!-- all tests run docker containers. Run them one by one... -->
         <basepom.test.fork-count>1</basepom.test.fork-count>
-        <!-- tests are slow, so run tests only if explictly asked for -->
-        <basepom.test.skip>true</basepom.test.skip>
         <!-- docker tests run long -->
         <basepom.test.timeout>600</basepom.test.timeout>
         <!-- Sigh. Java is really hard. Leave this at 0.3.2, all other versions are worse -->

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/ClickhouseJdbiTestContainerExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/ClickhouseJdbiTestContainerExtensionTest.java
@@ -13,11 +13,13 @@
  */
 package org.jdbi.v3.testing.junit5.tc;
 
+import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.ClickHouseContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Tag("slow")
 @Testcontainers
 class ClickhouseJdbiTestContainerExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/CockroachJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/CockroachJdbiTestContainersExtensionTest.java
@@ -13,11 +13,13 @@
  */
 package org.jdbi.v3.testing.junit5.tc;
 
+import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.CockroachContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Tag("slow")
 @Testcontainers
 class CockroachJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/MySQLJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/MySQLJdbiTestContainersExtensionTest.java
@@ -14,11 +14,13 @@
 package org.jdbi.v3.testing.junit5.tc;
 
 
+import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Tag("slow")
 @Testcontainers
 class MySQLJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/OracleXeJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/OracleXeJdbiTestContainersExtensionTest.java
@@ -13,12 +13,14 @@
  */
 package org.jdbi.v3.testing.junit5.tc;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Tag("slow")
 @Testcontainers
 @EnabledOnOs(architectures = {"x86_64"})
 class OracleXeJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/PostGisJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/PostGisJdbiTestContainersExtensionTest.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.testing.junit5.tc;
 
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -21,6 +22,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+@Tag("slow")
 @Testcontainers
 @EnabledOnOs(architectures = {"x86_64"})
 class PostGisJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TiDBJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TiDBJdbiTestContainersExtensionTest.java
@@ -14,11 +14,13 @@
 package org.jdbi.v3.testing.junit5.tc;
 
 
+import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.tidb.TiDBContainer;
 
+@Tag("slow")
 @Testcontainers
 class TiDBJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TimescaleJdbiTestContainerExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TimescaleJdbiTestContainerExtensionTest.java
@@ -13,12 +13,14 @@
  */
 package org.jdbi.v3.testing.junit5.tc;
 
+import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+@Tag("slow")
 @Testcontainers
 public class TimescaleJdbiTestContainerExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TrinoJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/TrinoJdbiTestContainersExtensionTest.java
@@ -15,11 +15,13 @@ package org.jdbi.v3.testing.junit5.tc;
 
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.TrinoContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Tag("slow")
 @Testcontainers
 class TrinoJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/YugabyteJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/YugabyteJdbiTestContainersExtensionTest.java
@@ -13,12 +13,14 @@
  */
 package org.jdbi.v3.testing.junit5.tc;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.YugabyteDBYSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Tag("slow")
 @Testcontainers
 @EnabledOnOs(architectures = {"x86_64"})
 class YugabyteJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {

--- a/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtendWithTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtendWithTest.java
@@ -15,11 +15,13 @@ package org.jdbi.v3.testing.junit5;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Tag("slow")
 @ExtendWith(JdbiOtjPostgresExtension.class)
 public class JdbiOtjPostgresExtendWithTest {
 

--- a/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtensionTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiOtjPostgresExtensionTest.java
@@ -13,11 +13,13 @@
  */
 package org.jdbi.v3.testing.junit5;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Tag("slow")
 public class JdbiOtjPostgresExtensionTest {
 
     @RegisterExtension


### PR DESCRIPTION
Move the container tests under a "slow" tag and activate only in
CI.
