### PR TITLE
Correctness fix for Handle

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -111,13 +111,12 @@ public class Handle implements Closeable, Configurable<Handle> {
         this.statementBuilder = statementBuilder;
         this.handleListeners = getConfig().get(Handles.class).copyListeners();
 
+        addCleanable(() -> statementBuilder.close(connection));
 
         // both of these methods are bad because they leak a reference to this handle before the c'tor finished.
         this.transactionHandler = transactionHandler.specialize(this);
         this.forceEndTransactions = !this.transactionHandler.isInTransaction(this);
 
-        addCleanable(() ->
-            statementBuilder.close(connection));
     }
 
     /**


### PR DESCRIPTION
There is a really obscure (and usually already fatal) error condition
where during handle creation, the connection object becomes no longer
viable (e.g. the database crashes, the connection gets closed). In that
case, either `transactionHandler.specialize()` or
`transactionHandler.isInTransaction()` will throw a SQLException (or a
runtime exception) and the cleanup handler for the connection is never
added. Technically, the handle will there leak the connection (which is
already non-viable because it caused the exception in the first
place). This fix moves the cleanup before calling the methods which will
ensure that the connection will be cleaned up in every situation.

This may change user visible behavior slightly; instead of a
SQLException, it is possible that now a `ConnectionException` with the
root exception attached is now observed. This is unlikely but possible.
