### PR TITLE
maven build warnings cleanup

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -126,6 +126,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.openjdk.jmh.Main</mainClass>
                                 </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
                             </transformers>
                             <filters>
                                 <filter>
@@ -135,9 +136,13 @@
                                     -->
                                     <artifact>*:*</artifact>
                                     <excludes>
+                                        <exclude>module-info.class</exclude>
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/LICENSE-notice.md</exclude>
+                                        <exclude>META-INF/maven/org.antlr/antlr4-runtime/pom.*</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -71,7 +71,7 @@
         <dep.antlr.version>4.13.1</dep.antlr.version>
         <dep.asciidoctorj-diagram.version>2.2.14</dep.asciidoctorj-diagram.version>
         <dep.asciidoctorj.version>2.5.10</dep.asciidoctorj.version>
-        <dep.assertj.version>3.24.2</dep.assertj.version>
+        <dep.assertj.version>3.25.1</dep.assertj.version>
         <dep.caffeine.version>3.1.8</dep.caffeine.version>
         <dep.checkerframework.version>3.42.0</dep.checkerframework.version>
         <dep.commons-compress.version>1.25.0</dep.commons-compress.version>
@@ -403,13 +403,6 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-guava</artifactId>
                 <version>${dep.assertj.version}</version>
-                <exclusions>
-                    <!-- exclusion is needed, otherwise the version checks on CI fail -->
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
@@ -524,13 +517,6 @@
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
                 <version>${dep.hikari-cp.version}</version>
-                <exclusions>
-                    <!-- excluded because it asks for 2.0.0 -->
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -85,4 +85,9 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+    </build>
 </project>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -100,4 +100,9 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+    </build>
 </project>


### PR DESCRIPTION
Here is a short summary:
* AssertJ version can be bumped to "3.25.1" Hopefully then CI will not fail even without exclusion of "guava", because guava version is upgraded to "33.0.0-jre" (the same like jdbi)
* HikariCP stop using slf4j-api 2.0.0 since they stop support of Java 8, so no need to exclude it
* Changes in "kotlin" and "kotlin-sqlobject" are recommended by https://kotlinlang.org/docs/maven.html#compile-kotlin-only-source-code
* Creation of "uberjar" in "beanchmark" faces the problem of "merging" of artefacts like "module-info.class", "MANIFEST.MF", etc. and is no way perfect. Now the conflicting once are excluded and it is not any worse (or better) than before. But at least multiple warnings are gone.

About remaining warnings:
* Another warning can be avoided if "<exclude>**/*.MockMaker</exclude>" is added to the respective pom.xml in "basepom" module.
* There are few warning because of disabled test.
* And one warning in "spring5" is caused by missing "jsr305", but as far as I understand "jdbi" is trying to avoit this library.
* There are few more warning coming from "kotlin" modules which I can try to remove.