### PR TITLE
Fix x86_64 only EnableOnOs annotations

### DIFF
--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/DB2JdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/DB2JdbiTestContainersExtensionTest.java
@@ -26,13 +26,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = {"x86_64"})
+@EnabledOnOs(architectures = { "x86_64", "amd64" })
 public class DB2JdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
     static JdbcDatabaseContainer<?> dbContainer =
         new Db2Container(DockerImageName.parse("icr.io/db2_community/db2:11.5.9.0")
-                .asCompatibleSubstituteFor("ibmcom/db2"))
+            .asCompatibleSubstituteFor("ibmcom/db2"))
             .acceptLicense();
 
     @Override

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/PostGisJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/PostGisJdbiTestContainersExtensionTest.java
@@ -24,7 +24,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = {"x86_64"})
+@EnabledOnOs(architectures = { "x86_64", "amd64" })
 class PostGisJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/YugabyteJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/YugabyteJdbiTestContainersExtensionTest.java
@@ -22,7 +22,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = {"x86_64"})
+@EnabledOnOs(architectures = { "x86_64", "amd64" })
 class YugabyteJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container


### PR DESCRIPTION
Ensure that all "x86 only" tests use both x86_64 and amd64 as selectors.
