### PR TITLE
Support null for bean, pojo, field, and method binding

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 - finally give up on trying to guess SQL script parsing and add a switch to control whether to strip trailing semicolons or not. Another attempt to
   fix SQL script parsing is (reported by @IrinaTerlizhenko, @2554).
+- add a new `integration-test` module for tests that require different parts of the code base. Should be used to write test cases for issue investigations.
+- support `null` as a value for binding bean, method, field and pojo objects (Suggested by @xak2000 in #2562)
 
 # 3.42.0
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -181,17 +181,20 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * Example: the prefix {@code foo} applied to a bean property {@code bar} will be bound as {@code foo.bar}.
      *
      * @param prefix a prefix to apply to all property names.
-     * @param bean source of named parameter values to use as arguments
+     * @param bean source of named parameter values to use as arguments. Can be null, in this case, nothing is bound.
      *
      * @return modified statement
      */
     public This bindBean(String prefix, Object bean) {
-        return bindNamedArgumentFinder(
+        if (bean != null) {
+            return bindNamedArgumentFinder(
                 NamedArgumentFinderFactory.BEAN,
                 prefix,
                 bean,
                 bean.getClass(),
                 () -> new BeanPropertyArguments(prefix, bean, getConfig()));
+        }
+        return typedThis;
     }
 
     /**
@@ -255,12 +258,15 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      */
     @Beta
     public This bindPojo(String prefix, Object pojo, Type type) {
-        return bindNamedArgumentFinder(
+        if (pojo != null) {
+            return bindNamedArgumentFinder(
                 NamedArgumentFinderFactory.POJO,
                 prefix,
                 pojo,
                 type,
                 () -> new PojoPropertyArguments(prefix, pojo, type, getConfig()));
+        }
+        return typedThis;
     }
 
     /**
@@ -311,17 +317,20 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * Binds public fields of the specified object as arguments for the query.
      *
      * @param prefix a prefix to apply to all field names.
-     * @param object source of the public fields to bind.
+     * @param object source of the public fields to bind. If the object is null, nothing is bound.
      *
      * @return modified statement
      */
     public This bindFields(String prefix, Object object) {
-        return bindNamedArgumentFinder(
+        if (object != null) {
+            return bindNamedArgumentFinder(
                 NamedArgumentFinderFactory.FIELDS,
                 prefix,
                 object,
                 object.getClass(),
                 () -> new ObjectFieldArguments(prefix, object));
+        }
+        return typedThis;
     }
 
     /**
@@ -339,17 +348,20 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * Binds methods with no parameters on the argument, with the given prefix.
      *
      * @param prefix a prefix to apply to all property names.
-     * @param object source of methods to use as arguments
+     * @param object source of methods to use as arguments. If the object is null, nothing is bound.
      *
      * @return modified statement
      */
     public This bindMethods(String prefix, Object object) {
-        return bindNamedArgumentFinder(
+        if (object != null) {
+            return bindNamedArgumentFinder(
                 NamedArgumentFinderFactory.METHODS,
                 prefix,
                 object,
                 object.getClass(),
                 () -> new ObjectMethodArguments(prefix, object));
+        }
+        return typedThis;
     }
 
     /**

--- a/integration-testing/pom.xml
+++ b/integration-testing/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jdbi.internal</groupId>
+        <artifactId>jdbi3-parent</artifactId>
+        <version>3.42.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.jdbi</groupId>
+    <artifactId>jdbi3-integration-testing</artifactId>
+
+    <name>jdbi3 - internal - integration testing</name>
+    <description>Integration tests for the full Jdbi code base</description>
+
+    <properties>
+        <basepom.deploy.skip>true</basepom.deploy.skip>
+        <basepom.install.skip>true</basepom.install.skip>
+        <moduleName>org.jdbi.v3.integrationtest</moduleName>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-freemarker</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-testing/src/test/java/org/jdbi/v3/integrationtest/TestIssue2562.java
+++ b/integration-testing/src/test/java/org/jdbi/v3/integrationtest/TestIssue2562.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.integrationtest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
+import org.jdbi.v3.freemarker.UseFreemarkerEngine;
+import org.jdbi.v3.freemarker.UseFreemarkerSqlLocator;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIssue2562 {
+
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+
+    private Handle handle;
+    private UserSearchDao dao;
+    private List<User> users = new ArrayList<>();
+
+    @BeforeEach
+    public void setUp() {
+        handle = h2Extension.getSharedHandle();
+        handle.registerRowMapper(User.class, ConstructorMapper.of(User.class));
+        handle.execute("CREATE TABLE users (user_id identity primary key, name varchar(64))");
+        dao = handle.attach(UserSearchDao.class);
+
+        for (int i = 0; i < 10; i++) {
+            handle.execute("INSERT INTO users (user_id, name) VALUES (?, ?)", i, "name_" + i);
+            users.add(dao.getById(i));
+        }
+    }
+
+    @Test
+    public void bindDefineTest() {
+        UserPageToken token = new UserPageToken(Direction.BACKWARD, 6);
+
+        List<User> result = dao.findAll(token, 10);
+        assertThat(result).hasSize(3).containsExactly(users.get(9), users.get(8), users.get(7));
+    }
+
+    @Test
+    public void bindDefineNullTest() {
+        List<User> result = dao.findAll(null, 10);
+        assertThat(result).hasSize(10).containsExactlyElementsOf(users);
+    }
+
+
+    public static final class User {
+        private final int userId;
+        private final String name;
+
+        public User(int userId, String name) {
+            this.userId = userId;
+            this.name = name;
+        }
+
+        public int getUserId() {
+            return userId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return new StringJoiner(", ", User.class.getSimpleName() + "[", "]")
+                .add("userId=" + userId)
+                .add("name='" + name + "'")
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            User user = (User) o;
+            return userId == user.userId && Objects.equals(name, user.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(userId, name);
+        }
+    }
+
+    public enum Direction {
+        FORWARD, BACKWARD
+    }
+
+    public static final class UserPageToken {
+
+        Direction direction;
+        int userId;
+
+        public UserPageToken(Direction direction, int userId) {
+            this.direction = direction;
+            this.userId = userId;
+        }
+
+        public Direction getDirection() {
+            return direction;
+        }
+
+        public int getUserId() {
+            return userId;
+        }
+    }
+
+    public interface UserSearchDao {
+        @SqlQuery
+        @UseFreemarkerEngine
+        @UseFreemarkerSqlLocator
+        List<User> findAll(@BindBean("pageToken") @Define UserPageToken pageToken, @Bind int limit);
+
+        @SqlQuery("SELECT * FROM users WHERE user_id = :userId")
+        User getById(int userId);
+    }
+}

--- a/integration-testing/src/test/resources/org/jdbi/v3/integrationtest/TestIssue2562$UserSearchDao/findAll.sql.ftl
+++ b/integration-testing/src/test/resources/org/jdbi/v3/integrationtest/TestIssue2562$UserSearchDao/findAll.sql.ftl
@@ -1,0 +1,36 @@
+<#--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+SELECT
+    *
+FROM
+    users u
+WHERE
+    1 = 1
+<#if pageToken??>
+        <#if pageToken.direction == "FORWARD">
+            AND u.user_id < :pageToken.userId
+        <#else>
+            AND u.user_id > :pageToken.userId
+        </#if>
+</#if>
+ORDER BY
+<#if !pageToken?? || pageToken.direction == "FORWARD">
+    u.user_id ASC
+<#else>
+    u.user_id DESC
+</#if>
+LIMIT
+    :limit

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
         <module>testing</module>
         <module>vavr</module>
 
+        <!-- we have lots of bug reports that use different parts of the
+             Jdbi stack and it becomes difficult to write tests that fit into
+             very specific places. Add an integration test module that allows
+             pulling in every module listed above as needed
+        -->
+        <module>integration-testing</module>
+
         <!-- support pieces, examples, benchmark, tests etc. -->
         <!-- none of those ship actual end-user code -->
         <module>benchmark</module>


### PR DESCRIPTION
Instead of throwing a NPE, do nothing. This allows for calling
the various Jdbi methods (and the annotations for sqlobject) to deal
with null objects.

While this is a behavior change, it is acceptable as callers had to
wrap this in `if (bean != null) { ...` conditionals and had to skip
binding for null values. Now the code does skip null values directly.
