### PR TITLE
Added Set<Annotation> argument to JsonMapper.forType()

### DIFF
--- a/gson2/src/main/java/org/jdbi/v3/gson2/GsonJsonMapper.java
+++ b/gson2/src/main/java/org/jdbi/v3/gson2/GsonJsonMapper.java
@@ -14,7 +14,9 @@
 package org.jdbi.v3.gson2;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Set;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
@@ -24,7 +26,7 @@ import org.jdbi.v3.json.JsonMapper;
 
 class GsonJsonMapper implements JsonMapper {
     @Override
-    public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+    public TypedJsonMapper forType(Type type, Set<? extends Annotation> annotations, ConfigRegistry config) {
         return new TypedJsonMapper() {
             @SuppressWarnings("rawtypes")
             private final TypeAdapter adapter = config.get(Gson2Config.class)

--- a/jackson2/src/main/java/org/jdbi/v3/jackson2/JacksonJsonMapper.java
+++ b/jackson2/src/main/java/org/jdbi/v3/jackson2/JacksonJsonMapper.java
@@ -14,7 +14,9 @@
 package org.jdbi.v3.jackson2;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
@@ -27,7 +29,7 @@ import org.jdbi.v3.json.JsonMapper;
 
 class JacksonJsonMapper implements JsonMapper {
     @Override
-    public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+    public TypedJsonMapper forType(Type type, Set<? extends Annotation> annotations, ConfigRegistry config) {
         return new TypedJsonMapper() {
             private final ObjectMapper mapper = config.get(Jackson2Config.class).getMapper();
             private final JavaType mappedType = mapper.constructType(type);

--- a/json/src/main/java/org/jdbi/v3/json/JsonMapper.java
+++ b/json/src/main/java/org/jdbi/v3/json/JsonMapper.java
@@ -13,7 +13,10 @@
  */
 package org.jdbi.v3.json;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Set;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 
@@ -29,15 +32,15 @@ import org.jdbi.v3.core.config.ConfigRegistry;
 public interface JsonMapper {
     @Deprecated(since = "3.40.0", forRemoval = true)
     default String toJson(Type type, Object value, ConfigRegistry config) {
-        return forType(type, config).toJson(value, config);
+        return forType(type, Collections.emptySet(), config).toJson(value, config);
     }
 
     @Deprecated(since = "3.40.0", forRemoval = true)
     default Object fromJson(Type type, String json, ConfigRegistry config) {
-        return forType(type, config).fromJson(json, config);
+        return forType(type, Collections.emptySet(), config).fromJson(json, config);
     }
 
-    TypedJsonMapper forType(Type type, ConfigRegistry config);
+    TypedJsonMapper forType(Type type, Set<? extends Annotation> annotations, ConfigRegistry config);
 
     interface TypedJsonMapper {
         String toJson(Object value, ConfigRegistry config);

--- a/json/src/main/java/org/jdbi/v3/json/internal/JsonArgumentFactory.java
+++ b/json/src/main/java/org/jdbi/v3/json/internal/JsonArgumentFactory.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.json.internal;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -43,7 +44,7 @@ public class JsonArgumentFactory implements ArgumentFactory.Preparable {
 
     @Override
     public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
-        TypedJsonMapper mapper = config.get(JsonConfig.class).getJsonMapper().forType(type, config);
+        TypedJsonMapper mapper = config.get(JsonConfig.class).getJsonMapper().forType(type, Collections.emptySet(), config);
         Arguments a = config.get(Arguments.class);
         // look for specialized json support first, revert to simple String binding if absent
         Function<Object, Argument> bindJson = JdbiOptionals.findFirstPresent(

--- a/json/src/main/java/org/jdbi/v3/json/internal/JsonColumnMapperFactory.java
+++ b/json/src/main/java/org/jdbi/v3/json/internal/JsonColumnMapperFactory.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.json.internal;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -47,7 +48,7 @@ public class JsonColumnMapperFactory implements ColumnMapperFactory {
                 () -> cm.findFor(String.class))
                 .orElseThrow(() -> new UnableToProduceResultException(JSON_NOT_RETRIEVABLE));
 
-        final TypedJsonMapper mapper = config.get(JsonConfig.class).getJsonMapper().forType(type, config);
+        final TypedJsonMapper mapper = config.get(JsonConfig.class).getJsonMapper().forType(type, Collections.emptySet(), config);
         return Optional.of((rs, i, ctx) ->
             mapper.fromJson(
                     Optional.ofNullable(jsonStringMapper.map(rs, i, ctx))

--- a/json/src/main/java/org/jdbi/v3/json/internal/UnimplementedJsonMapper.java
+++ b/json/src/main/java/org/jdbi/v3/json/internal/UnimplementedJsonMapper.java
@@ -13,7 +13,9 @@
  */
 package org.jdbi.v3.json.internal;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Set;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
@@ -28,7 +30,7 @@ public class UnimplementedJsonMapper implements JsonMapper {
     );
 
     @Override
-    public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+    public TypedJsonMapper forType(Type type, Set<? extends Annotation> annotations, ConfigRegistry config) {
         throw new UnableToCreateStatementException(NO_IMPL_INSTALLED);
     }
 }

--- a/json/src/test/java/org/jdbi/v3/json/JsonPluginTest.java
+++ b/json/src/test/java/org/jdbi/v3/json/JsonPluginTest.java
@@ -13,7 +13,9 @@
  */
 package org.jdbi.v3.json;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Set;
 
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -42,7 +44,7 @@ public class JsonPluginTest {
 
         jdbi.getConfig(JsonConfig.class).setJsonMapper(new JsonMapper() {
             @Override
-            public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+            public TypedJsonMapper forType(Type type, Set<? extends Annotation> annotations, ConfigRegistry config) {
                 assertThat(type).isEqualTo(Foo.class);
                 return new TypedJsonMapper() {
                     @Override

--- a/moshi/src/main/java/org/jdbi/v3/moshi/MoshiJsonMapper.java
+++ b/moshi/src/main/java/org/jdbi/v3/moshi/MoshiJsonMapper.java
@@ -14,7 +14,9 @@
 package org.jdbi.v3.moshi;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Set;
 
 import com.squareup.moshi.JsonAdapter;
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -23,9 +25,9 @@ import org.jdbi.v3.json.JsonMapper;
 
 class MoshiJsonMapper implements JsonMapper {
     @Override
-    public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+    public TypedJsonMapper forType(Type type, Set<? extends Annotation> annotations, ConfigRegistry config) {
         return new TypedJsonMapper() {
-            private final JsonAdapter<Object> adapter = config.get(MoshiConfig.class).getMoshi().adapter(type);
+            private final JsonAdapter<Object> adapter = config.get(MoshiConfig.class).getMoshi().adapter(type, annotations);
 
             @Override
             public String toJson(Object value, ConfigRegistry config) {


### PR DESCRIPTION
Added `Set<Annotation>` argument to `JsonMapper.forType()` method to allow json serialize to customize its behavior based on annotations of type/field that jdbi uses as argument or parses from result set. Related to issue #2824

FYI: @hgschmie

For this to work **in future** we'll need to inherit `JsonArgumentFactory` from `QualifiedArgumentFactory` and `JsonColumnMapperFactory` from `QualifiedColumnMapperFactory` so that builder methods can see annotations in qualified type.

For now I'd love to have this in main branch so I can new `JsonArgumentFactory` and `JsonColumnMapperFactory` locally.

---

Here is how I use it

```
// Annotation that contains reference to schema of Map<String, Value<?>> so that it can be serialized to proper json (e.g. Instant -> epoch/iso string)
@Retention(AnnotationRetention.RUNTIME)
@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.PROPERTY)
@JsonQualifier
@org.jdbi.v3.core.qualifier.Qualifier
annotation class WithBpTypes(val typeMap: KClass<out WithDescriptors>)

interface WithDescriptors {
    val fieldTypes: Map<String, ValueType>
}
```

and I have modified argument and column factories which we later can generalize to generic json classes that jdbi currently has. Mine look like this (I use moshi)

```
// Fixed moshi adapter so that it gets list of annotations from jdbi
class MoshiJsonMapper : JsonMapper {

    override fun forType(type: Type, annotations: Set<Annotation>, config: ConfigRegistry): TypedJsonMapper? {

        return object : TypedJsonMapper {
            private val adapter = config.get(org.jdbi.v3.moshi.MoshiConfig::class.java).moshi.adapter<Any>(type, annotations)

            override fun toJson(value: Any?, config: ConfigRegistry): String? {
                return adapter.toJson(value)
            }

            override fun fromJson(json: String, config: ConfigRegistry?): Any? {
                try {
                    return adapter.fromJson(json);
                } catch (e: IOException) {
                    throw UnableToProduceResultException(e);
                }
            }
        }
    }
}

class ValueMapJsonArgumentFactory : QualifiedArgumentFactory {

    override fun build(qt: QualifiedType<*>, value: Any?, config: ConfigRegistry): Optional<Argument> {
        return if (qt.qualifiers.any { it is WithBpTypes }) {

            val mapper = config.get(JsonConfig::class.java).jsonMapper.forType(qt.type, qt.qualifiers, config)
            val a = config.get<Arguments>(Arguments::class.java)

            // look for specialized json support first, revert to simple String binding if absent
            var bindJson = a.prepareFor(ENCODED_JSON).orElse(null)
                ?: a.prepareFor(String::class.java).orElse(null)
                ?: throw UnableToCreateStatementException(JSON_NOT_STORABLE)

            // json null -> sql null
            val json = value?.let { mapper.toJson(it, config).takeIf { it != "null" } }
            Optional.ofNullable(bindJson.apply(json))
        } else
            Optional.empty<Argument>()
    }

    companion object {
        @JvmStatic
        private val ENCODED_JSON: QualifiedType<String?> = QualifiedType.of<String?>(String::class.java).with(EncodedJson::class.java)

        @JvmStatic
        private val JSON_NOT_STORABLE = String.format(
            "No argument factory found for `@%s String` or 'String'",
            EncodedJson::class.java.getSimpleName()
        )
    }
}

class ValueMapJsonColumnMapperFactory : QualifiedColumnMapperFactory {

    override fun build(qualifiedType: QualifiedType<*>, config: ConfigRegistry): Optional<ColumnMapper<*>> {

        // If we don't check for presence of special annotation we'll end up with infinite recursive call in `cm.findFor()`
        return if (qualifiedType.qualifiers.any { it is WithBpTypes }) {

            val cm = config.get<ColumnMappers>(ColumnMappers::class.java)

            // look for specialized json support first, revert to simple String mapping if absent
            val jsonStringMapper =
                cm.findFor<String>(QualifiedType.of<String>(String::class.java).with(EncodedJson::class.java)).getOrNull()
                    ?: cm.findFor<String>(String::class.java).getOrNull()
                    ?: throw UnableToProduceResultException(JSON_NOT_RETRIEVABLE)

            val mapper = config.get<JsonConfig?>(JsonConfig::class.java).jsonMapper.forType(qualifiedType.type, qualifiedType.qualifiers, config)

            Optional.of<ColumnMapper<*>>(ColumnMapper { rs: ResultSet, columnNumber: Int, ctx: StatementContext? ->
                mapper.fromJson(
                    jsonStringMapper.map(rs, columnNumber, ctx) ?: "null", // sql null -> json null
                    config
                )
            })
        } else
            Optional.empty()
    }

    companion object {
        private val JSON_NOT_RETRIEVABLE = String.format("No column mapper found for '@%s String', or 'String'", Json::class.java.getSimpleName())
    }
} 
```

