### PR TITLE
Ensure that release build runs the enforcer

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -1262,6 +1262,7 @@
             <id>jdbi-release</id>
             <properties>
                 <basepom.check.skip-all>true</basepom.check.skip-all>
+                <basepom.check.skip-enforcer>false</basepom.check.skip-enforcer>
             </properties>
 
             <build>


### PR DESCRIPTION
Otherwise, the "require java 21" is not actually enforced when building
the release.
