### PR TITLE
Fix bad JFR test with GraalVM

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Only use JFR if the flight recorder was registered (#2736)
+
 # 3.49.2
 
 - Fix returning `long` update count from update statements (#2778)

--- a/core/src/main/java/org/jdbi/v3/core/statement/internal/JfrSupport.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/internal/JfrSupport.java
@@ -53,7 +53,7 @@ public final class JfrSupport {
     }
 
     public static OptionalEvent newStatementEvent() {
-        if (isJfrAvailable()) {
+        if (isFlightRecorderAvailable()) {
             return Holder.newEvent();
         } else {
             return new NoStatementEvent();

--- a/core/src/main/java/org/jdbi/v3/core/statement/internal/OptionalEvent.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/internal/OptionalEvent.java
@@ -14,6 +14,12 @@
 package org.jdbi.v3.core.statement.internal;
 
 public interface OptionalEvent {
+    /**
+     * @see jdk.jfr.Event#begin()
+     */
     void begin();
+    /**
+     * @see jdk.jfr.Event#shouldCommit()
+     */
     boolean shouldCommit();
 }


### PR DESCRIPTION
Test for explicit JFR flightrecorder enablement, not just presence of
the JFR module.
