### PR TITLE
Some backports from java 17 migration start

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/HandleCallbackDecorator.java
+++ b/core/src/main/java/org/jdbi/v3/core/HandleCallbackDecorator.java
@@ -20,6 +20,7 @@ import org.jdbi.v3.meta.Alpha;
  * {@link Jdbi#inTransaction(HandleCallback)} and {@link Jdbi#useTransaction(HandleConsumer)}.
  */
 @Alpha
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface HandleCallbackDecorator {
     HandleCallbackDecorator STANDARD_HANDLE_CALLBACK_DECORATOR = new HandleCallbackDecorator() {
         @Override

--- a/core/src/main/java/org/jdbi/v3/core/argument/ArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/ArgumentFactory.java
@@ -49,6 +49,7 @@ public interface ArgumentFactory {
      * ArgumentFactory extension interface that allows preparing arguments for efficient batch binding.
      */
     @Beta
+    @SuppressWarnings("PMD.ImplicitFunctionalInterface")
     interface Preparable extends ArgumentFactory {
         @Override
         default Optional<Argument> build(Type type, Object value, ConfigRegistry config) {

--- a/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/Configurable.java
@@ -53,6 +53,7 @@ import org.jdbi.v3.meta.Beta;
  *
  * @param <This> The subtype that implements this interface.
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface Configurable<This> {
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/config/JdbiConfig.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/JdbiConfig.java
@@ -22,6 +22,7 @@ package org.jdbi.v3.core.config;
  *
  * @param <This> A "This" type. Should always be the configuration class.
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface JdbiConfig<This extends JdbiConfig<This>> {
     /**
      * Returns a copy of this configuration object.

--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCache.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCache.java
@@ -22,6 +22,7 @@ import org.jdbi.v3.core.statement.StatementContext;
  *
  * @see ConfigCaches
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface ConfigCache<K, V> {
 
     V get(K key, ConfigRegistry config);

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandlerCustomizer.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionHandlerCustomizer.java
@@ -24,6 +24,7 @@ import org.jdbi.v3.meta.Alpha;
  * @since 3.38.0
  */
 @Alpha
+@FunctionalInterface
 public interface ExtensionHandlerCustomizer {
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/extension/UseAnnotationConfigCustomizerFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/UseAnnotationConfigCustomizerFactory.java
@@ -70,6 +70,7 @@ final class UseAnnotationConfigCustomizerFactory implements ConfigCustomizerFact
                 .collect(Collectors.toList());
     }
 
+    @FunctionalInterface
     private interface ConfigurerMethod {
 
         void configure(ExtensionConfigurer configurer, ConfigRegistry config, Annotation annotation);

--- a/core/src/main/java/org/jdbi/v3/core/interceptor/JdbiInterceptionChain.java
+++ b/core/src/main/java/org/jdbi/v3/core/interceptor/JdbiInterceptionChain.java
@@ -21,6 +21,7 @@ import org.jdbi.v3.meta.Alpha;
  * @param <T> Type of the transformation result.
  */
 @Alpha
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface JdbiInterceptionChain<T> {
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/internal/SqlScriptParser.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/SqlScriptParser.java
@@ -83,6 +83,7 @@ public class SqlScriptParser {
         return sb.toString();
     }
 
+    @FunctionalInterface
     public interface TokenHandler {
         void handle(Token t, StringBuilder sb);
     }

--- a/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Unchecked.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/exceptions/Unchecked.java
@@ -100,11 +100,13 @@ public class Unchecked {
         };
     }
 
+    @FunctionalInterface
     public interface SneakyCallable<T> extends Callable<T> {
         @Override
         T call(); // no 'throws Exception'
     }
 
+    @FunctionalInterface
     public interface CheckedRunnable {
         void run() throws Exception;
     }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ColumnNameMatcher.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ColumnNameMatcher.java
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.mapper.reflect;
 /**
  * Strategy for matching SQL column names to Java property, field, or parameter names.
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface ColumnNameMatcher {
     /**
      * Returns whether the column name fits the given Java identifier name.

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BuilderPojoPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/BuilderPojoPropertiesFactory.java
@@ -18,6 +18,7 @@ import java.util.function.Supplier;
 import org.jdbi.v3.core.config.internal.ConfigCache;
 import org.jdbi.v3.core.config.internal.ConfigCaches;
 
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface BuilderPojoPropertiesFactory extends PojoPropertiesFactory {
     ConfigCache<BuilderSpec<?, ?>, BuilderPojoProperties<?, ?>> BUILDER_CACHE =
         ConfigCaches.declare(s -> s.type, BuilderPojoProperties::new);

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ModifiablePojoPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/ModifiablePojoPropertiesFactory.java
@@ -28,6 +28,7 @@ import org.jdbi.v3.core.internal.exceptions.Unchecked;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.qualifier.Qualifiers;
 
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface ModifiablePojoPropertiesFactory extends PojoPropertiesFactory {
     ConfigCache<ModifiableSpec<?, ?>, ModifiablePojoProperties<?, ?>> MODIFIABLE_CACHE =
             ConfigCaches.declare(s -> s.type, ModifiablePojoProperties::new);

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoPropertiesFactory.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Type;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 
+@FunctionalInterface
 public interface PojoPropertiesFactory {
     PojoProperties<?> create(Type type, ConfigRegistry config);
 }

--- a/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultBearing.java
@@ -42,6 +42,7 @@ import org.jdbi.v3.core.statement.StatementContext;
 /**
  * Provides access to the contents of a {@link ResultSet} by mapping to Java types.
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface ResultBearing {
     /**
      * Returns a ResultBearing backed by the given result set supplier and context.

--- a/core/src/main/java/org/jdbi/v3/core/statement/CallableStatementMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/CallableStatementMapper.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 /**
  * Map an {@code OUT} parameter in a callable statement to a result type.
  */
+@FunctionalInterface
 public interface CallableStatementMapper {
     Object map(int position, CallableStatement stmt) throws SQLException;
 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementBuilderFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementBuilderFactory.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
  * whenever the Jdbi instance is used to create a Handle the factory will be used to create a
  * StatementBuilder for that specific handle.
  */
+@FunctionalInterface
 public interface StatementBuilderFactory {
     /**
      * Creates a new {@link StatementBuilder} from a {@link Connection} object.

--- a/core/src/test/java/org/jdbi/v3/core/JdbiOpenLeakTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/JdbiOpenLeakTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 public class JdbiOpenLeakTest {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     void cleanupCustomizeThrows() throws Exception {

--- a/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestClosingHandle.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestClosingHandle {
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testNotClosing() {

--- a/core/src/test/java/org/jdbi/v3/core/TestHandle.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestHandle.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestHandle {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     private Handle h;
 

--- a/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestJdbi.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestJdbi {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testDataSourceConstructor() {

--- a/core/src/test/java/org/jdbi/v3/core/TestJdbiNestedCallBehavior.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestJdbiNestedCallBehavior.java
@@ -34,7 +34,7 @@ import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.READ_UNCOMM
 public class TestJdbiNestedCallBehavior {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething().withPlugin(new TestPlugin());
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER).withPlugin(new TestPlugin());
 
     static class TestPlugin implements JdbiPlugin {
 

--- a/core/src/test/java/org/jdbi/v3/core/TestOptional.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestOptional.java
@@ -44,7 +44,7 @@ public class TestOptional {
         + "order by id";
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     Handle handle;
 

--- a/core/src/test/java/org/jdbi/v3/core/TestTooManyCursors.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestTooManyCursors.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestTooManyCursors {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testFoo() {

--- a/core/src/test/java/org/jdbi/v3/core/TestUri.java
+++ b/core/src/test/java/org/jdbi/v3/core/TestUri.java
@@ -25,7 +25,7 @@ public class TestUri {
     private static final URI TEST_URI = URI.create("http://example.invalid/wat.jpg");
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testUri() {

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestArgumentFactory.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestArgumentFactory {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testRegisterOnJdbi() {

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestBeanArguments.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestBeanArguments.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("deprecation")
 public class TestBeanArguments {
     @Mock
     PreparedStatement stmt;

--- a/core/src/test/java/org/jdbi/v3/core/argument/TestNamedParams.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestNamedParams.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestNamedParams {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testInsert() {

--- a/core/src/test/java/org/jdbi/v3/core/internal/lexer/TestDefineIdentifierPrefix.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/lexer/TestDefineIdentifierPrefix.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestDefineIdentifierPrefix {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testParse() {

--- a/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestClasspathSqlLocator {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testLocateNamed() {

--- a/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/v3/core/locator/TestClasspathSqlLocator.java
@@ -21,6 +21,7 @@ import org.jdbi.v3.core.junit5.H2DatabaseExtension;
 import org.jdbi.v3.core.statement.StatementException;
 import org.jdbi.v3.core.statement.StatementExceptions;
 import org.jdbi.v3.core.statement.StatementExceptions.MessageRendering;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -32,31 +33,38 @@ public class TestClasspathSqlLocator {
     @RegisterExtension
     public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
+    private ClasspathSqlLocator locator;
+
+    @BeforeEach
+    public void setUp() {
+        this.locator = ClasspathSqlLocator.removingComments();
+    }
+
     @Test
     public void testLocateNamed() {
         Handle h = h2Extension.getSharedHandle();
-        h.execute(ClasspathSqlLocator.findSqlOnClasspath("insert-keith"));
+        h.execute(locator.locate("insert-keith"));
         assertThat(h.select("select name from something").mapTo(String.class).list()).hasSize(1);
     }
 
     @Test
     public void testCommentsInExternalSql() {
         Handle h = h2Extension.getSharedHandle();
-        h.execute(ClasspathSqlLocator.findSqlOnClasspath("insert-eric-with-comments"));
+        h.execute(locator.locate("insert-eric-with-comments"));
         assertThat(h.select("select name from something").mapTo(String.class).list()).hasSize(1);
     }
 
     @Test
     public void testPositionalParamsInPrepared() {
         Handle h = h2Extension.getSharedHandle();
-        h.execute(ClasspathSqlLocator.findSqlOnClasspath("insert-id-name-positional"), 3, "Tip");
+        h.execute(locator.locate("insert-id-name-positional"), 3, "Tip");
         assertThat(h.select("select name from something").mapTo(String.class).list()).hasSize(1);
     }
 
     @Test
     public void testNamedParamsInExternal() {
         Handle h = h2Extension.getSharedHandle();
-        h.createUpdate(ClasspathSqlLocator.findSqlOnClasspath("insert-id-name"))
+        h.createUpdate(locator.locate("insert-id-name"))
                 .bind("id", 1)
                 .bind("name", "Tip")
                 .execute();
@@ -67,7 +75,7 @@ public class TestClasspathSqlLocator {
     public void testUsefulExceptionForBackTracing() {
         Handle h = h2Extension.getSharedHandle();
 
-        assertThatThrownBy(() -> h.createUpdate(ClasspathSqlLocator.findSqlOnClasspath("insert-id-name"))
+        assertThatThrownBy(() -> h.createUpdate(locator.locate("insert-id-name"))
                 .bind("id", 1)
                 .execute())
             .isInstanceOf(StatementException.class)
@@ -80,7 +88,7 @@ public class TestClasspathSqlLocator {
         Handle h = h2Extension.getSharedHandle();
         h.getConfig(StatementExceptions.class).setMessageRendering(MessageRendering.DETAIL);
 
-        assertThatThrownBy(() -> h.createUpdate(ClasspathSqlLocator.findSqlOnClasspath("insert-id-name"))
+        assertThatThrownBy(() -> h.createUpdate(locator.locate("insert-id-name"))
                 .bind("id", 1)
                 .execute())
             .isInstanceOf(StatementException.class)
@@ -91,7 +99,7 @@ public class TestClasspathSqlLocator {
 
     @Test
     public void testNonExistentResource() {
-        assertThatThrownBy(() -> ClasspathSqlLocator.findSqlOnClasspath("this-does-not-exist"))
+        assertThatThrownBy(() -> locator.locate("this-does-not-exist"))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -108,10 +116,10 @@ public class TestClasspathSqlLocator {
             }
         });
 
-        ClasspathSqlLocator.findSqlOnClasspath("caches-result-after-first-lookup");
+        locator.locate("caches-result-after-first-lookup");
         assertThat(loadCount.get()).isOne();
 
-        ClasspathSqlLocator.findSqlOnClasspath("caches-result-after-first-lookup");
+        locator.locate("caches-result-after-first-lookup");
         assertThat(loadCount.get()).isOne(); // has not increased since previous
 
         Thread.currentThread().setContextClassLoader(classLoader);
@@ -119,13 +127,13 @@ public class TestClasspathSqlLocator {
 
     @Test
     public void testLocateByMethodName() {
-        assertThat(ClasspathSqlLocator.findSqlOnClasspath(getClass(), "testLocateByMethodName"))
+        assertThat(locator.locate(getClass(), "testLocateByMethodName"))
                 .contains("select 1");
     }
 
     @Test
     public void testSelectByExtensionMethodName() {
-        assertThat(ClasspathSqlLocator.findSqlOnClasspath(getClass(), "test-locate-by-custom-name"))
+        assertThat(locator.locate(getClass(), "test-locate-by-custom-name"))
                 .contains("select 1");
     }
 
@@ -133,7 +141,7 @@ public class TestClasspathSqlLocator {
     public void testColonInComment() {
         // Used to throw exception in SQL statement lexer
         // see https://github.com/jdbi/jdbi/issues/748
-        assertThat(ClasspathSqlLocator.findSqlOnClasspath(getClass(), "test-colon-in-comment"))
+        assertThat(locator.locate(getClass(), "test-colon-in-comment"))
             .contains("SELECT 1.007 AS column_name");
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/mapper/MapOptionalTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/MapOptionalTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 public class MapOptionalTest {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testMapOptional() {

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestEnums.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestEnums {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     private Handle handle;
 

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestIssue2016.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestIssue2016.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestIssue2016 {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     private Handle h;
 

--- a/core/src/test/java/org/jdbi/v3/core/mapper/TestRegisteredMappers.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/TestRegisteredMappers.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.mock;
 public class TestRegisteredMappers {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testRegisterInferredOnJdbi() {

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class FieldMapperTest {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     RowMapper<SampleBean> mapper = FieldMapper.of(SampleBean.class);
 

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestCustomQualifier.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestCustomQualifier.java
@@ -40,7 +40,7 @@ import static org.jdbi.v3.core.qualifier.Reverser.reverse;
 public class TestCustomQualifier {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void registerArgumentFactory() {

--- a/core/src/test/java/org/jdbi/v3/core/result/TestIterator.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestIterator.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestIterator {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     private Handle h;
 

--- a/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
+++ b/core/src/test/java/org/jdbi/v3/core/result/TestReducing.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestReducing {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @BeforeEach
     public void setUp() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBatch.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestBatch {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testBasics() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestMessageFormatTemplateEngine.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestMessageFormatTemplateEngine.java
@@ -24,6 +24,7 @@ public class TestMessageFormatTemplateEngine {
     private StatementContext ctx;
 
     @BeforeEach
+    @SuppressWarnings("deprecation")
     public void setUp() {
         templateEngine = new MessageFormatTemplateEngine();
         ctx = StatementContextAccess.createContext();

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPositionalParameterBinding.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPositionalParameterBinding.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestPositionalParameterBinding {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testSetPositionalString() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.tuple;
 public class TestPreparedBatch {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void emptyBatch() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
@@ -49,7 +49,7 @@ import static org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath;
 public class TestQueries {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testCreateQueryObject() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestQueries.java
@@ -32,6 +32,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.argument.NullArgument;
 import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.jdbi.v3.core.locator.ClasspathSqlLocator;
 import org.jdbi.v3.core.result.NoResultsException;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.core.result.ResultIterator;
@@ -44,7 +45,6 @@ import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
-import static org.jdbi.v3.core.locator.ClasspathSqlLocator.findSqlOnClasspath;
 
 public class TestQueries {
 
@@ -336,7 +336,7 @@ public class TestQueries {
     public void testFetchSize() {
         try (Handle h = h2Extension.getSharedHandle()) {
 
-            try (Script script = h.createScript(findSqlOnClasspath("default-data"))) {
+            try (Script script = h.createScript(ClasspathSqlLocator.create().locate("default-data"))) {
                 script.execute();
             }
 

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestScript.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestScript.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class TestScript {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @RegisterExtension
     public static EmbeddedPgExtension pg = MultiDatabaseBuilder.instanceWithDefaults().build();

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestSqlMetaData.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestSqlMetaData.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestSqlMetaData {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testQueryCatalogs() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatementContext.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatementContext.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestStatementContext {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testFoo() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestStatements.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestStatements {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     @Test
     public void testStatement() {

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestTimingCollector.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestTimingCollector.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestTimingCollector {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     private TTC tc;
 

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactions.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestTransactions.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestTransactions {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withSomething();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
 
     int begin, commit, rollback;
 

--- a/docs/src/test/java/jdbi/doc/AsyncTest.java
+++ b/docs/src/test/java/jdbi/doc/AsyncTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jdbi.v3.core.async.JdbiExecutor;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -71,7 +72,7 @@ public class AsyncTest {
 
         assertThat(futureResult)
             .succeedsWithin(Duration.ofSeconds(10))
-            .asList()
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
             .contains("Alice");
         // end::withHandle[]
     }

--- a/docs/src/test/java/jdbi/doc/NonVirtualExtensionFactoryTest.java
+++ b/docs/src/test/java/jdbi/doc/NonVirtualExtensionFactoryTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jdbi.v3.core.extension.ExtensionFactory.FactoryFlag.NON_VIRTUAL_FACTORY;
 
+@SuppressWarnings("unchecked")
 class NonVirtualExtensionFactoryTest {
 
     @RegisterExtension

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
@@ -70,23 +70,23 @@ public class TestGuavaCollectors {
 
     @Test
     public void immutableList() {
-        ImmutableList<Integer> list = h2Extension.getSharedHandle().createQuery("select intValue from something")
+        var list = h2Extension.getSharedHandle().createQuery("select intValue from something")
             .collectInto(new GenericType<ImmutableList<Integer>>() {});
 
-        assertThat(list).containsOnlyElementsOf(expected);
+        assertThat(list).hasSameElementsAs(expected);
     }
 
     @Test
     public void immutableSet() {
-        ImmutableSet<Integer> set = h2Extension.getSharedHandle().createQuery("select intValue from something")
+        var set = h2Extension.getSharedHandle().createQuery("select intValue from something")
             .collectInto(new GenericType<ImmutableSet<Integer>>() {});
 
-        assertThat(set).containsOnlyElementsOf(expected);
+        assertThat(set).hasSameElementsAs(expected);
     }
 
     @Test
     public void immutableSortedSet() {
-        ImmutableSortedSet<Integer> set = h2Extension.getSharedHandle().createQuery("select intValue from something")
+        var set = h2Extension.getSharedHandle().createQuery("select intValue from something")
             .collectInto(new GenericType<ImmutableSortedSet<Integer>>() {});
 
         assertThat(set).containsExactlyElementsOf(expected);
@@ -106,14 +106,14 @@ public class TestGuavaCollectors {
 
     @Test
     public void optionalPresent() {
-        Optional<Integer> shouldBePresent = h2Extension.getSharedHandle().createQuery("select intValue from something where intValue = 1")
+        var shouldBePresent = h2Extension.getSharedHandle().createQuery("select intValue from something where intValue = 1")
             .collectInto(new GenericType<Optional<Integer>>() {});
         assertThat(shouldBePresent).contains(1);
     }
 
     @Test
     public void optionalAbsent() {
-        Optional<Integer> shouldBeAbsent = h2Extension.getSharedHandle().createQuery("select intValue from something where intValue = 100")
+        var shouldBeAbsent = h2Extension.getSharedHandle().createQuery("select intValue from something where intValue = 100")
             .collectInto(new GenericType<Optional<Integer>>() {});
         assertThat(shouldBeAbsent).isAbsent();
     }

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -970,6 +970,14 @@
                             </compilerArgs>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <compilerArgs combine.children="append">
+                                <arg>-Xlint:deprecation</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/jpa/src/main/java/org/jdbi/v3/jpa/internal/JpaMember.java
+++ b/jpa/src/main/java/org/jdbi/v3/jpa/internal/JpaMember.java
@@ -102,10 +102,12 @@ public class JpaMember {
                 .orElse(memberName);
     }
 
+    @FunctionalInterface
     interface Getter {
         Object get(Object obj) throws IllegalAccessException, InvocationTargetException;
     }
 
+    @FunctionalInterface
     interface Setter {
         void set(Object obj, Object value) throws IllegalAccessException, InvocationTargetException;
     }

--- a/json/src/main/java/org/jdbi/v3/json/JsonMapper.java
+++ b/json/src/main/java/org/jdbi/v3/json/JsonMapper.java
@@ -25,6 +25,7 @@ import org.jdbi.v3.core.config.ConfigRegistry;
  *
  * jdbi3-jackson2 and jdbi3-gson2 are readily available for this.
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface JsonMapper {
     @Deprecated(since = "3.40.0", forRemoval = true)
     default String toJson(Type type, Object value, ConfigRegistry config) {

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/CoroutineContextTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/CoroutineContextTest.kt
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.kotlin
 
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -158,7 +159,7 @@ class CoroutineContextTest {
     }
 
     @Test
-    @OptIn(DelicateCoroutinesApi::class)
+    @OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
     fun testSingleThreadedCoroutines() {
         with(h2Extension.sharedHandle) {
             execute("INSERT INTO something(id, name) VALUES(1, 'first name')")

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementParameterCustomizer.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/SqlStatementParameterCustomizer.java
@@ -21,6 +21,7 @@ import org.jdbi.v3.core.statement.SqlStatement;
 /**
  * Customize a {@link SqlStatement} according to the value of an annotated parameter.
  */
+@FunctionalInterface
 public interface SqlStatementParameterCustomizer {
 
     /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ParameterCustomizerFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/ParameterCustomizerFactory.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Type;
 
 import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
 
+@FunctionalInterface
 public interface ParameterCustomizerFactory {
     /**
      * Creates parameter customizer used to bind sql statement parameters

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlBatchHandler.java
@@ -379,6 +379,7 @@ public class SqlBatchHandler extends CustomizingStatementHandler<PreparedBatch> 
                 + method.getReturnType();
     }
 
+    @SuppressWarnings("PMD.ImplicitFunctionalInterface")
     private interface ChunkSizeFunction {
         int call(Object[] args);
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/TransactionalCallback.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/TransactionalCallback.java
@@ -20,6 +20,7 @@ package org.jdbi.v3.sqlobject.transaction;
  * @param <T> the SqlObject type to provide
  * @param <X> exception thrown
  */
+@FunctionalInterface
 public interface TransactionalCallback<R, T extends Transactional<T>, X extends Exception> {
     /**
      * Execute in a transaction. Will be committed afterwards, or rolled back if an exception is thrown.

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/TransactionalConsumer.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/transaction/TransactionalConsumer.java
@@ -19,6 +19,7 @@ package org.jdbi.v3.sqlobject.transaction;
  * @param <T> the SqlObject type to provide
  * @param <X> exception thrown
  */
+@FunctionalInterface
 public interface TransactionalConsumer<T extends Transactional<T>, X extends Exception> {
     /**
      * Execute in a transaction. Will be committed afterwards, or rolled back if an exception is thrown.

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseTemplateEngine.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestUseTemplateEngine.java
@@ -53,6 +53,7 @@ public class TestUseTemplateEngine {
         assertThat(selected).isEqualTo("foo");
     }
 
+    @SuppressWarnings("deprecation")
     public interface QueriesForMessageFormatTE {
         @UseTemplateEngine(MessageFormatTemplateEngine.class)
         @SqlQuery("select * from (values(''{0}''))")

--- a/vavr/src/main/java/org/jdbi/v3/vavr/VavrTupleRowMapperFactory.java
+++ b/vavr/src/main/java/org/jdbi/v3/vavr/VavrTupleRowMapperFactory.java
@@ -172,6 +172,7 @@ class VavrTupleRowMapperFactory implements RowMapperFactory {
                 .getColumn(tupleIndex));
     }
 
+    @FunctionalInterface
     private interface MapperValueResolver extends CheckedFunction1<Integer, Object> {
         /**
          * @param tupleIndex the 1-based tuple index

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrCollectorFactoryWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrCollectorFactoryWithDB.java
@@ -79,7 +79,7 @@ public class TestVavrCollectorFactoryWithDB {
     private <T extends Iterable<Integer>> void testType(GenericType<T> containerType) {
         T values = h2Extension.getSharedHandle().createQuery("select intValue from something")
             .collectInto(containerType);
-        assertThat(values).containsOnlyElementsOf(expected);
+        assertThat(values).hasSameElementsAs(expected);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class TestVavrCollectorFactoryWithDB {
     private <T extends Traversable<Tuple2<Integer, String>>> void testMapType(GenericType<T> containerType) {
         T values = h2Extension.getSharedHandle().createQuery("select intValue, name from something")
             .collectInto(containerType);
-        assertThat(values).containsOnlyElementsOf(expectedMap);
+        assertThat(values).hasSameElementsAs(expectedMap);
     }
 
     @Test
@@ -118,6 +118,7 @@ public class TestVavrCollectorFactoryWithDB {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testMultimapValuesAddAnotherDataSetShouldHave2ValuesForEachKey() {
         final int offset = 10;
         for (Integer i : expected) {
@@ -129,6 +130,6 @@ public class TestVavrCollectorFactoryWithDB {
 
         assertThat(result).hasSize(expected.size() * 2);
         expected.forEach(i -> assertThat(result.apply(i))
-                .containsOnlyElementsOf(List.of(i + "asString", (i + 10) + "asString")));
+                .hasSameElementsAs(List.of(i + "asString", (i + 10) + "asString")));
     }
 }

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrMapCollectorWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrMapCollectorWithDB.java
@@ -68,7 +68,7 @@ public class TestVavrMapCollectorWithDB {
         Boolean executed = jdbiWithKeyColAndValCol.withHandle(h -> {
             Map<String, String> valueMap = h.createQuery("select val_c, key_c from keyval")
                 .collectInto(new GenericType<Map<String, String>>() {});
-            assertThat(valueMap).containsOnlyElementsOf(expectedMap);
+            assertThat(valueMap).hasSameElementsAs(expectedMap);
             return true;
         });
 
@@ -82,17 +82,17 @@ public class TestVavrMapCollectorWithDB {
             .createQuery("select val_c, key_c from keyval")
             .collectInto(new GenericType<Map<String, String>>() {});
 
-        assertThat(valueMap).containsOnlyElementsOf(expectedMap);
+        assertThat(valueMap).hasSameElementsAs(expectedMap);
     }
 
     @Test
     public void testMapCollectorWithCorrespondingTupleColsShouldSucceed() {
-        Map<String, String> valueMap = h2Extension.getSharedHandle()
+        var valueMap = h2Extension.getSharedHandle()
             .configure(TupleMappers.class, c -> c.setColumn(1, "key_c").setColumn(2, "val_c"))
             .createQuery("select val_c, key_c from keyval")
             .collectInto(new GenericType<Map<String, String>>() {});
 
-        assertThat(valueMap).containsOnlyElementsOf(expectedMap);
+        assertThat(valueMap).hasSameElementsAs(expectedMap);
     }
 
     @Test
@@ -133,6 +133,7 @@ public class TestVavrMapCollectorWithDB {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testNonUniqueIndexWithMultimap() {
         Handle h = h2Extension.getSharedHandle();
         h.execute("create table \"user\" (id int, name varchar)");

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleMapperWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleMapperWithDB.java
@@ -62,21 +62,21 @@ public class TestVavrTupleMapperWithDB {
     @Test
     public void testTuple1CollectorWithSingleSelectShouldSucceed() {
         List<Tuple1<String>> expectedTuples = expected.map(i -> new Tuple1<>("t2" + i));
-        List<Tuple1<String>> tupleProjection = h2Extension.getSharedHandle()
+        var tupleProjection = h2Extension.getSharedHandle()
             .createQuery("select t2 from tuples")
             .collectInto(new GenericType<List<Tuple1<String>>>() {});
 
-        assertThat(tupleProjection).containsOnlyElementsOf(expectedTuples);
+        assertThat(tupleProjection).hasSameElementsAs(expectedTuples);
     }
 
     @Test
     public void testTuple1CollectorWithMultiSelectShouldSucceed() {
         List<Tuple1<Integer>> firstColumnTuples = expected.map(Tuple1::new);
-        List<Tuple1<Integer>> tupleProjection = h2Extension.getSharedHandle()
+        var tupleProjection = h2Extension.getSharedHandle()
             .createQuery("select * from tuples")
             .collectInto(new GenericType<List<Tuple1<Integer>>>() {});
 
-        assertThat(tupleProjection).containsOnlyElementsOf(firstColumnTuples);
+        assertThat(tupleProjection).hasSameElementsAs(firstColumnTuples);
     }
 
     @Test
@@ -94,17 +94,17 @@ public class TestVavrTupleMapperWithDB {
             .createQuery("select t1, t2 from tuples")
             .mapTo(new GenericType<Tuple2<Integer, String>>() {}).list();
 
-        assertThat(tupleProjection).containsOnlyElementsOf(expectedTuples);
+        assertThat(tupleProjection).hasSameElementsAs(expectedTuples);
     }
 
     @Test
     public void testTuple3CollectorWithSelectedKeyValueShouldSucceed() {
         List<Tuple3<Integer, String, String>> expectedTuples = expected.map(i -> new Tuple3<>(i, "t2" + i, "t3" + (i + 1)));
-        List<Tuple3<Integer, String, String>> tupleProjection = h2Extension.getSharedHandle()
+        var tupleProjection = h2Extension.getSharedHandle()
             .createQuery("select t1, t2, t3 from tuples")
             .collectInto(new GenericType<List<Tuple3<Integer, String, String>>>() {});
 
-        assertThat(tupleProjection).containsOnlyElementsOf(expectedTuples);
+        assertThat(tupleProjection).hasSameElementsAs(expectedTuples);
     }
 
 }


### PR DESCRIPTION
Remove a lot of warnings / deprecation messages, stop using more deprecated APIs.

Found while doing JDK 17 release prep, but useful for JDK 11 as well.

- **Add functional interface declarations**
- **Suppress PMD functional interface warnings**
- **suppress kotlin warning**
- **backport deprecation warnings**
- **remove withSomething() usage**
- **remove static findSqlOnClasspath use**
