### PR TITLE
Silence Java 21 warnings

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/mapper/FreeBuildersTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/FreeBuildersTest.java
@@ -163,6 +163,7 @@ public class FreeBuildersTest {
 
     @FreeBuilder
     public interface ByteArray {
+        @SuppressWarnings("mutable")
         byte[] value();
 
         class Builder extends FreeBuildersTest_ByteArray_Builder {}

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -875,6 +875,31 @@
 
     <profiles>
         <profile>
+            <id>java21</id>
+            <activation>
+                <jdk>[21,)</jdk>
+            </activation>
+            <properties>
+                <!-- see https://github.com/mockito/mockito/issues/3037 -->
+                <basepom.it.arguments>-XX:+EnableDynamicAgentLoading</basepom.it.arguments>
+                <basepom.test.arguments>-XX:+EnableDynamicAgentLoading</basepom.test.arguments>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <!-- see https://inside.java/2023/07/29/quality-heads-up/ -->
+                                <proc>full</proc>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
             <id>jdbi.jpms-auto-module</id>
             <activation>
                 <property>


### PR DESCRIPTION
- warning about annotation processing without `-proc:full`
- warning about dynamic byte code agent loading (fix is only temporary,
  JDK 23 will most likely permanently disable dynamic byte code loading
