### PR TITLE
Fix flaky tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-java@v3
         id: build_jdk
         with:
-          java-version: 17
+          java-version: 21
           distribution: ${{ matrix.distribution }}
           cache: maven
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
     branches:
       - master
 
-env:
-  tarFile: "output-${{ github.job }}-${{ github.run_number }}-${{ github.run_attempt }}.tar.gz"
-
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -62,22 +59,3 @@ jobs:
           MAVEN_CONFIG: "-B -fae"
         run: |
           make run-tests
-
-      - name: Package
-        if: failure()
-        run: |
-          FOLDER=$(basename `pwd`)
-          cd ..
-          tar czf ${{ runner.temp }}/${{ env.tarFile }} --exclude=.git $FOLDER
-          mv ${{ runner.temp }}/${{ env.tarFile }} ${{ github.workspace }}
-
-      - uses: keithweaver/aws-s3-github-action@v1.0.0
-        name: Upload
-        if: failure()
-        with:
-          command: cp
-          source: ${{ github.workspace }}/${{ env.tarFile }}
-          destination: s3://github-action-error-logs/${{ github.repository }}/${{ env.tarFile }}
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-east-1

--- a/core/src/test/java/org/jdbi/v3/core/cache/DeadlockTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/cache/DeadlockTest.java
@@ -16,7 +16,6 @@ package org.jdbi.v3.core.cache;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -54,8 +53,8 @@ class DeadlockTest {
             jdbi.useHandle(h -> {
                 try (Update u = h.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")) {
                     u.bind("id", id)
-                        .bind("name", "name_" + id)
-                        .execute();
+                            .bind("name", "name_" + id)
+                            .execute();
                 }
             });
         }
@@ -65,28 +64,22 @@ class DeadlockTest {
     void testIssue2274() throws Exception {
         jdbi.getConfig(SqlStatements.class).setTemplateCache(DefaultJdbiCacheBuilder.builder().maxSize(10));
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT,
-            new ThreadFactoryBuilder().setNameFormat("test-%d").setDaemon(true).build());
-
-        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+                new ThreadFactoryBuilder().setNameFormat("test-%d").setDaemon(true).build());
 
         List<Future<Integer>> futures = new ArrayList<>();
         for (int i = 0; i < THREAD_COUNT; i++) {
             final int id = i;
             Callable<Integer> c = () -> {
-                int result = jdbi.withHandle(h -> {
+                return jdbi.withHandle(h -> {
                     try (Query q = h.createQuery(format("SELECT <value> FROM something where %d = :id AND id = :id", id))) {
                         q.bind("id", id);
                         q.define("value", id);
                         return q.mapTo(Integer.class).one();
                     }
                 });
-                latch.countDown();
-                latch.await();
-                return result;
             };
             futures.add(executorService.submit(c));
         }
-        latch.await();
 
         for (int i = 0; i < THREAD_COUNT; i++) {
             assertThat(futures.get(i).get()).isEqualTo(i);


### PR DESCRIPTION
Fix all the flaky multithreaded tests

In a multithreaded environment, it was possible that a thread received
the connection from another thread:

* thread 1 calls "lastConnection = DriverManager.getConnection(...)
* thread 2 calls "lastConnection = DriverManager.getConnection(...)
* thread 1 returns "lastConnection" which holds the object from thread 2
* thread 2 returns "lastConncetion" which holds the object from thread 2

=> leak checker reports "handle already added"
=> threads see "ClosedConnection" errors even though they never closed
   the connection

This explains all the problems with the tests. :-)

Fix the logic for lastConnection to never share the returned connection,
add some explanation what this was intended for.

This PR also reverts all the test code that was added to figure this out.
