### PR TITLE
Mark spotbugs-annotations as optional so it does not end up in transitive dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,6 +74,7 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -52,6 +52,7 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -46,6 +46,7 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
We don't need to include spotbugs deps at runtime, and it can interfere with build configuration downstream