### PR TITLE
ci: remove slf4j version 1.x test

### DIFF
--- a/.github/workflows/versions-check.yml
+++ b/.github/workflows/versions-check.yml
@@ -508,7 +508,7 @@ jobs:
 
     strategy:
       matrix:
-        test-version: [ 2.1.0-alpha1, 1.7.36 ]
+        test-version: [ 2.1.0-alpha1 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - Add new `jackson3` artifact for Jackson 3 ( #2878 )
+- Update to SLF4J 2, to allow for configurable log levels in SqlLogger (#2902)
+
 - Deprecate for removal installPlugins plugin discovery. It's too easy to get yourself into trouble.
 - Support TYPE_USE `@Nullable` annotations like JSpecify ( #2899, thanks @protocol7 ! )
 


### PR DESCRIPTION
slf4j 1.x is no longer supported, and we'd like to use new 2.x features)