### PR TITLE
Add support for MS SQLServer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,10 @@
 # Unreleased
 
 - finally give up on trying to guess SQL script parsing and add a switch to control whether to strip trailing semicolons or not. Another attempt to
-  fix SQL script parsing is (reported by @IrinaTerlizhenko, @2554).
+  fix SQL script parsing is (reported by @IrinaTerlizhenko, #2554).
 - add a new `integration-test` module for tests that require different parts of the code base. Should be used to write test cases for issue investigations.
 - support `null` as a value for binding bean, method, field and pojo objects (Suggested by @xak2000 in #2562)
+- Add testcontainers support for MS SQLServer
 
 # 3.42.0
 

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -6025,7 +6025,7 @@ class TestWithContainers {
 
 The link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] has built-in support to isolate each test method in a test class. The container can be declared as a static class member which speeds up test execution significantly.
 
-There is built-in support for MySQL, MariaDB, TiDB, PostgreSQL, CockroachDB, YugabyteDB, ClickHouse, Oracle XE and Trino. It also supports the various compatible flavors (such as PostGIS for PostgreSQL).
+There is built-in support for MySQL, MariaDB, TiDB, PostgreSQL, CockroachDB, YugabyteDB, ClickHouse, Oracle XE, Trino and MS SQLServer. It also supports the various compatible flavors (such as PostGIS for PostgreSQL).
 
 ==== Providing custom database information
 

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -123,7 +123,7 @@
         <dep.spring.version>5.3.30</dep.spring.version>
         <dep.sqlite.version>3.43.2.1</dep.sqlite.version>
         <dep.stringtemplate4.version>4.3.4</dep.stringtemplate4.version>
-        <dep.testcontainers.version>1.19.1</dep.testcontainers.version>
+        <dep.testcontainers.version>1.19.3</dep.testcontainers.version>
         <dep.vavr.version>0.9.3</dep.vavr.version>
         <jdbi.check.fail-detekt>${jdbi.check.fail-kotlin}</jdbi.check.fail-detekt>
         <jdbi.check.fail-kotlin>${basepom.check.fail-extended}</jdbi.check.fail-kotlin>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -37,6 +37,7 @@
         <dep.oracle-xe.version>23.2.0.0</dep.oracle-xe.version>
         <dep.trino.version>429</dep.trino.version>
         <dep.yugabyte.version>42.3.5-yb-3</dep.yugabyte.version>
+        <dep.mssql.version>12.4.2.jre11</dep.mssql.version>
         <moduleName>org.jdbi.v3.testcontainers</moduleName>
     </properties>
 
@@ -72,6 +73,12 @@
                 <groupId>io.trino</groupId>
                 <artifactId>trino-jdbc</artifactId>
                 <version>${dep.trino.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>${dep.mssql.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -157,6 +164,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- containers -->
 
         <dependency>
@@ -204,6 +217,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>yugabytedb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mssqlserver</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/TestcontainersDatabaseInformation.java
+++ b/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/TestcontainersDatabaseInformation.java
@@ -64,6 +64,10 @@ public final class TestcontainersDatabaseInformation {
     private static final TestcontainersDatabaseInformation TRINO =
         of(null, "memory", null, (catalogName, schemaName) -> format("CREATE SCHEMA %s", schemaName));
 
+    private static final TestcontainersDatabaseInformation MSSQL =
+        of("sa", null, null, (catalogName, schemaName) -> format("CREATE DATABASE %s", catalogName));
+
+
     private static final Map<String, TestcontainersDatabaseInformation> KNOWN_CONTAINERS;
 
     static {
@@ -82,6 +86,7 @@ public final class TestcontainersDatabaseInformation {
         knownContainers.put("org.testcontainers.containers.ClickHouseContainer", TestcontainersDatabaseInformation.CLICKHOUSE);
         knownContainers.put("org.testcontainers.containers.OracleContainer", TestcontainersDatabaseInformation.ORACLE_XE);
         knownContainers.put("org.testcontainers.containers.TrinoContainer", TestcontainersDatabaseInformation.TRINO);
+        knownContainers.put("org.testcontainers.containers.MSSQLServerContainer", TestcontainersDatabaseInformation.MSSQL);
 
         KNOWN_CONTAINERS = knownContainers;
     }

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/MSSQLJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/MSSQLJdbiTestContainersExtensionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Tag("slow")
+@Testcontainers
+class MSSQLJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2017-CU12")
+        .acceptLicense();
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+}


### PR DESCRIPTION
Testcontainers now supports MS SQLServer, so we should support it, too.
