### PR TITLE
Run CI tests with different timezone and locale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,28 @@ jobs:
           MAVEN_CONFIG: "-B -fae"
         run: |
           make run-tests
+
+  ci-locale:
+    name: Run tests with different timezone and locale
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: maven
+
+      - name: install code
+        env:
+          MAVEN_CONFIG: "-B -fae"
+        run: |
+          make install-fast
+
+      - name: run tests
+        env:
+          MAVEN_CONFIG: "-B -fae -Djdbi.test.timezone=Asia/Colombo -Djdbi.test.language=tr -Djdbi.test.region=TR"
+        run: |
+          make run-tests

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -38,3 +38,28 @@ jobs:
           MAVEN_CONFIG: "-B -fae -Ddep.testcontainers.version=${{ matrix.testcontainer-version }}"
         run: |
           make run-slow-tests
+
+  slow-tests-locale:
+    name: Run slow tests with different timezone and locale
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: maven
+
+      - name: install code
+        env:
+          MAVEN_CONFIG: "-B -fae"
+        run: |
+          make install-fast
+
+      - name: run slow tests
+        env:
+          MAVEN_CONFIG: "-B -fae -Djdbi.test.timezone=Asia/Colombo -Djdbi.test.language=tr -Djdbi.test.region=TR"
+        run: |
+          make run-slow-tests

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -134,6 +134,9 @@
         <jdbi.check.skip-ktlint>${jdbi.check.skip-kotlin}</jdbi.check.skip-ktlint>
         <jdbi.check.skip-sortpom>${basepom.check.skip-basic}</jdbi.check.skip-sortpom>
         <jdbi.test.pg-version>15</jdbi.test.pg-version>
+        <jdbi.test.timezone>UTC</jdbi.test.timezone>
+        <jdbi.test.language>en</jdbi.test.language>
+        <jdbi.test.region>US</jdbi.test.region>
         <kotlin.compiler.apiVersion>1.6</kotlin.compiler.apiVersion>
         <kotlin.compiler.jvmTarget>${project.build.targetJdk}</kotlin.compiler.jvmTarget>
         <kotlin.compiler.languageVersion>1.6</kotlin.compiler.languageVersion>
@@ -850,8 +853,11 @@
                         <groups />
                         <!-- junit 4 and 5 -->
                         <excludedGroups>slow,org.jdbi.v3.testing.SlowTests</excludedGroups>
-                        <systemPropertyVariables combine.children="append">
+                        <systemPropertyVariables combine.children="override">
                             <pg-embedded.postgres-version>${jdbi.test.pg-version}</pg-embedded.postgres-version>
+                            <user.timezone>${jdbi.test.timezone}</user.timezone>
+                            <user.language>${jdbi.test.language}</user.language>
+                            <user.region>${jdbi.test.region}</user.region>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Add CI flows that run all tests with different timezone and locale

- Asia/Colombo was chosen because it has a 5:30 offset
- tr_TR was chosen because it has letters that have no capitalization

addresses #2598
