### PR TITLE
Test Basepom 64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ Makefile:: ;
 clean::
 	${MAVEN} clean
 
-install:: MAVEN_ARGS += -Djdbi.it.skip-install=false
+install:: MAVEN_ARGS += -Dbasepom.it.skip-install=false
 install::
 	${MAVEN} clean install
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -27,6 +27,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Function;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import jakarta.annotation.Nullable;
 
 import org.jdbi.v3.core.Handle;
@@ -41,6 +43,7 @@ import org.jdbi.v3.meta.Beta;
 /**
  * Configuration holder for {@link SqlStatement}s.
  */
+@NotThreadSafe
 public final class SqlStatements implements JdbiConfig<SqlStatements> {
 
     /** The default size of the SQL template cache. */
@@ -52,17 +55,17 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     private SqlParser sqlParser;
     private SqlLogger sqlLogger;
     private Integer queryTimeout;
-    private volatile boolean allowUnusedBindings;
-    private volatile boolean attachAllStatementsForCleanup;
-    private volatile boolean attachCallbackStatementsForCleanup = true;
-    private volatile boolean scriptStatementsNeedSemicolon = true;
+    private boolean allowUnusedBindings;
+    private boolean attachAllStatementsForCleanup;
+    private boolean attachCallbackStatementsForCleanup = true;
+    private boolean scriptStatementsNeedSemicolon = true;
     private final Collection<StatementCustomizer> customizers;
 
     private final Collection<StatementContextListener> contextListeners;
 
     // Don't emit unlimited amounts of data via telemetry
-    private volatile int jfrSqlMaxLength = 512;
-    private volatile int jfrParamMaxLength = 512;
+    private int jfrSqlMaxLength = 512;
+    private int jfrParamMaxLength = 512;
 
     public SqlStatements() {
         attributes = Collections.synchronizedMap(new HashMap<>());

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
@@ -32,6 +32,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collector;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import jakarta.annotation.Nullable;
 
 import org.jdbi.v3.core.CloseException;
@@ -67,6 +69,7 @@ import static java.util.Objects.requireNonNull;
  * DISCLAIMER: The class is not intended to be extended. The final modifier is absent to allow
  * mock tools to create a mock object of this class in the user code.
  */
+@NotThreadSafe
 public class StatementContext implements Closeable {
 
     private final ConfigRegistry config;
@@ -82,14 +85,14 @@ public class StatementContext implements Closeable {
     private Connection connection;
     private Binding binding = new Binding(this);
 
-    private volatile boolean returningGeneratedKeys = false;
+    private boolean returningGeneratedKeys = false;
     private String[] generatedKeysColumnNames = new String[0];
-    private volatile boolean concurrentUpdatable = false;
+    private boolean concurrentUpdatable = false;
 
     private Instant executionMoment;
     private Instant completionMoment;
     private Instant exceptionMoment;
-    private volatile long mappedRows;
+    private long mappedRows;
     private String traceId;
 
     static StatementContext create(final ConfigRegistry config, final ExtensionMethod extensionMethod, final Type jdbiStatementType) {

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -59,6 +59,7 @@
         <basepom.at-end.deploy>true</basepom.at-end.deploy>
         <basepom.check.fail-all>true</basepom.check.fail-all>
         <basepom.it.skip>true</basepom.it.skip>
+        <basepom.it.skip-install>true</basepom.it.skip-install>
         <basepom.it.timeout>600</basepom.it.timeout>
         <basepom.javadoc.exclude-package-names>*.internal.*:*.internal</basepom.javadoc.exclude-package-names>
         <basepom.javadoc.legacy-mode>true</basepom.javadoc.legacy-mode>
@@ -146,7 +147,6 @@
         <jdbi.check.skip-ktlint>${jdbi.check.skip-kotlin}</jdbi.check.skip-ktlint>
         <jdbi.check.skip-sbom>${basepom.check.skip-extended}</jdbi.check.skip-sbom>
         <jdbi.check.skip-sortpom>${basepom.check.skip-basic}</jdbi.check.skip-sortpom>
-        <jdbi.it.skip-install>true</jdbi.it.skip-install>
         <jdbi.test.language>en</jdbi.test.language>
         <jdbi.test.mysql-version>mysql:lts</jdbi.test.mysql-version>
         <jdbi.test.pg-version>17</jdbi.test.pg-version>
@@ -990,8 +990,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
                     <configuration>
-                        <scope>test</scope>
-                        <skipInstallation>${jdbi.it.skip-install}</skipInstallation>
                         <extraArtifacts>
                             <extraArtifact>org.jdbi:jdbi3-bom:${project.version}:pom</extraArtifact>
                         </extraArtifacts>

--- a/internal/policy/src/main/resources/policy/pmd.xml
+++ b/internal/policy/src/main/resources/policy/pmd.xml
@@ -103,7 +103,11 @@
         <exclude name="ReturnEmptyCollectionRatherThanNull"/>
         <!-- exclude b/c TestingInitializers -->
         <exclude name="TestClassWithoutTestCases"/>
+        <!-- see https://github.com/pmd/pmd/issues/6025 -->
+        <exclude name="ReplaceJavaUtilCalendar"/>
+        <exclude name="ReplaceJavaUtilDate"/>
     </rule>
+
     <rule ref="category/java/errorprone.xml/EmptyCatchBlock">
         <properties>
             <property name="allowCommentedBlocks" value="true"/>

--- a/internal/root/pom.xml
+++ b/internal/root/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.basepom</groupId>
         <artifactId>basepom-oss</artifactId>
-        <version>63</version>
+        <version>64-SNAPSHOT</version>
         <!-- null out the relative path, otherwise maven complains that the referenced POM is not in the parent directory -->
         <relativePath />
     </parent>

--- a/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/JdbiRule.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.sql.DataSource;
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
@@ -30,6 +31,7 @@ import org.junit.rules.ExternalResource;
 /**
  * JUnit {@code @Rule} to manage a Jdbi instance pointed to a managed database.
  */
+@NotThreadSafe
 public abstract class JdbiRule extends ExternalResource {
 
     private final List<JdbiPlugin> plugins = new ArrayList<>();
@@ -38,7 +40,7 @@ public abstract class JdbiRule extends ExternalResource {
     private Jdbi jdbi;
     private Handle handle;
     private Flyway flyway;
-    private volatile boolean installPlugins;
+    private boolean installPlugins;
     private Migration migration;
 
     protected abstract DataSource createDataSource();

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExtension.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiExtension.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.sql.DataSource;
 
 import jakarta.annotation.Nonnull;
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  * @see JdbiExternalPostgresExtension
  * @see JdbiOtjPostgresExtension
  */
+@NotThreadSafe
 public abstract class JdbiExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
     private final Set<JdbiPlugin> plugins = new LinkedHashSet<>();
@@ -68,8 +70,8 @@ public abstract class JdbiExtension implements BeforeAllCallback, AfterAllCallba
 
     private Optional<JdbiExtensionInitializer> initializerMaybe = Optional.empty();
 
-    private volatile boolean installPlugins = false;
-    private volatile boolean enableLeakchecker = true;
+    private boolean installPlugins = false;
+    private boolean enableLeakchecker = true;
 
     private volatile Jdbi jdbi;
     private volatile Handle sharedHandle;

--- a/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiFlywayMigration.java
+++ b/testing/src/main/java/org/jdbi/v3/testing/junit5/JdbiFlywayMigration.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.sql.DataSource;
 
 import org.flywaydb.core.Flyway;
@@ -26,11 +27,12 @@ import org.jdbi.v3.core.Handle;
 /**
  * Use {@link Flyway} to create a database schema and/or preload a database instance.
  */
+@NotThreadSafe
 public final class JdbiFlywayMigration implements JdbiExtensionInitializer {
 
     private final List<String> schemas = new ArrayList<>();
     private final List<String> paths = new ArrayList<>();
-    private volatile boolean cleanAfter = true;
+    private boolean cleanAfter = true;
 
     private volatile Flyway flyway;
 


### PR DESCRIPTION
- **test with basepom snapshot**
- **use basepom IT skipping**
- **disable java.util.Date etc. deprecation warnings**
- **use spotbugs 4.9.4 NotThreadSafe changes to undo the unneeded volatiles and atomics**
