### PR TITLE
bump to basepom 61

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -64,6 +64,7 @@
         <basepom.javadoc.legacy-mode>true</basepom.javadoc.legacy-mode>
         <basepom.maven.version>3.9.0</basepom.maven.version>
         <basepom.nexus-staging.staging-url>https://oss.sonatype.org/</basepom.nexus-staging.staging-url>
+        <basepom.release.preparation-goals>clean verify</basepom.release.preparation-goals>
         <basepom.release.profiles>basepom.deploy-release,jdbi-release</basepom.release.profiles>
         <basepom.release.tag-name-format>v@{project.version}</basepom.release.tag-name-format>
         <basepom.test.fork-count>4</basepom.test.fork-count>

--- a/internal/policy/src/main/resources/policy/pmd.xml
+++ b/internal/policy/src/main/resources/policy/pmd.xml
@@ -28,7 +28,7 @@
         <exclude name="AccessorMethodGeneration"/>
         <exclude name="AvoidStringBufferField"/>
         <exclude name="GuardLogStatement"/>
-        <exclude name="JUnit4TestShouldUseTestAnnotation"/>
+        <exclude name="UnitTestShouldUseTestAnnotation"/>
         <exclude name="LooseCoupling"/>
         <exclude name="UnusedFormalParameter"/>
         <exclude name="UseVarargs"/>

--- a/internal/root/pom.xml
+++ b/internal/root/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.basepom</groupId>
         <artifactId>basepom-oss</artifactId>
-        <version>60</version>
+        <version>61</version>
         <!-- null out the relative path, otherwise maven complains that the referenced POM is not in the parent directory -->
         <relativePath />
     </parent>


### PR DESCRIPTION
- bump basepom version
- fix renamed PMD rule
- stage with 'clean verify', do not install locally
