### PR TITLE
Improve concurrency of cache loading in the case of slow loader functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Add support for PGvector types (#2830)
+- Improve concurrency of statement cache loading (#2834)
 
 # 3.49.5
 

--- a/cache/caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/pom.xml
@@ -43,6 +43,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>
             <scope>test</scope>

--- a/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCache.java
+++ b/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCache.java
@@ -13,39 +13,18 @@
  */
 package org.jdbi.v3.cache.caffeine;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.stats.CacheStats;
-import org.jdbi.v3.core.cache.JdbiCache;
-import org.jdbi.v3.core.cache.JdbiCacheLoader;
 
 /**
  * Cache implementation using the caffeine cache library.
  *
  * @param <K> The key type.
  * @param <V> The value type.
+ * @deprecated should not be public API
  */
-public final class CaffeineCache<K, V> implements JdbiCache<K, V> {
-
-    private final Cache<K, V> cache;
-
+@Deprecated(forRemoval = true, since = "3.50")
+public final class CaffeineCache<K, V> extends JdbiCaffeineCache<K, V> {
     CaffeineCache(Caffeine<Object, Object> caffeine) {
-        this.cache = caffeine.build();
-    }
-
-    @Override
-    public V get(K key) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public V getWithLoader(K key, JdbiCacheLoader<K, V> loader) {
-        return cache.get(key, loader::create);
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public CacheStats getStats() {
-        return cache.stats();
+        super(caffeine, null);
     }
 }

--- a/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCacheBuilder.java
+++ b/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineCacheBuilder.java
@@ -19,7 +19,7 @@ import org.jdbi.v3.core.cache.JdbiCacheBuilder;
 import org.jdbi.v3.core.cache.JdbiCacheLoader;
 
 /**
- * Cache builder using the caffeine caching library.
+ * Cache builder using the Caffeine caching library.
  */
 public final class CaffeineCacheBuilder implements JdbiCacheBuilder {
 
@@ -49,12 +49,12 @@ public final class CaffeineCacheBuilder implements JdbiCacheBuilder {
 
     @Override
     public <K, V> JdbiCache<K, V> build() {
-        return new CaffeineCache<>(caffeine);
+        return new JdbiCaffeineCache<>(caffeine, null);
     }
 
     @Override
     public <K, V> JdbiCache<K, V> buildWithLoader(JdbiCacheLoader<K, V> cacheLoader) {
-        return new CaffeineLoadingCache<>(caffeine, cacheLoader);
+        return new JdbiCaffeineCache<>(caffeine, cacheLoader);
     }
 
     @Override

--- a/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineLoadingCache.java
+++ b/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/CaffeineLoadingCache.java
@@ -24,7 +24,9 @@ import org.jdbi.v3.core.cache.JdbiCacheLoader;
  *
  * @param <K> The key type.
  * @param <V> The value type.
+ * @deprecated should not be public API
  */
+@Deprecated(forRemoval = true, since = "3.50")
 public final class CaffeineLoadingCache<K, V> implements JdbiCache<K, V> {
 
     private final LoadingCache<K, V> loadingCache;

--- a/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/JdbiCaffeineCache.java
+++ b/cache/caffeine-cache/src/main/java/org/jdbi/v3/cache/caffeine/JdbiCaffeineCache.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.cache.caffeine;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheLoader;
+
+class JdbiCaffeineCache<K, V> implements JdbiCache<K, V> {
+    private final Cache<K, CompletableFuture<V>> cache;
+    private final JdbiCacheLoader<K, V> loader;
+
+    JdbiCaffeineCache(Caffeine<Object, Object> caffeine, JdbiCacheLoader<K, V> loader) {
+        this.loader = loader;
+        this.cache = caffeine.build();
+    }
+
+    @Override
+    public V get(K key) {
+        return doGet(key, loader);
+    }
+
+    @Override
+    public V getWithLoader(K key, JdbiCacheLoader<K, V> myLoader) {
+        return doGet(key, myLoader);
+    }
+
+    // Future used as fine-grained lock instead of cache stripe lock
+    // https://github.com/jdbi/jdbi/issues/2834
+    @SuppressFBWarnings("JLM_JSR166_UTILCONCURRENT_MONITORENTER")
+    private V doGet(K key, JdbiCacheLoader<K, V> loader) {
+        CompletableFuture<V> future = cache.asMap().computeIfAbsent(key, k -> new CompletableFuture<>());
+        if (future.isDone()) {
+            return future.join();
+        }
+        synchronized (future) {
+            if (!future.isDone()) {
+                future.complete(loader == null ? null : loader.create(key));
+            }
+            return future.join();
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public CacheStats getStats() {
+        return cache.stats();
+    }
+}

--- a/cache/caffeine-cache/src/test/java/org/jdbi/v3/cache/caffeine/CaffeineCacheTest.java
+++ b/cache/caffeine-cache/src/test/java/org/jdbi/v3/cache/caffeine/CaffeineCacheTest.java
@@ -16,26 +16,13 @@ package org.jdbi.v3.cache.caffeine;
 import java.time.Duration;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
 import org.jdbi.v3.core.cache.internal.JdbiCacheTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class CaffeineCacheTest extends JdbiCacheTest {
-
-    @BeforeEach
-    void beforeEach() {
-        this.builder = CaffeineCacheBuilder.instance();
-    }
-
-    @Test
-    void testCaffeineWithGlobalLoader() {
+    @Override
+    protected JdbiCacheBuilder setupBuilder() {
         Caffeine<Object, Object> caffeine = Caffeine.newBuilder().expireAfterAccess(Duration.ofSeconds(5)).initialCapacity(10);
-        doTestWithGlobalLoader(new CaffeineCacheBuilder(caffeine).buildWithLoader(cacheLoader));
-    }
-
-    @Test
-    void testCaffeineWithDirectLoader() {
-        Caffeine<Object, Object> caffeine = Caffeine.newBuilder().expireAfterAccess(Duration.ofSeconds(5)).initialCapacity(10);
-        doTestWithLoader(new CaffeineCacheBuilder(caffeine).build());
+        return new CaffeineCacheBuilder(caffeine);
     }
 }

--- a/cache/noop-cache/src/test/java/org/jdbi/v3/cache/noop/NoopCacheTest.java
+++ b/cache/noop-cache/src/test/java/org/jdbi/v3/cache/noop/NoopCacheTest.java
@@ -16,16 +16,16 @@ package org.jdbi.v3.cache.noop;
 import java.util.UUID;
 
 import org.jdbi.v3.core.cache.JdbiCache;
+import org.jdbi.v3.core.cache.JdbiCacheBuilder;
 import org.jdbi.v3.core.cache.internal.JdbiCacheTest;
-import org.junit.jupiter.api.BeforeEach;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class NoopCacheTest extends JdbiCacheTest {
 
-    @BeforeEach
-    void beforeEach() {
-        this.builder = NoopCache.builder();
+    @Override
+    protected JdbiCacheBuilder setupBuilder() {
+        return NoopCache.builder();
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheTest.java
@@ -17,24 +17,24 @@ import java.util.UUID;
 
 import org.jdbi.v3.core.cache.JdbiCache;
 import org.jdbi.v3.core.cache.JdbiCacheBuilder;
-import org.jdbi.v3.core.cache.internal.JdbiCacheTest.TestingCacheLoader;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DefaultJdbiCacheTest {
+public class DefaultJdbiCacheTest extends JdbiCacheTest {
 
-    private final JdbiCacheBuilder builder = DefaultJdbiCacheBuilder.builder();
-
-    private final TestingCacheLoader cacheLoader = new TestingCacheLoader();
+    @Override
+    protected JdbiCacheBuilder setupBuilder() {
+        return DefaultJdbiCacheBuilder.builder();
+    }
 
     @Test
     void testUntouchedCacheExpunge() {
         int keyCount = 0;
 
         int size = 10;
-        JdbiCache<String, String> cache = builder.maxSize(size).buildWithLoader(cacheLoader);
+        JdbiCache<String, String> cache = setupBuilder().maxSize(size).buildWithLoader(cacheLoader);
 
         // tests specific DefaultJdbiCache LRU behavior. Skip for all other cache types.
         Assumptions.assumeTrue(cache instanceof DefaultJdbiCache);
@@ -78,7 +78,7 @@ public class DefaultJdbiCacheTest {
         int keyCount = 0;
 
         int size = 10;
-        JdbiCache<String, String> cache = builder.maxSize(size).buildWithLoader(cacheLoader);
+        JdbiCache<String, String> cache = setupBuilder().maxSize(size).buildWithLoader(cacheLoader);
 
         // tests specific DefaultJdbiCache LRU behavior. Skip for all other cache types.
         Assumptions.assumeTrue(cache instanceof DefaultJdbiCache);


### PR DESCRIPTION
Inspired by ["recursive computation" section in Caffeine FAQ](https://github.com/ben-manes/caffeine/wiki/Faq#recursive-computations)

Fixes #2834