### PR TITLE
Replace JdbiOptionals.stream() with Optional.stream()

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/argument/BuiltInArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/BuiltInArgumentFactory.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.enums.EnumByName;
-import org.jdbi.v3.core.internal.JdbiOptionals;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.statement.SqlStatement;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
@@ -56,14 +55,14 @@ public class BuiltInArgumentFactory implements ArgumentFactory.Preparable {
     @Override
     public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
         return FACTORIES.stream()
-            .flatMap(factory -> JdbiOptionals.stream(factory.prepare(type, config)))
+            .flatMap(factory -> factory.prepare(type, config).stream())
             .findFirst();
     }
 
     @Override
     public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
         return FACTORIES.stream()
-            .flatMap(factory -> JdbiOptionals.stream(factory.build(expectedType, value, config)))
+            .flatMap(factory -> factory.build(expectedType, value, config).stream())
             .findFirst();
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/array/SqlArrayTypes.java
+++ b/core/src/main/java/org/jdbi/v3/core/array/SqlArrayTypes.java
@@ -24,7 +24,6 @@ import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.core.enums.internal.EnumSqlArrayTypeFactory;
 import org.jdbi.v3.core.interceptor.JdbiInterceptionChainHolder;
-import org.jdbi.v3.core.internal.JdbiOptionals;
 import org.jdbi.v3.meta.Alpha;
 
 /**
@@ -136,7 +135,7 @@ public class SqlArrayTypes implements JdbiConfig<SqlArrayTypes> {
      */
     public Optional<SqlArrayType<?>> findFor(Type elementType) {
         return factories.stream()
-                .flatMap(factory -> JdbiOptionals.stream(factory.build(elementType, registry)))
+                .flatMap(factory -> factory.build(elementType, registry).stream())
                 .findFirst();
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/internal/JdbiOptionals.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/JdbiOptionals.java
@@ -25,11 +25,7 @@ public class JdbiOptionals {
     @SafeVarargs
     public static <T> Optional<T> findFirstPresent(Supplier<Optional<T>>... suppliers) {
         return Stream.of(suppliers)
-                .flatMap(supplier -> stream(supplier.get()))
+                .flatMap(supplier -> supplier.get().stream())
                 .findFirst();
-    }
-
-    public static <T> Stream<T> stream(Optional<T> optional) {
-        return optional.map(Stream::of).orElseGet(Stream::empty);
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/BuiltInMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/BuiltInMapperFactory.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
-import org.jdbi.v3.core.internal.JdbiOptionals;
 
 /**
  * @deprecated will be replaced by an opt-out plugin to give the core no hardwired behavior
@@ -41,7 +40,7 @@ public class BuiltInMapperFactory implements ColumnMapperFactory {
     @Override
     public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
         return FACTORIES.stream()
-            .flatMap(factory -> JdbiOptionals.stream(factory.build(type, config)))
+            .flatMap(factory -> factory.build(type, config).stream())
             .findFirst();
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -37,7 +37,6 @@ import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.argument.NamedArgumentFinder;
 import org.jdbi.v3.core.argument.internal.NamedArgumentFinderFactory.PrepareKey;
 import org.jdbi.v3.core.argument.internal.TypedValue;
-import org.jdbi.v3.core.internal.JdbiOptionals;
 import org.jdbi.v3.core.internal.exceptions.CheckedConsumer;
 import org.jdbi.v3.core.internal.exceptions.Sneaky;
 import org.jdbi.v3.core.qualifier.QualifiedType;
@@ -227,9 +226,9 @@ class ArgumentBinder {
                         preparedBindingTemplate.prepareKeys.keySet().stream()
                             .map(pk -> new AbstractMap.SimpleImmutableEntry<>(pk, batch.preparedFinders.get(pk)))
                             .flatMap(e ->
-                                JdbiOptionals.stream(e.getValue()
+                                e.getValue()
                                     .apply(name)
-                                    .<Entry<PrepareKey, Function<Object, Argument>>>map(pf -> new AbstractMap.SimpleImmutableEntry<>(e.getKey(), pf))))
+                                    .<Entry<PrepareKey, Function<Object, Argument>>>map(pf -> new AbstractMap.SimpleImmutableEntry<>(e.getKey(), pf)).stream())
                             .findFirst();
                     if (preparation.isPresent()) {
                         Entry<PrepareKey, Function<Object, Argument>> p = preparation.get();
@@ -240,11 +239,11 @@ class ArgumentBinder {
                     } else {
                         innerBinders.add(wrapCheckedConsumer(name,
                             binding -> binding.namedArgumentFinder.stream()
-                                .flatMap(naf -> JdbiOptionals.stream(naf.find(name, ctx)))
+                                .flatMap(naf -> naf.find(name, ctx).stream())
                                 .findFirst()
                                 .orElseGet(() ->
                                     binding.realizedBackupArgumentFinders.get().stream()
-                                        .flatMap(naf -> JdbiOptionals.stream(naf.find(name, ctx)))
+                                        .flatMap(naf -> naf.find(name, ctx).stream())
                                         .findFirst()
                                         .orElseThrow(() -> missingNamedParameter(name, binding)))
                                 .apply(index + 1, stmt, ctx)));

--- a/core/src/main/java/org/jdbi/v3/core/statement/Binding.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Binding.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.NamedArgumentFinder;
 import org.jdbi.v3.core.argument.internal.TypedValue;
-import org.jdbi.v3.core.internal.JdbiOptionals;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 
 import static org.jdbi.v3.core.statement.ArgumentBinder.unwrap;
@@ -123,7 +122,7 @@ public class Binding {
         }
 
         return namedArgumentFinder.stream()
-                .flatMap(arguments -> JdbiOptionals.stream(arguments.find(name, ctx2)))
+                .flatMap(arguments -> arguments.find(name, ctx2).stream())
                 .findFirst();
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handlers.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handlers.java
@@ -21,7 +21,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.core.extension.ExtensionHandlerFactory;
-import org.jdbi.v3.core.internal.JdbiOptionals;
 
 /**
  * Registry for {@link HandlerFactory handler factories}, which produce {@link Handler handlers} for SQL object methods.
@@ -61,7 +60,7 @@ public class Handlers implements JdbiConfig<Handlers> {
 
     public Optional<Handler> findFor(Class<?> sqlObjectType, Method method) {
         return factories.stream()
-                .flatMap(factory -> JdbiOptionals.stream(factory.buildHandler(sqlObjectType, method)))
+                .flatMap(factory -> factory.buildHandler(sqlObjectType, method).stream())
                 .findFirst();
     }
 


### PR DESCRIPTION
Optional.stream() requires Java 9+, but since 3.40 JDBI has required Java 11+, so this compatibility code is no longer needed