### PR TITLE
Switch Mockito to proxy-only mode and disable byte-buddy agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 11, 17, 21 ]
+        java-version: [ 11, 17, 21, 22-ea ]
 
     steps:
       - uses: actions/checkout@v4

--- a/commons-text/src/test/java/org/jdbi/v3/commonstext/TestStringSubstitutorTemplateEngine.java
+++ b/commons-text/src/test/java/org/jdbi/v3/commonstext/TestStringSubstitutorTemplateEngine.java
@@ -13,36 +13,20 @@
  */
 package org.jdbi.v3.commonstext;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.StatementContextAccess;
 import org.jdbi.v3.core.statement.TemplateEngine;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 public class TestStringSubstitutorTemplateEngine {
 
-    @Mock
-    private StatementContext ctx;
-
-    private final Map<String, Object> attributes = new HashMap<>();
-
-    @BeforeEach
-    public void before() {
-        when(ctx.getAttributes()).thenReturn(attributes);
-    }
+    private StatementContext ctx = StatementContextAccess.createContext();
 
     @Test
     public void testDefaults() {
-        attributes.put("name", "foo");
+        ctx.define("name", "foo");
 
         assertThat(new StringSubstitutorTemplateEngine().render("create table ${name};", ctx))
             .isEqualTo("create table foo;");
@@ -50,8 +34,6 @@ public class TestStringSubstitutorTemplateEngine {
 
     @Test
     public void testMissingAttribute() {
-        attributes.clear();
-
         TemplateEngine engine = StringSubstitutorTemplateEngine.between('<', '>');
 
         assertThat(engine.render("select * from foo where x=<x>", ctx))
@@ -60,7 +42,7 @@ public class TestStringSubstitutorTemplateEngine {
 
     @Test
     public void testNullAttribute() {
-        attributes.put("x", null);
+        ctx.define("x", null);
 
         TemplateEngine engine = StringSubstitutorTemplateEngine.between('<', '>');
 
@@ -70,7 +52,7 @@ public class TestStringSubstitutorTemplateEngine {
 
     @Test
     public void testCustomPrefixSuffix() {
-        attributes.put("name", "foo");
+        ctx.define("name", "foo");
 
         TemplateEngine engine = StringSubstitutorTemplateEngine.between('<', '>');
 
@@ -80,7 +62,7 @@ public class TestStringSubstitutorTemplateEngine {
 
     @Test
     public void testEscapeCharacter() {
-        attributes.put("name", "foo");
+        ctx.define("name", "foo");
 
         TemplateEngine engine = StringSubstitutorTemplateEngine.between('<', '>', '@');
 

--- a/core/src/main/java/org/jdbi/v3/core/Handle.java
+++ b/core/src/main/java/org/jdbi/v3/core/Handle.java
@@ -144,7 +144,7 @@ public class Handle implements Closeable, Configurable<Handle> {
      * @return the JDBC {@link Connection} this Handle uses.
      */
     public Connection getConnection() {
-        return this.connection;
+        return connection;
     }
 
     /**

--- a/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
+++ b/core/src/test/java/org/jdbi/v3/core/HandleAccess.java
@@ -16,12 +16,10 @@ package org.jdbi.v3.core;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.DefaultStatementBuilder;
 import org.jdbi.v3.core.transaction.LocalTransactionHandler;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Utilities for testing jdbi internal classes.
@@ -36,9 +34,9 @@ public final class HandleAccess {
     public static Handle createHandle() throws SQLException {
         Connection fakeConnection = mock(Connection.class);
 
-        ConfigRegistry configRegistry = new ConfigRegistry();
-        Jdbi fakeJdbi = mock(Jdbi.class);
-        when(fakeJdbi.getConfig()).thenReturn(configRegistry);
+        Jdbi fakeJdbi = Jdbi.create(() -> {
+            throw new UnsupportedOperationException();
+        });
 
         return Handle.createHandle(fakeJdbi, fakeConnection::close, new LocalTransactionHandler(),
             new DefaultStatementBuilder(), fakeConnection);

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestAbstractArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestAbstractArgumentFactory.java
@@ -24,6 +24,7 @@ import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.StatementContextAccess;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -39,8 +40,7 @@ public class TestAbstractArgumentFactory {
     @Mock
     PreparedStatement statement;
 
-    @Mock
-    StatementContext ctx;
+    StatementContext ctx = StatementContextAccess.createContext();
 
     static class SimpleType {
         final String value;

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestLocalDateArgument.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestLocalDateArgument.java
@@ -18,7 +18,7 @@ import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.Optional;
 
-import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.StatementContextAccess;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -37,9 +37,6 @@ public class TestLocalDateArgument {
     @Mock
     PreparedStatement stmt;
 
-    @Mock
-    StatementContext ctx;
-
     @Test
     public void testBindLocalDate() throws SQLException {
         ArgumentFactory factory = new JavaTimeArgumentFactory();
@@ -50,7 +47,7 @@ public class TestLocalDateArgument {
         assertThat(optionalArgument).isPresent();
 
         Argument argument = optionalArgument.get();
-        argument.apply(5, stmt, ctx);
+        argument.apply(5, stmt, StatementContextAccess.createContext());
 
         verify(stmt).setDate(5, java.sql.Date.valueOf(date));
     }

--- a/core/src/test/java/org/jdbi/v3/core/statement/ArgumentBinderTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/ArgumentBinderTest.java
@@ -17,9 +17,6 @@ import java.sql.PreparedStatement;
 import java.util.Arrays;
 
 import org.jdbi.v3.core.argument.Argument;
-import org.jdbi.v3.core.argument.Arguments;
-import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.qualifier.Qualifiers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +27,6 @@ import org.mockito.quality.Strictness;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -39,16 +35,11 @@ public class ArgumentBinderTest {
 
     @Mock
     private PreparedStatement stmt;
-    @Mock
-    private StatementContext ctx;
-
-    private SqlStatements statements = new SqlStatements();
+    StatementContext ctx;
 
     @BeforeEach
     public void before() {
-        when(ctx.getConfig(Qualifiers.class)).thenReturn(new Qualifiers());
-        when(ctx.getConfig(SqlStatements.class)).thenReturn(statements);
-        when(ctx.getConfig(Arguments.class)).thenReturn(new Arguments(new ConfigRegistry()));
+        ctx = StatementContextAccess.createContext();
     }
 
     @Test
@@ -130,6 +121,6 @@ public class ArgumentBinderTest {
     }
 
     private void allowUnused() {
-        statements.setUnusedBindingAllowed(true);
+        ctx.getConfig(SqlStatements.class).setUnusedBindingAllowed(true);
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestMessageFormatTemplateEngine.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestMessageFormatTemplateEngine.java
@@ -13,66 +13,56 @@
  */
 package org.jdbi.v3.core.statement;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TestMessageFormatTemplateEngine {
     private TemplateEngine templateEngine;
     private StatementContext ctx;
-    private Map<String, Object> attributes;
 
     @BeforeEach
     public void setUp() {
         templateEngine = new MessageFormatTemplateEngine();
-        attributes = new HashMap<>();
-        ctx = mock(StatementContext.class);
-        when(ctx.getAttributes()).thenReturn(attributes);
+        ctx = StatementContextAccess.createContext();
     }
 
     @Test
     public void testNoPlaceholdersNoValues() {
-        attributes.clear();
-
         assertThat(templateEngine.render("foo bar", ctx)).isEqualTo("foo bar");
     }
 
     @Test
     public void testWithPlaceholdersAndValues() {
-        attributes.put("02", "!");
-        attributes.put("000", "hello");
-        attributes.put("01", "world");
+        ctx.define("02", "!");
+        ctx.define("000", "hello");
+        ctx.define("01", "world");
 
         assertThat(templateEngine.render("{0} {1}{2}", ctx)).isEqualTo("hello world!");
     }
 
     @Test
     public void testManyValues() {
-        attributes.put("000", "a");
-        attributes.put("001", "b");
-        attributes.put("002", "c");
-        attributes.put("003", "d");
-        attributes.put("004", "e");
-        attributes.put("005", "f");
-        attributes.put("006", "g");
-        attributes.put("007", "h");
-        attributes.put("008", "i");
-        attributes.put("009", "j");
-        attributes.put("010", "k");
+        ctx.define("000", "a");
+        ctx.define("001", "b");
+        ctx.define("002", "c");
+        ctx.define("003", "d");
+        ctx.define("004", "e");
+        ctx.define("005", "f");
+        ctx.define("006", "g");
+        ctx.define("007", "h");
+        ctx.define("008", "i");
+        ctx.define("009", "j");
+        ctx.define("010", "k");
 
         assertThat(templateEngine.render("{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}", ctx)).isEqualTo("abcdefghijk");
     }
 
     @Test
     public void testNoPlaceholdersButWithValues() {
-        attributes.put("0", "hello");
+        ctx.define("0", "hello");
 
         assertThatThrownBy(() -> templateEngine.render("foo bar", ctx))
             .isInstanceOf(IllegalArgumentException.class)
@@ -81,8 +71,6 @@ public class TestMessageFormatTemplateEngine {
 
     @Test
     public void testWithPlaceholdersButNoValues() {
-        attributes.clear();
-
         assertThatThrownBy(() -> templateEngine.render("{0} bar", ctx))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("expected 1 keys but got 0");
@@ -90,7 +78,7 @@ public class TestMessageFormatTemplateEngine {
 
     @Test
     public void testNullValue() {
-        attributes.put("0", null);
+        ctx.define("0", null);
 
         assertThat(templateEngine.render("{0} bar", ctx))
             .isEqualTo("null bar");
@@ -98,7 +86,7 @@ public class TestMessageFormatTemplateEngine {
 
     @Test
     public void testNegativeKey() {
-        attributes.put("-1", "hello");
+        ctx.define("-1", "hello");
 
         assertThatThrownBy(() -> templateEngine.render("{0} bar", ctx))
             .isInstanceOf(IllegalArgumentException.class)
@@ -107,8 +95,8 @@ public class TestMessageFormatTemplateEngine {
 
     @Test
     public void testDuplicateKey() {
-        attributes.put("0", "hello");
-        attributes.put("00", "world");
+        ctx.define("0", "hello");
+        ctx.define("00", "world");
 
         assertThatThrownBy(() -> templateEngine.render("{0} {1}", ctx))
             .isInstanceOf(IllegalArgumentException.class)
@@ -117,8 +105,8 @@ public class TestMessageFormatTemplateEngine {
 
     @Test
     public void testSkippedKey() {
-        attributes.put("0", "hello");
-        attributes.put("2", "world");
+        ctx.define("0", "hello");
+        ctx.define("2", "world");
 
         assertThatThrownBy(() -> templateEngine.render("{0} {1}", ctx))
             .isInstanceOf(IllegalArgumentException.class)
@@ -127,7 +115,7 @@ public class TestMessageFormatTemplateEngine {
 
     @Test
     public void testNonNumericKey() {
-        attributes.put("abc", "hello");
+        ctx.define("abc", "hello");
 
         assertThatThrownBy(() -> templateEngine.render("{0} bar", ctx))
             .isInstanceOf(IllegalArgumentException.class)
@@ -136,7 +124,7 @@ public class TestMessageFormatTemplateEngine {
 
     @Test
     public void testWhitespaceInKey() {
-        attributes.put(" 1 ", "hello");
+        ctx.define(" 1 ", "hello");
 
         assertThatThrownBy(() -> templateEngine.render("{0} bar", ctx))
             .isInstanceOf(IllegalArgumentException.class)
@@ -145,7 +133,7 @@ public class TestMessageFormatTemplateEngine {
 
     @Test
     public void testBlankKey() {
-        attributes.put(" ", "hello");
+        ctx.define(" ", "hello");
 
         assertThatThrownBy(() -> templateEngine.render("{0} bar", ctx))
             .isInstanceOf(IllegalArgumentException.class)
@@ -154,7 +142,7 @@ public class TestMessageFormatTemplateEngine {
 
     @Test
     public void testEscaping() {
-        attributes.put("0", "foo");
+        ctx.define("0", "foo");
 
         assertThat(templateEngine.render("select * from {0} where name = ''john'' and stuff = '''{0}'''", ctx))
             .isEqualTo("select * from foo where name = 'john' and stuff = '{0}'");

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
@@ -16,22 +16,18 @@ package org.jdbi.v3.core.transaction;
 import java.sql.Connection;
 
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ExtendWith(MockitoExtension.class)
 public class TestLocalTransactionHandler {
-    @Mock
-    Handle h;
 
-    @Mock
-    Connection c;
+    Connection c = Mockito.mock(Connection.class);
+
+    Handle h = Jdbi.create(() -> c).open();
 
     @Test
     public void testRollbackThrow() throws Exception {
@@ -39,8 +35,7 @@ public class TestLocalTransactionHandler {
         RuntimeException inner = new RuntimeException("Rollback throws!");
 
         Mockito.when(c.getAutoCommit()).thenReturn(true);
-        Mockito.when(h.getConnection()).thenReturn(c);
-        Mockito.when(h.rollback()).thenThrow(inner);
+        Mockito.doThrow(inner).when(c).rollback();
 
         try {
             new LocalTransactionHandler().inTransaction(h, x -> {
@@ -58,7 +53,6 @@ public class TestLocalTransactionHandler {
         Error error = new Error("Transaction throws!");
 
         Mockito.when(c.getAutoCommit()).thenReturn(true);
-        Mockito.when(h.getConnection()).thenReturn(c);
 
         assertThatThrownBy(() ->
             new LocalTransactionHandler().inTransaction(h, x -> {

--- a/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-proxy

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -379,6 +379,12 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${dep.mockito.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy-agent</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -906,11 +912,6 @@
             <activation>
                 <jdk>[21,)</jdk>
             </activation>
-            <properties>
-                <!-- see https://github.com/mockito/mockito/issues/3037 -->
-                <basepom.it.arguments>-XX:+EnableDynamicAgentLoading</basepom.it.arguments>
-                <basepom.test.arguments>-XX:+EnableDynamicAgentLoading</basepom.test.arguments>
-            </properties>
             <build>
                 <pluginManagement>
                     <plugins>


### PR DESCRIPTION
A possible path to get rid of the byte-buddy agent entirely.
Depends on: #2595 
Fixes: #2549
Fixes: #2506 (while this does not remove all tests, the remaining ones I think are reasonably well justified)
Replaces: #2569 