### PR TITLE
Fix script parsing for END with semicolon

### DIFF
--- a/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/SqlScriptLexer.g4
+++ b/core/src/main/antlr4/org/jdbi/v3/core/internal/lexer/SqlScriptLexer.g4
@@ -48,7 +48,7 @@ BLOCK_BEGIN
     ;
 
 BLOCK_END
-    : 'END' WHITESPACE+
+    : 'END' WHITESPACE*
     ;
 
 fragment ESCAPE_SEQUENCE

--- a/core/src/main/java/org/jdbi/v3/core/locator/ClasspathSqlLocator.java
+++ b/core/src/main/java/org/jdbi/v3/core/locator/ClasspathSqlLocator.java
@@ -115,10 +115,8 @@ public final class ClasspathSqlLocator {
      * @return A new ClasspathSqlLocator that returns SQL with comments removed.
      */
     public static ClasspathSqlLocator removingComments() {
-        final SqlScriptParser commentStripper =
-                new SqlScriptParser((t, sb) -> sb.append(t.getText()));
-        return new ClasspathSqlLocator(
-                r -> commentStripper.parse(CharStreams.fromStream(r)));
+        final SqlScriptParser commentStripper = new SqlScriptParser((t, sb) -> sb.append(t.getText()));
+        return new ClasspathSqlLocator(r -> commentStripper.parse(CharStreams.fromStream(r)));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/Script.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Script.java
@@ -13,12 +13,12 @@
  */
 package org.jdbi.v3.core.statement;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.internal.SqlScriptParser;
+import org.jdbi.v3.core.internal.SqlScriptParser.ScriptTokenHandler;
 
 /**
  * Represents a number of SQL statements delimited by semicolon which will be executed in order in a batch statement.
@@ -68,21 +68,10 @@ public class Script extends SqlStatement<Script> {
     }
 
     private List<String> splitToStatements(String script) {
-        final List<String> statements = new ArrayList<>();
-        String lastStatement = new SqlScriptParser((t, sb) -> {
-            addStatement(sb.toString(), statements);
-            sb.setLength(0);
-        }).parse(CharStreams.fromString(script));
-        addStatement(lastStatement, statements);
+        ScriptTokenHandler scriptTokenHandler = new ScriptTokenHandler();
+        String lastStatement = new SqlScriptParser(scriptTokenHandler)
+            .parse(CharStreams.fromString(script));
 
-        return statements;
-    }
-
-    private void addStatement(String statement, List<String> statements) {
-        String trimmedStatement = statement.trim();
-        if (trimmedStatement.isEmpty()) {
-            return;
-        }
-        statements.add(trimmedStatement);
+        return scriptTokenHandler.addStatement(lastStatement);
     }
 }

--- a/mysql/src/test/java/org/jdbi/v3/mysql/TestMySQL.java
+++ b/mysql/src/test/java/org/jdbi/v3/mysql/TestMySQL.java
@@ -45,7 +45,7 @@ public class TestMySQL {
 
     @RegisterExtension
     JdbiExtension extension = JdbiTestcontainersExtension.instance(dbContainer)
-            .withPlugin(new SqlObjectPlugin());
+        .withPlugin(new SqlObjectPlugin());
 
     @Test
     void testIssue2402() {
@@ -76,13 +76,13 @@ public class TestMySQL {
         List<Contact> getAllContacts();
 
         @SqlQuery("SELECT contact_id "
-                + " FROM contacts "
-                + " WHERE RIGHT(etag, 1) = RIGHT(:etag, 1)")
+            + " FROM contacts "
+            + " WHERE RIGHT(etag, 1) = RIGHT(:etag, 1)")
         List<String> testOne(@Bind("etag") String etag);
 
         @SqlQuery("SELECT contact_id"
-                + " FROM contacts "
-                + " WHERE etag LIKE \\'%<etagPattern>\\'")
+            + " FROM contacts "
+            + " WHERE etag LIKE \\'%<etagPattern>\\'")
         List<String> testTwo(@Define("etagPattern") String etag);
     }
 
@@ -103,5 +103,28 @@ public class TestMySQL {
         public String etag() {
             return etag;
         }
+    }
+
+
+    @Test
+    public void testIssue2535PassesSingleLine() {
+        String sqlScript = "CREATE PROCEDURE QWE() "
+            + "BEGIN "
+            + "END; "
+            + "DROP PROCEDURE IF EXISTS QWE;";
+        int[] result = extension.getJdbi().withHandle(h -> h.createScript(sqlScript).execute());
+
+        assertThat(result).isEqualTo(new int[] {0, 0 });
+    }
+
+    @Test
+    public void testIssue2535FailsMultiLine() {
+        String sqlScript = "CREATE PROCEDURE QWE()\n"
+            + "BEGIN\n"
+            + "END;\n"
+            + "DROP PROCEDURE IF EXISTS QWE;\n";
+        int[] result = extension.getJdbi().withHandle(h -> h.createScript(sqlScript).execute());
+
+        assertThat(result).isEqualTo(new int[] {0, 0});
     }
 }


### PR DESCRIPTION
Script parsing raises its ugly head again. Again. Allow for `END;`
as it is used within MySQL scripts.

Fixes #2535
