### PR TITLE
Fix native Spring compile with `@JdbiRepository`

### DIFF
--- a/spring5/src/main/java/org/jdbi/v3/spring5/JdbiRepositoryFactoryBean.java
+++ b/spring5/src/main/java/org/jdbi/v3/spring5/JdbiRepositoryFactoryBean.java
@@ -52,6 +52,7 @@ public class JdbiRepositoryFactoryBean implements FactoryBean<Object>, Applicati
     /**
      * The object type of the repository.
      */
+    @SuppressWarnings("unused")
     public void setObjectType(Class<?> objectType) {
         this.objectType = objectType;
     }
@@ -61,6 +62,7 @@ public class JdbiRepositoryFactoryBean implements FactoryBean<Object>, Applicati
      * @param jdbiQualifier The name of the jdbi bean to bind the repository to.
      *                      if <code>null</code> then no name will be specified during resolution.
      */
+    @SuppressWarnings("unused")
     public void setJdbiQualifier(@Nullable String jdbiQualifier) {
         this.jdbiQualifier = jdbiQualifier;
     }


### PR DESCRIPTION
Resolves #2694.

For every SQL object annotated with `JdbiRepository`, the `JdbiRepositoryRegistrar` currently instantiates a `JdbiRepositoryFactoryBean` itself and then passes a reference to its `getObject` method to the bean definition registry to be called at a later time by the application context.

This works fine in the standard JVM but not with AOT and GraalVM where building the native image fails if the feature is used. The problem is that in AOT mode Spring generates the bean definitions at compile time to write corresponding Java code that GraalVM can then compile. But when it tries to do so for the bean definitions generated by `JdbiRepositoryRegistrar`, it can't as it cannot determine how the passed instance of the `JdbiRepositoryFactoryBean` has been built. Compilation then stops with the error message `instance supplier is not supported`.

The PR fixes this by letting `JdbiRepositoryRegistrar` register bean definitions for the `JdbiRepositoryFactoryBean`s instead that Spring AOT knows how to generate explicit code for.

With this fix, a native image can be compiled (unless of course there are other issues in the application), but it does not fix the issue that the native image will fail to run unless native hints are provided for some of the JDBI classes during compilation.