### PR TITLE
build: switch -fae for -ff

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           NEXUS_REPO_USER: ${{ secrets.NEXUS_REPO_USER }}
           NEXUS_REPO_PASSWORD: ${{ secrets.NEXUS_REPO_PASSWORD }}
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make deploy
 
@@ -55,6 +55,6 @@ jobs:
       - name: publish docs
         env:
           SITE_DEPLOY: ${{ secrets.SITE_DEPLOY_TOKEN  }}
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make publish-docs

--- a/.github/workflows/checkers.yml
+++ b/.github/workflows/checkers.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: run code checkers
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-notests
 
@@ -52,12 +52,12 @@ jobs:
 
       - name: run first build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-notests
 
       - name: compare builds
         env:
-          MAVEN_CONFIG: "-B -fae -Dbasepom.test.skip=true"
+          MAVEN_CONFIG: "-B -ff -Dbasepom.test.skip=true"
         run: |
           make compare-reproducible

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: build distribution
         env:
           JAVA_HOME: ${{ steps.build_jdk.outputs.path }}
-          MAVEN_CONFIG: "-Dbasepom.check.skip-enforcer=false -B -fae"
+          MAVEN_CONFIG: "-Dbasepom.check.skip-enforcer=false -B -ff"
         run: |
           make install-fast
 
@@ -55,7 +55,7 @@ jobs:
       - name: run tests
         env:
           JAVA_HOME: ${{ steps.test_jdk.outputs.path }}
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make run-tests
 
@@ -74,12 +74,12 @@ jobs:
 
       - name: install code
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: run tests
         env:
-          MAVEN_CONFIG: "-B -fae -Djdbi.test.timezone=Asia/Colombo -Djdbi.test.language=tr -Djdbi.test.region=TR"
+          MAVEN_CONFIG: "-B -ff -Djdbi.test.timezone=Asia/Colombo -Djdbi.test.language=tr -Djdbi.test.region=TR"
         run: |
           make run-tests

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,6 +27,6 @@ jobs:
 
       - name: docs
         env:
-          MAVEN_CONFIG: "-Dbasepom.check.fail-javadoc=true -B -fae"
+          MAVEN_CONFIG: "-Dbasepom.check.fail-javadoc=true -B -ff"
         run: |
           make docs

--- a/.github/workflows/flyway-versions.yml
+++ b/.github/workflows/flyway-versions.yml
@@ -27,12 +27,12 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: test flyway versions
         env:
-          MAVEN_CONFIG: "-B -fae -pl :jdbi3-testing -Ddep.flyway.version=${{ matrix.flyway-version }}"
+          MAVEN_CONFIG: "-B -ff -pl :jdbi3-testing -Ddep.flyway.version=${{ matrix.flyway-version }}"
         run: |
           make run-tests

--- a/.github/workflows/pg-versions.yml
+++ b/.github/workflows/pg-versions.yml
@@ -32,12 +32,12 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -Dpg-embedded.postgres-version=${{ matrix.postgres-version }}"
+          MAVEN_CONFIG: "-B -ff -Dpg-embedded.postgres-version=${{ matrix.postgres-version }}"
         run: |
           make run-tests

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -34,13 +34,13 @@ jobs:
 
       - name: install code
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: run slow tests
         env:
-          MAVEN_CONFIG: "-B -fae -Ddep.testcontainers.version=${{ matrix.testcontainer-version }} -Djdbi.test.mysql-version=${{ matrix.mysql-version }}"
+          MAVEN_CONFIG: "-B -ff -Ddep.testcontainers.version=${{ matrix.testcontainer-version }} -Djdbi.test.mysql-version=${{ matrix.mysql-version }}"
         run: |
           make run-slow-tests
 
@@ -59,12 +59,12 @@ jobs:
 
       - name: install code
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: run slow tests
         env:
