### PR TITLE
docs: exclude aopalliance jars from guice dep

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -80,6 +80,12 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-guice</artifactId>
+            <exclusions>
+              <exclusion>
+                <groupId>aopalliance</groupId>
+                <artifactId>aopalliance</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>


### PR DESCRIPTION
this conflicts with spring-aop, which is coming in from #2528
we don't need these annotations in the docs either way.