### PR TITLE
Fix JUnit 4 slow test skipping

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -822,7 +822,8 @@
                     <configuration>
                         <!-- exclude "slow" group by default -->
                         <groups />
-                        <excludedGroups>slow</excludedGroups>
+                        <!-- junit 4 and 5 -->
+                        <excludedGroups>slow,org.jdbi.v3.testing.SlowTests</excludedGroups>
                         <systemPropertyVariables combine.children="append">
                             <pg-embedded.postgres-version>${jdbi.test.pg-version}</pg-embedded.postgres-version>
                         </systemPropertyVariables>
@@ -1188,7 +1189,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <groups>slow</groups>
                             <excludedGroups combine.self="override" />
                         </configuration>
                     </plugin>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -93,6 +93,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
             <scope>test</scope>

--- a/testing/src/test/java/org/jdbi/v3/testing/JdbiRuleTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/JdbiRuleTest.java
@@ -19,11 +19,13 @@ import javax.sql.DataSource;
 
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(SlowTests.class)
 public class JdbiRuleTest {
     @Test
     public void migrateWithFlywayDefaultLocation() throws Throwable {

--- a/testing/src/test/java/org/jdbi/v3/testing/SlowTests.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/SlowTests.java
@@ -13,21 +13,4 @@
  */
 package org.jdbi.v3.testing;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-@Category(SlowTests.class)
-public class JdbiRulePostgresTest {
-    @Rule
-    public JdbiRule postgres = JdbiRule.embeddedPostgres();
-
-    @Test
-    public void isAlive() {
-        Integer one = postgres.getJdbi().withHandle(h -> h.createQuery("select 1").mapTo(Integer.class).one());
-
-        assertThat(one).isOne();
-    }
-}
+public interface SlowTests {}


### PR DESCRIPTION
Turn off the final few "I need to get docker going" tests in the testing module
