### PR TITLE
Fix sbom generation (again)

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -922,6 +922,7 @@
                     <version>${dep.plugin.cyclonedx.version}</version>
                     <configuration>
                         <skip>${jdbi.check.skip-sbom}</skip>
+                        <skipNotDeployed>false</skipNotDeployed>
                         <includeTestScope>false</includeTestScope>
                         <includeLicenseText>false</includeLicenseText>
                         <outputReactorProjects>true</outputReactorProjects>


### PR DESCRIPTION
Ignore the broken skip deployment logic in the cyclonedx plugin, always generate sboms
when the plugin is enabled.
