### PR TITLE
Sample code for qualified column mappers

### DIFF
--- a/examples/src/main/java/org/jdbi/v3/examples/QualifiedTypes.java
+++ b/examples/src/main/java/org/jdbi/v3/examples/QualifiedTypes.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.examples;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import com.google.common.base.Splitter;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+import org.jdbi.v3.core.qualifier.Qualifier;
+import org.jdbi.v3.core.statement.StatementContext;
+
+/**
+ * Demonstrates the use of qualified types. This class contains two column mappers for the same data type (string in SQL, List&lt;String&gt; in Java) that can
+ * be differentiated by registering as {@link org.jdbi.v3.core.qualifier.QualifiedType} with different annotations. As the {@link ColumnMapper} classes return a
+ * generic type, they use a qualified {@link org.jdbi.v3.core.generic.GenericType}.
+ * <p>
+ * The use of this code is demonstrated in the test class.
+ */
+public final class QualifiedTypes {
+
+    private QualifiedTypes() {
+        throw new AssertionError("do not instantiate");
+    }
+
+    public static void registerMappers(Jdbi jdbi) {
+        jdbi.registerColumnMapper(QualifiedType.of(new GenericType<List<String>>() {}).with(Colon.class), new ColonMapper());
+        jdbi.registerColumnMapper(QualifiedType.of(new GenericType<List<String>>() {}).with(Comma.class), new CommaMapper());
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE })
+    @Qualifier
+    public @interface Comma {}
+
+    public static class CommaMapper implements ColumnMapper<List<String>> {
+        @Override
+        public List<String> map(ResultSet rs, int columnNumber, StatementContext ctx) throws SQLException {
+            String value = rs.getString(columnNumber);
+            if (value == null) {
+                return null;
+            }
+            return Splitter.on(",").splitToList(value);
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE })
+    @Qualifier
+    public @interface Colon {}
+
+    public static class ColonMapper implements ColumnMapper<List<String>> {
+        @Override
+        public List<String> map(ResultSet rs, int columnNumber, StatementContext ctx) throws SQLException {
+            String value = rs.getString(columnNumber);
+            if (value == null) {
+                return null;
+            }
+            return Splitter.on(":").splitToList(value);
+        }
+    }
+}

--- a/examples/src/test/java/org/jdbi/v3/examples/TestQualifiedTypes.java
+++ b/examples/src/test/java/org/jdbi/v3/examples/TestQualifiedTypes.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.examples;
+
+import java.util.List;
+
+import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
+import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
+import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
+import org.jdbi.v3.examples.QualifiedTypes.Colon;
+import org.jdbi.v3.examples.QualifiedTypes.Comma;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestQualifiedTypes {
+
+    @RegisterExtension
+    public static EmbeddedPgExtension pg = MultiDatabaseBuilder.instanceWithDefaults().build();
+
+    @RegisterExtension
+    public JdbiExtension pgExtension = JdbiExtension.postgres(pg)
+            .withInitializer((ds, h) -> {
+                h.execute("CREATE TABLE data (id serial primary key, comma varchar(50), colon varchar(50))");
+                h.execute("INSERT INTO data (comma,colon) VALUES ('one,two,three,four', 'eins:zwei:drei:vier')");
+            })
+            .withPlugin(new SqlObjectPlugin());
+
+    private DataDao dao;
+
+    @BeforeEach
+    public void setUp() {
+        var jdbi = pgExtension.getJdbi();
+        jdbi.registerRowMapper(Data.class, ConstructorMapper.of(Data.class));
+        QualifiedTypes.registerMappers(jdbi);
+        this.dao = jdbi.onDemand(DataDao.class);
+    }
+
+    @Test
+    public void test() {
+        var data = dao.getData(1);
+        assertThat(data.getComma()).isNotEmpty().containsExactly("one", "two", "three", "four");
+        assertThat(data.getColon()).isNotEmpty().containsExactly("eins", "zwei", "drei", "vier");
+    }
+
+    public static class Data {
+        private final int id;
+        private final List<String> comma;
+        private final List<String> colon;
+
+        @JdbiConstructor
+        public Data(int id, @Comma List<String> comma, @Colon List<String> colon) {
+            this.id = id;
+            this.comma = comma;
+            this.colon = colon;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public List<String> getComma() {
+            return comma;
+        }
+
+        public List<String> getColon() {
+            return colon;
+        }
+    }
+
+    public interface DataDao {
+        @SqlQuery("SELECT * FROM data WHERE id = :id")
+        Data getData(int id);
+    }
+}


### PR DESCRIPTION
Demonstrates on how to use Qualified types to register column mappers
for the same java type and how to use annotations to select the right
mapper.
