### PR TITLE
Turn off URL inheritance in the poms

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -29,32 +29,6 @@
     <name>jdbi3 - internal - build parent</name>
     <description>Jdbi3 build settings. This is a Jdbi internal module and not part of the public API.</description>
 
-    <!-- do not remove URL and SCM, otherwise OSS refuses to accept the release -->
-    <url>https://jdbi.org/</url>
-
-    <licenses>
-        <license>
-            <name>Apache License 2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>jdbi</id>
-            <name>The Jdbi Team</name>
-            <url>https://github.com/jdbi/jdbi/blob/master/CONTRIBUTORS.md</url>
-        </developer>
-    </developers>
-
-    <scm>
-        <connection>scm:git:git://github.com/jdbi/jdbi.git</connection>
-        <developerConnection>scm:git:git@github.com:jdbi/jdbi.git</developerConnection>
-        <tag>HEAD</tag>
-        <url>https://github.com/jdbi/jdbi/</url>
-    </scm>
-
     <properties>
         <basepom.at-end.deploy>true</basepom.at-end.deploy>
         <basepom.check.fail-all>true</basepom.check.fail-all>

--- a/internal/root/pom.xml
+++ b/internal/root/pom.xml
@@ -12,7 +12,10 @@
 ~   See the License for the specific language governing permissions and
 ~   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         child.project.url.inherit.append.path="false">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -56,7 +59,9 @@
     <!-- do not remove URL and SCM, otherwise OSS refuses to accept the release -->
     <url>https://jdbi.org/</url>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false"
+         child.scm.developerConnection.inherit.append.path="false"
+         child.scm.url.inherit.append.path="false">
         <connection>scm:git:git://github.com/jdbi/jdbi.git</connection>
         <developerConnection>scm:git:git@github.com:jdbi/jdbi.git</developerConnection>
         <tag>HEAD</tag>


### PR DESCRIPTION
One never stops learning about Maven. It is actually possible to
stop it from rewriting the urls for connections and sites.
