### PR TITLE
Add Oracle-free to the build

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -193,7 +193,7 @@ jobs:
 
     strategy:
       matrix:
-        test-version: [ '21-slim-faststart', '18-slim-faststart' ]
+        test-version: [ 'latest', 'latest-faststart', 'full-faststart' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 # 3.49.5
 
 - Fix SerializableTransactionRunner retry with failures wrapped in batch exceptions
+- Add Oracle-Free tests
 
 # 3.49.4
 

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -104,6 +104,12 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>oracle-free</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>

--- a/oracle12/src/test/java/org/jdbi/v3/oracle12/TestGetGeneratedKeysOracle.java
+++ b/oracle12/src/test/java/org/jdbi/v3/oracle12/TestGetGeneratedKeysOracle.java
@@ -29,11 +29,10 @@ import org.jdbi.v3.testing.junit5.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.oracle.OracleContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,10 +41,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = {"x86_64", "amd64"})
 public class TestGetGeneratedKeysOracle {
 
-    static final String CONTAINER_VERSION = "gvenzl/oracle-xe:" + System.getProperty("oracle.container.version", "slim-faststart");
+    static final String CONTAINER_VERSION = "gvenzl/oracle-free:" + System.getProperty("oracle.container.version", "slim-faststart");
 
     @Container
     static OracleContainer oc = new OracleContainer(CONTAINER_VERSION);

--- a/oracle12/src/test/java/org/jdbi/v3/oracle12/TestOracleReturning.java
+++ b/oracle12/src/test/java/org/jdbi/v3/oracle12/TestOracleReturning.java
@@ -25,11 +25,10 @@ import org.jdbi.v3.testing.junit5.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.oracle.OracleContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jdbi.v3.oracle12.OracleReturning.returnParameters;
@@ -40,10 +39,9 @@ import static org.jdbi.v3.oracle12.OracleReturning.returningDml;
  */
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = {"x86_64", "amd64"})
 public class TestOracleReturning {
 
-    static final String CONTAINER_VERSION = "gvenzl/oracle-xe:" + System.getProperty("oracle.container.version", "slim-faststart");
+    static final String CONTAINER_VERSION = "gvenzl/oracle-free:" + System.getProperty("oracle.container.version", "slim-faststart");
 
     @Container
     static OracleContainer oc = new OracleContainer(CONTAINER_VERSION);

--- a/oracle12/src/test/java/org/jdbi/v3/oracle12/TestOutparameterCursor.java
+++ b/oracle12/src/test/java/org/jdbi/v3/oracle12/TestOutparameterCursor.java
@@ -24,20 +24,18 @@ import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.oracle.OracleContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = {"x86_64", "amd64"})
 public class TestOutparameterCursor {
 
-    static final String CONTAINER_VERSION = "gvenzl/oracle-xe:" + System.getProperty("oracle.container.version", "slim-faststart");
+    static final String CONTAINER_VERSION = "gvenzl/oracle-free:" + System.getProperty("oracle.container.version", "slim-faststart");
 
     @Container
     static OracleContainer oc = new OracleContainer(CONTAINER_VERSION);

--- a/oracle12/src/test/java/org/jdbi/v3/oracle12/TestScript.java
+++ b/oracle12/src/test/java/org/jdbi/v3/oracle12/TestScript.java
@@ -28,20 +28,18 @@ import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.oracle.OracleContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = {"x86_64", "amd64"})
 public class TestScript {
 
-    static final String CONTAINER_VERSION = "gvenzl/oracle-xe:" + System.getProperty("oracle.container.version", "slim-faststart");
+    static final String CONTAINER_VERSION = "gvenzl/oracle-free:" + System.getProperty("oracle.container.version", "slim-faststart");
 
     @Container
     static OracleContainer oc = new OracleContainer(CONTAINER_VERSION);

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -190,6 +190,12 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>oracle-free</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>

--- a/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/OracleFreeJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/v3/testing/junit5/tc/OracleFreeJdbiTestContainersExtensionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.testing.junit5.tc;
+
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.oracle.OracleContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Tag("slow")
+@Testcontainers
+class OracleFreeJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+
+    @Container
+    static JdbcDatabaseContainer<?> dbContainer = new OracleContainer(
+        DockerImageName.parse("gvenzl/oracle-free:slim-faststart"));
+
+    @Override
+    JdbcDatabaseContainer<?> getDbContainer() {
+        return dbContainer;
+    }
+}


### PR DESCRIPTION
- move all oracle tests to use oracle-free (which has an arm64 version)
- add tests for oracle-free to testcontainers
