### PR TITLE
Kotlin coroutine support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 - Move from Kotlin 1.5 to 1.6 as 1.5 is deprecated and will be removed.
 - Add support for Function arguments, similar to Consumer arguments, to SQL objects (#2326)
 - Fix kotlin deprecation warnings (#2511) - Thanks @lwach-allegro for contributing a PR
+- Support Kotlin coroutine scope. (#2524) - Suggested by @anderssv on the mailing list
 
 # 3.41.3
 - Fix regression introduced by #2481 where `-` at the end of named parameters get swallowed. (#2499, thanks @gokristian for reporting).

--- a/core/src/main/java/org/jdbi/v3/core/HandleScope.java
+++ b/core/src/main/java/org/jdbi/v3/core/HandleScope.java
@@ -11,10 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.internal;
+package org.jdbi.v3.core;
 
-import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.extension.HandleSupplier;
+import org.jdbi.v3.core.internal.ThreadLocalHandleScope;
 
 /**
  * Jdbi manages Handles to allow transaction nesting and extension
@@ -43,6 +43,14 @@ public interface HandleScope {
      * @param handleSupplier A {@link HandleSupplier} object. Must not be null.
      */
     void set(HandleSupplier handleSupplier);
+
+    /**
+     * Associate a {@link Handle} with the current scope.
+     * @param handle A {@link Handle} object. Must not be null.
+     */
+    default void set(Handle handle) {
+        set(ConstantHandleSupplier.of(handle));
+    }
 
     /**
      * Remove a current {@link HandleSupplier association}. The {@link #get()} method will

--- a/core/src/main/java/org/jdbi/v3/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/v3/core/Jdbi.java
@@ -32,7 +32,6 @@ import org.jdbi.v3.core.extension.ExtensionFactory;
 import org.jdbi.v3.core.extension.Extensions;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.extension.NoSuchExtensionException;
-import org.jdbi.v3.core.internal.HandleScope;
 import org.jdbi.v3.core.internal.OnDemandExtensions;
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 import org.jdbi.v3.core.spi.JdbiPlugin;

--- a/core/src/main/java/org/jdbi/v3/core/internal/ThreadLocalHandleScope.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/ThreadLocalHandleScope.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.core.internal;
 
+import org.jdbi.v3.core.HandleScope;
 import org.jdbi.v3.core.extension.HandleSupplier;
 
 import static java.util.Objects.requireNonNull;
@@ -20,9 +21,9 @@ import static java.util.Objects.requireNonNull;
 /**
  * The default implementation for {@link HandleScope}. Uses a {@link ThreadLocal} to manage per-thread scope.
  */
-public class ThreadLocalHandleScope implements HandleScope {
+public final class ThreadLocalHandleScope implements HandleScope {
 
-    protected final ThreadLocal<HandleSupplier> threadLocal = new ThreadLocal<>();
+    private final ThreadLocal<HandleSupplier> threadLocal = new ThreadLocal<>();
 
     @Override
     public HandleSupplier get() {

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -15,7 +15,8 @@
 :docinfo: private
 
 :jdbidocs: ./apidocs/org/jdbi/v3
-:jdkdocs: https://docs.oracle.com/javase/8/docs/api
+:kotlindocs: ./apidocs-kotlin/jdbi3-kotlin/jdbi3-kotlin/org.jdbi.v3.
+:jdkdocs: https://docs.oracle.com/javase/11/docs/api
 :jakartadocs: https://jakarta.ee/specifications/platform/10/apidocs
 
 :projecthome: https://github.com/jdbi/jdbi
@@ -6989,7 +6990,7 @@ Ensure the Kotlin compiler's https://kotlinlang.org/docs/reference/using-maven.h
 <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
 ----
 
-Then install the plugin into the link:{jdbidocs}/core/Jdbi.html[Jdbi^] instance:
+Then install the link:{kotlindocs}core.kotlin/-kotlin-plugin/[Kotlin Plugin^] into the link:{jdbidocs}/core/Jdbi.html[Jdbi^] instance:
 
 [source,kotlin]
 ----
@@ -7036,6 +7037,99 @@ and for using a Sequence that is auto closed:
 ----
 qryAll.mapTo<Thing>.useSequence {
     it.forEach(::println)
+}
+----
+
+==== Coroutine support
+
+[NOTE]
+Coroutine support is very much experimental and not yet proven. If you find a bug or see a problem, please file a https://github.com/jdbi/jdbi/issues[bug report].
+
+Kotlin offers a https://kotlinlang.org/docs/coroutines-overview.html[coroutine extension^] to support asynchronous programming on the Kotlin platform.
+
+Coroutines work similar to "green threads" where operations are mapped onto a thread pool and may be executed on multiple threads. This clashes with the internal model that Jdbi uses to manage Handles (which is by default local to each thread).
+
+The Kotlin module offers support for coroutines with Jdbi. It allows handles to move across thread boundaries and
+allows seamless use of handles in coroutines.
+
+Coroutine support is disabled by default and is activated by passing the `enableCoroutineSupport = true` property to the constructor of the link:{kotlindocs}core.kotlin/-kotlin-plugin/[Kotlin Plugin^].
+
+[source,kotlin]
+----
+val jdbi = Jdbi.create( ... )
+    .installPlugin(KotlinPlugin(enableCoroutineSupport = true))
+
+jdbi.inTransactionUnchecked { transactionHandle ->
+    runBlocking(jdbi.inCoroutineContext()) { <1>
+        withContext(Dispatchers.Default + jdbi.inCoroutineContext(transactionHandle)) { <2>
+            launch () {
+                jdbi.useHandleUnchecked { handle -> <3>
+                    ...
+                }
+            }
+        }
+
+        launch(Dispatchers.Default) { <4>
+            jdbi.useHandleUnchecked { handle -> <5>
+                ...
+            }
+        }
+    }
+}
+----
+
+<1> calling the link:{kotlindocs}core.kotlin/in-coroutine-context.html[Jdbi#inCoroutineContext()^] extension method without a parameter disconnects the coroutine scope from any existing thread local elements.
+<2> calling the link:{kotlindocs}core.kotlin/in-coroutine-context.html[Jdbi#inCoroutineContext()^] extension method with a handle object uses this handle for all coroutines in this scope.
+<3> calling Jdbi methods within the coroutine scope will use the handle that was provided above.
+<4> Launching a coroutine without an explicitly attached handle works as well, in this case, a new handle gets created
+<5> The handle here is a newly created handle that only exists within the jdbi callback.
+
+[WARNING]
+Coroutines that are executed in parallel by different threads at the same time will get the same handle as they share the same coroutine context. While the Handle object can be shared by multiple threads (if the underlying connection object supports it), they are designed
+to be used by "one thread at a time" so additional coordination is required in this case.
+
+Coroutines are also supported for extension objects such as the <<SQL Objects, SQL Object extension>>:
+
+[source,kotlin]
+----
+val jdbi = Jdbi.create( ... )
+    .installPlugin(KotlinPlugin(enableCoroutineSupport = true))
+    .installPlugin(SqlObjectPlugin())
+
+data class Something(
+    val id: Int,
+    val name: String
+)
+
+@RegisterKotlinMapper(Something::class)
+interface SomethingDao : SqlObject {
+    @SqlUpdate("insert into something (id, name) values (:id, :name)")
+    fun insert(@BindKotlin something: Something)
+
+    @SqlQuery("select id, name from something where id=:id")
+    fun findById(@Bind("id") id: Int): Something
+}
+
+jdbi.withExtensionUnchecked(SomethingDao::class) { dao ->
+    runBlocking(Dispatchers.IO + jdbi.inCoroutineContext()) {
+        coroutineScope {
+            insertSomething(dao)
+
+            val first = selectSomething(dao, 1)
+            delay(1000L)
+        }
+
+        val second = selectSomething(dao, 2)
+    }
+}
+
+private suspend fun insertSomething(dao: SomethingDao): Unit = coroutineScope {
+    dao.insert(Something(1, "first name"))
+    dao.insert(Something(2, "second name"))
+}
+
+private suspend fun selectSomething(dao: SomethingDao, id: Int): Something = coroutineScope {
+    dao.findById(id)
 }
 ----
 

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -102,6 +102,7 @@
         <dep.jts.version>1.19.0</dep.jts.version>
         <dep.junit5.version>5.10.0</dep.junit5.version>
         <dep.kotlin.version>1.6.21</dep.kotlin.version>
+        <dep.kotlinx-coroutines.version>1.6.4</dep.kotlinx-coroutines.version>
         <dep.lombok.version>1.18.30</dep.lombok.version>
         <dep.mockito.version>5.6.0</dep.mockito.version>
         <dep.moshi.version>1.15.0</dep.moshi.version>
@@ -412,6 +413,12 @@
 
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>${dep.kotlin.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-common</artifactId>
                 <version>${dep.kotlin.version}</version>
             </dependency>
@@ -432,6 +439,12 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-test-junit5</artifactId>
                 <version>${dep.kotlin.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+                <version>${dep.kotlinx-coroutines.version}</version>
             </dependency>
 
             <dependency>
@@ -1094,6 +1107,11 @@
                         <groupId>org.jetbrains.kotlin</groupId>
                         <artifactId>kotlin-maven-plugin</artifactId>
                         <extensions>true</extensions>
+                        <configuration>
+                            <args>
+                                <arg>-opt-in=kotlin.RequiresOptIn</arg>
+                            </args>
+                        </configuration>
                     </plugin>
 
                     <plugin>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -62,6 +62,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>
             <scope>test</scope>

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/v3/sqlobject/kotlin/CoroutineSqlObjectTest.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/v3/sqlobject/kotlin/CoroutineSqlObjectTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject.kotlin
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.kotlin.KotlinPlugin
+import org.jdbi.v3.core.kotlin.withExtensionUnchecked
+import org.jdbi.v3.sqlobject.SqlObject
+import org.jdbi.v3.sqlobject.SqlObjectPlugin
+import org.jdbi.v3.sqlobject.customizer.Bind
+import org.jdbi.v3.sqlobject.statement.SqlQuery
+import org.jdbi.v3.sqlobject.statement.SqlUpdate
+import org.jdbi.v3.testing.junit5.JdbiExtension
+import org.jdbi.v3.testing.junit5.internal.TestingInitializers
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class CoroutineSqlObjectTest {
+
+    @RegisterExtension
+    @JvmField
+    val h2Extension: JdbiExtension = JdbiExtension.h2()
+        .withPlugin(KotlinPlugin(enableCoroutineSupport = true))
+        .withPlugin(SqlObjectPlugin())
+        .withInitializer(TestingInitializers.something())
+
+    private lateinit var jdbi: Jdbi
+
+    @BeforeEach
+    fun setup() {
+        jdbi = h2Extension.jdbi
+    }
+
+    data class Something(
+        val id: Int,
+        val name: String
+    )
+
+    @RegisterKotlinMapper(Something::class)
+    interface SomethingDao : SqlObject {
+        @SqlUpdate("insert into something (id, name) values (:id, :name)")
+        fun insert(@BindKotlin something: Something)
+
+        @SqlQuery("select id, name from something where id=:id")
+        fun findById(@Bind("id") id: Int): Something
+
+        @SqlQuery("select id, name from something")
+        fun list(): List<Something>
+    }
+
+    @Test
+    fun testTransactionIODispatcher() {
+        jdbi.withExtensionUnchecked(SomethingDao::class) { dao ->
+            val origHandle = dao.handle
+
+            val handle1: Handle?
+            val handle2: Handle?
+            val handle3: Handle?
+
+            runBlocking(Dispatchers.IO) {
+                coroutineScope {
+                    // all Jdbi operations will map onto the attached handle in this coroutine context
+                    handle1 = insertSomething(dao)
+
+                    handle2 = selectSomething(dao, 1, "first name")
+                    delay(1000L)
+                }
+
+                handle3 = selectSomething(dao, 2, "second name")
+            }
+
+            assertThat(origHandle).isSameAs(handle1).isSameAs(handle2).isSameAs(handle3)
+        }
+    }
+
+    @Test
+    fun testAsyncCoroutines() {
+        jdbi.withExtensionUnchecked(SomethingDao::class) { dao ->
+            val origHandle = dao.handle
+
+            dao.insert(Something(1, "first name"))
+            dao.insert(Something(2, "second name"))
+
+            runBlocking {
+                // run on separate threads, do not share handle
+                val first = async { selectSomething(dao, 1, "first name") }
+                val second = async {
+                    delay(1000L)
+                    selectSomething(dao, 2, "second name")
+                }
+
+                val firstHandle = first.await()
+                val secondHandle = second.await()
+
+                // and the threads do not share the handle, so they need to be different as well
+                assertThat(origHandle).isSameAs(firstHandle).isSameAs(secondHandle)
+            }
+        }
+    }
+
+    private suspend fun insertSomething(dao: SomethingDao) = coroutineScope {
+        dao.insert(Something(1, "first name"))
+        dao.insert(Something(2, "second name"))
+        dao.handle
+    }
+
+    private suspend fun selectSomething(dao: SomethingDao, id: Int, expected: String): Handle = coroutineScope {
+        val result = dao.findById(id)
+        assertThat(result.name).isEqualTo(expected)
+        dao.handle
+    }
+}

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -39,6 +39,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit5</artifactId>
             <scope>test</scope>

--- a/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/CoroutineHandleScope.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/CoroutineHandleScope.kt
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.kotlin
+
+import kotlinx.coroutines.CopyableThreadContextElement
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.HandleScope
+import org.jdbi.v3.core.extension.HandleSupplier
+import org.jdbi.v3.core.internal.ThreadLocalHandleScope
+import kotlin.coroutines.CoroutineContext
+
+@OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+internal class CoroutineHandleScope private constructor(
+    var handle: Handle?,
+    private val delegate: HandleScope
+) : CopyableThreadContextElement<HandleSupplier?>, HandleScope {
+
+    override val key: CoroutineContext.Key<CoroutineHandleScope> = Key
+
+    constructor() : this(handle = null, delegate = ThreadLocalHandleScope())
+
+    override fun updateThreadContext(context: CoroutineContext): HandleSupplier? {
+        val oldState: HandleSupplier? = delegate.get()
+
+        // if a handle was set, use that handle instead of the current (which comes
+        // out of the thread local). Otherwise clear out the state (coroutine then
+        // creates a new handle)
+        if (handle == null) {
+            delegate.clear()
+        } else {
+            delegate.set(handle)
+        }
+        return oldState
+    }
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: HandleSupplier?) {
+        if (oldState == null) {
+            delegate.clear()
+        } else {
+            delegate.set(oldState)
+        }
+    }
+
+    override fun copyForChild(): CoroutineHandleScope = copy()
+    // Copy from the ThreadLocal source of truth at child coroutine launch time. This makes
+    // ThreadLocal writes between resumption of the parent coroutine and the launch of the
+    // child coroutine visible to the child.
+
+    override fun mergeForChild(overwritingElement: CoroutineContext.Element): CoroutineContext {
+        // Merge operation defines how to handle situations when both
+        // the parent coroutine has an element in the context and
+        // an element with the same key was also
+        // explicitly passed to the child coroutine.
+        // If merging does not require special behavior,
+        // the copy of the element can be returned.
+        return if (overwritingElement is CoroutineHandleScope) {
+            overwritingElement.copy()
+        } else {
+            this
+        }
+    }
+
+    private fun copy(): CoroutineHandleScope = CoroutineHandleScope(handle = handle, delegate = delegate)
+
+    override fun get(): HandleSupplier? = delegate.get()
+
+    override fun set(handleSupplier: HandleSupplier?) {
+        delegate.set(handleSupplier)
+    }
+
+    override fun clear() {
+        delegate.clear()
+    }
+
+    companion object Key : CoroutineContext.Key<CoroutineHandleScope>
+}

--- a/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinPlugin.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/v3/core/kotlin/KotlinPlugin.kt
@@ -23,11 +23,16 @@ import org.jdbi.v3.core.spi.JdbiPlugin
  * <ul>
  *     <li>Kotlin inference interceptor that handles the {@link KotlinMapper} for registered types</li>
  *     <li>Kotlin mapper factory that creates implicit mappers for any data class</li>
+ *     <li>Support for using Handles in Coroutines</li>
  * <ul>
  *
  *     @property installKotlinMapperFactory If true, install the {@link KotlinMapperFactory}.
+ *     @property enableCoroutineSupport If true, enable support for Kotlin Coroutines.
  */
-class KotlinPlugin(private val installKotlinMapperFactory: Boolean = true) : JdbiPlugin.Singleton() {
+class KotlinPlugin(
+    private val installKotlinMapperFactory: Boolean = true,
+    private val enableCoroutineSupport: Boolean = false
+) : JdbiPlugin.Singleton() {
 
     override fun customizeJdbi(jdbi: Jdbi) {
         jdbi.configure(RowMappers::class.java) {
@@ -36,6 +41,15 @@ class KotlinPlugin(private val installKotlinMapperFactory: Boolean = true) : Jdb
 
         if (installKotlinMapperFactory) {
             jdbi.registerRowMapper(KotlinMapperFactory())
+        }
+
+        // install a special handle supplier holder that can deal with coroutines.
+        //
+        // Note that this needs to be revisited in the future if we move from the ThreadLocal in Jdbi
+        // to e.g. structured concurrency. Right now, this store exposes out the thread local to the
+        // Kotlin coroutine machinery which in turn manages the thread local for us.
+        if (enableCoroutineSupport) {
+            jdbi.handleScope = CoroutineHandleScope()
         }
     }
 }

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/CoroutineContextTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/CoroutineContextTest.kt
@@ -1,0 +1,243 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.kotlin
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.testing.junit5.JdbiExtension
+import org.jdbi.v3.testing.junit5.internal.TestingInitializers
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class CoroutineContextTest {
+
+    @RegisterExtension
+    @JvmField
+    val h2Extension: JdbiExtension = JdbiExtension.h2().withPlugin(KotlinPlugin(enableCoroutineSupport = true))
+        .withInitializer(TestingInitializers.something())
+
+    private lateinit var jdbi: Jdbi
+
+    @BeforeEach
+    fun setup() {
+        jdbi = h2Extension.jdbi
+    }
+
+    @Test
+    fun testTransactionIODispatcher() {
+        jdbi.inTransactionUnchecked { transactionHandle ->
+            // empty attach clears out a possible handle in the current thread
+            runBlocking(Dispatchers.IO + jdbi.inCoroutineContext()) {
+                // empty attachToContext cleaned out the thread local
+                assertThat(coroutineContext[CoroutineHandleScope.Key]?.handle).isNull()
+                withContext(jdbi.inCoroutineContext(transactionHandle)) {
+                    assertThat(coroutineContext[CoroutineHandleScope.Key]?.handle).isSameAs(transactionHandle)
+
+                    // all Jdbi operations will map onto the attached handle in this coroutine context
+                    val handle1 = insertSomething()
+                    assertThat(handle1).isSameAs(transactionHandle)
+
+                    val handle2 = countSomething(1, "Could not find result in transaction")
+                    assertThat(handle2).isSameAs(transactionHandle)
+
+                    delay(1000L)
+                    transactionHandle.rollback()
+                }
+
+                val handle3 = countSomething(0, "Could not find result outside transaction")
+                assertThat(handle3).isNotSameAs(transactionHandle)
+            }
+        }
+    }
+
+    @Test
+    fun testTransactionDefaultDispatcher() {
+        jdbi.inTransactionUnchecked { transactionHandle ->
+            // empty attach clears out a possible handle in the current thread
+            runBlocking(jdbi.inCoroutineContext()) {
+                // empty attachToContext cleaned out the thread local
+                assertThat(coroutineContext[CoroutineHandleScope.Key]?.handle).isNull()
+
+                withContext(Dispatchers.Default + jdbi.inCoroutineContext(transactionHandle)) {
+                    // all Jdbi operations will map onto the attached handle in this coroutine context
+                    assertThat(coroutineContext[CoroutineHandleScope.Key]?.handle).isSameAs(transactionHandle)
+
+                    val handle1 = insertSomething()
+                    assertThat(handle1).isSameAs(transactionHandle)
+
+                    val handle2 = countSomething(1, "Could not find result in transaction")
+                    assertThat(handle2).isSameAs(transactionHandle)
+
+                    delay(1000L)
+                    transactionHandle.rollback()
+                }
+
+                // no handle attached
+                val handle3 = countSomething(0, "Could not find result outside transaction")
+                assertThat(handle3).isNotSameAs(transactionHandle)
+            }
+        }
+    }
+
+    private suspend fun insertSomething() = coroutineScope {
+        jdbi.withHandleUnchecked { h ->
+            h.execute("INSERT INTO something(id, name) VALUES(1, 'first name')")
+            h
+        }
+    }
+
+    private suspend fun countSomething(expected: Int, msg: String): Handle = coroutineScope {
+        jdbi.withHandleUnchecked { h ->
+            val count = h.createQuery("SELECT COUNT(*) as count FROM something").mapTo(Int::class).single()
+            assertThat(count).withFailMessage(msg).isEqualTo(expected)
+            h
+        }
+    }
+
+    @Test
+    fun testAsyncCoroutines() {
+        with(h2Extension.sharedHandle) {
+            execute("INSERT INTO something(id, name) VALUES(1, 'first name')")
+            execute("INSERT INTO something(id, name) VALUES(2, 'second name')")
+        }
+
+        runBlocking(jdbi.inCoroutineContext()) {
+            assertThat(coroutineContext[CoroutineHandleScope.Key]?.handle).isNull()
+
+            // run on separate threads, do not share handle
+            val first = async { selectSomething(1, "first name") }
+            val second = async {
+                delay(1000L)
+                selectSomething(2, "second name")
+            }
+
+            val firstHandle = first.await()
+            val secondHandle = second.await()
+
+            // and the threads do not share the handle, so they need to be different as well
+            assertThat(firstHandle).isNotSameAs(secondHandle)
+        }
+    }
+
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testSingleThreadedCoroutines() {
+        with(h2Extension.sharedHandle) {
+            execute("INSERT INTO something(id, name) VALUES(1, 'first name')")
+            execute("INSERT INTO something(id, name) VALUES(2, 'second name')")
+        }
+
+        newSingleThreadContext("test-dispatcher").use { dispatcher ->
+            runBlocking(dispatcher + jdbi.inCoroutineContext()) {
+                assertThat(coroutineContext[CoroutineHandleScope.Key]?.handle).isNull()
+
+                // run on the same thread, but do not share handle
+                val handle1 = selectSomething(1, "first name")
+                val handle2 = selectSomething(2, "second name")
+
+                // but they do not share the handle
+                assertThat(handle1).isNotSameAs(handle2)
+            }
+        }
+    }
+
+    @Test
+    fun testCoroutinesWithSharedHandle() {
+        with(h2Extension.sharedHandle) {
+            execute("INSERT INTO something(id, name) VALUES(1, 'first name')")
+            execute("INSERT INTO something(id, name) VALUES(2, 'second name')")
+        }
+
+        runBlocking(Dispatchers.IO + jdbi.inCoroutineContext(h2Extension.sharedHandle)) {
+            assertThat(coroutineContext[CoroutineHandleScope.Key]?.handle).isSameAs(h2Extension.sharedHandle)
+
+            val handle1 = selectSomething(1, "first name")
+            val handle2 = selectSomething(2, "second name")
+
+            assertThat(handle1).isSameAs(handle2)
+            assertThat(handle1).isSameAs(h2Extension.sharedHandle)
+        }
+    }
+
+    @Test
+    fun testAsyncCoroutinesWithSharedHandle() {
+        with(h2Extension.sharedHandle) {
+            execute("INSERT INTO something(id, name) VALUES(1, 'first name')")
+            execute("INSERT INTO something(id, name) VALUES(2, 'second name')")
+        }
+
+        runBlocking(jdbi.inCoroutineContext(h2Extension.sharedHandle)) {
+            assertThat(coroutineContext[CoroutineHandleScope.Key]?.handle).isSameAs(h2Extension.sharedHandle)
+
+            // run on separate threads, do not share handle
+            val first = async { selectSomething(1, "first name") }
+            val second = async {
+                delay(1000L)
+                selectSomething(2, "second name")
+            }
+
+            val firstHandle = first.await()
+            val secondHandle = second.await()
+
+            assertThat(firstHandle).isSameAs(secondHandle)
+            assertThat(firstHandle).isSameAs(h2Extension.sharedHandle)
+        }
+    }
+
+    @Test
+    fun testFlow() {
+        with(h2Extension.sharedHandle) {
+            execute("INSERT INTO something(id, name) VALUES(1, 'first name')")
+            execute("INSERT INTO something(id, name) VALUES(2, 'second name')")
+            execute("INSERT INTO something(id, name) VALUES(3, 'third name')")
+        }
+
+        runBlocking(Dispatchers.IO + jdbi.inCoroutineContext(h2Extension.sharedHandle)) {
+            assertThat(coroutineContext[CoroutineHandleScope.Key]?.handle).isSameAs(h2Extension.sharedHandle)
+
+            // collect all results from a flow asynchronously and ensure that
+            // all operations use the same handle
+            fetchFlow().collect { value -> assertThat(value).isSameAs(h2Extension.sharedHandle) }
+        }
+    }
+
+    private fun fetchFlow(): Flow<Handle> = flow {
+        emit(selectSomething(1, "first name"))
+        emit(selectSomething(2, "second name"))
+        emit(selectSomething(3, "third name"))
+    }
+
+    private suspend fun selectSomething(id: Int, expected: String): Handle = coroutineScope {
+        jdbi.withHandleUnchecked { h ->
+            val name = h.createQuery("SELECT name FROM something WHERE id = :id")
+                .bind("id", id)
+                .mapTo(String::class)
+                .single()
+            assertThat(name).isEqualTo(expected)
+            h
+        }
+    }
+}


### PR DESCRIPTION
Support Kotlin coroutines

Allows using Jdbi objects (handles and extension objects) with kotlin coroutines. Objects can be shared between coroutines (even across threads) as long as the caller can guarantee that not multiple coroutines use them at the same time.