### PR TITLE
Make build work on java 22-ea

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           JAVA_HOME: ${{ steps.test_jdk.outputs.path }}
         run: |
           echo "$JAVA_HOME/bin" >> ${GITHUB_PATH}
+          ./mvnw --version
 
       - name: run tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           JAVA_HOME: ${{ steps.build_jdk.outputs.path }}
         run: |
           echo "$JAVA_HOME/bin" >> ${GITHUB_PATH}
+          ./mvnw --version
 
       - name: build distribution
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 11, 17, 21 ]
+        java-version: [ 11, 17, 21, 22-ea ]
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ docs: install
 
 run-tests:: MAVEN_CONFIG += -Dbasepom.it.skip=false
 run-tests::
-	${MAVEN} surefire:test invoker:install invoker:integration-test invoker:verify
+	${MAVEN} dependency:properties surefire:test invoker:install invoker:integration-test invoker:verify
 
 run-slow-tests:: MAVEN_CONFIG += -Pslow-tests
 run-slow-tests:: run-tests

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install-fast:: install
 docs: MAVEN_CONFIG += -Ppublish-docs -Pfast -Dbasepom.javadoc.skip=false
 docs: install
 
-run-tests:: MAVEN_CONFIG += -Dbasepom.it.skip=false
+run-tests:: MAVEN_CONFIG += -Dbasepom.it.skip=false -Dbasepom.check.skip-dependency=false
 run-tests::
 	${MAVEN} dependency:properties surefire:test invoker:install invoker:integration-test invoker:verify
 

--- a/cache/caffeine-cache/src/it/test-caffeine-cache/invoker.properties
+++ b/cache/caffeine-cache/src/it/test-caffeine-cache/invoker.properties
@@ -12,6 +12,6 @@
 # limitations under the License.
 #
 
-invoker.goals=clean surefire:test
+invoker.goals=clean dependency:properties surefire:test
 invoker.buildResult = success
 invoker.failureBehavior = fail-at-end

--- a/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
@@ -25,6 +25,8 @@
 
     <properties>
         <basepom.check.skip-all>true</basepom.check.skip-all>
+        <!-- b/c we need dependency:properties for the mockito agent to work -->
+        <basepom.check.skip-dependency>false</basepom.check.skip-dependency>
     </properties>
 
     <dependencies>

--- a/cache/noop-cache/src/it/test-noop-cache/invoker.properties
+++ b/cache/noop-cache/src/it/test-noop-cache/invoker.properties
@@ -12,6 +12,6 @@
 # limitations under the License.
 #
 
-invoker.goals=clean surefire:test
+invoker.goals=clean dependency:properties surefire:test
 invoker.buildResult = success
 invoker.failureBehavior = fail-at-end

--- a/cache/noop-cache/src/it/test-noop-cache/pom.xml
+++ b/cache/noop-cache/src/it/test-noop-cache/pom.xml
@@ -25,6 +25,8 @@
 
     <properties>
         <basepom.check.skip-all>true</basepom.check.skip-all>
+        <!-- b/c we need dependency:properties for the mockito agent to work -->
+        <basepom.check.skip-dependency>false</basepom.check.skip-dependency>
     </properties>
 
     <dependencies>

--- a/core/src/it/test-inline-jar/invoker.properties
+++ b/core/src/it/test-inline-jar/invoker.properties
@@ -12,6 +12,6 @@
 # limitations under the License.
 #
 
-invoker.goals=clean surefire:test
+invoker.goals=clean dependency:properties surefire:test
 invoker.buildResult = success
 invoker.failureBehavior = fail-at-end

--- a/core/src/it/test-inline-jar/pom.xml
+++ b/core/src/it/test-inline-jar/pom.xml
@@ -25,6 +25,8 @@
 
     <properties>
         <basepom.check.skip-all>true</basepom.check.skip-all>
+        <!-- b/c we need dependency:properties for the mockito agent to work -->
+        <basepom.check.skip-dependency>false</basepom.check.skip-dependency>
     </properties>
 
     <dependencies>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -72,6 +72,7 @@
         <dep.asciidoctorj-diagram.version>2.2.14</dep.asciidoctorj-diagram.version>
         <dep.asciidoctorj.version>2.5.10</dep.asciidoctorj.version>
         <dep.assertj.version>3.24.2</dep.assertj.version>
+        <dep.byte-buddy.version>1.14.10</dep.byte-buddy.version>
         <dep.caffeine.version>3.1.8</dep.caffeine.version>
         <dep.checkerframework.version>3.42.0</dep.checkerframework.version>
         <dep.commons-compress.version>1.25.0</dep.commons-compress.version>
@@ -381,6 +382,18 @@
             </dependency>
 
             <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${dep.byte-buddy.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${dep.byte-buddy.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${dep.assertj.version}</version>
@@ -578,6 +591,13 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- needed for Java 21 and mockito -->
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -890,6 +910,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dependency-properties</id>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${net.bytebuddy:byte-buddy-agent:jar} @{basepom.coverage.test-args} -Xmx${basepom.test.memory} -Dfile.encoding=${project.build.sourceEncoding} ${basepom.test.arguments}</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -899,11 +941,6 @@
             <activation>
                 <jdk>[21,)</jdk>
             </activation>
-            <properties>
-                <!-- see https://github.com/mockito/mockito/issues/3037 -->
-                <basepom.it.arguments>-XX:+EnableDynamicAgentLoading</basepom.it.arguments>
-                <basepom.test.arguments>-XX:+EnableDynamicAgentLoading</basepom.test.arguments>
-            </properties>
             <build>
                 <pluginManagement>
                     <plugins>


### PR DESCRIPTION
Revisit the mockito setup (this can be improved once
https://github.com/mockito/mockito/pull/3137 has landed and was
released with mockito). For now, we add the bytebuddy agent directly.

Also update spotbugs and junit, which is needed to pass build under
Java 22-ea.
