### PR TITLE
tests: reduce usage of installPlugins, which exposes tests to inadvertent plugin registering

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/argument/TestPreparedArguments.java
+++ b/core/src/test/java/org/jdbi/v3/core/argument/TestPreparedArguments.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPreparedArguments {
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.withPlugins();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
 
     @Test
     public void disablePreparedArguments() {

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaCollectors.java
@@ -54,7 +54,7 @@ import static org.assertj.guava.api.Assertions.entry;
 public class TestGuavaCollectors {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().installPlugins().withInitializer(TestingInitializers.something());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new GuavaPlugin()).withInitializer(TestingInitializers.something());
 
     private Collection<Integer> expected;
 

--- a/guava/src/test/java/org/jdbi/v3/guava/TestGuavaOptional.java
+++ b/guava/src/test/java/org/jdbi/v3/guava/TestGuavaOptional.java
@@ -44,7 +44,8 @@ public class TestGuavaOptional {
         + "order by id";
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().installPlugins().withInitializer(TestingInitializers.something());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new GuavaPlugin())
+            .withInitializer(TestingInitializers.something());
 
     Handle handle;
 

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/Jdbi858ExtensionsTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/Jdbi858ExtensionsTest.kt
@@ -16,6 +16,7 @@ package org.jdbi.v3.core.kotlin
 import org.assertj.core.api.Assertions.assertThat
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.transaction.TransactionIsolationLevel
+import org.jdbi.v3.sqlobject.SqlObjectPlugin
 import org.jdbi.v3.sqlobject.statement.SqlQuery
 import org.jdbi.v3.testing.junit5.JdbiExtension
 import org.junit.jupiter.api.BeforeEach
@@ -32,7 +33,7 @@ class Jdbi858ExtensionsTest {
 
     @RegisterExtension
     @JvmField
-    val h2Extension: JdbiExtension = JdbiExtension.h2().installPlugins()
+    val h2Extension: JdbiExtension = JdbiExtension.h2().withPlugin(SqlObjectPlugin())
 
     lateinit var jdbi: Jdbi
 

--- a/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinPluginTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/v3/core/kotlin/KotlinPluginTest.kt
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.kotlin
 
 import org.jdbi.v3.core.extension.ExtensionCallback
 import org.jdbi.v3.core.extension.ExtensionConsumer
+import org.jdbi.v3.sqlobject.SqlObjectPlugin
 import org.jdbi.v3.sqlobject.customizer.Bind
 import org.jdbi.v3.sqlobject.statement.SqlQuery
 import org.jdbi.v3.testing.junit5.JdbiExtension
@@ -27,7 +28,7 @@ import kotlin.test.assertEquals
 class KotlinPluginTest {
     @RegisterExtension
     @JvmField
-    val h2Extension: JdbiExtension = JdbiExtension.h2().installPlugins().withInitializer(TestingInitializers.something())
+    val h2Extension: JdbiExtension = JdbiExtension.h2().withPlugins(KotlinPlugin(), SqlObjectPlugin()).withInitializer(TestingInitializers.something())
 
     data class Thing(
         val id: Int,

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrCollectorFactoryWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrCollectorFactoryWithDB.java
@@ -39,6 +39,7 @@ import io.vavr.collection.TreeSet;
 import io.vavr.collection.Vector;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.result.ResultSetException;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +52,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestVavrCollectorFactoryWithDB {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).installPlugins();
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something())
+            .withPlugins(new SqlObjectPlugin(), new VavrPlugin());
 
     private Seq<Integer> expected = List.range(0, 10);
     private Map<Integer, String> expectedMap = expected.toMap(i -> new Tuple2<>(i, i + "asString"));

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrMapCollectorWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrMapCollectorWithDB.java
@@ -27,6 +27,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.MapEntryMappers;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,8 @@ public class TestVavrMapCollectorWithDB {
     private static final String KEY_PREFIX = "keyCol";
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().installPlugins();
+    public JdbiExtension h2Extension = JdbiExtension.h2()
+            .withPlugins(new SqlObjectPlugin(), new VavrPlugin());
 
     private Seq<Integer> expected = List.range(0, 9);
     private Map<String, String> expectedMap = expected.toMap(i -> new Tuple2<>("keyCol" + i, "valCol" + (i + 1)));

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrOptionMapperWithDB.java
@@ -24,6 +24,7 @@ import org.jdbi.v3.core.mapper.NoSuchMapperException;
 import org.jdbi.v3.core.mapper.reflect.BeanMapper;
 import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestVavrOptionMapperWithDB {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).installPlugins();
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something())
+            .withPlugins(new SqlObjectPlugin(), new VavrPlugin());
 
     @BeforeEach
     public void addData() {

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleMapperWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleMapperWithDB.java
@@ -20,6 +20,7 @@ import io.vavr.Tuple3;
 import io.vavr.collection.List;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.result.ResultSetException;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestVavrTupleMapperWithDB {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().installPlugins();
+    public JdbiExtension h2Extension = JdbiExtension.h2()
+            .withPlugins(new SqlObjectPlugin(), new VavrPlugin());
 
     private List<Integer> expected = List.range(0, 9);
 

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleRowMapperFactoryWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrTupleRowMapperFactoryWithDB.java
@@ -22,6 +22,7 @@ import org.jdbi.v3.core.Something;
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;
 import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +35,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestVavrTupleRowMapperFactoryWithDB {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).installPlugins();
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something())
+            .withPlugins(new SqlObjectPlugin(), new VavrPlugin());
 
     @BeforeEach
     public void addData() {

--- a/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrValueArgumentFactoryWithDB.java
+++ b/vavr/src/test/java/org/jdbi/v3/vavr/TestVavrValueArgumentFactoryWithDB.java
@@ -22,6 +22,7 @@ import io.vavr.control.Try;
 import io.vavr.control.Validation;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Something;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +41,8 @@ public class TestVavrValueArgumentFactoryWithDB {
     private static final Something BRIANSOMETHING = new Something(2, "brian");
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).installPlugins();
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something())
+            .withPlugins(new SqlObjectPlugin(), new VavrPlugin());
 
     @BeforeEach
     public void createTestData() {


### PR DESCRIPTION
this matters esp when combining multiple `test-jar`s together.