### PR TITLE
Allow setting the maven command from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 SHELL = /bin/sh
 .SUFFIXES:
 
-MAVEN = ./mvnw
+MAVEN ?= ./mvnw
 
 export MAVEN_OPTS
 export MAVEN_ARGS


### PR DESCRIPTION
Support `MAVEN='mvnd' make install-fast` (except that there is a bug in
mvnd which ignores setting the MAVEN_ARGS).
