### PR TITLE
Refactor HandleSupplier management

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handles.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handles.java
@@ -42,7 +42,7 @@ public class Handles implements JdbiConfig<Handles> {
      * {@link Handle} is closed. This check is enabled by default. If enabled,
      * and a handle is closed while a transaction is active (i.e. not committed
      * or rolled back), an exception will be thrown.
-     *
+     * <br>
      * This check does not apply to handles allocated with a connection that
      * already has an open transaction.
      *

--- a/core/src/main/java/org/jdbi/v3/core/internal/HandleScope.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/HandleScope.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.internal;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.extension.HandleSupplier;
+
+/**
+ * Jdbi manages Handles to allow transaction nesting and extension
+ * objects to share the same handle as long as they are within a specific scope.
+ * <br>
+ * The default scope is "per thread", which is managed by the default implementation
+ * of this interface.
+ * <br>
+ * It is possible to provide a different implementation by calling {@link Jdbi#setHandleScope(HandleScope)}
+ * to support e.g. structured concurrency in modern Java or Kotlin coroutines.
+ */
+public interface HandleScope {
+
+    static HandleScope threadLocal() {
+        return new ThreadLocalHandleScope();
+    }
+
+    /**
+     * Returns a {@link HandleSupplier} that provides a {@link org.jdbi.v3.core.Handle} in the given context.
+     * @return A handle object or null.
+     */
+    HandleSupplier get();
+
+    /**
+     * Associate a {@link HandleSupplier} with the current scope.
+     * @param handleSupplier A {@link HandleSupplier} object. Must not be null.
+     */
+    void set(HandleSupplier handleSupplier);
+
+    /**
+     * Remove a current {@link HandleSupplier association}. The {@link #get()} method will
+     * return {@code null} after calling this method.
+     */
+    void clear();
+}

--- a/core/src/main/java/org/jdbi/v3/core/internal/ThreadLocalHandleScope.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/ThreadLocalHandleScope.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.internal;
+
+import org.jdbi.v3.core.extension.HandleSupplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The default implementation for {@link HandleScope}. Uses a {@link ThreadLocal} to manage per-thread scope.
+ */
+public class ThreadLocalHandleScope implements HandleScope {
+
+    protected final ThreadLocal<HandleSupplier> threadLocal = new ThreadLocal<>();
+
+    @Override
+    public HandleSupplier get() {
+        return threadLocal.get();
+    }
+
+    @Override
+    public void set(HandleSupplier handleSupplier) {
+        requireNonNull(handleSupplier, "handleSupplier is null");
+        threadLocal.set(handleSupplier);
+    }
+
+    @Override
+    public void clear() {
+        threadLocal.remove();
+    }
+}


### PR DESCRIPTION
Pull the thread local into a pluggable object. This will open the path
to more sophisticated ways of managing handles across different execution
paths than just "by thread". This is most interesting right now for Kotlin
coroutines but also future structured concurrency will benefit from this.

This is a core piece of Jdbi, so basically every test checks whether this
change breaks anything. So there are no explicit tests.
