### PR TITLE
Update testcontainers and derby

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -16,7 +16,12 @@ jobs:
 
     strategy:
       matrix:
-        testcontainer-version: [ 1.18.3, 1.19.3 ]
+        testcontainer-version: [ 1.19.4 ]
+        mysql-version: [ "mysql:latest" ]
+        # 1.18.3 does not work with mysql:latest (8.3.x).
+        include:
+          - testcontainer-version: 1.18.3
+            mysql-version: "mysql:8.0"
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +40,7 @@ jobs:
 
       - name: run slow tests
         env:
-          MAVEN_CONFIG: "-B -fae -Ddep.testcontainers.version=${{ matrix.testcontainer-version }}"
+          MAVEN_CONFIG: "-B -fae -Ddep.testcontainers.version=${{ matrix.testcontainer-version }} -Djdbi.test.mysql-version=${{ matrix.mysql-version }}"
         run: |
           make run-slow-tests
 

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -77,8 +77,8 @@
         <dep.commons-compress.version>1.25.0</dep.commons-compress.version>
         <dep.commons-lang.version>3.14.0</dep.commons-lang.version>
         <dep.commons-text.version>1.11.0</dep.commons-text.version>
-        <!-- derby 10.16 is JDK 17 only, keep it on 10.15 for now -->
-        <dep.derby.version>10.15.2.0</dep.derby.version>
+        <!-- derby 10.17 is JDK 21 only, keep it on 10.16 for now -->
+        <dep.derby.version>10.16.1.1</dep.derby.version>
         <dep.detekt.version>1.23.4</dep.detekt.version>
         <dep.errorprone.version>2.24.0</dep.errorprone.version>
         <dep.flyway.version>9.22.3</dep.flyway.version>
@@ -124,7 +124,7 @@
         <dep.spring.version>5.3.31</dep.spring.version>
         <dep.sqlite.version>3.44.1.0</dep.sqlite.version>
         <dep.stringtemplate4.version>4.3.4</dep.stringtemplate4.version>
-        <dep.testcontainers.version>1.19.3</dep.testcontainers.version>
+        <dep.testcontainers.version>1.19.4</dep.testcontainers.version>
         <dep.vavr.version>0.9.3</dep.vavr.version>
         <jdbi.check.fail-detekt>${jdbi.check.fail-kotlin}</jdbi.check.fail-detekt>
         <jdbi.check.fail-kotlin>${basepom.check.fail-extended}</jdbi.check.fail-kotlin>
@@ -133,9 +133,7 @@
         <jdbi.check.skip-kotlin>${basepom.check.skip-extended}</jdbi.check.skip-kotlin>
         <jdbi.check.skip-ktlint>${jdbi.check.skip-kotlin}</jdbi.check.skip-ktlint>
         <jdbi.check.skip-sortpom>${basepom.check.skip-basic}</jdbi.check.skip-sortpom>
-        <!-- see https://github.com/testcontainers/testcontainers-java/pull/8131. -->
-        <!-- tc 1.19.4 will fix this but we need to retain the property for integration testing with older tc -->
-        <jdbi.test.mysql-version>mysql:8.0</jdbi.test.mysql-version>
+        <jdbi.test.mysql-version>mysql:latest</jdbi.test.mysql-version>
         <jdbi.test.pg-version>15</jdbi.test.pg-version>
         <jdbi.test.timezone>UTC</jdbi.test.timezone>
         <jdbi.test.language>en</jdbi.test.language>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -32,8 +32,7 @@
         <basepom.test.fork-count>1</basepom.test.fork-count>
         <!-- docker tests run long -->
         <basepom.test.timeout>600</basepom.test.timeout>
-        <!-- Sigh. Java is really hard. Leave this at 0.3.2, all other versions are worse -->
-        <dep.clickhouse.version>0.3.2</dep.clickhouse.version>
+        <dep.clickhouse.version>0.6.0</dep.clickhouse.version>
         <dep.oracle-xe.version>23.3.0.23.09</dep.oracle-xe.version>
         <dep.trino.version>435</dep.trino.version>
         <dep.yugabyte.version>42.3.5-yb-4</dep.yugabyte.version>
@@ -53,13 +52,7 @@
                 <groupId>com.clickhouse</groupId>
                 <artifactId>clickhouse-jdbc</artifactId>
                 <version>${dep.clickhouse.version}</version>
-                <exclusions>
-                    <!-- sigh. Java is hard -->
-                    <exclusion>
-                        <groupId>com.clickhouse</groupId>
-                        <artifactId>clickhouse-grpc-client</artifactId>
-                    </exclusion>
-                </exclusions>
+                <classifier>all</classifier>
             </dependency>
 
             <dependency>
@@ -124,6 +117,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
+            <classifier>all</classifier>
             <scope>test</scope>
         </dependency>
 

--- a/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/TestcontainersDatabaseInformation.java
+++ b/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/TestcontainersDatabaseInformation.java
@@ -36,9 +36,8 @@ import static java.lang.String.format;
 @Beta
 public final class TestcontainersDatabaseInformation {
 
-    // Clickhouse driver uses schema for database selection...
     private static final TestcontainersDatabaseInformation CLICKHOUSE =
-        of(null, null, null, (catalogName, schemaName) -> format("CREATE DATABASE %s Engine = Memory", schemaName));
+        of(null, null, null, (catalogName, schemaName) -> format("CREATE DATABASE %s Engine = Memory", catalogName));
 
     private static final TestcontainersDatabaseInformation MYSQL =
         of("root", null, null, (catalogName, schemaName) -> format("CREATE DATABASE %s", catalogName));

--- a/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiGenericExtensionTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiGenericExtensionTest.java
@@ -19,10 +19,13 @@ import java.util.UUID;
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@EnabledForJreRange(min = JRE.JAVA_17)
 public class JdbiGenericExtensionTest {
 
     @RegisterExtension


### PR DESCRIPTION
tc 1.19.4 contains the mysql fix for mysql 8.3.x
derby 1.16 runs on JDK 17+ only
