### PR TITLE
Cache types in ConstructorMapper

### DIFF
--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/ConstructorBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/ConstructorBenchmark.java
@@ -59,7 +59,7 @@ public class ConstructorBenchmark {
 
     public static void main(final String[] args) throws RunnerException {
         final Options options = new OptionsBuilder()
-            .include(BeanBindingBenchmark.class.getSimpleName())
+            .include(ConstructorBenchmark.class.getSimpleName())
             .forks(0)
             .build();
         new Runner(options).run();

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -207,14 +207,14 @@ public final class ConstructorMapper<T> implements RowMapper<T> {
                                                List<String> unmatchedColumns) {
         final int count = factory.getParameterCount();
         final Parameter[] parameters = factory.getParameters();
-        final Type[] types = factory.getTypes();
+        final List<Type> types = factory.getTypes();
         boolean matchedColumns = false;
         final List<String> unmatchedParameters = new ArrayList<>();
         final List<ParameterData> paramData = new ArrayList<>();
 
         for (int i = 0; i < count; i++) {
             final Parameter parameter = parameters[i];
-            final Type parameterType = types[i];
+            final Type parameterType = types.get(i);
             boolean nullable = isNullable(parameter);
             Nested nested = parameter.getAnnotation(Nested.class);
             if (nested == null) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/InstanceFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/InstanceFactory.java
@@ -18,12 +18,14 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
 import jakarta.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 abstract class InstanceFactory<T> {
     private final Executable executable;
@@ -44,10 +46,10 @@ abstract class InstanceFactory<T> {
         return executable.getParameters();
     }
 
-    Type[] getTypes() {
+    List<Type> getTypes() {
         return Arrays.stream(getParameters())
             .map(Parameter::getParameterizedType)
-            .toArray(Type[]::new);
+            .collect(toUnmodifiableList());
     }
 
     @Nullable


### PR DESCRIPTION
Cache types to avoid expensive calculations in ConstructorInstanceFactory.
Following up on suggestions from #2648.

The constructor lookup should be quick: `hashCode` is class name and `equals` compares parameters using object equality.