### PR TITLE
Add a test case showing that even if commit() always fails, Jdbi will commit

### DIFF
--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
@@ -193,7 +193,6 @@ public class TestBatching {
     }
 
     @Test
-    @Disabled // XXX: https://github.com/jdbi/jdbi/pull/2595
     public void testBatchingWithSerializableTransactionRunner() throws SQLException {
         var delegateAnswer = AdditionalAnswers.delegatesTo(
                 h2Extension.getSharedHandle().getConnection());


### PR DESCRIPTION
I think this might have crept in with the transaction handling rewrite - even if `commit()` always throws, Jdbi will accidentally (?) commit due to skipping `rollback` before `setAutoCommit(false)`
This behavior is pretty surprising to me -- wdyt @hgschmie?