### PR TITLE
commit throws still commits

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- fix edge condition when calling `Connection#commit()` threw an Exception, we called commit() again. Now the
+  code explicitly calls `Connection#rollback()`. Fixes #2595
+
 # 3.43.0
 
 ** POTENTIAL BREAKING CHANGE **

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
@@ -35,7 +35,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBatching.java
@@ -193,7 +193,6 @@ public class TestBatching {
     }
 
     @Test
-    @Disabled // XXX: https://github.com/jdbi/jdbi/pull/2595
     public void testBatchingWithSerializableTransactionRunner() throws SQLException {
         var delegateAnswer = AdditionalAnswers.delegatesTo(
                 h2Extension.getSharedHandle().getConnection());


### PR DESCRIPTION
Fix situation where an exception in `Connection#commit()` still called `commit()`.

Fixes #2595
