### PR TITLE
Remove testcontainer version tests

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -19,16 +19,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 35000
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
-          remove-docker-images: true
-
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -85,16 +75,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 35000
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
-          remove-docker-images: true
-
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -155,16 +135,6 @@ jobs:
         test-version: [ 'latest-faststart', 'full-faststart' ]
 
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 35000
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
-          remove-docker-images: true
-
       - uses: actions/checkout@v4
         with:
           fetch-tags: true


### PR DESCRIPTION
github actions no longer support older testcontainer versions that use
an old docker API. Remove the integration test.
