### PR TITLE
sqlite: use named memory database so contents are shared

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - geantyref 2.0.0
+- sqlite: fix sqlite extension memory database usage to share between different connection (#2688)
 
 # 3.45.4
 

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiSqliteExtension.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiSqliteExtension.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.testing.junit5;
 
+import java.util.UUID;
+
 import javax.sql.DataSource;
 
 import org.sqlite.SQLiteDataSource;
@@ -51,25 +53,31 @@ import org.sqlite.SQLiteDataSource;
  */
 public class JdbiSqliteExtension extends JdbiExtension {
 
-    private static final String URL = "jdbc:sqlite::memory:";
+    private static final String JDBC_URL_TEMPLATE = "jdbc:sqlite:file:%s?mode=memory&cache=shared";
+
+    private final String url;
 
     static JdbiExtension instance() {
         return new JdbiSqliteExtension();
     }
 
-    public JdbiSqliteExtension() {}
+    public JdbiSqliteExtension() {
+        this(String.format(JDBC_URL_TEMPLATE, UUID.randomUUID().toString()));
+    }
+
+    public JdbiSqliteExtension(String url) {
+        this.url = url;
+    }
 
     @Override
     public String getUrl() {
-        return URL;
+        return url;
     }
 
     @Override
     protected DataSource createDataSource() {
         SQLiteDataSource ds = new SQLiteDataSource();
         ds.setUrl(getUrl());
-
         return ds;
     }
-
 }

--- a/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiSqliteExtendWithTest.java
+++ b/testing/src/test/java/org/jdbi/v3/testing/junit5/JdbiSqliteExtendWithTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @ExtendWith(JdbiSqliteExtension.class)
 public class JdbiSqliteExtendWithTest {
@@ -35,5 +36,16 @@ public class JdbiSqliteExtendWithTest {
         Integer one = handle.createQuery("select 1").mapTo(Integer.class).one();
 
         assertThat(one).isOne();
+    }
+
+    @Test
+    public void dataSourceSharesData(Jdbi jdbi) {
+        jdbi.useHandle(h -> {
+            h.execute("create table shared_data (id integer)");
+        });
+        assertThatNoException().isThrownBy(() ->
+                jdbi.useHandle(h -> {
+                    h.execute("insert into shared_data(id) values(1)");
+                }));
     }
 }


### PR DESCRIPTION
fixes #2688