### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/versions-check.yml
+++ b/.github/workflows/versions-check.yml
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        test-version: [ 2.11.0-beta2, 2.9.3 ]
+        test-version: [ 2.10.1, 2.9.3 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
 
     strategy:
       matrix:
-        test-version: [ 2.19.0, 2.17.3, 2.16.2 ]
+        test-version: [ 2.19.1, 2.17.3, 2.16.2 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -386,7 +386,7 @@ jobs:
 
     strategy:
       matrix:
-        test-version: [ 2.2.0-Beta1, 2.0.21, 1.9.25 ]
+        test-version: [ 2.1.21, 2.0.21, 1.9.25 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -70,19 +70,20 @@
         <basepom.test.fork-count>4</basepom.test.fork-count>
         <basepom.test.timeout>240</basepom.test.timeout>
         <dep.antlr.version>4.13.2</dep.antlr.version>
-        <dep.asciidoctorj-diagram.version>2.3.2</dep.asciidoctorj-diagram.version>
+        <dep.asciidoctorj-diagram-ditaamini.version>1.0.3</dep.asciidoctorj-diagram-ditaamini.version>
+        <dep.asciidoctorj-diagram.version>3.0.1</dep.asciidoctorj-diagram.version>
         <dep.asciidoctorj.version>3.0.0</dep.asciidoctorj.version>
         <!-- leave at 3.x for now, 4.0.0 needs Java 17 -->
         <dep.assertj.version>3.27.3</dep.assertj.version>
-        <dep.caffeine.version>3.2.0</dep.caffeine.version>
-        <dep.checkerframework.version>3.49.3</dep.checkerframework.version>
+        <dep.caffeine.version>3.2.1</dep.caffeine.version>
+        <dep.checkerframework.version>3.49.5</dep.checkerframework.version>
         <dep.commons-compress.version>1.27.1</dep.commons-compress.version>
         <dep.commons-lang.version>3.17.0</dep.commons-lang.version>
         <dep.commons-text.version>1.13.1</dep.commons-text.version>
         <!-- derby 10.17 is JDK 21 only, keep it on 10.16 for now -->
         <dep.derby.version>10.16.1.1</dep.derby.version>
         <dep.detekt.version>1.23.8</dep.detekt.version>
-        <dep.errorprone.version>2.38.0</dep.errorprone.version>
+        <dep.errorprone.version>2.39.0</dep.errorprone.version>
         <!-- last flyway version to support java 11 -->
         <dep.flyway.version>9.22.3</dep.flyway.version>
         <dep.freebuilder.version>2.8.0</dep.freebuilder.version>
@@ -95,8 +96,8 @@
         <dep.h2.version>2.3.232</dep.h2.version>
         <dep.hikari-cp.version>6.3.0</dep.hikari-cp.version>
         <dep.hsqldb.version>2.7.4</dep.hsqldb.version>
-        <dep.immutables.version>2.10.1</dep.immutables.version>
-        <dep.jackson2.version>2.18.3</dep.jackson2.version>
+        <dep.immutables.version>2.11.0</dep.immutables.version>
+        <dep.jackson2.version>2.18.4</dep.jackson2.version>
         <dep.jakarta-annotation-api.version>3.0.0</dep.jakarta-annotation-api.version>
         <dep.jakarta-inject-api.version>2.0.1.MR</dep.jakarta-inject-api.version>
         <dep.javax-inject.version>1</dep.javax-inject.version>
@@ -105,36 +106,36 @@
         <dep.jfrunit.version>1.0.0.Alpha2</dep.jfrunit.version>
         <dep.joda-time.version>2.14.0</dep.joda-time.version>
         <dep.jts.version>1.20.0</dep.jts.version>
-        <dep.junit5.version>5.13.0</dep.junit5.version>
-        <dep.kotlin.version>2.1.20</dep.kotlin.version>
+        <dep.junit5.version>5.13.3</dep.junit5.version>
+        <dep.kotlin.version>2.2.0</dep.kotlin.version>
         <dep.kotlinx-coroutines.version>1.10.2</dep.kotlinx-coroutines.version>
         <dep.lombok.version>1.18.38</dep.lombok.version>
-        <dep.mockito.version>5.17.0</dep.mockito.version>
+        <dep.mockito.version>5.18.0</dep.mockito.version>
         <dep.moshi.version>1.15.2</dep.moshi.version>
-        <dep.mssql.version>12.10.0.jre11</dep.mssql.version>
-        <dep.mysql.version>9.2.0</dep.mysql.version>
-        <dep.opentelemetry.version>1.49.0</dep.opentelemetry.version>
-        <dep.oracle-xe.version>23.7.0.25.01</dep.oracle-xe.version>
-        <dep.otj-pg-embedded.version>1.1.0</dep.otj-pg-embedded.version>
+        <dep.mssql.version>12.10.1.jre11</dep.mssql.version>
+        <dep.mysql.version>9.3.0</dep.mysql.version>
+        <dep.opentelemetry.version>1.51.0</dep.opentelemetry.version>
+        <dep.oracle-xe.version>23.8.0.25.04</dep.oracle-xe.version>
+        <dep.otj-pg-embedded.version>1.1.1</dep.otj-pg-embedded.version>
         <dep.pg-embedded.version>5.3.0</dep.pg-embedded.version>
         <dep.plugin.asciidoctor.version>3.2.0</dep.plugin.asciidoctor.version>
         <dep.plugin.cyclonedx.version>2.9.1</dep.plugin.cyclonedx.version>
         <dep.plugin.detekt.version>1.23.8</dep.plugin.detekt.version>
         <dep.plugin.dokka.version>2.0.0</dep.plugin.dokka.version>
-        <dep.plugin.flatten.version>1.7.0</dep.plugin.flatten.version>
-        <dep.plugin.inline.version>1.5.0</dep.plugin.inline.version>
+        <dep.plugin.flatten.version>1.7.1</dep.plugin.flatten.version>
+        <dep.plugin.inline.version>1.5.1</dep.plugin.inline.version>
         <!-- remove after next basepom release (63) -->
         <dep.plugin.jacoco.version>0.8.13</dep.plugin.jacoco.version>
         <dep.plugin.japicmp.version>0.23.1</dep.plugin.japicmp.version>
         <dep.plugin.kotlin.version>${dep.kotlin.version}</dep.plugin.kotlin.version>
         <dep.plugin.ktlint.version>3.5.0</dep.plugin.ktlint.version>
         <dep.plugin.sortpom.version>4.0.0</dep.plugin.sortpom.version>
-        <dep.postgresql.version>42.7.5</dep.postgresql.version>
+        <dep.postgresql.version>42.7.7</dep.postgresql.version>
         <dep.slf4j.version>2.0.17</dep.slf4j.version>
-        <dep.spring.version>6.2.7</dep.spring.version>
-        <dep.sqlite.version>3.49.1.0</dep.sqlite.version>
+        <dep.spring.version>6.2.8</dep.spring.version>
+        <dep.sqlite.version>3.50.2.0</dep.sqlite.version>
         <dep.stringtemplate4.version>4.3.4</dep.stringtemplate4.version>
-        <dep.testcontainers.version>1.21.0</dep.testcontainers.version>
+        <dep.testcontainers.version>1.21.3</dep.testcontainers.version>
         <dep.vavr.version>0.10.6</dep.vavr.version>
         <dep.xz.version>1.10</dep.xz.version>
         <jdbi.check.fail-detekt>${jdbi.check.fail-kotlin}</jdbi.check.fail-detekt>
@@ -738,6 +739,11 @@
                             <groupId>org.asciidoctor</groupId>
                             <artifactId>asciidoctorj-diagram</artifactId>
                             <version>${dep.asciidoctorj-diagram.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj-diagram-ditaamini</artifactId>
+                            <version>${dep.asciidoctorj-diagram-ditaamini.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -32,10 +32,11 @@
         <basepom.test.fork-count>1</basepom.test.fork-count>
         <!-- docker tests run long -->
         <basepom.test.timeout>600</basepom.test.timeout>
+        <dep.clickhouse.version>0.9.0</dep.clickhouse.version>
         <dep.clickhouse.version>0.6.0</dep.clickhouse.version>
-        <dep.db2.version>11.5.9.0</dep.db2.version>
-        <dep.trino.version>437</dep.trino.version>
-        <dep.yugabyte.version>42.3.5-yb-4</dep.yugabyte.version>
+        <dep.db2.version>12.1.2.0</dep.db2.version>
+        <dep.trino.version>476</dep.trino.version>
+        <dep.yugabyte.version>42.7.3-yb-4</dep.yugabyte.version>
         <moduleName>org.jdbi.v3.testcontainers</moduleName>
     </properties>
 
@@ -47,6 +48,13 @@
                 <artifactId>clickhouse-jdbc</artifactId>
                 <version>${dep.clickhouse.version}</version>
                 <classifier>all</classifier>
+                <!-- -all is supposed to bring all dependencies -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Maven:

update to 3.9.10
flatten plugin to 1.7.1 (from 1.7.0)
inline plugin to 1.5.1 (from 1.5.0)

Docs:

update asciidoctorj diagram to 3.0.1, add diagram-ditaamini

Annotation Jars:

checkerframework to 3.49.5 (from 3.49.3)
errorprone to 2.39.0 (from 2.38.0)

Build related:

junit to 5.13.3 (from 5.13.0)
kotlin to 2.2.0 (from 2.1.20), updated CI to test with 2.1.21
mockito to 5.18.0 (from 5.17.0)
ojt-pg-embedded to 1.1.1 (from 1.1.0)
testcontainers to 1.21.3 (from 1.21.0)

Dependencies:

caffeine to 3.2.1 (from 3.2.0)
immutables to 2.11.0 (from 2.10.0), updated CI
jackson2 to 2.18.4 (from 2.18.3)
opentelemetry to 1.51.0 (from 1.49.0)
spring to 6.2.8 (from 6.2.7)

Drivers:

clickhouse to 0.9.0 (from 0.6.0)
db2 to 12.1.2.0 (from 11.5.9.0)
mssql to 12.10.1.jre11 (from 12.10.0.jre11)
mysql to 9.3.0 (from 9.2.0)
oracle-xe to 23.8.0.25.04 (from 23.7.0.25.01)
postgresql to 42.7.7 (from 42.7.5)
sqlite to 3.50.2.0 (from 3.49.1.0)
trino to 476 (from 437)
yugabyte to 42.7.3-yb-4 (from 42.3.5-yb-4)
