### PR TITLE
spring: replace spring-jcl adapter with jcl-over-slf4j

### DIFF
--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -236,6 +236,12 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${dep.spring.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-jcl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -64,6 +64,19 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>

--- a/spring5/pom.xml
+++ b/spring5/pom.xml
@@ -74,6 +74,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
spring-jcl tries to autodetect log4j which is pointless here, and it has duplicate classes to jcl-over-slf4j, so the two cannot mix.

jcl-over-slf4j is a dependency of maven-loader, coming in through pg-embedded.

this means you cannot mix the `jdbi3-spring` and `jdbi3-postgres` `test-jar`s together, or the duplicate finder complains

so, standardize on jcl-over-slf4j + slf4j-simple, and nuke spring-jcl