### PR TITLE
ExtensionHandler: since target does not vary, pull out the method handle binding

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 - Add support for PGvector types (#2830)
 - Improve concurrency of statement cache loading (#2834)
+- ExtensionHandler interface pulls out handling of target object into new AttachedExtensionHandler interface (#2828)
 
 # 3.49.5
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/AttachedExtensionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/AttachedExtensionHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.meta.Alpha;
+import org.jdbi.v3.meta.Beta;
+
+/**
+ * Extension handler with a target object attached.
+ */
+@FunctionalInterface
+@Alpha
+public interface AttachedExtensionHandler {
+    /**
+     * Gets invoked to return a value for the method that this handler was is handling, on the attached target instance.
+     * @param handleSupplier A {@link HandleSupplier} instance for accessing the handle and its related objects
+     * @param args Optional arguments for the handler
+     * @return The return value for the method that was bound to the extension handler. Can be null
+     * @throws Exception Any exception from the underlying code
+     */
+    Object invoke(HandleSupplier handleSupplier, Object... args) throws Exception;
+
+    /**
+     * Called after the method handler is constructed to pre-initialize any important
+     * configuration data structures.
+     *
+     * @param config the method configuration to use for warming up
+     */
+    @Beta
+    default void warm(ConfigRegistry config) {}
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/BuiltInExtensionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/BuiltInExtensionHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+enum BuiltInExtensionHandler implements ExtensionHandler {
+    /** Implementation for the {@link Object#equals(Object)} method. Each object using this handler is only equal to itself. */
+    EQUALS_HANDLER {
+        @SuppressWarnings("PMD.CompareObjectsWithEquals")
+        @Override
+        public AttachedExtensionHandler attachTo(ConfigRegistry config, Object target) {
+            return (handleSupplier, args) -> target == args[0];
+        }
+    },
+    /** Implementation for the {@link Object#hashCode()} method. */
+    HASHCODE_HANDLER {
+        @Override
+        public AttachedExtensionHandler attachTo(ConfigRegistry config, Object target) {
+            return (handleSupplier, args) -> System.identityHashCode(target);
+        }
+    },
+    /** Handler that only returns null independent of any input parameters. */
+    NULL_HANDLER {
+        @Override
+        public AttachedExtensionHandler attachTo(ConfigRegistry config, Object target) {
+            return (handleSupplier, args) -> null;
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactoryDelegate.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactoryDelegate.java
@@ -27,11 +27,11 @@ import org.jdbi.v3.core.internal.JdbiClassUtils.MethodKey;
 
 import static java.lang.String.format;
 
+import static org.jdbi.v3.core.extension.BuiltInExtensionHandler.EQUALS_HANDLER;
+import static org.jdbi.v3.core.extension.BuiltInExtensionHandler.HASHCODE_HANDLER;
+import static org.jdbi.v3.core.extension.BuiltInExtensionHandler.NULL_HANDLER;
 import static org.jdbi.v3.core.extension.ExtensionFactory.FactoryFlag.DONT_USE_PROXY;
 import static org.jdbi.v3.core.extension.ExtensionFactory.FactoryFlag.NON_VIRTUAL_FACTORY;
-import static org.jdbi.v3.core.extension.ExtensionHandler.EQUALS_HANDLER;
-import static org.jdbi.v3.core.extension.ExtensionHandler.HASHCODE_HANDLER;
-import static org.jdbi.v3.core.extension.ExtensionHandler.NULL_HANDLER;
 import static org.jdbi.v3.core.internal.JdbiClassUtils.EQUALS_METHOD;
 import static org.jdbi.v3.core.internal.JdbiClassUtils.HASHCODE_METHOD;
 import static org.jdbi.v3.core.internal.JdbiClassUtils.MethodKey.methodKey;
@@ -126,7 +126,7 @@ final class ExtensionFactoryDelegate implements ExtensionFactory {
         // those will only be added if they don't already exist in the method handler map.
 
         // If these methods are added, they are special because they operate on the proxy object itself, not the underlying object
-        final ExtensionHandler toStringHandler = (h, target, args) ->
+        final ExtensionHandler toStringHandler = (methodConfig, target) -> (h, args) ->
                 "Jdbi extension proxy for " + extensionType.getName() + "@" + Integer.toHexString(proxy.hashCode());
         handlers.put(methodKey(TOSTRING_METHOD), extensionMetaData.new ExtensionHandlerInvoker(proxy, TOSTRING_METHOD, toStringHandler, handleSupplier, instanceConfig));
 

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestDefaultExtensionMethods.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestDefaultExtensionMethods.java
@@ -99,11 +99,9 @@ public class TestDefaultExtensionMethods {
     @Retention(RetentionPolicy.RUNTIME)
     @UseExtensionHandler(id = "test", value = TestExtensionAnnotations.Foo.Impl.class)
     public @interface ForTest {
-
-        class Impl implements ExtensionHandler {
-
+        class Impl implements ExtensionHandler.Simple {
             @Override
-            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) {
+            public Object invoke(HandleSupplier handleSupplier, Object... args) {
                 return "foo";
             }
         }

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionAnnotations.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionAnnotations.java
@@ -48,7 +48,6 @@ public class TestExtensionAnnotations {
     }
 
     public interface Broken {
-
         @ExtensionOne
         @ExtensionTwo
         void bogus();
@@ -62,7 +61,6 @@ public class TestExtensionAnnotations {
     }
 
     public interface Dao {
-
         @Foo
         String foo();
     }
@@ -70,11 +68,9 @@ public class TestExtensionAnnotations {
     @Retention(RetentionPolicy.RUNTIME)
     @UseExtensionHandler(id = "test", value = Foo.Impl.class)
     public @interface Foo {
-
-        class Impl implements ExtensionHandler {
-
+        class Impl implements ExtensionHandler.Simple {
             @Override
-            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) {
+            public Object invoke(HandleSupplier handleSupplier, Object... args) {
                 return "foo";
             }
         }
@@ -84,11 +80,9 @@ public class TestExtensionAnnotations {
     @Target({ElementType.METHOD})
     @UseExtensionHandler(id = "test", value = Impl.class)
     public @interface ExtensionOne {
-
-        class Impl implements ExtensionHandler {
-
+        class Impl implements ExtensionHandler.Simple {
             @Override
-            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception {
+            public Object invoke(HandleSupplier handleSupplier, Object... args) {
                 return null;
             }
         }
@@ -98,11 +92,9 @@ public class TestExtensionAnnotations {
     @Target({ElementType.METHOD})
     @UseExtensionHandler(id = "test", value = ExtensionTwo.Impl.class)
     public @interface ExtensionTwo {
-
-        class Impl implements ExtensionHandler {
-
+        class Impl implements ExtensionHandler.Simple {
             @Override
-            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception {
+            public Object invoke(HandleSupplier handleSupplier, Object... args) {
                 return null;
             }
         }

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionCustomizers.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionCustomizers.java
@@ -109,9 +109,9 @@ public class TestExtensionCustomizers {
     public void testRegisteredDecorator() {
         testHandle.getConfig(Extensions.class).registerHandlerCustomizer(
                 (base, sqlObjectType, method) ->
-                        (handleSupplier, target, args) -> {
+                        (config, target) -> (handleSupplier, args) -> {
                             invoked("custom");
-                            return base.invoke(handleSupplier, target, args);
+                            return base.attachTo(config, target).invoke(handleSupplier, args);
                         });
 
         testHandle.attach(Dao.class).orderedFooBar();
@@ -190,9 +190,9 @@ public class TestExtensionCustomizers {
 
             @Override
             public ExtensionHandler customize(ExtensionHandler base, Class<?> sqlObjectType, Method method) {
-                return (handleSupplier, target, args) -> {
+                return (config, target) -> (handleSupplier, args) -> {
                     invoked("foo");
-                    return base.invoke(handleSupplier, target, args);
+                    return base.attachTo(config, target).invoke(handleSupplier, args);
                 };
             }
         }
@@ -206,9 +206,9 @@ public class TestExtensionCustomizers {
 
             @Override
             public ExtensionHandler customize(ExtensionHandler base, Class<?> sqlObjectType, Method method) {
-                return (handleSupplier, target, args) -> {
+                return (config, target) -> (handleSupplier, args) -> {
                     invoked("bar");
-                    return base.invoke(handleSupplier, target, args);
+                    return base.attachTo(config, target).invoke(handleSupplier, args);
                 };
             }
         }
@@ -221,8 +221,8 @@ public class TestExtensionCustomizers {
         class Factory implements ExtensionHandlerCustomizer {
 
             @Override
-            public ExtensionHandler customize(ExtensionHandler base, Class<?> sqlObjectType, Method method) {
-                return (handleSupplier, target, args) -> {
+            public ExtensionHandler.Simple customize(ExtensionHandler base, Class<?> sqlObjectType, Method method) {
+                return (handleSupplier, args) -> {
                     invoked("abort");
                     return null;
                 };
@@ -234,10 +234,9 @@ public class TestExtensionCustomizers {
     @UseExtensionHandler(id = "test", value = CustomExtensionHandler.Impl.class)
     public @interface CustomExtensionHandler {
 
-        class Impl implements ExtensionHandler {
-
+        class Impl implements ExtensionHandler.Simple {
             @Override
-            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) {
+            public Object invoke(HandleSupplier handleSupplier, Object... args) throws Exception {
                 invoked("method");
                 return null;
             }

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestUseCustomExtensionHandlerFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestUseCustomExtensionHandlerFactory.java
@@ -58,7 +58,7 @@ public class TestUseCustomExtensionHandlerFactory {
             @Override
             public Optional<ExtensionHandler> createExtensionHandler(Class<?> extensionType, Method method) {
                 return getImplementation(extensionType, method).map(m ->
-                        (handleSupplier, target, args) -> m.invoke(null, Stream.concat(Stream.of(target), Stream.of(args)).toArray())
+                        (config, target) -> (handleSupplier, args) -> m.invoke(null, Stream.concat(Stream.of(target), Stream.of(args)).toArray())
                 );
             }
 
@@ -113,11 +113,9 @@ public class TestUseCustomExtensionHandlerFactory {
     @Target({ ElementType.METHOD })
     @UseExtensionHandler(id = "test", value = Insert.Impl.class)
     public @interface Insert {
-
-        class Impl implements ExtensionHandler {
-
+        class Impl implements ExtensionHandler.Simple {
             @Override
-            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception {
+            public Object invoke(HandleSupplier handleSupplier, Object... args) throws Exception {
                 Handle handle = handleSupplier.getHandle();
                 try (Update update = handle.createUpdate("insert into something (id, name) values (:id, :name)")) {
                     return update.bindBean(args[0]).execute();
@@ -130,11 +128,9 @@ public class TestUseCustomExtensionHandlerFactory {
     @Target({ ElementType.METHOD })
     @UseExtensionHandler(id = "test", value = Retrieve.Impl.class)
     public @interface Retrieve {
-
-        class Impl implements ExtensionHandler {
-
+        class Impl implements ExtensionHandler.Simple {
             @Override
-            public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception {
+            public Object invoke(HandleSupplier handleSupplier, Object... args) throws Exception {
                 Handle handle = handleSupplier.getHandle();
                 try (Query query = handle.createQuery("select id, name from something where id = :id")) {
                     return query.bind("id", args[0])

--- a/docs/src/test/java/jdbi/doc/ExtensionHandlerAnnotationTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionHandlerAnnotationTest.java
@@ -80,10 +80,9 @@ class ExtensionHandlerAnnotationTest {
             value = SomethingExtensionHandler.class) // <7>
     @interface SomethingAnnotation {}
 
-    public static class SomethingExtensionHandler implements ExtensionHandler {
-
+    public static class SomethingExtensionHandler implements ExtensionHandler.Simple {
         @Override
-        public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) {
+        public Object invoke(HandleSupplier handleSupplier, Object... args) throws Exception {
             return new Something((int) args[0], (String) args[1]);
         }
     }

--- a/docs/src/test/java/jdbi/doc/ExtensionHandlerTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionHandlerTest.java
@@ -93,9 +93,9 @@ class ExtensionHandlerTest {
     // end::extension-handler-factory[]
 
     // tag::extension-handler[]
-    public static class TestExtensionHandler implements ExtensionHandler {
+    public static class TestExtensionHandler implements ExtensionHandler.Simple {
         @Override
-        public Object invoke(HandleSupplier handleSupplier, Object target, Object... args) {
+        public Object invoke(HandleSupplier handleSupplier, Object... args) {
             return new Something((int) args[0], (String) args[1]); // <1>
         }
     }

--- a/docs/src/test/java/jdbi/doc/ExtensionMetadataTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionMetadataTest.java
@@ -113,7 +113,8 @@ class ExtensionMetadataTest {
 
         @Override
         public Optional<ExtensionHandler> createExtensionHandler(Class<?> extensionType, Method method) {
-            return Optional.of((handleSupplier, target, args) -> new Something((int) args[0], (String) args[1]));
+            return Optional.of((ExtensionHandler.Simple)
+                    (handleSupplier, args) -> new Something((int) args[0], (String) args[1]));
         }
     }
 

--- a/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/KotlinDefaultMethodHandlerFactory.kt
+++ b/kotlin-sqlobject/src/main/kotlin/org/jdbi/v3/sqlobject/kotlin/KotlinDefaultMethodHandlerFactory.kt
@@ -13,6 +13,7 @@
  */
 package org.jdbi.v3.sqlobject.kotlin
 
+import org.jdbi.v3.core.extension.AttachedExtensionHandler
 import org.jdbi.v3.core.extension.ExtensionHandler
 import org.jdbi.v3.core.extension.ExtensionHandlerFactory
 import org.jdbi.v3.core.kotlin.isKotlinClass
@@ -32,13 +33,15 @@ class KotlinDefaultMethodHandlerFactory : ExtensionHandlerFactory {
         val implementation = getImplementation(sqlObjectType, method) ?: return Optional.empty()
 
         return Optional.of(
-            ExtensionHandler { _, t, a ->
-                @Suppress("SwallowedException")
-                try {
-                    @Suppress("SpreadOperator")
-                    implementation.invoke(null, t, *a)
-                } catch (e: InvocationTargetException) {
-                    throw e.targetException
+            ExtensionHandler { _, t ->
+                AttachedExtensionHandler { _, a ->
+                    @Suppress("SwallowedException")
+                    try {
+                        @Suppress("SpreadOperator")
+                        implementation.invoke(null, t, *a)
+                    } catch (e: InvocationTargetException) {
+                        throw e.targetException
+                    }
                 }
             }
         )

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -128,4 +128,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <!-- XXX (scs) Temporary! Remove after 3.51 -->
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>org.jdbi.v3.sqlobject.Handler#invoke(org.jdbi.v3.core.extension.HandleSupplier, java.lang.Object,java.lang.Object[])</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/AbstractSqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/AbstractSqlObjectFactory.java
@@ -32,9 +32,10 @@ import org.jdbi.v3.core.internal.JdbiClassUtils;
 abstract class AbstractSqlObjectFactory implements ExtensionFactory {
 
     @SuppressWarnings("unchecked")
-    private static final ExtensionHandler WITH_HANDLE_HANDLER = (handleSupplier, target, args) ->
+    private static final ExtensionHandler WITH_HANDLE_HANDLER = (ExtensionHandler.Simple) (handleSupplier, args) ->
             ((HandleCallback<?, RuntimeException>) args[0]).withHandle(handleSupplier.getHandle());
-    private static final ExtensionHandler GET_HANDLE_HANDLER = (handleSupplier, target, args) -> handleSupplier.getHandle();
+    private static final ExtensionHandler GET_HANDLE_HANDLER = (ExtensionHandler.Simple) (handleSupplier, args) ->
+            handleSupplier.getHandle();
     private static final Method GET_HANDLE_METHOD = JdbiClassUtils.methodLookup(SqlObject.class, "getHandle");
     private static final Method WITH_HANDLE_METHOD = JdbiClassUtils.methodLookup(SqlObject.class, "withHandle", HandleCallback.class);
 
@@ -42,7 +43,7 @@ abstract class AbstractSqlObjectFactory implements ExtensionFactory {
     public void buildExtensionMetadata(ExtensionMetadata.Builder builder) {
         final Class<?> extensionType = builder.getExtensionType();
 
-        ExtensionHandler toStringHandler = (handlerSupplier, target, args) ->
+        ExtensionHandler toStringHandler = (config, target) -> (handlerSupplier, args) ->
                 "Jdbi sqlobject proxy for " + extensionType.getName() + "@" + Integer.toHexString(target.hashCode());
         builder.addMethodHandler(JdbiClassUtils.TOSTRING_METHOD, toStringHandler);
         builder.addMethodHandler(GET_HANDLE_METHOD, GET_HANDLE_HANDLER);

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handler.java
@@ -13,6 +13,8 @@
  */
 package org.jdbi.v3.sqlobject;
 
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.extension.AttachedExtensionHandler;
 import org.jdbi.v3.core.extension.ExtensionHandler;
 import org.jdbi.v3.core.extension.HandleSupplier;
 import org.jdbi.v3.core.internal.JdbiClassUtils;
@@ -38,7 +40,7 @@ public interface Handler extends ExtensionHandler {
     Object invoke(Object target, Object[] args, HandleSupplier handleSupplier) throws Exception;
 
     @Override
-    default Object invoke(HandleSupplier handleSupplier, Object target, Object... args) throws Exception {
-        return invoke(target, JdbiClassUtils.safeVarargs(args), handleSupplier);
+    default AttachedExtensionHandler attachTo(ConfigRegistry config, Object target) {
+        return (handleSupplier, args) -> invoke(target, JdbiClassUtils.safeVarargs(args), handleSupplier);
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlQueryHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlQueryHandler.java
@@ -29,7 +29,6 @@ public class SqlQueryHandler extends CustomizingStatementHandler<Query> {
     private final UseRowMapper useRowMapper;
     private final UseRowReducer useRowReducer;
 
-
     public SqlQueryHandler(Class<?> sqlObjectType, Method method) {
         super(sqlObjectType, method);
         this.resultReturner = ResultReturner.forMethod(sqlObjectType, method);
@@ -43,8 +42,7 @@ public class SqlQueryHandler extends CustomizingStatementHandler<Query> {
     }
 
     @Override
-    public void warm(ConfigRegistry config) {
-        super.warm(config);
+    protected void warm(ConfigRegistry config) {
         resultReturner.warm(config);
     }
 

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlUpdateHandler.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/internal/SqlUpdateHandler.java
@@ -81,8 +81,7 @@ public class SqlUpdateHandler extends CustomizingStatementHandler<Update> {
     }
 
     @Override
-    public void warm(ConfigRegistry config) {
-        super.warm(config);
+    protected void warm(ConfigRegistry config) {
         if (resultReturner != null) {
             resultReturner.warm(config);
         }


### PR DESCRIPTION
This also flattens the call stack on every SqlObject invocation by inlining an Unchecked usage

This is a breaking change, but the extension interface is still declared as `@Alpha` so I don't feel too bad about it.