### PR TITLE
create sbom files in package phase

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -1295,7 +1295,7 @@
                                 <goals>
                                     <goal>makeBom</goal>
                                 </goals>
-                                <phase>verify</phase>
+                                <phase>package</phase>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Otherwise they are not signed by the gpg plugin for a release and
the release fails.
