### PR TITLE
first step in chipping away mockito

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/TestPlugins.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestPlugins.java
@@ -21,6 +21,7 @@ import org.jdbi.v3.core.junit5.H2DatabaseExtension;
 import org.jdbi.v3.core.spi.JdbiPlugin;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPlugins {


### PR DESCRIPTION
I just started familiarising myself with the codebase.
[Remove all mockito tests](https://github.com/jdbi/jdbi/issues/2506) seemed like a good starting point

The changes replace mocks with h2 connections. May be dumb idea. But I will refactor as my understanding grows. 

`make tests` was failing for me. 

I had to comment out `postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java` just to make sure my change works.
I restored the class after my test.

