### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.7.2

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -120,7 +120,7 @@
         <dep.plugin.kotlin.version>1.9.22</dep.plugin.kotlin.version>
         <dep.plugin.ktlint.version>2.0.0</dep.plugin.ktlint.version>
         <dep.plugin.sortpom.version>3.3.0</dep.plugin.sortpom.version>
-        <dep.postgresql.version>42.7.1</dep.postgresql.version>
+        <dep.postgresql.version>42.7.2</dep.postgresql.version>
         <dep.slf4j.version>1.7.36</dep.slf4j.version>
         <dep.spring.version>5.3.31</dep.spring.version>
         <dep.sqlite.version>3.44.1.0</dep.sqlite.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.7.1
- [CVE-2024-1597](https://www.oscs1024.com/hd/CVE-2024-1597)


### What did I do？
Upgrade org.postgresql:postgresql from 42.7.1 to 42.7.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS