### PR TITLE
Simplify collectInto generic type parameter

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/result/ResultIterable.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/ResultIterable.java
@@ -376,7 +376,7 @@ public interface ResultIterable<T> extends Iterable<T> {
      * @since 3.38.0
      */
     @Alpha
-    default <R extends Collection<? super T>> R collectInto(Type containerType) {
+    default <R> R collectInto(Type containerType) {
         throw new UnsupportedOperationException();
     }
 
@@ -389,7 +389,7 @@ public interface ResultIterable<T> extends Iterable<T> {
      * @since 3.38.0
      */
     @Alpha
-    default <R extends Collection<? super T>> R collectInto(GenericType<R> containerType) {
+    default <R> R collectInto(GenericType<R> containerType) {
         return collectInto(containerType.getType());
     }
 

--- a/core/src/main/java/org/jdbi/v3/core/result/internal/ResultSetResultIterable.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/internal/ResultSetResultIterable.java
@@ -16,7 +16,6 @@ package org.jdbi.v3.core.result.internal;
 import java.lang.reflect.Type;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -56,7 +55,7 @@ public class ResultSetResultIterable<T> implements ResultIterable<T> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <R extends Collection<? super T>> R collectInto(Type containerType) {
+    public <R> R collectInto(Type containerType) {
 
         Type type = containerType;
         if (containerType instanceof Class) {


### PR DESCRIPTION
Motivation
----------

The collectInto methods allow callers the ability to pass their own type to collect their results into. The type will use a CollectorFactory to lookup a Collector for the appropriate return type. Currently, the collectInto methods require the given type to be a subtype of the JDK Collection type. Not all collections extend from this interface (e.g. Eclipse Collections) so having the generic type parameter require this makes the method call more restrictive than it has to be. Relaxing the parameter type to just the return type allows for Collectors that don't leverage the JDK collection to be used.

Modifications
-------------

The generic type parameter has been simplified from <R extends Collection<? super T>> to \<R>. This is also in line with how the ResultBearing interface handles it's collectInto methods.

Result
------

The result is the collectInto methods on ResultIterable can support collectors that don't use the JDK Collection type. This fixes issue #2849.