### PR TITLE
Fix IT execution for slow tests

### DIFF
--- a/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/src/it/test-caffeine-cache/pom.xml
@@ -123,7 +123,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.jdbi:jdbi3-core:*:*:tests</dependency>
+                        <dependency>org.jdbi:jdbi3-core:*:tests</dependency>
                     </dependenciesToScan>
                     <systemProperties combine.children="append">
                         <jdbi.test.cache-plugin>org.jdbi.v3.cache.caffeine.CaffeineCachePlugin</jdbi.test.cache-plugin>

--- a/cache/noop-cache/src/it/test-noop-cache/pom.xml
+++ b/cache/noop-cache/src/it/test-noop-cache/pom.xml
@@ -123,7 +123,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.jdbi:jdbi3-core:*:*:tests</dependency>
+                        <dependency>org.jdbi:jdbi3-core:*:tests</dependency>
                     </dependenciesToScan>
                     <systemProperties combine.children="append">
                         <jdbi.test.cache-plugin>org.jdbi.v3.cache.noop.NoopCachePlugin</jdbi.test.cache-plugin>

--- a/core/src/it/test-inline-jar/pom.xml
+++ b/core/src/it/test-inline-jar/pom.xml
@@ -117,7 +117,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.jdbi:jdbi3-core:*:*:tests</dependency>
+                        <dependency>org.jdbi:jdbi3-core:*:tests</dependency>
                     </dependenciesToScan>
                 </configuration>
             </plugin>


### PR DESCRIPTION
For some reason, the set of included tests was wrong. This somehow
used to work before but broke at some point.
