### PR TITLE
Support ResultSet from stored procedures

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
 - add a new `integration-test` module for tests that require different parts of the code base. Should be used to write test cases for issue investigations.
 - support `null` as a value for binding bean, method, field and pojo objects (Suggested by @xak2000 in #2562)
 - Add testcontainers support for MS SQLServer
+- support returning a `ResultSet` from `Call` statements for databases that do not support cursor parameters. (suggested in #2557 by @metaforte and @0x1F528 in #2546)
+- support `int`, `long`, `short`, `double` and `float` return values from out parameters directly.
 
 # 3.42.0
 

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultProducers.java
@@ -20,6 +20,7 @@ import java.sql.Statement;
 import java.util.function.Supplier;
 
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.result.internal.EmptyResultSet;
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**
@@ -126,10 +127,10 @@ public class ResultProducers implements JdbiConfig<ResultProducers> {
         return this;
     }
 
-    @FunctionalInterface
     /**
      * Returns a ResultSet from a Statement.
      */
+    @FunctionalInterface
     public interface ResultSetCreator {
 
         /**

--- a/core/src/main/java/org/jdbi/v3/core/result/internal/EmptyResultSet.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/internal/EmptyResultSet.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.result;
+package org.jdbi.v3.core.result.internal;
 
 import java.io.InputStream;
 import java.io.Reader;
@@ -34,7 +34,7 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Map;
 
-class EmptyResultSet implements ResultSet {
+public final class EmptyResultSet implements ResultSet {
     @Override
     public <T> T unwrap(Class<T> iface) {
         return iface.cast(this);

--- a/core/src/main/java/org/jdbi/v3/core/result/internal/EmptyResultSetMetaData.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/internal/EmptyResultSetMetaData.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.v3.core.result;
+package org.jdbi.v3.core.result.internal;
 
 import java.sql.ResultSetMetaData;
 

--- a/core/src/main/java/org/jdbi/v3/core/result/internal/ResultSetResultIterable.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/internal/ResultSetResultIterable.java
@@ -48,10 +48,7 @@ public class ResultSetResultIterable<T> implements ResultIterable<T> {
     @Override
     public ResultIterator<T> iterator() {
         try {
-            ResultSet resultSet = resultSetSupplier.get();
-            ctx.addCleanable(resultSet::close);
-
-            return new ResultSetResultIterator<>(resultSet, mapper, ctx);
+            return new ResultSetResultIterator<>(resultSetSupplier, mapper, ctx);
         } catch (final SQLException e) {
             throw new ResultSetException("Unable to iterate result set", e, ctx);
         }

--- a/core/src/main/java/org/jdbi/v3/core/result/internal/ResultSetResultIterator.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/internal/ResultSetResultIterator.java
@@ -96,10 +96,6 @@ class ResultSetResultIterator<T> implements ResultIterator<T> {
             throw new NoSuchElementException("No element to advance to");
         }
 
-        if (closed) {
-            throw new IllegalStateException("iterator is closed");
-        }
-
         try {
             return rowMapper.map(resultSet, context);
         } catch (SQLException e) {

--- a/core/src/main/java/org/jdbi/v3/core/result/internal/ResultSetSupplier.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/internal/ResultSetSupplier.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.result.internal;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import org.jdbi.v3.core.statement.Cleanable;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public abstract class ResultSetSupplier implements Supplier<ResultSet>, Cleanable {
+
+    public static ResultSetSupplier closingContext(Supplier<ResultSet> supplier, StatementContext context) {
+        return new ResultSetSupplier(supplier) {
+            @Override
+            public void close() throws SQLException {
+                try (context) {
+                    cleanable.close();
+                }
+            }
+        };
+    }
+
+    public static ResultSetSupplier notClosingContext(Supplier<ResultSet> supplier) {
+        return new ResultSetSupplier(supplier) {
+            @Override
+            public void close() throws SQLException {
+                cleanable.close();
+            }
+        };
+    }
+
+    private final Supplier<ResultSet> supplier;
+
+    protected Cleanable cleanable = Cleanable.NO_OP;
+
+    private ResultSetSupplier(Supplier<ResultSet> supplier) {
+        this.supplier = supplier;
+    }
+
+    @Override
+    public ResultSet get() {
+        ResultSet resultSet = supplier.get();
+        if (resultSet != null) {
+            this.cleanable = resultSet::close;
+        }
+        return resultSet;
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -17,6 +17,7 @@ import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
@@ -153,6 +154,57 @@ public class Call extends SqlStatement<Call> {
             }
         }
         return resultComputer.apply(out);
+    }
+
+    /**
+     * Specify the fetch size for the call. This should cause the results to be
+     * fetched from the underlying RDBMS in groups of rows equal to the number passed.
+     * This is useful for doing chunked streaming of results when exhausting memory
+     * could be a problem.
+     *
+     * @param fetchSize the number of rows to fetch in a bunch
+     *
+     * @return the modified call
+     */
+    public Call setFetchSize(final int fetchSize) {
+        return addCustomizer(StatementCustomizers.fetchSize(fetchSize));
+    }
+
+    /**
+     * Specify the maximum number of rows the call is to return. This uses the underlying JDBC
+     * {@link Statement#setMaxRows(int)}}.
+     *
+     * @param maxRows maximum number of rows to return
+     *
+     * @return modified call
+     */
+    public Call setMaxRows(final int maxRows) {
+        return addCustomizer(StatementCustomizers.maxRows(maxRows));
+    }
+
+    /**
+     * Specify the maximum field size in the result set. This uses the underlying JDBC
+     * {@link Statement#setMaxFieldSize(int)}
+     *
+     * @param maxFields maximum field size
+     *
+     * @return modified call
+     */
+    public Call setMaxFieldSize(final int maxFields) {
+        return addCustomizer(StatementCustomizers.maxFieldSize(maxFields));
+    }
+
+    /**
+     * Specify that the result set should be concurrent updatable.
+     *
+     * This will allow the update methods to be called on the result set produced by this
+     * Call.
+     *
+     * @return the modified call
+     */
+    public Call concurrentUpdatable() {
+        getContext().setConcurrentUpdatable(true);
+        return this;
     }
 
     // TODO tostring?

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -29,18 +29,16 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.internal.exceptions.Sneaky;
 import org.jdbi.v3.core.result.ResultBearing;
+import org.jdbi.v3.core.result.internal.ResultSetSupplier;
 
 /**
  * Used for invoking stored procedures. The most common way to use this is to register {@link OutParameters} with the call and then use the {@link Call#invoke()} method
  * to retrieve the return values from the invoked procedure.
  * <br>
- * There are some databases, most prominently MS SqlServer that only support limited out parameters, especially do not support cursors
+ * There are some databases, most prominently MS SqlServer that only support limited OUT parameters, especially do not support cursors
  * (for MS SqlServer see <a href="https://learn.microsoft.com/en-us/sql/connect/jdbc/using-a-stored-procedure-with-output-parameters">Using a stored procedure with output parameters</a>).
- * Those databases may support returning a result set from the procedure invocation, in this case, use the {@link OutParameters#getResultSet()} method to retrieve
+ * Those databases may support returning a result set from the procedure invocation, to access this result set use the {@link OutParameters#getResultSet()} method to retrieve
  * the result set from the underlying call operation.
- * <br>
- * There is currently a limitation that Jdbi supports <b>either</b> using the result set from the call operation <b>or</b> outparameters. The JDBC 3.0 standard
- * suggests that databases should support both at the same time. This limitation will be lifted in a later release.
  */
 public class Call extends SqlStatement<Call> {
     private final List<OutParamArgument> outParamArguments = new ArrayList<>();
@@ -143,7 +141,8 @@ public class Call extends SqlStatement<Call> {
             }
         };
 
-        final ResultBearing resultSet = ResultBearing.of(resultSetSupplier, getContext());
+
+        final ResultBearing resultSet = ResultBearing.of(ResultSetSupplier.notClosingContext(resultSetSupplier), getContext());
 
         OutParameters out = new OutParameters(resultSet, getContext());
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/Call.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Call.java
@@ -141,7 +141,6 @@ public class Call extends SqlStatement<Call> {
             }
         };
 
-
         final ResultBearing resultSet = ResultBearing.of(ResultSetSupplier.notClosingContext(resultSetSupplier), getContext());
 
         OutParameters out = new OutParameters(resultSet, getContext());
@@ -149,7 +148,7 @@ public class Call extends SqlStatement<Call> {
         outParamArguments.forEach(outparamArgument -> {
             Supplier<Object> supplier = outparamArgument.supplier((CallableStatement) stmt);
             // index is 0 based, position is 1 based.
-            out.setValue(outparamArgument.position - 1, outparamArgument.name, supplier);
+            out.putValueSupplier(outparamArgument.position - 1, outparamArgument.name, supplier);
         });
 
         return resultComputer.apply(out);
@@ -164,6 +163,7 @@ public class Call extends SqlStatement<Call> {
      * @param fetchSize the number of rows to fetch in a bunch
      *
      * @return the modified call
+     * @since 3.43.0
      */
     public Call setFetchSize(final int fetchSize) {
         return addCustomizer(StatementCustomizers.fetchSize(fetchSize));
@@ -176,6 +176,7 @@ public class Call extends SqlStatement<Call> {
      * @param maxRows maximum number of rows to return
      *
      * @return modified call
+     * @since 3.43.0
      */
     public Call setMaxRows(final int maxRows) {
         return addCustomizer(StatementCustomizers.maxRows(maxRows));
@@ -188,6 +189,7 @@ public class Call extends SqlStatement<Call> {
      * @param maxFields maximum field size
      *
      * @return modified call
+     * @since 3.43.0
      */
     public Call setMaxFieldSize(final int maxFields) {
         return addCustomizer(StatementCustomizers.maxFieldSize(maxFields));
@@ -200,6 +202,7 @@ public class Call extends SqlStatement<Call> {
      * Call.
      *
      * @return the modified call
+     * @since 3.43.0
      */
     public Call concurrentUpdatable() {
         getContext().setConcurrentUpdatable(true);

--- a/core/src/main/java/org/jdbi/v3/core/statement/Cleanable.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Cleanable.java
@@ -25,6 +25,10 @@ import java.sql.SQLException;
  */
 @FunctionalInterface
 public interface Cleanable extends AutoCloseable {
+
+    /** A cleanable that does nothing. */
+    Cleanable NO_OP = () -> {};
+
     @Override
     void close() throws SQLException;
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/Cleanable.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Cleanable.java
@@ -26,7 +26,11 @@ import java.sql.SQLException;
 @FunctionalInterface
 public interface Cleanable extends AutoCloseable {
 
-    /** A cleanable that does nothing. */
+    /**
+     * A cleanable that does nothing.
+     *
+     * @since 3.43.0
+     */
     Cleanable NO_OP = () -> {};
 
     @Override

--- a/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
@@ -32,10 +32,22 @@ import static java.lang.String.format;
  */
 public class OutParameters {
     private final StatementContext ctx;
+    private final ResultBearing resultSet;
     private final Map<Object, Object> map = new HashMap<>();
 
-    OutParameters(StatementContext ctx) {
+    OutParameters(ResultBearing resultSet, StatementContext ctx) {
+        this.resultSet = resultSet;
         this.ctx = ctx;
+    }
+
+    /**
+     * Returns a ResultBearing backed by the main result set returned by the procedure. This is not
+     * supported by all databases.
+     *
+     * @return a ResultBearing
+     */
+    public ResultBearing getResultSet() {
+        return resultSet;
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
@@ -539,19 +539,21 @@ public class OutParameters {
         }
 
         Object getValue(int index) {
-            if (!map.containsKey(index)) {
-                throw new IllegalArgumentException(format("Parameter #%d does not exist", index));
-            }
             Supplier<Object> supplier = map.get(index);
-            return supplier != null ? supplier.get() : null;
+            if (supplier != null) {
+                return supplier.get();
+            }
+
+            throw new IllegalArgumentException(format("Parameter #%d does not exist", index));
         }
 
         Object getValue(String name) {
-            if (!map.containsKey(name)) {
-                throw new IllegalArgumentException(format("Parameter '%s' does not exist", name));
-            }
             Supplier<Object> supplier = map.get(name);
-            return supplier != null ? supplier.get() : null;
+            if (supplier != null) {
+                return supplier.get();
+            }
+
+            throw new IllegalArgumentException(format("Parameter '%s' does not exist", name));
         }
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
@@ -29,9 +29,10 @@ import org.jdbi.v3.core.result.internal.ResultSetSupplier;
 import static java.lang.String.format;
 
 /**
- * Represents output from a Call (CallableStatement).
+ * Holds all output parameters from a stored procedure call using {@link Call}.
  *
  * @see Call
+ * @see java.sql.CallableStatement
  */
 public class OutParameters {
     private final StatementContext ctx;
@@ -44,21 +45,23 @@ public class OutParameters {
     }
 
     /**
-     * Returns a ResultBearing backed by the main result set returned by the procedure. This is not supported by all databases.
+     * Returns a {@link ResultBearing} backed by the main result set returned by the procedure. This is not supported by all databases.
      *
-     * @return a ResultBearing
+     * @return A {@link ResultBearing}. This is never null but may be empty.
+     * @since 3.43.0
      */
     public ResultBearing getResultSet() {
         return resultSet;
     }
 
     /**
-     * Type-casting convenience method which obtains an object from the map, the object obtained should have been created with {@link CallableStatementMapper}
+     * Retrieves an out parameter and casts it to a specific type.
      *
      * @param name The out parameter name
      * @param type The java type to obtain
      * @param <T>  the output parameter type
      * @return the output of name as type T
+     * @throws ClassCastException If the parameter can not be cast to type T
      */
     @Nullable
     public <T> T getObject(String name, Class<T> type) {
@@ -66,10 +69,24 @@ public class OutParameters {
     }
 
     /**
-     * Obtains an object from the map, the object obtained should have been created with {@link CallableStatementMapper}
+     * Retrieves an out parameter and casts it to a specific type.
+     *
+     * @param pos The out parameter index
+     * @param type The java type to obtain
+     * @param <T>  the output parameter type
+     * @return the output of name as type T
+     * @throws ClassCastException If the parameter can not be cast to type T
+     */
+    @Nullable
+    public <T> T getObject(int pos, Class<T> type) {
+        return type.cast(getObject(pos));
+    }
+
+    /**
+     * Retrieves an out parameter as an object.
      *
      * @param name The out parameter name
-     * @return the output of name as type T
+     * @return The value as an Object. Can be null.
      */
     @Nullable
     public Object getObject(String name) {
@@ -77,156 +94,391 @@ public class OutParameters {
     }
 
     /**
-     * Type-casting convenience method which obtains an object from the results positionally object obtained should have been created with
-     * {@link CallableStatementMapper}
+     * Retrieves an out parameter as an object.
      *
-     * @param position The out parameter name
-     * @return the output of name as type T
+     * @param pos The out parameter index
+     * @return The value as an Object. Can be null.
      */
     @Nullable
-    public Object getObject(int position) {
-        return map.getValue(position);
+    public Object getObject(int pos) {
+        return map.getValue(pos);
     }
 
     /**
-     * Type-casting convenience method which obtains an object from the map positionally object obtained should have been created with
-     * {@link CallableStatementMapper}
+     * Retrieves an out parameter as a string.
      *
-     * @param pos  The out parameter position
-     * @param type The java type to obtain
-     * @param <T>  the output parameter type
-     * @return the output of name as type T
+     * @param name The out parameter name
+     * @return The value as a String. Can be null.
      */
-    @Nullable
-    public <T> T getObject(int pos, Class<T> type) {
-        return type.cast(getObject(pos));
-    }
-
     @Nullable
     public String getString(String name) {
         Object obj = getObject(name);
         return obj == null ? null : obj.toString();
     }
 
+    /**
+     * Retrieves an out parameter as a string.
+     *
+     * @param pos The out parameter index
+     * @return The value as a String. Can be null.
+     */
     @Nullable
     public String getString(int pos) {
         Object obj = map.getValue(pos);
         return obj == null ? null : obj.toString();
     }
 
+    /**
+     * Retrieves an out parameter as a byte array.
+     *
+     * @param name The out parameter name
+     * @return The value as a byte array. Can be null.
+     */
     @Nullable
     public byte[] getBytes(String name) {
-        Object obj = getObject(name);
-        if (obj == null) {
-            return null;
-        } else if (obj instanceof byte[]) {
-            return (byte[]) obj;
-        } else {
-            throw new IllegalArgumentException(format("Parameter '%s' is a %s, not a byte[]", name, obj.getClass()));
+        try {
+            return getObject(name, byte[].class);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(format("Parameter '%s' is not a byte[]", name), e);
         }
     }
 
+    /**
+     * Retrieves an out parameter as a byte array.
+     *
+     * @param pos The out parameter index
+     * @return The value as a byte array. Can be null.
+     */
     @Nullable
     public byte[] getBytes(int pos) {
-        Object obj = map.getValue(pos);
-        if (obj == null) {
-            return null;
-        } else if (obj instanceof byte[]) {
-            return (byte[]) obj;
-        } else {
-            throw new IllegalArgumentException(format("Parameter at %d is a %s, not a byte[]", pos, obj.getClass()));
+        try {
+            return getObject(pos, byte[].class);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(format("Parameter #%d is not a byte[]", pos), e);
         }
     }
 
+    /**
+     * Retrieves an out parameter as a Integer object.
+     *
+     * @param name The out parameter name
+     * @return The value as an Integer object. Can be null.
+     */
     @Nullable
     public Integer getInt(String name) {
         final Number n = getNumber(name);
         return n == null ? null : n.intValue();
     }
 
+    /**
+     * Retrieves an out parameter as a Integer object.
+     *
+     * @param pos The out parameter index
+     * @return The value as an Integer object. Can be null.
+     */
     @Nullable
     public Integer getInt(int pos) {
         final Number n = getNumber(pos);
         return n == null ? null : n.intValue();
     }
 
+    /**
+     * Retrieves an out parameter as a int value.
+     *
+     * @param name The out parameter name
+     * @return The value as an int. Returns 0 if the value is absent.
+     * @since 3.43.0
+     */
+    public int getIntValue(String name) {
+        final Number n = getNumber(name);
+        return n == null ? 0 : n.intValue();
+    }
+
+    /**
+     * Retrieves an out parameter as a int value.
+     *
+     * @param pos The out parameter index
+     * @return The value as an int. Returns 0 if the value is absent.
+     * @since 3.43.0
+     */
+    public int getIntValue(int pos) {
+        final Number n = getNumber(pos);
+        return n == null ? 0 : n.intValue();
+    }
+
+    /**
+     * Retrieves an out parameter as a Long object.
+     *
+     * @param name The out parameter name
+     * @return The value as an Long object. Can be null.
+     */
     @Nullable
     public Long getLong(String name) {
         final Number n = getNumber(name);
         return n == null ? null : n.longValue();
     }
 
+    /**
+     * Retrieves an out parameter as a Long object.
+     *
+     * @param pos The out parameter index
+     * @return The value as an Long object. Can be null.
+     */
     @Nullable
     public Long getLong(int pos) {
         final Number n = getNumber(pos);
         return n == null ? null : n.longValue();
     }
 
+    /**
+     * Retrieves an out parameter as a long value.
+     *
+     * @param name The out parameter name
+     * @return The value as an long. Returns 0 if the value is absent.
+     * @since 3.43.0
+     */
+    public long getLongValue(String name) {
+        final Number n = getNumber(name);
+        return n == null ? 0L : n.longValue();
+    }
+
+    /**
+     * Retrieves an out parameter as a long value.
+     *
+     * @param pos The out parameter index
+     * @return The value as an long. Returns 0 if the value is absent.
+     * @since 3.43.0
+     */
+    public long getLongValue(int pos) {
+        final Number n = getNumber(pos);
+        return n == null ? 0L : n.longValue();
+    }
+
+    /**
+     * Retrieves an out parameter as a Short object.
+     *
+     * @param name The out parameter name
+     * @return The value as an Short object. Can be null.
+     */
     @Nullable
     public Short getShort(String name) {
         final Number n = getNumber(name);
         return n == null ? null : n.shortValue();
     }
 
+    /**
+     * Retrieves an out parameter as a Short object.
+     *
+     * @param pos The out parameter index
+     * @return The value as an Short object. Can be null.
+     */
     @Nullable
     public Short getShort(int pos) {
         final Number n = getNumber(pos);
         return n == null ? null : n.shortValue();
     }
 
+    /**
+     * Retrieves an out parameter as a short value.
+     *
+     * @param name The out parameter name
+     * @return The value as an short. Returns 0 if the value is absent.
+     * @since 3.43.0
+     */
+    public short getShortValue(String name) {
+        final Number n = getNumber(name);
+        return n == null ? 0 : n.shortValue();
+    }
+
+    /**
+     * Retrieves an out parameter as a short value.
+     *
+     * @param pos The out parameter index
+     * @return The value as an short. Returns 0 if the value is absent.
+     * @since 3.43.0
+     */
+    public short getShortValue(int pos) {
+        final Number n = getNumber(pos);
+        return n == null ? 0 : n.shortValue();
+    }
+
+    /**
+     * Retrieves an out parameter as a {@link Date} object.
+     *
+     * @param name The out parameter name
+     * @return The value as a {@link Date} object. Can be null.
+     */
     @Nullable
     public Date getDate(String name) {
-        Long epoch = getEpoch(name);
-        return epoch == null ? null : new Date(epoch);
+        try {
+            return getObject(name, Date.class);
+        } catch (ClassCastException e) {
+            Long epoch = getEpoch(name);
+            return epoch == null ? null : new Date(epoch);
+        }
     }
 
+    /**
+     * Retrieves an out parameter as a {@link Date} object.
+     *
+     * @param pos The out parameter index
+     * @return The value as a {@link Date} object. Can be null.
+     */
     @Nullable
     public Date getDate(int pos) {
-        Long epoch = getEpoch(pos);
-        return epoch == null ? null : new Date(epoch);
+        try {
+            return getObject(pos, Date.class);
+        } catch (ClassCastException e) {
+            Long epoch = getEpoch(pos);
+            return epoch == null ? null : new Date(epoch);
+        }
     }
 
+    /**
+     * Retrieves an out parameter as a {@link Timestamp} object.
+     *
+     * @param name The out parameter name
+     * @return The value as a {@link Timestamp} object. Can be null.
+     */
     @Nullable
     public Timestamp getTimestamp(String name) {
-        Long epoch = getEpoch(name);
-        return epoch == null ? null : new Timestamp(epoch);
+        try {
+            return getObject(name, Timestamp.class);
+        } catch (ClassCastException e) {
+            Long epoch = getEpoch(name);
+            return epoch == null ? null : new Timestamp(epoch);
+        }
     }
 
+    /**
+     * Retrieves an out parameter as a {@link Timestamp} object.
+     *
+     * @param pos The out parameter index
+     * @return The value as a {@link Timestamp} object. Can be null.
+     */
     @Nullable
     public Timestamp getTimestamp(int pos) {
-        Long epoch = getEpoch(pos);
-        return epoch == null ? null : new Timestamp(epoch);
+        try {
+            return getObject(pos, Timestamp.class);
+        } catch (ClassCastException e) {
+            Long epoch = getEpoch(pos);
+            return epoch == null ? null : new Timestamp(epoch);
+        }
     }
 
+    /**
+     * Retrieves an out parameter as a Double object.
+     *
+     * @param name The out parameter name
+     * @return The value as an Double object. Can be null.
+     */
     @Nullable
     public Double getDouble(String name) {
         final Number n = getNumber(name);
         return n == null ? null : n.doubleValue();
     }
 
+    /**
+     * Retrieves an out parameter as a Double object.
+     *
+     * @param pos The out parameter index
+     * @return The value as an Double object. Can be null.
+     */
     @Nullable
     public Double getDouble(int pos) {
         final Number n = getNumber(pos);
         return n == null ? null : n.doubleValue();
     }
 
+    /**
+     * Retrieves an out parameter as a double value.
+     *
+     * @param name The out parameter name
+     * @return The value as an double. Returns 0.0d if the value is absent.
+     * @since 3.43.0
+     */
+    public double getDoubleValue(String name) {
+        final Number n = getNumber(name);
+        return n == null ? 0.0d : n.doubleValue();
+    }
+
+    /**
+     * Retrieves an out parameter as a double value.
+     *
+     * @param pos The out parameter index
+     * @return The value as an double. Returns 0.0d if the value is absent.
+     * @since 3.43.0
+     */
+    public double getDoubleValue(int pos) {
+        final Number n = getNumber(pos);
+        return n == null ? 0.0d : n.doubleValue();
+    }
+
+    /**
+     * Retrieves an out parameter as a Float object.
+     *
+     * @param name The out parameter name
+     * @return The value as an Float object. Can be null.
+     */
     @Nullable
     public Float getFloat(String name) {
         final Number n = getNumber(name);
         return n == null ? null : n.floatValue();
     }
 
+    /**
+     * Retrieves an out parameter as a Float object.
+     *
+     * @param pos The out parameter index
+     * @return The value as an Float object. Can be null.
+     */
     @Nullable
     public Float getFloat(int pos) {
         final Number n = getNumber(pos);
         return n == null ? null : n.floatValue();
     }
 
+    /**
+     * Retrieves an out parameter as a float value.
+     *
+     * @param name The out parameter name
+     * @return The value as an float. Returns 0.0f if the value is absent.
+     * @since 3.43.0
+     */
+    public float getFloatValue(String name) {
+        final Number n = getNumber(name);
+        return n == null ? 0.0f : n.floatValue();
+    }
+
+    /**
+     * Retrieves an out parameter as a float value.
+     *
+     * @param pos The out parameter index
+     * @return The value as an float. Returns 0.0f if the value is absent.
+     * @since 3.43.0
+     */
+    public float getFloatValue(int pos) {
+        final Number n = getNumber(pos);
+        return n == null ? 0.0f : n.floatValue();
+    }
+
+    /**
+     * Retrieves a {@link ResultBearing} for an out parameter. This usually requires that the out parameter is a cursor type.
+     * @param name The out parameter name
+     * @return A {@link ResultBearing} object representing the out parameter and backed by the cursor.
+     * This is not supported by all database drivers. Never null but may be empty.
+     */
     @Nonnull
     public ResultBearing getRowSet(String name) {
         return ResultBearing.of(ResultSetSupplier.notClosingContext(() -> getObject(name, ResultSet.class)), ctx);
     }
 
+    /**
+     * Retrieves a {@link ResultBearing} for an out parameter. This usually requires that the out parameter is a cursor type.
+     * @param pos The out parameter index
+     * @return A {@link ResultBearing} object representing the out parameter and backed by the cursor.
+     * This is not supported by all database drivers. Never null but may be empty.
+     */
     @Nonnull
     public ResultBearing getRowSet(int pos) {
         return ResultBearing.of(ResultSetSupplier.notClosingContext(() -> getObject(pos, ResultSet.class)), ctx);
@@ -234,64 +486,52 @@ public class OutParameters {
 
     @Nullable
     private Number getNumber(String name) {
-        Object obj = getObject(name);
-        if (obj == null) {
-            return null;
-        } else if (obj instanceof Number) {
-            return (Number) obj;
-        } else {
-            throw new IllegalArgumentException(format("Parameter '%s' is a %s, not a number", name, obj.getClass()));
+        try {
+            return getObject(name, Number.class);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(format("Parameter '%s' is not a number", name), e);
         }
     }
 
     @Nullable
     private Number getNumber(int pos) {
-        Object obj = map.getValue(pos);
-        if (obj == null) {
-            return null;
-        } else if (obj instanceof Number) {
-            return (Number) obj;
-        } else {
-            throw new IllegalArgumentException(format("Parameter %d is a %s, not a number", pos, obj.getClass()));
+        try {
+            return getObject(pos, Number.class);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(format("Parameter #%d is not a number", pos), e);
         }
     }
 
     @Nullable
     @SuppressWarnings("JavaUtilDate")
     private Long getEpoch(String name) {
-        Object obj = getObject(name);
-
-        if (obj == null) {
-            return null;
-        } else if (obj instanceof java.util.Date) {
-            return ((java.util.Date) obj).getTime();
-        } else {
-            throw new IllegalArgumentException(format("Parameter '%s' is a %s, not a Date", name, obj.getClass()));
+        try {
+            var date = getObject(name, java.util.Date.class);
+            return date == null ? null : date.getTime();
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(format("Parameter '%s' is not a java.util.Date", name), e);
         }
     }
 
     @Nullable
     @SuppressWarnings("JavaUtilDate")
     private Long getEpoch(int pos) {
-        Object obj = map.getValue(pos);
-
-        if (obj == null) {
-            return null;
-        } else if (obj instanceof java.util.Date) {
-            return ((java.util.Date) obj).getTime();
-        } else {
-            throw new IllegalArgumentException(format("Parameter at %d is a %s, not a Date", pos, obj.getClass()));
+        try {
+            var date = getObject(pos, java.util.Date.class);
+            return date == null ? null : date.getTime();
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(format("Parameter #%d is not a java.util.Date", pos), e);
         }
     }
 
-    void setValue(int index, String key, Supplier<Object> value) {
-        map.setValue(index, key, value);
+    void putValueSupplier(int index, String key, Supplier<Object> value) {
+        map.putValueSupplier(index, key, value);
     }
 
     private static final class ParameterValueMap {
         private final Map<Object, Supplier<Object>> map = new HashMap<>();
 
-        void setValue(int index, String key, Supplier<Object> value) {
+        void putValueSupplier(int index, String key, Supplier<Object> value) {
             map.put(index, value);
             if (key != null) {
                 map.put(key, value);

--- a/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/OutParameters.java
@@ -24,6 +24,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 import org.jdbi.v3.core.result.ResultBearing;
+import org.jdbi.v3.core.result.internal.ResultSetSupplier;
 
 import static java.lang.String.format;
 
@@ -223,24 +224,12 @@ public class OutParameters {
 
     @Nonnull
     public ResultBearing getRowSet(String name) {
-        return ResultBearing.of(() -> {
-            ResultSet resultSet = getObject(name, ResultSet.class);
-            if (resultSet != null) {
-                ctx.addCleanable(resultSet::close);
-            }
-            return resultSet;
-        }, ctx);
+        return ResultBearing.of(ResultSetSupplier.notClosingContext(() -> getObject(name, ResultSet.class)), ctx);
     }
 
     @Nonnull
     public ResultBearing getRowSet(int pos) {
-        return ResultBearing.of(() -> {
-            ResultSet resultSet = getObject(pos, ResultSet.class);
-            if (resultSet != null) {
-                ctx.addCleanable(resultSet::close);
-            }
-            return resultSet;
-        }, ctx);
+        return ResultBearing.of(ResultSetSupplier.notClosingContext(() -> getObject(pos, ResultSet.class)), ctx);
     }
 
     @Nullable

--- a/core/src/test/java/org/jdbi/v3/core/result/TestIterator.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestIterator.java
@@ -194,7 +194,7 @@ public class TestIterator {
         it.next();
         assertThat(it).isExhausted();
 
-        assertThatThrownBy(it::next).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(it::next).isInstanceOf(NoSuchElementException.class);
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/v3/core/result/internal/TestResultSetResultIterator.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/internal/TestResultSetResultIterator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.result.internal;
+
+import java.sql.ResultSet;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.StatementContextAccess;
+import org.jdbi.v3.core.statement.StatementContextListener;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestResultSetResultIterator {
+    AtomicBoolean closed;
+    StatementContext context;
+
+    @BeforeEach
+    void setUp() {
+        this.closed = new AtomicBoolean();
+        this.context = StatementContextAccess.createContext();
+        context.getConfig(SqlStatements.class).addContextListener(getCloseListener(closed));
+    }
+
+
+    @Test
+    public void testNullClosesIterator() throws Exception {
+        Supplier<ResultSet> nullSupplier = () -> null;
+        RowMapper<Integer> mapper = context.findMapperFor(Integer.class).orElseGet(Assertions::fail);
+
+        Iterator<Integer> it = new ResultSetResultIterator<>(nullSupplier, mapper, context);
+        assertThat(it).isExhausted();
+
+        // context was closed
+        assertThat(closed).isTrue();
+    }
+
+    @Test
+    public void testEmptyClosesIterator() throws Exception {
+        Supplier<ResultSet> emptySupplier = EmptyResultSet::new;
+
+        RowMapper<Integer> mapper = context.findMapperFor(Integer.class).orElseGet(Assertions::fail);
+
+        Iterator<Integer> it = new ResultSetResultIterator<>(emptySupplier, mapper, context);
+        assertThat(it).isExhausted();
+
+        // calling hasNext() closes context
+        assertThat(closed).isTrue();
+    }
+
+    private StatementContextListener getCloseListener(AtomicBoolean closed) {
+        return new StatementContextListener() {
+            @Override
+            public void contextCleaned(StatementContext statementContext) {
+                closed.set(true);
+            }
+        };
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/result/internal/TestResultSetSupplier.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/internal/TestResultSetSupplier.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.result.internal;
+
+import java.sql.ResultSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.StatementContextAccess;
+import org.jdbi.v3.core.statement.StatementContextListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestResultSetSupplier {
+    AtomicBoolean closed;
+    StatementContext statementContext;
+
+    @BeforeEach
+    void setUp() {
+        this.closed = new AtomicBoolean();
+        this.statementContext = StatementContextAccess.createContext();
+        this.statementContext.getConfig(SqlStatements.class).addContextListener(getCloseListener(closed));
+    }
+
+    @Test
+    void testCloseContext() throws Exception {
+        Supplier<ResultSet> emptySupplier = EmptyResultSet::new;
+        ResultSetSupplier closingSupplier = ResultSetSupplier.closingContext(emptySupplier, statementContext);
+
+        closingSupplier.close();
+
+        assertThat(closed.get()).isTrue();
+    }
+
+    @Test
+    void testCloseContextResultSet() throws Exception {
+        Supplier<ResultSet> emptySupplier = EmptyResultSet::new;
+        ResultSetSupplier closingSupplier = ResultSetSupplier.closingContext(emptySupplier, statementContext);
+        final ResultSet resultSet = closingSupplier.get();
+        assertThat(resultSet).isNotNull();
+
+        closingSupplier.close();
+
+        assertThat(closed.get()).isTrue();
+    }
+
+    @Test
+    void testCloseContextNullResultSet() throws Exception {
+        Supplier<ResultSet> emptySupplier = () -> null;
+        ResultSetSupplier closingSupplier = ResultSetSupplier.closingContext(emptySupplier, statementContext);
+        final ResultSet resultSet = closingSupplier.get();
+        assertThat(resultSet).isNull();
+
+        closingSupplier.close();
+
+        assertThat(closed.get()).isTrue();
+    }
+
+    @Test
+    void testNonClosingContext() throws Exception {
+        Supplier<ResultSet> emptySupplier = EmptyResultSet::new;
+        ResultSetSupplier closingSupplier = ResultSetSupplier.notClosingContext(emptySupplier);
+
+        closingSupplier.close();
+
+        assertThat(closed.get()).isFalse();
+    }
+
+    @Test
+    void testNonClosingContextResultSet() throws Exception {
+        Supplier<ResultSet> emptySupplier = EmptyResultSet::new;
+        ResultSetSupplier closingSupplier = ResultSetSupplier.notClosingContext(emptySupplier);
+        final ResultSet resultSet = closingSupplier.get();
+        assertThat(resultSet).isNotNull();
+
+        closingSupplier.close();
+
+        assertThat(closed.get()).isFalse();
+    }
+
+    @Test
+    void testNonClosingContextNullResultSet() throws Exception {
+        Supplier<ResultSet> emptySupplier = () -> null;
+        ResultSetSupplier closingSupplier = ResultSetSupplier.notClosingContext(emptySupplier);
+        final ResultSet resultSet = closingSupplier.get();
+        assertThat(resultSet).isNull();
+
+        closingSupplier.close();
+
+        assertThat(closed.get()).isFalse();
+    }
+
+    private StatementContextListener getCloseListener(AtomicBoolean closed) {
+        return new StatementContextListener() {
+            @Override
+            public void contextCleaned(StatementContext statementContext) {
+                closed.set(true);
+            }
+        };
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestCallable.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestCallable.java
@@ -69,74 +69,80 @@ public class TestCallable {
 
     @Test
     public void testStatement() {
-        OutParameters ret = h.createCall("CALL TO_DEGREES(?, ?)")
-            .registerOutParameter(0, Types.DOUBLE)
-            .bind(1, 100.0d)
-            .invoke();
+        try (Call call = h.createCall("CALL TO_DEGREES(?, ?)")) {
+            OutParameters ret = call.registerOutParameter(0, Types.DOUBLE)
+                .bind(1, 100.0d)
+                .invoke();
 
-        Double expected = Math.toDegrees(100.0d);
-        assertThat(ret.getDouble(0)).isEqualTo(expected, Offset.offset(0.001));
-        assertThat(ret.getLong(0).longValue()).isEqualTo(expected.longValue());
-        assertThat(ret.getShort(0).shortValue()).isEqualTo(expected.shortValue());
-        assertThat(ret.getInt(0).intValue()).isEqualTo(expected.intValue());
-        assertThat(ret.getFloat(0).floatValue()).isEqualTo(expected.floatValue(), Offset.offset(0.001f));
+            Double expected = Math.toDegrees(100.0d);
+            assertThat(ret.getDouble(0)).isEqualTo(expected, Offset.offset(0.001));
+            assertThat(ret.getLong(0).longValue()).isEqualTo(expected.longValue());
+            assertThat(ret.getShort(0).shortValue()).isEqualTo(expected.shortValue());
+            assertThat(ret.getInt(0).intValue()).isEqualTo(expected.intValue());
+            assertThat(ret.getFloat(0).floatValue()).isEqualTo(expected.floatValue(), Offset.offset(0.001f));
 
-        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ret.getDate(0));
-        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ret.getDate(1));
+            assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ret.getDate(0));
+            assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ret.getDate(1));
+        }
     }
 
     @Test
     public void testStatementWithNamedParam() {
-        OutParameters ret = h.createCall("CALL TO_DEGREES(:x, :y)")
-            .registerOutParameter("x", Types.DOUBLE)
-            .bind("y", 100.0d)
-            .invoke();
+        try (Call call = h.createCall("CALL TO_DEGREES(:x, :y)")) {
+            OutParameters ret = call
+                .registerOutParameter("x", Types.DOUBLE)
+                .bind("y", 100.0d)
+                .invoke();
 
-        Double expected = Math.toDegrees(100.0d);
-        assertThat(ret.getDouble("x")).isEqualTo(expected, Offset.offset(0.001));
-        assertThat(ret.getLong("x").longValue()).isEqualTo(expected.longValue());
-        assertThat(ret.getShort("x").shortValue()).isEqualTo(expected.shortValue());
-        assertThat(ret.getInt("x").intValue()).isEqualTo(expected.intValue());
-        assertThat(ret.getFloat("x")).isEqualTo(expected.floatValue());
+            Double expected = Math.toDegrees(100.0d);
+            assertThat(ret.getDouble("x")).isEqualTo(expected, Offset.offset(0.001));
+            assertThat(ret.getLong("x").longValue()).isEqualTo(expected.longValue());
+            assertThat(ret.getShort("x").shortValue()).isEqualTo(expected.shortValue());
+            assertThat(ret.getInt("x").intValue()).isEqualTo(expected.intValue());
+            assertThat(ret.getFloat("x")).isEqualTo(expected.floatValue());
 
-        assertThatExceptionOfType(Exception.class).isThrownBy(() -> ret.getDate("x"));
-        assertThatExceptionOfType(Exception.class).isThrownBy(() -> ret.getDate("y"));
+            assertThatExceptionOfType(Exception.class).isThrownBy(() -> ret.getDate("x"));
+            assertThatExceptionOfType(Exception.class).isThrownBy(() -> ret.getDate("y"));
+        }
     }
 
     @Test
     public void testWithNullReturn() {
-        OutParameters ret = h.createCall("CALL DO_LENGTH(?, ?)")
-            .bind(0, (String) null)
-            .registerOutParameter(1, Types.INTEGER)
-            .invoke();
+        try (Call call = h.createCall("CALL DO_LENGTH(?, ?)")) {
+            OutParameters ret = call.bind(0, (String) null)
+                .registerOutParameter(1, Types.INTEGER)
+                .invoke();
 
-        Integer out = ret.getInt(1);
-        assertThat(out).isNull();
+            Integer out = ret.getInt(1);
+            assertThat(out).isNull();
+        }
     }
 
     @Test
     public void testWithNullReturnWithNamedParam() {
-        OutParameters ret = h.createCall("CALL DO_LENGTH(:in, :out)")
-            .bindNull("in", Types.VARCHAR)
-            .registerOutParameter("out", Types.INTEGER)
-            .invoke();
+        try (Call call = h.createCall("CALL DO_LENGTH(:in, :out)")) {
+            OutParameters ret = call.bindNull("in", Types.VARCHAR)
+                .registerOutParameter("out", Types.INTEGER)
+                .invoke();
 
-        Integer out = ret.getInt(1);
-        assertThat(out).isNull();
+            Integer out = ret.getInt(1);
+            assertThat(out).isNull();
+        }
     }
 
     @Test
     public void testProcedureWithoutOutParameter() {
-        h.createCall("CALL WITH_SIDE_EFFECT(:id, :name)")
-            .bind("id", 10)
-            .bind("name", "John")
-            .invoke();
+        try (Call call = h.createCall("CALL WITH_SIDE_EFFECT(:id, :name)")) {
+            call.bind("id", 10)
+                .bind("name", "John")
+                .invoke();
 
-        String name = h.createQuery("SELECT name FROM something WHERE id = :id")
-            .bind("id", 10)
-            .mapTo(String.class)
-            .one();
+            String name = h.createQuery("SELECT name FROM something WHERE id = :id")
+                .bind("id", 10)
+                .mapTo(String.class)
+                .one();
 
-        assertThat(name).isEqualTo("John Doe");
+            assertThat(name).isEqualTo("John Doe");
+        }
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestCallable.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestCallable.java
@@ -145,4 +145,40 @@ public class TestCallable {
             assertThat(name).isEqualTo("John Doe");
         }
     }
+
+    @Test
+    public void testNullValue() {
+        h.execute("CREATE OR REPLACE PROCEDURE RETURN_VALUE(input integer, OUT result integer) AS $$\n"
+            + "BEGIN\n"
+            + "result := input;\n"
+            + "END;\n"
+            + "$$ LANGUAGE plpgsql;");
+
+        try (Call call = h.createCall("CALL RETURN_VALUE(:in, :out)")) {
+            OutParameters result = call.bind("in", 10)
+                .registerOutParameter("out", Types.INTEGER)
+                .invoke();
+
+            int out = result.getIntValue("out");
+            assertThat(out).isEqualTo(10);
+        }
+
+        try (Call call = h.createCall("CALL RETURN_VALUE(:in, :out)")) {
+            OutParameters result = call.bindNull("in", Types.INTEGER)
+                .registerOutParameter("out", Types.INTEGER)
+                .invoke();
+
+            int out = result.getIntValue("out");
+            assertThat(out).isZero();
+        }
+
+        try (Call call = h.createCall("CALL RETURN_VALUE(:in, :out)")) {
+            OutParameters result = call.bindNull("in", Types.INTEGER)
+                .registerOutParameter("out", Types.INTEGER)
+                .invoke();
+
+            Integer out = result.getInt("out");
+            assertThat(out).isNull();
+        }
+    }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestCallable.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestCallable.java
@@ -75,11 +75,11 @@ public class TestCallable {
                 .invoke();
 
             Double expected = Math.toDegrees(100.0d);
-            assertThat(ret.getDouble(0)).isEqualTo(expected, Offset.offset(0.001));
-            assertThat(ret.getLong(0).longValue()).isEqualTo(expected.longValue());
-            assertThat(ret.getShort(0).shortValue()).isEqualTo(expected.shortValue());
-            assertThat(ret.getInt(0).intValue()).isEqualTo(expected.intValue());
-            assertThat(ret.getFloat(0).floatValue()).isEqualTo(expected.floatValue(), Offset.offset(0.001f));
+            assertThat(ret.getDoubleValue(0)).isEqualTo(expected, Offset.offset(0.001));
+            assertThat(ret.getLongValue(0)).isEqualTo(expected.longValue());
+            assertThat(ret.getShortValue(0)).isEqualTo(expected.shortValue());
+            assertThat(ret.getIntValue(0)).isEqualTo(expected.intValue());
+            assertThat(ret.getFloatValue(0)).isEqualTo(expected.floatValue(), Offset.offset(0.001f));
 
             assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ret.getDate(0));
             assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ret.getDate(1));
@@ -95,11 +95,11 @@ public class TestCallable {
                 .invoke();
 
             Double expected = Math.toDegrees(100.0d);
-            assertThat(ret.getDouble("x")).isEqualTo(expected, Offset.offset(0.001));
-            assertThat(ret.getLong("x").longValue()).isEqualTo(expected.longValue());
-            assertThat(ret.getShort("x").shortValue()).isEqualTo(expected.shortValue());
-            assertThat(ret.getInt("x").intValue()).isEqualTo(expected.intValue());
-            assertThat(ret.getFloat("x")).isEqualTo(expected.floatValue());
+            assertThat(ret.getDoubleValue("x")).isEqualTo(expected, Offset.offset(0.001));
+            assertThat(ret.getLongValue("x")).isEqualTo(expected.longValue());
+            assertThat(ret.getShortValue("x")).isEqualTo(expected.shortValue());
+            assertThat(ret.getIntValue("x")).isEqualTo(expected.intValue());
+            assertThat(ret.getFloatValue("x")).isEqualTo(expected.floatValue());
 
             assertThatExceptionOfType(Exception.class).isThrownBy(() -> ret.getDate("x"));
             assertThatExceptionOfType(Exception.class).isThrownBy(() -> ret.getDate("y"));

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -164,12 +164,13 @@ public class TestStatements {
 
         h.execute("CREATE ALIAS TO_DEGREES FOR \"java.lang.Math.toDegrees\"");
 
-        Call call = h.createCall("? = CALL TO_DEGREES(?)")
-            .registerOutParameter(0, Types.DOUBLE)
-            .bind(1, 100.0d)
-            .bind(2, "foo");
+        try (Call call = h.createCall("? = CALL TO_DEGREES(?)")) {
+            call.registerOutParameter(0, Types.DOUBLE)
+                .bind(1, 100.0d)
+                .bind(2, "foo");
 
-        assertThatThrownBy(call::invoke).isInstanceOf(UnableToCreateStatementException.class);
+            assertThatThrownBy(call::invoke).isInstanceOf(UnableToCreateStatementException.class);
+        }
     }
 
     @Test
@@ -177,13 +178,13 @@ public class TestStatements {
         Handle h = h2Extension.getSharedHandle();
 
         h.execute("CREATE ALIAS TO_DEGREES FOR \"java.lang.Math.toDegrees\"");
+        h.configure(SqlStatements.class, stmts -> stmts.setUnusedBindingAllowed(true));
+        try (Call call = h.createCall("? = CALL TO_DEGREES(?)")) {
+            call.registerOutParameter(0, Types.DOUBLE)
+                .bind(1, 100.0d)
+                .bind(2, "foo");
 
-        Call call = h.configure(SqlStatements.class, stmts -> stmts.setUnusedBindingAllowed(true))
-            .createCall("? = CALL TO_DEGREES(?)")
-            .registerOutParameter(0, Types.DOUBLE)
-            .bind(1, 100.0d)
-            .bind(2, "foo");
-
-        assertThatCode(call::invoke).doesNotThrowAnyException();
+            assertThatCode(call::invoke).doesNotThrowAnyException();
+        }
     }
 }

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -824,9 +824,17 @@ Suppressed: org.postgresql.util.PSQLException: ERROR: duplicate key value violat
 
 ==== Stored Procedure Calls
 
-A *Call* invokes a database stored procedure.
+A *Call* invokes a database stored procedure. Stored procedures execute on the database and take input and output parameters.
 
-Let's assume an existing stored procedure as an example:
+Most databases solely support input and output parameters. Input parameters can be mapped using the standard Jdbi
+mechanisms for parameters, while output values are returned using link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] objects.
+
+Some databases do not support all SQL types as out parameters but use a mechanism similar to a query and
+return a link:{jdkdocs}/java.sql/java/sql/ResultSet.html[ResultSet^] object.
+
+===== Using OutParameters to access database return values
+
+This is an example for a PostgreSQL stored procedure. PostgreSQL (and most other databases) stored procedures use `IN` parameters to pass values into the procedure and `OUT` parameters to return values.
 
 [source,sql]
 ----
@@ -853,25 +861,70 @@ include::{exampledir}/CallTest.java[tags=invokeProcedure]
 
 Invoking the stored procedure returns an
 link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] object, which
-contains the value(s) returned from the stored procedure call.
-
-Now we can extract the result(s) from link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^]:
+contains the value(s) returned from the stored procedure call and the results can
+be extracted from it:
 
 [source,java,indent=0]
 ----
 include::{exampledir}/CallTest.java[tags=getOutParameters]
 ----
 
-It is possible to return open cursors as a result-like object by declaring it
-as `Types.REF_CURSOR` and then inspecting it via `OutParameters.getRowSet()`.
-Usually this must be done in a transaction, and the results must be consumed
-before closing the statement by processing it using the `Call.invoke(Consumer)`
-or `Call.invoke(Function)` callback style.
+It is possible to access open cursors as a result set objects by declaring them
+as link:{jdkdocs}/java.sql/java/sql/Types.html#REF_CURSOR[Types.REF_CURSOR^] and then using link:{jdbidocs}/core/statement/OutParameters.html#getRowSet(int)[OutParameters#getRowSet()^] to access them as link:{jdbidocs}/core/result/ResultBearing.html[ResultBearing^] objects. This requires  support from the JDBC driver for the database and is not supported by all databases. Please consult the documentation for the database driver first before filing a bug.
+
+Results must be consumed before closing the statement because closing it will also close all resources and result sets associated with it.
+
+The link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] object can either be returned from the Call using link:{jdbidocs}/core/statement/Call.html#invoke()[Call#invoke()^] or it can be processed as
+a consumer argument with link:{jdbidocs}/core/statement/Call.html#invoke(java.util.function.Consumer)[Call#invoke(Consumer)^] or a function argument with
+link:{jdbidocs}/core/statement/Call.html#invoke(java.util.function.Function)[Call#invoke(Function)^].
 
 [WARNING]
 Due to design constraints within JDBC, the parameter data types available
-through link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] is limited to those types supported directly by JDBC.
-This cannot be expanded through e.g. mapper registration.
+through link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] are limited to those types supported directly by JDBC. This cannot be expanded through e.g. mapper registration.
+
+
+===== Using a ResultSet for procedure output values
+
+Some database drivers might return a link:{jdkdocs}/java.sql/java/sql/ResultSet.html[ResultSet^] containing the results of a stored procedure. This result set is available as a link:{jdbidocs}/core/result/ResultBearing.html[ResultBearing^] object by calling link:{jdbidocs}/core/statement/OutParameters.html#getResultSet()[OutParameters#getResultSet()^].
+
+[NOTE]
+While returning a result set from a procedure call is supported in the JDBC standard, it is pretty uncommon and only very few databases support it. The most prominent one is the JDBC driver for MS SQLServer. Most databases will either return null or an empty result set; in this case the link:{jdbidocs}/core/statement/OutParameters.html#getResultSet()[OutParameters#getResultSet()^] will return an empty link:{jdbidocs}/core/result/ResultBearing.html[ResultBearing^] object.
+
+This is the equivalent procedure from above for MS SQLServer using a result set:
+
+[source,sql]
+----
+CREATE PROCEDURE mssql_add
+    @a INT,
+    @b INT
+AS
+BEGIN
+  SELECT @a + @b;
+END
+----
+
+To access data from this procedure, it retrieves the result set using link:{jdbidocs}/core/statement/OutParameters.html#getResultSet()[OutParameters#getResultSet()^]:
+
+[source, java]
+----
+try (Call call = h.createCall("{call mssql_add(:a, :b)}")) {
+    call.bind("a", 13)
+        .bind("b", 9);
+    OutParameters output = call.invoke();
+
+    int sum = output.getResultSet() // <1>
+        .mapTo(Integer.class) // <2>
+        .one();
+
+    assertThat(sum).isEqualTo(22);
+}
+----
+<1> Retrieve the output from the procedure using a result set.
+<2> Map the first column in the result set to an integer value.
+
+It may not be necessary to use a result set if the JDBC driver also supports OUT parameters. However, e.g. MS SQL Server does not allow link:{jdkdocs}/java.sql/java/sql/Types.html#REF_CURSOR[Types.REF_CURSOR^] as OUT parameters and requires the use of a result set.
+
+It is possible to mix OUT parameters and a result set. In this case, the result set should be consumed before accessing any out parameters as the database driver might invalidate the result set when accessing out parameters.
 
 
 ==== Scripts
@@ -1229,6 +1282,70 @@ jdbi.useHandle(handle -> {
             // consume the iterator contents
         });
     });
+----
+
+
+==== OutParameters return values for stored procedures
+
+Interacting with stored procedures generally involves passing values back and forth from database. Jdbi uses link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] objects which are returned from the various invoke methods of the link:{jdbidocs}/core/statement/Call.html[Call^] object.
+
+When using link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] with stored procedures, the link:{jdbidocs}/core/statement/Call.html[Call^] statement *must* be managed. Calling link:{jdkdocs}/java.base/java/lang/AutoCloseable.html#close--[close()^] on the statement terminates the operation and release all resources.
+
+Closing the stream or iterator associated with an object returned by link:{jdbidocs}/core/statement/OutParameters.html#getResultSet()[OutParameters#getResultSet()^] or link:{jdbidocs}/core/statement/OutParameters.html#getRowSet(int)[OutParameters#getRowSet()^] is *not* sufficient as the link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] object may hold multiple result sets.
+
+[source, java]
+----
+try (Call call = h.createCall("{call some_procedure()}")) {
+    OutParameters output = call.invoke();
+
+    output.getRowSet("result") // <1>
+        .mapTo(SomeType.class) // <2>
+        .useStream(stream -> { ... consume stream ... }); <3>
+}
+----
+<1> Retrieve the cursor for the `result` parameter
+<2> Map the results onto a data type using a row mapper
+<3> Consume the stream of objects with a consumer argument.
+
+When the stream terminates, the link:{jdbidocs}/core/statement/Call.html[Call^] statement is *not* closed as it may have returned multiple cursor parameters. It must be managed using try-with-resources as shown above.
+
+link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] objects are cursor-type "live" objects. They require an active statment and any operation that closes and releases the statement will cause future operations on a related link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] object to fail.
+
+The following code *does not work*:
+
+[source,java,indent=0]
+----
+// DOES NOT WORK!
+OutParameters out  = jdbi.withHandle(handle -> {
+    Call call = handle.createCall("{call some_procedure()}");
+    return call.invoke(); // <1>
+}); // <2>
+String result = out.getString("result"); // <3>
+----
+<1> Creates an OutParameter object and returns it from withHandle.
+<2> Leaving the callback closes the handle and releases all resources including the statement.
+<3> throws an exception because closing the handle and the statement invalidates the link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] object.
+
+This can be avoided by either processing the link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] object within the handle callback or by using either the link:{jdbidocs}/core/statement/Call.html#invoke(java.util.function.Consumer)[Call#invoke(Consumer)^] or
+link:{jdbidocs}/core/statement/Call.html#invoke(java.util.function.Function)[Call#invoke(Function)^] callback methods:
+
+[source,java,indent=0]
+----
+// process the OutParameters within the handle callback
+String result  = jdbi.withHandle(handle -> {
+    Call call = handle.createCall("{call some_procedure()}");
+    OutParameters out = call.invoke();
+    return out.getString("result");
+});
+----
+
+[source,java,indent=0]
+----
+// use a callback method from the Call statement
+String result  = jdbi.withHandle(handle -> {
+    Call call = handle.createCall("{call some_procedure()}");
+    return call.invoke(out -> out.getString("result"));
+});
 ----
 
 
@@ -1646,7 +1763,7 @@ include::{exampledir}/ResultsTest.java[tags=inlineRowMapper]
 
 [TIP]
 There are three different types being used in the above example. link:{jdbidocs}/core/statement/Query.html[Query^],
-returned by `Handle.createQuery()`, implements the `ResultBearing` interface.
+returned by `Handle.createQuery()`, implements the link:{jdbidocs}/core/result/ResultBearing.html[ResultBearing^] interface.
 The `ResultBearing.map()` method takes a link:{jdbidocs}/core/mapper/RowMapper.html[RowMapper<T>^] and returns a
 `ResultIterable<T>`. Finally, `ResultBearing.list()` collects each row in the
 result set into a link:{jdkdocs}/java.base/java/util/List.html[List<T>^].
@@ -3915,25 +4032,43 @@ link:{jdbidocs}/sqlobject/statement/SqlCall.html[@SqlCall^] methods can return `
 link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] if the stored procedure has any output parameters. Each output parameter must be registered
 with the link:{jdbidocs}/sqlobject/customizer/OutParameter.html[@OutParameter^] annotation.
 
+Returning an link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] object from an extension method is *incompatible* with <<on-demand-extension, on-demand objects>>. Any <<using-jdbi-extensions, other extension method>> can be used to create extension objects that can provide output parameters. Alternatively, it is possible to use <<sql-call-consumer-arguments, consumer or function arguments>> with on-demand extensions.
+
+
 [source,java,indent=0]
 ----
 public interface OrderDao {
+    // only works with Handle#attach() or Jdbi#withExtension() / Jdbi#useExtension()
     @SqlCall("{call prepare_order_from_cart(:cartId, :orderId, :orderTotal)}")
     @OutParameter(name = "orderId",    sqlType = java.sql.Types.BIGINT)
     @OutParameter(name = "orderTotal", sqlType = java.sql.Types.DECIMAL)
     OutParameters prepareOrderFromCart(@Bind("cartId") long cartId);
+
+    // using a consumer argument works with any extension method
+    @SqlCall("{call prepare_order_from_cart(:cartId, :orderId, :orderTotal)}")
+    @OutParameter(name = "orderId",    sqlType = java.sql.Types.BIGINT)
+    @OutParameter(name = "orderTotal", sqlType = java.sql.Types.DECIMAL)
+    prepareOrderFromCart(@Bind("cartId") long cartId, Consumer<OutParameters> consumer);
+
+    // using a function argument also works with any extension method
+    @SqlCall("{call prepare_order_from_cart(:cartId, :orderId, :orderTotal)}")
+    @OutParameter(name = "orderId",    sqlType = java.sql.Types.BIGINT)
+    @OutParameter(name = "orderTotal", sqlType = java.sql.Types.DECIMAL)
+    SomeResult prepareOrderFromCart(@Bind("cartId") long cartId, Function<OutParameters, SomeResult> function);
 }
 ----
 
 Individual output parameters can be extracted from the
-link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] returned from
-the method:
+link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] object:
 
 [source,java,indent=0]
 ----
-OutParameters outParams = orderDao.prepareOrderFromCart(cartId);
-long orderId = outParams.getLong("orderId");
-double orderTotal = outParams.getDouble("orderTotal");
+db.useExtension(OrderDao.class, orderDao -> {
+    OutParameters outParams = orderDao.prepareOrderFromCart(cartId);
+    long orderId = outParams.getLong("orderId");
+    double orderTotal = outParams.getDouble("orderTotal");
+    ...
+});
 ----
 
 link:{jdbidocs}/sqlobject/statement/SqlCall.html[@SqlCall^] supports <<sql-call-consumer-arguments, special arguments>> for link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] processing.
@@ -4016,6 +4151,8 @@ long bobId = dao.insertFullContact(bob); // <1>
 <1> each of these operations creates and releases a new database connection.
 
 The performance of on-demand objects depends on the database and database connection pooling. For performance critical operations, it may be better to manage the handle manually and use attached objects.
+
+On-demand instances open and close the underlying link:{jdkdocs}/java.sql/java/sql/PreparedStatement.html[PreparedStatement^] objects for every call to an extension method. They are incompatible with any object or operation that relies on an open statement to retrieve data from the database (e.g. link:{jdkdocs}/java/util/stream/Stream.html[Stream^] and link:{jdkdocs}/java/util/Iterator.html[Iterator^] for query operations or link:{jdbidocs}/core/statement/OutParameters.html[OutParameters^] for call operations). It is possible to use <<consumer-and-function-arguments, consumer or function arguments>> to process these values as the callback is executed while the statement is still open.
 
 
 ==== Interface default methods
@@ -4201,6 +4338,7 @@ void insert(long id, String name);
 ----
 
 
+[#consumer-and-function-arguments]
 ==== Consumer and Function arguments
 
 ===== Consumer arguments
@@ -8059,6 +8197,7 @@ The Extension framework is generic and supports any type of extension that can b
 Jdbi provides the <<sql-objects,SQLObject plugin>>, which offers a declarative API by placing annotations on interface methods.
 
 
+[#using-jdbi-extensions]
 === Using Jdbi extensions
 
 _Extension types are usually java interface classes._ Any interface can be an extension type.
@@ -8106,6 +8245,7 @@ include::{exampledir}/ExtensionFrameworkTest.java[tags=handle_attach]
 The link:{jdbidocs}/core/Jdbi.html#withExtension(java.lang.Class,org.jdbi.v3.core.extension.ExtensionCallback)[Jdbi#withExtension()^], link:{jdbidocs}/core/Jdbi.html#useExtension(java.lang.Class,org.jdbi.v3.core.extension.ExtensionConsumer)[Jdbi#useExtension()^] and link:{jdbidocs}/core/Handle.html#attach(java.lang.Class)[Handle#attach()^] methods are the most common way to use extension type implementations.
 
 
+[#on-demand-extension]
 ==== On-demand extensions
 
 An extension type implementation can be acquired by calling the link:{jdbidocs}/core/Jdbi.html#onDemand(java.lang.Class)[Jdbi#onDemand()^] method which returns
@@ -9382,7 +9522,7 @@ Core API:
 * `ResultColumnMapperFactory` -> link:{jdbidocs}/core/mapper/ColumnMapperFactory.html[ColumnMapperFactory^]
 * link:{jdbidocs}/core/statement/Query.html[Query^] no longer maps to `Map<String, Object>` by default. Call
   `Query.mapToMap()`, `.mapToBean(type)`, `.map(mapper)` or `.mapTo(type)`.
-* `ResultBearing<T>` was refactored into `ResultBearing` (no generic parameter)
+* `ResultBearing<T>` was refactored into link:{jdbidocs}/core/result/ResultBearing.html[ResultBearing^] (no generic parameter)
   and `ResultIterable<T>`. Call `.mapTo(type)` to get a `ResultIterable<T>`.
 * `TransactionConsumer` and `TransactionCallback` only take a link:{jdbidocs}/core/Handle.html[Handle^] now--the
   `TransactionStatus` argument is removed. Just rollback the handle now.

--- a/docs/src/test/java/jdbi/doc/CallTest.java
+++ b/docs/src/test/java/jdbi/doc/CallTest.java
@@ -18,6 +18,7 @@ import java.sql.Types;
 import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
 import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.Call;
 import org.jdbi.v3.core.statement.OutParameters;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.junit.jupiter.api.Test;
@@ -41,18 +42,18 @@ public class CallTest {
         handle.execute(findSqlOnClasspath("create_stored_proc_add"));
 
         // tag::invokeProcedure[]
-        OutParameters result = handle
-            .createCall("{:sum = call add(:a, :b)}") // <1>
-                .bind("a", 13) // <2>
+        try (Call call = handle.createCall("{:sum = call add(:a, :b)}")) { // <1>
+            OutParameters result = call.bind("a", 13) // <2>
                 .bind("b", 9) // <2>
                 .registerOutParameter("sum", Types.INTEGER) // <3> <4>
                 .invoke(); // <5>
-        // end::invokeProcedure[]
+            // end::invokeProcedure[]
 
-        // tag::getOutParameters[]
-        int sum = result.getInt("sum");
-        // end::getOutParameters[]
+            // tag::getOutParameters[]
+            int sum = result.getInt("sum");
+            // end::getOutParameters[]
 
-        assertThat(sum).isEqualTo(22);
+            assertThat(sum).isEqualTo(22);
+        }
     }
 }

--- a/integration-testing/pom.xml
+++ b/integration-testing/pom.xml
@@ -30,6 +30,8 @@
     <properties>
         <basepom.deploy.skip>true</basepom.deploy.skip>
         <basepom.install.skip>true</basepom.install.skip>
+        <!-- docker tests run long -->
+        <basepom.test.timeout>600</basepom.test.timeout>
         <moduleName>org.jdbi.v3.integrationtest</moduleName>
     </properties>
 
@@ -59,6 +61,30 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>test</scope>
@@ -75,5 +101,35 @@
             <artifactId>pg-embedded</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mssqlserver</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>no-docker</id>
+            <activation>
+                <property>
+                    <name>no-docker</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/testcontainer/*</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/integration-testing/src/test/java/org/jdbi/v3/integrationtest/testcontainer/TestMSSQLStoredProcedure.java
+++ b/integration-testing/src/test/java/org/jdbi/v3/integrationtest/testcontainer/TestMSSQLStoredProcedure.java
@@ -22,7 +22,6 @@ import org.jdbi.v3.core.statement.OutParameters;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.tc.JdbiTestcontainersExtension;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -86,7 +85,6 @@ class TestMSSQLStoredProcedure {
     }
 
     @Test
-    @Disabled
     void testMsSqlOutParametersAndResultSet() {
         Handle h = extension.getSharedHandle();
         h.execute("CREATE PROCEDURE passValues\n"
@@ -112,4 +110,26 @@ class TestMSSQLStoredProcedure {
             assertThat(output.getString(2)).isEqualTo("hello");
         }
     }
+
+    @Test
+    void testMsSqlDocExample() {
+        Handle h = extension.getSharedHandle();
+        h.execute("CREATE PROCEDURE mssql_add\n"
+            + "@a INT,\n"
+            + "@b INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "SELECT @a + @b;\n"
+            + "END");
+
+        try (Call call = h.createCall("{ call mssql_add(:a, :b)}")) {
+            call.bind("a", 13)
+                .bind("b", 9);
+            OutParameters output = call.invoke();
+
+            int sum = output.getResultSet().mapTo(Integer.class).one();
+            assertThat(sum).isEqualTo(22);
+        }
+    }
+
 }

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -106,6 +106,7 @@
         <dep.lombok.version>1.18.30</dep.lombok.version>
         <dep.mockito.version>5.8.0</dep.mockito.version>
         <dep.moshi.version>1.15.0</dep.moshi.version>
+        <dep.mssql.version>12.4.2.jre11</dep.mssql.version>
         <dep.mysql.version>8.2.0</dep.mysql.version>
         <dep.otj-pg-embedded.version>1.0.2</dep.otj-pg-embedded.version>
         <dep.pg-embedded.version>5.1.0</dep.pg-embedded.version>
@@ -314,6 +315,12 @@
                 <groupId>com.mysql</groupId>
                 <artifactId>mysql-connector-j</artifactId>
                 <version>${dep.mysql.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>${dep.mssql.version}</version>
             </dependency>
 
             <dependency>

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlCall.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestSqlCall.java
@@ -16,10 +16,13 @@ package org.jdbi.v3.sqlobject;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.core.statement.Call;
+import org.jdbi.v3.core.statement.OutParameters;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlCall;
@@ -54,14 +57,14 @@ public class TestSqlCall {
     @Test
     public void testFoo() {
         Dao dao = handle.attach(Dao.class);
-//        OutParameters out = handle.createCall(":num = call stored_insert(:id, :name)")
-//                                  .bind("id", 1)
-//                                  .bind("name", "Jeff")
-//                                  .registerOutParameter("num", Types.INTEGER)
-//                                  .invoke();
-        dao.insert(1, "Jeff");
+        try (Call call = handle.createCall(":num = call stored_insert(:id, :name)")) {
+            OutParameters out = call.bind("id", 1)
+                .bind("name", "Jeff")
+                .registerOutParameter("num", Types.INTEGER)
+                .invoke();
+        }
 
-        assertThat(handle.attach(Dao.class).findById(1)).isEqualTo(new Something(1, "Jeff"));
+        assertThat(dao.findById(1)).isEqualTo(new Something(1, "Jeff"));
     }
 
     public interface Dao {

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -34,7 +34,6 @@
         <basepom.test.timeout>600</basepom.test.timeout>
         <!-- Sigh. Java is really hard. Leave this at 0.3.2, all other versions are worse -->
         <dep.clickhouse.version>0.3.2</dep.clickhouse.version>
-        <dep.mssql.version>12.4.2.jre11</dep.mssql.version>
         <dep.oracle-xe.version>23.3.0.23.09</dep.oracle-xe.version>
         <dep.trino.version>435</dep.trino.version>
         <dep.yugabyte.version>42.3.5-yb-4</dep.yugabyte.version>
@@ -73,12 +72,6 @@
                 <groupId>io.trino</groupId>
                 <artifactId>trino-jdbc</artifactId>
                 <version>${dep.trino.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.microsoft.sqlserver</groupId>
-                <artifactId>mssql-jdbc</artifactId>
-                <version>${dep.mssql.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fully support JDBC drivers that return stored procedure results as a
ResultSet. Allow mixing standard out parameters with ResultSet.

Also support returning values from OutParameters.
