### PR TITLE
native-image: remove deprecated directives

### DIFF
--- a/sqlobject/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-sqlobject/reachability-metadata.json
+++ b/sqlobject/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-sqlobject/reachability-metadata.json
@@ -244,8 +244,8 @@
   ],
   "serialization": [
     {"type":"java.lang.String"},
-    {"type":"org.jdbi.v3.core.CloseException","customTargetConstructorClass": "java.lang.Object"},
-    {"type":"org.jdbi.v3.core.transaction.TransactionException","customTargetConstructorClass":"java.lang.Object"},
+    {"type":"org.jdbi.v3.core.CloseException"},
+    {"type":"org.jdbi.v3.core.transaction.TransactionException"},
     {"type":"org.jdbi.v3.sqlobject.config.LongValue"},
     {"type":"org.jdbi.v3.sqlobject.config.StringValue"}
   ],


### PR DESCRIPTION
> Warning: "customTargetConstructorClass" is deprecated in reachability-metadata.json. All serializable classes can be instantiated through any superclass constructor without the use of the flag.