-          MAVEN_CONFIG: "-B -fae -Djdbi.test.timezone=Asia/Colombo -Djdbi.test.language=tr -Djdbi.test.region=TR"
+          MAVEN_CONFIG: "-B -ff -Djdbi.test.timezone=Asia/Colombo -Djdbi.test.language=tr -Djdbi.test.region=TR"
         run: |
           make run-slow-tests

--- a/.github/workflows/versions-check.yml
+++ b/.github/workflows/versions-check.yml
@@ -29,13 +29,13 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -pl :jdbi3-guava,:jdbi3-guice -Ddep.guava.version=${{ matrix.test-version }}"
+          MAVEN_CONFIG: "-B -ff -pl :jdbi3-guava,:jdbi3-guice -Ddep.guava.version=${{ matrix.test-version }}"
         run: |
           make run-tests
 
@@ -58,13 +58,13 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -pl :jdbi3-core -Ddep.immutables.version=${{ matrix.test-version }}"
+          MAVEN_CONFIG: "-B -ff -pl :jdbi3-core -Ddep.immutables.version=${{ matrix.test-version }}"
         run: |
           make run-tests
 
@@ -87,13 +87,13 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -pl :jdbi3-jackson2 -Ddep.jackson2.version=${{ matrix.test-version }}"
+          MAVEN_CONFIG: "-B -ff -pl :jdbi3-jackson2 -Ddep.jackson2.version=${{ matrix.test-version }}"
         run: |
           make run-tests
 
@@ -116,13 +116,13 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -pl :jdbi3-jodatime2 -Ddep.joda-time.version=${{ matrix.test-version }}"
+          MAVEN_CONFIG: "-B -ff -pl :jdbi3-jodatime2 -Ddep.joda-time.version=${{ matrix.test-version }}"
         run: |
           make run-tests
 
@@ -145,13 +145,13 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -pl :jdbi3-vavr -Ddep.vavr.version=${{ matrix.test-version }}"
+          MAVEN_CONFIG: "-B -ff -pl :jdbi3-vavr -Ddep.vavr.version=${{ matrix.test-version }}"
         run: |
           make run-tests
 
@@ -174,13 +174,13 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -pl :jdbi3-guice -Ddep.guice.version=${{ matrix.test-version }}"
+          MAVEN_CONFIG: "-B -ff -pl :jdbi3-guice -Ddep.guice.version=${{ matrix.test-version }}"
         run: |
           make run-tests
 
@@ -203,13 +203,13 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -pl :jdbi3-kotlin,:jdbi3-kotlin-sqlobject -Ddep.kotlin.version=${{ matrix.test-version }}"
+          MAVEN_CONFIG: "-B -ff -pl :jdbi3-kotlin,:jdbi3-kotlin-sqlobject -Ddep.kotlin.version=${{ matrix.test-version }}"
         run: |
           make run-tests
 
@@ -232,13 +232,13 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -pl :jdbi3-spring5 -Ddep.spring.version=${{ matrix.test-version }}"
+          MAVEN_CONFIG: "-B -ff -pl :jdbi3-spring5 -Ddep.spring.version=${{ matrix.test-version }}"
         run: |
           make run-tests
 
@@ -261,12 +261,12 @@ jobs:
 
       - name: Build
         env:
-          MAVEN_CONFIG: "-B -fae"
+          MAVEN_CONFIG: "-B -ff"
         run: |
           make install-fast
 
       - name: Test
         env:
-          MAVEN_CONFIG: "-B -fae -Doracle.container.version=${{ matrix.test-version }}"
+          MAVEN_CONFIG: "-B -ff -Doracle.container.version=${{ matrix.test-version }}"
         run: |
           make run-slow-tests


### PR DESCRIPTION
The CI logs are hard to interpret right now since the failure is in the middle of many thousands of lines of log output with no easy way to jump to the failure

I personally prefer failing fast so the error is right at the end of the log

I appreciate this means if there are multiple problems, you might not get to the second failure. It's a tradeoff... WDYT?