### PR TITLE
Handle constructing record classes

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorInstanceFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorInstanceFactory.java
@@ -14,6 +14,13 @@
 package org.jdbi.v3.core.mapper.reflect;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.jdbi.v3.core.internal.exceptions.Unchecked;
 
@@ -22,9 +29,17 @@ import static java.util.Objects.requireNonNull;
 class ConstructorInstanceFactory<T> extends InstanceFactory<T> {
     private final Constructor<T> constructor;
 
+    private final Supplier<Type[]> typeSupplier;
+
     ConstructorInstanceFactory(Constructor<T> constructor) {
         super(constructor);
         this.constructor = requireNonNull(constructor, "constructor is null");
+        this.typeSupplier = getTypeSupplier(constructor, super::getTypes);
+    }
+
+    @Override
+    Type[] getTypes() {
+        return typeSupplier.get();
     }
 
     @Override
@@ -35,5 +50,43 @@ class ConstructorInstanceFactory<T> extends InstanceFactory<T> {
     @Override
     public String toString() {
         return constructor.toString();
+    }
+
+    // Note: this can be removed once https://bugs.openjdk.org/browse/JDK-8320575 is resolved
+    private static <T> boolean isGenericInformationLost(Constructor<T> factory) {
+        // If there is more than one constructor, ensure that the factory constructor is the canonical constructor.
+        // If so it will need to get the type parameters from the declared fields.
+        if (factory.getParameters().length != getFields(factory)
+            .count()) {
+            return false;
+        }
+        boolean lossDetected = false;
+        for (int i = 0; i < factory.getParameters().length; i++) {
+            Parameter parameter = factory.getParameters()[i];
+            Field field = factory.getDeclaringClass().getDeclaredFields()[i];
+            if (!parameter.getName().equals(field.getName()) || !parameter.getType().equals(field.getType())) {
+                return false;
+            }
+            // Check if the generic type information is lost, due to jdk21 record constructor: https://bugs.openjdk.org/browse/JDK-8320575
+            if (parameter.getType().getTypeParameters().length > 0
+                && !parameter.getParameterizedType().equals(field.getGenericType())) {
+                lossDetected = true;
+            }
+        }
+        return lossDetected;
+    }
+
+    private static <T> Supplier<Type[]> getTypeSupplier(Constructor<T> constructor, Supplier<Type[]> defaultSupplier) {
+        if (isGenericInformationLost(constructor)) {
+            return () -> getFields(constructor)
+                .map(Field::getGenericType)
+                .toArray(Type[]::new);
+        }
+        return defaultSupplier;
+    }
+
+    private static <T> Stream<Field> getFields(Constructor<T> constructor) {
+        return Arrays.stream(constructor.getDeclaringClass().getDeclaredFields())
+            .filter(field -> !Modifier.isStatic(field.getModifiers()));
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -17,6 +17,7 @@ import java.beans.ConstructorProperties;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -206,14 +207,14 @@ public final class ConstructorMapper<T> implements RowMapper<T> {
                                                List<String> unmatchedColumns) {
         final int count = factory.getParameterCount();
         final Parameter[] parameters = factory.getParameters();
-
+        final Type[] types = factory.getTypes();
         boolean matchedColumns = false;
         final List<String> unmatchedParameters = new ArrayList<>();
         final List<ParameterData> paramData = new ArrayList<>();
 
         for (int i = 0; i < count; i++) {
             final Parameter parameter = parameters[i];
-
+            final Type parameterType = types[i];
             boolean nullable = isNullable(parameter);
             Nested nested = parameter.getAnnotation(Nested.class);
             if (nested == null) {
@@ -224,7 +225,7 @@ public final class ConstructorMapper<T> implements RowMapper<T> {
 
                 if (columnIndex.isPresent()) {
                     int colIndex = columnIndex.getAsInt();
-                    final QualifiedType<?> type = QualifiedType.of(parameter.getParameterizedType())
+                    final QualifiedType<?> type = QualifiedType.of(parameterType)
                         .withAnnotations(ctx.getConfig(Qualifiers.class).findFor(parameter));
                     paramData.add(new ParameterData(i, parameter, ctx.findColumnMapperFor(type)
                         .map(mapper -> new SingleColumnMapper<>(mapper, colIndex + 1))

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/InstanceFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/InstanceFactory.java
@@ -16,6 +16,8 @@ package org.jdbi.v3.core.mapper.reflect;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -40,6 +42,12 @@ abstract class InstanceFactory<T> {
 
     Parameter[] getParameters() {
         return executable.getParameters();
+    }
+
+    Type[] getTypes() {
+        return Arrays.stream(getParameters())
+            .map(Parameter::getParameterizedType)
+            .toArray(Type[]::new);
     }
 
     @Nullable


### PR DESCRIPTION
Get paramater types for records from RecordComponent. Record constructors lose generic type information. This is due to https://bugs.openjdk.org/browse/JDK-8320575.