### PR TITLE
Fix invoking subclass methods with on-demand extensions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fix onDemand extension handling of method invocations from a subtype (#2769, thanks @djsstarburst!)
 - Move all kotlin deps into the module poms (fixes #2762, thanks @simonolander)
 - Drop explicit support for obsolete Kotlin versions < 1.9 (#2764)
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactoryDelegate.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactoryDelegate.java
@@ -13,7 +13,6 @@
  */
 package org.jdbi.v3.core.extension;
 
-import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Collection;
 import java.util.Collections;
@@ -25,6 +24,7 @@ import java.util.stream.Collectors;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.ExtensionMetadata.Builder;
 import org.jdbi.v3.core.extension.ExtensionMetadata.ExtensionHandlerInvoker;
+import org.jdbi.v3.core.internal.JdbiClassUtils.MethodKey;
 
 import static java.lang.String.format;
 
@@ -35,6 +35,7 @@ import static org.jdbi.v3.core.extension.ExtensionHandler.HASHCODE_HANDLER;
 import static org.jdbi.v3.core.extension.ExtensionHandler.NULL_HANDLER;
 import static org.jdbi.v3.core.internal.JdbiClassUtils.EQUALS_METHOD;
 import static org.jdbi.v3.core.internal.JdbiClassUtils.HASHCODE_METHOD;
+import static org.jdbi.v3.core.internal.JdbiClassUtils.MethodKey.methodKey;
 import static org.jdbi.v3.core.internal.JdbiClassUtils.TOSTRING_METHOD;
 
 final class ExtensionFactoryDelegate implements ExtensionFactory {
@@ -84,7 +85,7 @@ final class ExtensionFactoryDelegate implements ExtensionFactory {
     @Override
     public <E> E attach(Class<E> extensionType, HandleSupplier handleSupplier) {
 
-        Set<FactoryFlag> factoryFlags = getFactoryFlags();
+        final Set<FactoryFlag> factoryFlags = getFactoryFlags();
 
         // If the extension declares that it supports classes, then the proxy logic
         // in the delegate is bypassed. This code uses the Java proxy class which does not
@@ -111,11 +112,11 @@ final class ExtensionFactoryDelegate implements ExtensionFactory {
         final ExtensionMetadata extensionMetaData = extensions.findMetadata(extensionType, delegatedFactory);
         final ConfigRegistry instanceConfig = extensionMetaData.createInstanceConfiguration(config);
 
-        Map<Method, ExtensionHandlerInvoker> handlers = new HashMap<>();
+        final Map<MethodKey, ExtensionHandlerInvoker> handlers = new HashMap<>();
         final Object proxy = Proxy.newProxyInstance(
                 extensionType.getClassLoader(),
                 new Class[] {extensionType},
-                (proxyInstance, method, args) -> handlers.get(method).invoke(args));
+                (proxyInstance, method, args) -> handlers.get(methodKey(method)).invoke(args));
 
         // if the object created by the delegated factory has actual methods (it is not delegating), attach the
         // delegate and pass it to the handlers. Otherwise assume that there is no backing object and do not call
@@ -126,19 +127,19 @@ final class ExtensionFactoryDelegate implements ExtensionFactory {
         // those will only be added if they don't already exist in the method handler map.
 
         // If these methods are added, they are special because they operate on the proxy object itself, not the underlying object
-        ExtensionHandler toStringHandler = (h, target, args) ->
+        final ExtensionHandler toStringHandler = (h, target, args) ->
                 "Jdbi extension proxy for " + extensionType.getName() + "@" + Integer.toHexString(proxy.hashCode());
-        handlers.put(TOSTRING_METHOD, extensionMetaData.new ExtensionHandlerInvoker(proxy, TOSTRING_METHOD, toStringHandler, handleSupplier, instanceConfig));
+        handlers.put(methodKey(TOSTRING_METHOD), extensionMetaData.new ExtensionHandlerInvoker(proxy, TOSTRING_METHOD, toStringHandler, handleSupplier, instanceConfig));
 
-        handlers.put(EQUALS_METHOD, extensionMetaData.new ExtensionHandlerInvoker(proxy, EQUALS_METHOD, EQUALS_HANDLER, handleSupplier, instanceConfig));
-        handlers.put(HASHCODE_METHOD, extensionMetaData.new ExtensionHandlerInvoker(proxy, HASHCODE_METHOD, HASHCODE_HANDLER, handleSupplier, instanceConfig));
+        handlers.put(methodKey(EQUALS_METHOD), extensionMetaData.new ExtensionHandlerInvoker(proxy, EQUALS_METHOD, EQUALS_HANDLER, handleSupplier, instanceConfig));
+        handlers.put(methodKey(HASHCODE_METHOD), extensionMetaData.new ExtensionHandlerInvoker(proxy, HASHCODE_METHOD, HASHCODE_HANDLER, handleSupplier, instanceConfig));
 
         // add all methods that are delegated to the underlying object / existing handlers
         extensionMetaData.getExtensionMethods().forEach(method ->
-                handlers.put(method, extensionMetaData.createExtensionHandlerInvoker(delegatedInstance, method, handleSupplier, instanceConfig)));
+                handlers.put(methodKey(method), extensionMetaData.createExtensionHandlerInvoker(delegatedInstance, method, handleSupplier, instanceConfig)));
 
         // finalize is double special. Add this unconditionally, even if subclasses try to override it.
-        extensionMetaData.getFinalizer().ifPresent(method -> handlers.put(method,
+        extensionMetaData.getFinalizer().ifPresent(method -> handlers.put(methodKey(method),
                 extensionMetaData.new ExtensionHandlerInvoker(proxy, method, NULL_HANDLER, handleSupplier, instanceConfig)));
 
         return extensionType.cast(proxy);

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
@@ -31,6 +31,7 @@ import org.jdbi.v3.core.config.ConfigCustomizer;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.internal.ConfigCustomizerChain;
 import org.jdbi.v3.core.internal.JdbiClassUtils;
+import org.jdbi.v3.core.internal.JdbiClassUtils.MethodKey;
 import org.jdbi.v3.core.internal.exceptions.Sneaky;
 import org.jdbi.v3.meta.Alpha;
 
@@ -161,7 +162,7 @@ public final class ExtensionMetadata {
 
             this.extensionTypeMethods.stream()
                     .filter(m -> !m.isSynthetic())
-                    .collect(Collectors.groupingBy(m -> Arrays.asList(m.getName(), Arrays.asList(m.getParameterTypes()))))
+                    .collect(Collectors.groupingBy(MethodKey::methodKey))
                     .values()
                     .stream()
                     .filter(methodCount -> methodCount.size() > 1)

--- a/core/src/main/java/org/jdbi/v3/core/internal/JdbiClassUtils.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/JdbiClassUtils.java
@@ -19,6 +19,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -272,5 +273,43 @@ public final class JdbiClassUtils {
     @FunctionalInterface
     public interface MethodHandleInvoker {
         Object createInstance(MethodHandle handle) throws Throwable;
+    }
+
+    public static final class MethodKey {
+        public final String name;
+        public final MethodType type;
+
+        public MethodKey(String name, MethodType type) {
+            this.name = name;
+            this.type = type;
+        }
+
+        public static MethodKey methodKey(Method method) {
+            return new MethodKey(
+                    method.getName(),
+                    MethodType.methodType(
+                            method.getReturnType(),
+                            method.getParameterTypes()));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, type);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof MethodKey)) {
+                return false;
+            }
+            MethodKey castObj = (MethodKey) obj;
+            return name.equals(castObj.name) && type.equals(castObj.type);
+        }
+
+        @Override
+        public String toString() {
+            return "MethodKey[" + name + "(" + type.parameterList().stream()
+                    .map(Class::toString).collect(Collectors.joining(",")) + ")]";
+        }
     }
 }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNestedExtensionSubtype.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestNestedExtensionSubtype.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.extension.ExtensionFactory;
+import org.jdbi.v3.core.extension.HandleSupplier;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.ColumnMapperFactory;
+import org.jdbi.v3.sqlobject.config.RegisterColumnMapperFactory;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestNestedExtensionSubtype {
+    @RegisterExtension
+    JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin());
+
+    Jdbi jdbi;
+
+    @BeforeEach
+    void setUp() {
+        jdbi = h2Extension.getJdbi();
+        jdbi.registerExtension(new ExtensionFactory() {
+            @Override
+            public boolean accepts(final Class<?> extensionType) {
+                return Supertype.class.equals(extensionType);
+            }
+
+            @Override
+            public Set<FactoryFlag> getFactoryFlags() {
+                return EnumSet.of(FactoryFlag.DONT_USE_PROXY);
+            }
+
+            @Override
+            public <E> E attach(final Class<E> extensionType, final HandleSupplier handleSupplier) {
+                return extensionType.cast(handleSupplier.getHandle().attach(Subtype.class));
+            }
+        });
+    }
+
+    @Test
+    public void testOverrideMethodAttach() {
+        jdbi.useHandle(h ->
+                assertThat(h.attach(Supertype.class).overrideInt())
+                        .isInstanceOf(SubInt.class)
+                        .extracting(SuperInt::value)
+                        .isEqualTo(42));
+    }
+
+    @Test
+    public void testOverrideMethodOnDemand() {
+        assertThat(jdbi.onDemand(Supertype.class).overrideInt())
+                .isInstanceOf(SubInt.class)
+                .extracting(SuperInt::value)
+                .isEqualTo(42);
+    }
+
+    @RegisterColumnMapperFactory(SuperIntFactory.class)
+    interface Supertype {
+        @SqlQuery("select 41")
+        SuperInt overrideInt();
+    }
+
+    interface Subtype extends Supertype {
+        @Override
+        @SqlQuery("select 42")
+        SubInt overrideInt();
+    }
+
+    static class SuperInt {
+        final int value;
+
+        SuperInt(final int value) {
+            this.value = value;
+        }
+
+        int value() {
+            return value;
+        }
+    }
+
+    // Use a varying return type to make sure e.g. bridge methods also work
+    static class SubInt extends SuperInt {
+        SubInt(final int value) {
+            super(value);
+        }
+    }
+
+    public static class SuperIntFactory implements ColumnMapperFactory {
+        @Override
+        public Optional<ColumnMapper<?>> build(final Type type, final ConfigRegistry config) {
+            if (SuperInt.class.equals(type)) {
+                return Optional.of((r, c, ctx) -> new SuperInt(r.getInt(c)));
+            } else if (SubInt.class.equals(type)) {
+                return Optional.of((r, c, ctx) -> new SubInt(r.getInt(c)));
+            }
+            return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
Right now we build a Map with Method keys. The Method refers to the declaring type, but we don't actually care if it is some super or subtype, we just want to call the handler either way. We already know there's only one possible entry due to checks in the extension metadata builder

Fixes #2769