### PR TITLE
Support creating a ConstructorMapper using a static factory method

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -97,6 +97,30 @@ public final class ConstructorMapper<T> implements RowMapper<T> {
     }
 
     /**
+     * Use the only declared static factory method to map a class.
+     *
+     * @param clazz the class to static factory method for
+     * @param factoryMethodClass the type to inspect for a static factory method
+     * @return the factory
+     */
+    public static RowMapperFactory factory(Class<?> clazz, Class<?> factoryMethodClass) {
+        return RowMapperFactory.of(clazz, of(clazz, factoryMethodClass));
+    }
+
+
+    /**
+     * Use the only declared static factory method to map a class.
+     *
+     * @param clazz the class to static factory method for
+     * @param factoryMethodClass the type to inspect for a static factory method
+     * @param prefix a prefix for the parameter names
+     * @return the factory
+     */
+    public static RowMapperFactory factory(Class<?> clazz, Class<?> factoryMethodClass, String prefix) {
+        return RowMapperFactory.of(clazz, of(clazz, factoryMethodClass, prefix));
+    }
+
+    /**
      * Use a {@code Constructor<T>} to map its declaring type.
      *
      * @param constructor the constructor to invoke
@@ -138,6 +162,31 @@ public final class ConstructorMapper<T> implements RowMapper<T> {
      */
     public static <T> RowMapper<T> of(Class<T> type, String prefix) {
         return new ConstructorMapper<>(findFactoryFor(type), prefix);
+    }
+
+    /**
+     * Return a ConstructorMapper for the given type, based on a static factory method found in the given class.
+     *
+     * @param <T>  the type to map
+     * @param type the mapped type
+     * @param factoryMethodClass the type to inspect for a static factory method
+     * @return the mapper
+     */
+    public static <T> RowMapper<T> of(Class<T> type, Class<?> factoryMethodClass) {
+        return of(type, factoryMethodClass, DEFAULT_PREFIX);
+    }
+
+    /**
+     * Return a ConstructorMapper for the given type and prefix, based on a static factory method found in the given class.
+     *
+     * @param <T>    the type to map
+     * @param type   the mapped type
+     * @param factoryMethodClass the type to inspect for a static factory method
+     * @param prefix the column name prefix
+     * @return the mapper
+     */
+    public static <T> RowMapper<T> of(Class<T> type, Class<?> factoryMethodClass, String prefix) {
+        return new ConstructorMapper<>(findFactoryFor(type, factoryMethodClass), prefix);
     }
 
     /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterConstructorMapper.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/RegisterConstructorMapper.java
@@ -42,4 +42,11 @@ public @interface RegisterConstructorMapper {
      * @return Column name prefix for the mapped type.
      */
     String prefix() default "";
+
+    /**
+     * If specified, find a static factory method in the given class to instantiate the mapped type.
+     *
+     * @return The type to inspect for a static factory method
+     */
+    Class<?> usingStaticMethodIn() default void.class;
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterConstructorMapperImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterConstructorMapperImpl.java
@@ -28,14 +28,17 @@ public class RegisterConstructorMapperImpl extends SimpleExtensionConfigurer {
 
     public RegisterConstructorMapperImpl(Annotation annotation) {
         RegisterConstructorMapper registerConstructorMapper = (RegisterConstructorMapper) annotation;
+        constructorMapper = createFactory(registerConstructorMapper);
+    }
 
-        Class<?> constructorClass = registerConstructorMapper.value();
-        String prefix = registerConstructorMapper.prefix();
-
-        if (prefix.isEmpty()) {
-            constructorMapper = ConstructorMapper.factory(constructorClass);
+    static RowMapperFactory createFactory(RegisterConstructorMapper annotation) {
+        Class<?> constructorClass = annotation.value();
+        String prefix = annotation.prefix();
+        Class<?> factoryMethodClass = annotation.usingStaticMethodIn();
+        if (void.class.equals(factoryMethodClass)) {
+            return ConstructorMapper.factory(constructorClass, prefix);
         } else {
-            constructorMapper = ConstructorMapper.factory(constructorClass, prefix);
+            return ConstructorMapper.factory(constructorClass, factoryMethodClass, prefix);
         }
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterConstructorMappersImpl.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/config/internal/RegisterConstructorMappersImpl.java
@@ -21,7 +21,6 @@ import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.RowMappers;
-import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMappers;
 
@@ -34,14 +33,7 @@ public class RegisterConstructorMappersImpl extends SimpleExtensionConfigurer {
         this.constructorMappers = new ArrayList<>(registerConstructorMappers.value().length);
 
         for (RegisterConstructorMapper registerConstructorMapper : registerConstructorMappers.value()) {
-            Class<?> constructorClass = registerConstructorMapper.value();
-            String prefix = registerConstructorMapper.prefix();
-
-            if (prefix.isEmpty()) {
-                this.constructorMappers.add(ConstructorMapper.factory(constructorClass));
-            } else {
-                this.constructorMappers.add(ConstructorMapper.factory(constructorClass, prefix));
-            }
+            this.constructorMappers.add(RegisterConstructorMapperImpl.createFactory(registerConstructorMapper));
         }
     }
 

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterConstructorMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestRegisterConstructorMapper.java
@@ -47,6 +47,14 @@ public class TestRegisterConstructorMapper {
     }
 
     @Test
+    public void testStaticFactoryMapperRegistered() {
+        dao.insert(1, "brain");
+        Something brain = dao.getByIdUsingFactoryMethod(1);
+        assertThat(brain.getId()).isOne();
+        assertThat(brain.getName()).isEqualTo("brain");
+    }
+
+    @Test
     public void testMapperPrefixed() {
         dao.insert(1, "brain");
         Something brain = dao.getByIdPrefixed(1);
@@ -61,6 +69,13 @@ public class TestRegisterConstructorMapper {
         }
     }
 
+    public static class FactoryClass {
+        @SuppressWarnings("unused")
+        public static Something createSomething(int id, String name) {
+            return new SubSomething(id, name);
+        }
+    }
+
     public interface Dao {
         @SqlUpdate("insert into something (id, name) values (:id, :name)")
         void insert(@Bind("id") int id, @Bind("name") String name);
@@ -68,6 +83,10 @@ public class TestRegisterConstructorMapper {
         @SqlQuery("select id, name from something where id=:id")
         @RegisterConstructorMapper(SubSomething.class)
         SubSomething getById(@Bind("id") int id);
+
+        @SqlQuery("select id, name from something where id=:id")
+        @RegisterConstructorMapper(value = Something.class, usingStaticMethodIn = FactoryClass.class)
+        Something getByIdUsingFactoryMethod(@Bind("id") int id);
 
         @SqlQuery("select id thing_id, name thing_name from something where id=:id")
         @RegisterConstructorMapper(value = SubSomething.class, prefix = "thing_")


### PR DESCRIPTION
Sometimes a mapper needs to do some logic or transformation that does not belong in the constructor. JDBI already supports using a static method annotated with `@JdbiConstructor`.

This merge request adds support for defining the static factory method in a different class (e.g. in the sqlobject interface).