### PR TITLE
Clarify primitive value coalescing

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/ColumnMappers.java
@@ -227,9 +227,9 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
     }
 
     /**
-     * Returns true if database {@code null} values should be transformed to the default value for primitives.
+     * Returns true if database {@code NULL} values should be transformed to the default value for primitives.
      *
-     * @return {@code true} if database {@code null}s should translate to the Java defaults for primitives, or throw an exception otherwise.
+     * @return {@code true} if database {@code NULL}s should translate to the JDBC defaults for primitives, or throw an exception otherwise.
      *
      * Default value is true: nulls will be coalesced to defaults.
      */
@@ -237,6 +237,12 @@ public class ColumnMappers implements JdbiConfig<ColumnMappers> {
         return coalesceNullPrimitivesToDefaults;
     }
 
+    /**
+     * Use the JDBC default value for primitive types if a SQL NULL value was returned by the database.
+     * If this property is set to {@code false}, Jdbi will throw an exception when trying to map a SQL {@code NULL} value to a primitive type.
+     *
+     * @param coalesceNullPrimitivesToDefaults If true, then use the JDBC default value, otherwise throw an exception.
+     */
     public void setCoalesceNullPrimitivesToDefaults(boolean coalesceNullPrimitivesToDefaults) {
         this.coalesceNullPrimitivesToDefaults = coalesceNullPrimitivesToDefaults;
     }

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2095,7 +2095,7 @@ All Java primitive types have default mappings to their corresponding JDBC types
 Generally, Jdbi will automatically perform boxing and unboxing as appropriate when
 it encounters wrapper types.
 
-By default, SQL `null` mapped to a primitive type will adopt the Java default value.
+By default, SQL `null` mapped to a primitive type will adopt the JDBC default value.
 This may be disabled by configuring
 `jdbi.getConfig(ColumnMappers.class).setCoalesceNullPrimitivesToDefaults(false)`.
 
@@ -3304,7 +3304,7 @@ See <<JdbiConfig>> for more advanced implementation details.
 
 | link:{jdbidocs}/core/mapper/ColumnMappers.html[ColumnMappers^] | coalesceNullPrimitivesToDefaults
     | boolean  | `true`
-    | Uses the driver default value for primitive types if a SQL NULL value was returned by the database. The exact value used is specific to the database driver.
+    | Uses the JDBC default value for primitive types if a SQL NULL value was returned by the database.
 
 | link:{jdbidocs}/core/enums/Enums.html[Enums^] | enumStrategy
     | link:{jdbidocs}/core/enums/EnumStrategy.html[EnumStrategy^] | `BY_NAME`


### PR DESCRIPTION
Add missing javadoc for setter, reword docs to state that the default
is the JDBC default value, not some driver value.

Clarifies #2477
