### PR TITLE
feat: Support TYPE_USE @Nullable annotations (e.g., jspecify)

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -358,7 +358,9 @@ public final class ConstructorMapper<T> implements RowMapper<T> {
 
     private boolean isNullable(Parameter parameter) {
         // Any annotation named @Nullable is honored. We're nice that way.
-        return Stream.of(parameter.getAnnotations())
+        // Check both parameter annotations and type-use annotations (e.g., jspecify @Nullable)
+        return Stream.of(parameter.getAnnotations(), parameter.getAnnotatedType().getAnnotations())
+            .flatMap(Stream::of)
             .map(Annotation::annotationType)
             .map(Class::getSimpleName)
             .anyMatch("Nullable"::equals);

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
@@ -605,4 +605,45 @@ public class ConstructorMapperTest {
             .hasMessageContaining("or specify it with @JdbiConstructor");
     }
 
+    // Test TYPE_USE @Nullable annotations (e.g., jspecify)
+    @Test
+    public void testTypeUseNullableParameterPresent() {
+        TypeUseNullableParameterBean bean = handle
+            .registerRowMapper(ConstructorMapper.factory(TypeUseNullableParameterBean.class))
+            .select("select s, i from bean")
+            .mapTo(TypeUseNullableParameterBean.class)
+            .one();
+        assertThat(bean.s).isEqualTo("3");
+        assertThat(bean.i).isEqualTo(2);
+    }
+
+    @Test
+    public void testTypeUseNullableParameterAbsent() {
+        TypeUseNullableParameterBean bean = handle
+            .registerRowMapper(ConstructorMapper.factory(TypeUseNullableParameterBean.class))
+            .select("select i from bean")
+            .mapTo(TypeUseNullableParameterBean.class)
+            .one();
+        assertThat(bean.s).isNull();
+        assertThat(bean.i).isEqualTo(2);
+    }
+
+    @Test
+    public void testTypeUseNonNullableAbsent() {
+        handle.registerRowMapper(ConstructorMapper.factory(TypeUseNullableParameterBean.class));
+        assertThatThrownBy(() -> selectOne("select s from bean", TypeUseNullableParameterBean.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("parameter '[i]' has no matching columns in the result set");
+    }
+
+    static class TypeUseNullableParameterBean {
+        private final String s;
+        private final int i;
+
+        TypeUseNullableParameterBean(@org.jdbi.v3.core.mapper.reflect.typeuse.Nullable String s, int i) {
+            this.s = s;
+            this.i = i;
+        }
+    }
+
 }

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/typeuse/Nullable.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/typeuse/Nullable.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper.reflect.typeuse;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Test annotation for TYPE_USE @Nullable (similar to jspecify).
+ * This annotation is used to test that JDBI properly recognizes TYPE_USE nullable annotations.
+ */
+@Documented
+@Target(ElementType.TYPE_USE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Nullable {}


### PR DESCRIPTION
Add support for TYPE_USE @Nullable annotations in ConstructorMapper, enabling compatibility with modern nullability frameworks like JSpecify.

Background on Type Annotations and JSpecify:
---------------------------------------------

Traditional nullable annotations use @Target(PARAMETER), appearing directly on method/constructor parameters:
  void method(@Nullable String param)

Type-use annotations (@Target(TYPE_USE)) appear on types themselves, introduced in Java 8 (JSR 308). They provide more precise nullability information:
  void method(@Nullable String param)  // nullable applies to String type

JSpecify is a modern nullability annotation framework that uses TYPE_USE annotations with RUNTIME retention. This allows:
- More precise nullability checking by static analysis tools
- Better IDE support and null-safety guarantees
- Runtime reflection of nullability information

The Problem:
-----------

JDBI's ConstructorMapper.isNullable() only checked parameter.getAnnotations(), which returns annotations with @Target(PARAMETER). This missed TYPE_USE annotations like JSpecify's @Nullable, causing constructor parameter mapping to fail even when parameters were correctly annotated as nullable.

Example failure:
  @JdbiConstructor
  public Bean(@Nullable String optional, String required) {...}

When 'optional' column was missing from result set, JDBI would throw: "parameter '[optional]' has no matching columns in the result set" despite the @Nullable annotation being present.

The Fix:
--------

Modified isNullable() to check both:
1. parameter.getAnnotations() - for traditional @Target(PARAMETER)
2. parameter.getAnnotatedType().getAnnotations() - for TYPE_USE

This is a minimal, backward-compatible change that maintains existing behavior while adding support for TYPE_USE nullable annotations.

Benefits:
- Full JSpecify compatibility
- Supports other TYPE_USE nullable annotations
- No breaking changes to existing code

Testing:
--------

Added comprehensive tests using a TYPE_USE @Nullable test annotation:
- testTypeUseNullableParameterPresent: nullable param with column present
- testTypeUseNullableParameterAbsent: nullable param with column absent
- testTypeUseNonNullableAbsent: non-nullable param requires column