### PR TITLE
TestSqlArrays: make independent of timezone

### DIFF
--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestSqlArrays.java
@@ -61,7 +61,7 @@ public class TestSqlArrays {
     public JdbiExtension pgExtension = JdbiExtension.postgres(pg).withPlugins(new SqlObjectPlugin(), new PostgresPlugin())
         .withInitializer((ds, h) -> h.useTransaction(th -> {
             th.execute("DROP TABLE IF EXISTS uuids");
-            th.execute("CREATE TABLE uuids (u UUID[], i INT[], t TIMESTAMP[])");
+            th.execute("CREATE TABLE uuids (u UUID[], i INT[], t TIMESTAMPTZ[])");
         }));
 
     private Handle handle;
@@ -71,7 +71,7 @@ public class TestSqlArrays {
     public void setUp() {
         handle = pgExtension.openHandle()
             // register array type to the handle
-            .registerArrayType(Instant.class, "timestamp");
+            .registerArrayType(Instant.class, "timestamptz");
 
         // attach the array object to the handle as well.
         ao = handle.attach(ArrayObject.class);


### PR DESCRIPTION
Right now if you run this test in e.g. PST, it fails due to zone offset, which is a known issue with pg TIMESTAMP type

fix is to use TIMESTAMPTZ