### PR TITLE
Also use the 2022-latest image for MSSQL test

### DIFF
--- a/e2e/src/test/java/org/jdbi/v3/e2e/testcontainer/TestMSSQLStoredProcedure.java
+++ b/e2e/src/test/java/org/jdbi/v3/e2e/testcontainer/TestMSSQLStoredProcedure.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TestMSSQLStoredProcedure {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new MSSQLServerContainer<>()
+    static JdbcDatabaseContainer<?> dbContainer = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2022-latest")
         .acceptLicense();
 
     @RegisterExtension


### PR DESCRIPTION
There seems to be some problem with the latest ubuntu runners on Github
actions that make the 2017 versions of MSSQL crash.
