### PR TITLE
Make jdbi testcontainers shutdown configurable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 - Test DB2 basic integration (#2625, thanks @stoyants)
 - create CycloneDX SBOM files for release versions
+- add `JdbiTestContainersExtension#setShutdownWaitTime(int)` to control waiting for extension shutdown if a database is very slow. Addresses #2629 (thanks @stoyants).
 
 # 3.44.1
 

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -6187,7 +6187,7 @@ The `dbContainer` object is registered as class level field for sharing between 
 
 The link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] has built-in support to isolate each test method in a test class. The container can be declared as a static class member which speeds up test execution significantly.
 
-There is built-in support for MySQL, MariaDB, TiDB, PostgreSQL, CockroachDB, YugabyteDB, ClickHouseDB, Oracle XE, Oracle free, Trino and MS SQLServer. It also supports the various compatible flavors (such as PostGIS for PostgreSQL).
+There is built-in support for MySQL, MariaDB, TiDB, PostgreSQL, CockroachDB, YugabyteDB, ClickHouseDB, Oracle XE, Oracle free, Trino, MS SQLServer and DB2. It also supports the various compatible flavors (such as PostGIS for PostgreSQL).
 
 By default, Jdbi tries to run every test with its own schema instance in a single schema. For database engines that do not support schemas, it will use separate catalogs. For database engines that do not support catalogs or schemas (e.g. MySQL), it will use separate databases.
 
@@ -6203,6 +6203,7 @@ For each database, Jdbi can provide custom user, catalog and schema names and re
 | Oracle XE, Oracle free | Schema | `system` | (default catalog) | (random)
 | Trino | Schema | (default) | `memory` | (random)
 | MS SQLServer | Catalog | `sa` | (random) |
+| DB2 | Schema | (default) | `test` | (random) |
 |=====
 
 - Database user _(default)_: Jdbi uses the default user as returned by the testcontainer class.
@@ -6249,6 +6250,20 @@ private static final TestcontainersDatabaseInformation CUSTOM_MYSQL =
 
 
 The Javadoc for the link:{jdbidocs}/testing/junit5/tc/TestcontainersDatabaseInformation.html[TestcontainersDatabaseInformation^] class has additional details on how to create custom link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] instances.
+
+==== Controlling the extension shutdown timeout
+
+Some testcontainer based database may take a long time to create a new schema so when tests run very fast, shutting down the link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] at the end of a test may interrupt this process and log spurious messages in the logs. Those messages are benign and can be safely ignored. If it is necessary (e.g. because there is a "no messages" policy in place at your organization), the shutdown time can be extended by setting the wait time to a higher value than the default of 10 seconds:
+
+[source,java,indent=0]
+----
+@RegisterExtension
+JdbiExtension extension = JdbiTestcontainersExtension.instance(CUSTOM_MYSQL, dbContainer)
+    .setShutdownWaitTimeInSeconds(20); // set shutdown wait time to 20 seconds
+----
+
+[WARNING]
+Using a wait time of 0 seconds will wait until all of the internal state has been shutdown completely. This may result in infinite hangs of the tests when shutting down.
 
 
 == Third-Party Integration

--- a/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/JdbiTestcontainersExtension.java
+++ b/testcontainers/src/main/java/org/jdbi/v3/testing/junit5/tc/JdbiTestcontainersExtension.java
@@ -17,6 +17,7 @@ import javax.sql.DataSource;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.jdbi.v3.meta.Alpha;
 import org.jdbi.v3.meta.Beta;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -45,7 +46,7 @@ public final class JdbiTestcontainersExtension extends JdbiExtension {
      * @return An initialized {@link JdbiExtension} instance that uses the database container.
      * @throws IllegalArgumentException If the provided container class is not supported.
      */
-    public static JdbiExtension instance(JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
+    public static JdbiTestcontainersExtension instance(JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
         TestcontainersDatabaseInformation databaseInformation = TestcontainersDatabaseInformation.forTestcontainerClass(jdbcDatabaseContainer.getClass());
 
         if (databaseInformation == null) {
@@ -62,7 +63,7 @@ public final class JdbiTestcontainersExtension extends JdbiExtension {
      * @param jdbcDatabaseContainer A {@link JdbcDatabaseContainer} instance.
      * @return An initialized {@link JdbiExtension} instance that uses the database container.
      */
-    public static JdbiExtension instance(TestcontainersDatabaseInformation databaseInformation, JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
+    public static JdbiTestcontainersExtension instance(TestcontainersDatabaseInformation databaseInformation, JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
         return new JdbiTestcontainersExtension(databaseInformation, jdbcDatabaseContainer);
     }
 
@@ -70,6 +71,19 @@ public final class JdbiTestcontainersExtension extends JdbiExtension {
         this.jdbcDatabaseContainer = jdbcDatabaseContainer;
         this.databaseInformation = databaseInformation;
         this.instanceProvider = new TestcontainersDatabaseInformationSupplier(databaseInformation);
+    }
+
+    /**
+     * Sets the maximum wait time for shutting down the extension.
+     * @see TestcontainersDatabaseInformation#setShutdownWaitTimeInSeconds(int)
+     *
+     * @since 3.45.0
+     */
+    @Alpha
+    public JdbiTestcontainersExtension setShutdownWaitTimeInSeconds(int seconds) {
+        this.databaseInformation.setShutdownWaitTimeInSeconds(seconds);
+
+        return this;
     }
 
     @Override


### PR DESCRIPTION
Allow setting the timeout for shutting down the JdbiTestContainersExtension. This addresses the
issue that the database may shut down before init scripts are completely executed which results
in spurious error messages.

Addresses #2629
