### PR TITLE
Raise exception if a positional param is missing

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -71,11 +71,10 @@ class ArgumentBinder {
     }
 
     void bindPositional(Binding binding) {
-        boolean moreArgumentsProvidedThanDeclared = binding.positionals.size() != params.getParameterCount();
-        if (moreArgumentsProvidedThanDeclared && !ctx.getConfig(SqlStatements.class).isUnusedBindingAllowed()) {
-            throw new UnableToCreateStatementException("Superfluous positional param at (0 based) position " + params.getParameterCount(), ctx);
-        }
         for (int index = 0; index < params.getParameterCount(); index++) {
+            if (!binding.positionals.containsKey(index)) {
+                throw new UnableToCreateStatementException(format("Missing positional parameter %d in binding:%s", index, binding), ctx);
+            }
             QualifiedType<?> type = typeOf(binding.positionals.get(index));
             try {
                 argumentFactoryForType(type)
@@ -84,6 +83,10 @@ class ArgumentBinder {
             } catch (SQLException e) {
                 throw new UnableToCreateStatementException("Exception while binding positional param at (0 based) position " + index, e, ctx);
             }
+        }
+        boolean moreArgumentsProvidedThanDeclared = binding.positionals.size() != params.getParameterCount();
+        if (moreArgumentsProvidedThanDeclared && !ctx.getConfig(SqlStatements.class).isUnusedBindingAllowed()) {
+            throw new UnableToCreateStatementException("Superfluous positional param at (0 based) position " + params.getParameterCount(), ctx);
         }
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestArgumentBinder.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestArgumentBinder.java
@@ -287,15 +287,15 @@ public class TestArgumentBinder {
     @Test
     public void testMissingParamThrowsError() {
         try (Handle h = pgDatabaseExtension.openHandle()) {
-            assertThatThrownBy(() -> {
+            assertThatThrownBy(
                 // Right number of params, but indexes are non-contiguous by mistake.
                 h.createQuery("SELECT COUNT(1) from binder_test WHERE i = ? OR i = ? OR i = ?")
                     .bind(0, 100)
                     .bind(1, 101)
                     .bind(3, 102)
                     .mapTo(Integer.class)
-                    .one();
-            }).isInstanceOf(UnableToCreateStatementException.class)
+                    ::one
+            ).isInstanceOf(UnableToCreateStatementException.class)
                 .hasMessage("Param at (0 based) position 2 was not provided");
         }
     }
@@ -303,13 +303,13 @@ public class TestArgumentBinder {
     @Test
     public void testOneBasedIndexingThrowsError() {
         try (Handle h = pgDatabaseExtension.openHandle()) {
-            assertThatThrownBy(() -> {
+            assertThatThrownBy(
                 // Mistakenly thought the params are 1-based.
                 h.createQuery("SELECT COUNT(1) from binder_test WHERE i = ?")
                     .bind(1, 100)
                     .mapTo(Integer.class)
-                    .one();
-            }).isInstanceOf(UnableToCreateStatementException.class)
+                    ::one
+            ).isInstanceOf(UnableToCreateStatementException.class)
                 .hasMessage("Param at (0 based) position 0 was not provided");
         }
     }

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestArgumentBinder.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestArgumentBinder.java
@@ -296,7 +296,7 @@ public class TestArgumentBinder {
                     .mapTo(Integer.class)
                     ::one
             ).isInstanceOf(UnableToCreateStatementException.class)
-                .hasMessage("Param at (0 based) position 2 was not provided");
+                .hasMessageStartingWith("Missing positional parameter 2 in binding:{positional:{0:100,1:101,3:102}, named:{}, finder:[]}");
         }
     }
 
@@ -310,7 +310,7 @@ public class TestArgumentBinder {
                     .mapTo(Integer.class)
                     ::one
             ).isInstanceOf(UnableToCreateStatementException.class)
-                .hasMessage("Param at (0 based) position 0 was not provided");
+                .hasMessageStartingWith("Missing positional parameter 0 in binding:{positional:{1:100}, named:{}, finder:[]}");
         }
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestArgumentBinder.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestArgumentBinder.java
@@ -286,7 +286,7 @@ public class TestArgumentBinder {
 
     @Test
     public void testMissingParamThrowsError() {
-        try (Handle h = pgDatabaseExtension.openHandle()) {
+        pgDatabaseExtension.getJdbi().useHandle(h ->
             assertThatThrownBy(
                 // Right number of params, but indexes are non-contiguous by mistake.
                 h.createQuery("SELECT COUNT(1) from binder_test WHERE i = ? OR i = ? OR i = ?")
@@ -296,13 +296,13 @@ public class TestArgumentBinder {
                     .mapTo(Integer.class)
                     ::one
             ).isInstanceOf(UnableToCreateStatementException.class)
-                .hasMessageStartingWith("Missing positional parameter 2 in binding:{positional:{0:100,1:101,3:102}, named:{}, finder:[]}");
-        }
+                .hasMessageStartingWith("Missing positional parameter 2 in binding:{positional:{0:100,1:101,3:102}, named:{}, finder:[]}")
+        );
     }
 
     @Test
     public void testOneBasedIndexingThrowsError() {
-        try (Handle h = pgDatabaseExtension.openHandle()) {
+        pgDatabaseExtension.getJdbi().useHandle(h ->
             assertThatThrownBy(
                 // Mistakenly thought the params are 1-based.
                 h.createQuery("SELECT COUNT(1) from binder_test WHERE i = ?")
@@ -310,8 +310,8 @@ public class TestArgumentBinder {
                     .mapTo(Integer.class)
                     ::one
             ).isInstanceOf(UnableToCreateStatementException.class)
-                .hasMessageStartingWith("Missing positional parameter 0 in binding:{positional:{1:100}, named:{}, finder:[]}");
-        }
+                .hasMessageStartingWith("Missing positional parameter 0 in binding:{positional:{1:100}, named:{}, finder:[]}")
+        );
     }
 
     public static class TestBean {


### PR DESCRIPTION
Fixes #2674

I made it match the wording of the existing `missingNamedParameter` exception: https://github.com/jdbi/jdbi/blob/18958cb2ca00def74f1bedc29363a66ca1db98b5/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java#L170-L172

The only concern I have is that this could be a breaking change for any existing code relying on the current implicit-null behaviour. However, I can't imagine why anyone would intentionally have a SQL param that's always NULL, and given that named params already error if any are missing, I think this change is justifiable. Any code it breaks is probably buggy?

I moved the param count check after this check because missing param seems a more useful error message, so we check it first.