### PR TITLE
make annotation jars available in all modules

### DIFF
--- a/cache/caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/pom.xml
@@ -43,13 +43,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>
             <scope>test</scope>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,11 +51,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
         </dependency>
@@ -63,18 +58,6 @@
         <dependency>
             <groupId>io.leangen.geantyref</groupId>
             <artifactId>geantyref</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -258,15 +258,10 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -49,13 +49,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
             <classifier>tests</classifier>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -43,13 +43,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
             <classifier>tests</classifier>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -561,6 +561,7 @@
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>${dep.spotbugs.version}</version>
                 <scope>provided</scope>
+                <optional>true</optional>
             </dependency>
 
             <dependency>
@@ -605,6 +606,29 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- annotation jars available everywhere -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
@@ -866,11 +890,13 @@
                     <version>${dep.plugin.flatten.version}</version>
                     <configuration>
                         <flattenMode>bom</flattenMode>
+                        <flattenDependencyMode>direct</flattenDependencyMode>
                         <pomElements>
                             <properties>remove</properties>
                             <distributionManagement>remove</distributionManagement>
                             <repositories>remove</repositories>
                             <dependencyManagement>interpolate</dependencyManagement>
+                            <dependencies>remove</dependencies>
                         </pomElements>
                     </configuration>
                 </plugin>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -72,18 +72,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
             <classifier>tests</classifier>


### PR DESCRIPTION
We use some of the annotation jars in modules but currently this needs to be added to each module specifically.

As we make the jars provided and optional, we can pull them into the build pom which makes them available everywhere evenly.

This also requires a small change to the BOM generation which would currently pull compile dependencies in (so we turn those off).
