### PR TITLE
Document how to create custom qualifying annotations

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/qualifier/Reversed.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/Reversed.java
@@ -16,6 +16,8 @@ package org.jdbi.v3.core.qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+// tag::qualifier[]
 @Retention(RetentionPolicy.RUNTIME)
 @Qualifier
 public @interface Reversed {}
+// end::qualifier[]

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringArgumentFactory.java
@@ -19,7 +19,8 @@ import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.config.ConfigRegistry;
 
-@Reversed
+// tag::argumentfactory[]
+@Reversed // <1>
 public class ReversedStringArgumentFactory extends AbstractArgumentFactory<String> {
     public ReversedStringArgumentFactory() {
         super(Types.VARCHAR);
@@ -30,3 +31,4 @@ public class ReversedStringArgumentFactory extends AbstractArgumentFactory<Strin
         return (pos, stmt, ctx) -> stmt.setString(pos, Reverser.reverse(value));
     }
 }
+// end::argumentfactory[]

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringMapper.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/ReversedStringMapper.java
@@ -19,10 +19,12 @@ import java.sql.SQLException;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
-@Reversed
+// tag::columnmapper[]
+@Reversed // <1>
 public class ReversedStringMapper implements ColumnMapper<String> {
     @Override
     public String map(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
         return Reverser.reverse(r.getString(columnNumber));
     }
 }
+// end::columnmapper[]

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -27,6 +27,7 @@
 :coreexampledir: ../../../core/src/test/java/org/jdbi/v3/core/mapper
 :guavaexampledir: ../../../guava/src/test/java/org/jdbi/v3/guava
 :sqlobjectexampledir: ../../../sqlobject/src/test/java/org/jdbi/v3/sqlobject
+:coreexamples: ../../../core/src/test/java
 
 [preface]
 image::logo.svg[Jdbi logo]
@@ -5790,6 +5791,40 @@ link:{jdbidocs}/core/statement/SqlStatement.html#bindBean(java.lang.Object)[bind
 - link:{jdbidocs}/jpa/BindJpa.html[@BindJpa^] and `JpaMapper` respect qualifiers on getters and setters.
 
 - link:{kotlinsqldocs}sqlobject.kotlin/-bind-kotlin/[@BindKotlin^], link:{kotlindocs}core.kotlin/bind-kotlin.html[bindKotlin()^], and link:{kotlindocs}core.kotlin/-kotlin-mapper/index.html[KotlinMapper^] respect qualifiers on constructor parameters, getters, setters, and setter parameters.
+
+==== Creating custom qualifiers
+
+A custom qualifier is a user-defined annotation that is meta-annotated with link:{jdbidocs}/core/qualifier/Qualifier.html[@Qualifier^]:
+
+[source,java,indent=0]
+----
+include::{coreexamples}/org/jdbi/v3/core/qualifier/Reversed.java[tags=qualifier]
+----
+
+To handle qualified values, create an link:{jdbidocs}/core/argument/ArgumentFactory.html[ArgumentFactory^] and/or a link:{jdbidocs}/core/mapper/ColumnMapper.html[ColumnMapper^] annotated with the qualifier.
+Jdbi matches factories to values by their qualifier annotations:
+
+[source,java,indent=0]
+----
+include::{coreexamples}/org/jdbi/v3/core/qualifier/ReversedStringArgumentFactory.java[tags=argumentfactory]
+----
+
+[source,java,indent=0]
+----
+include::{coreexamples}/org/jdbi/v3/core/qualifier/ReversedStringMapper.java[tags=columnmapper]
+----
+
+<1> The qualifier annotation on the factory and mapper class tells Jdbi that these handle `@Reversed` qualified `String` values.
+
+Register the factories and use them with link:{jdbidocs}/core/qualifier/QualifiedType.html[QualifiedType^]:
+
+[source,java,indent=0]
+----
+include::{coreexamples}/org/jdbi/v3/core/qualifier/TestCustomQualifier.java[tags=usage]
+----
+
+<1> Bind the value using `bindByType` with the qualified type so the `@Reversed` factory is selected.
+<2> Map the result using the qualified type so the `@Reversed` mapper is selected.
 
 [#query-templating]
 === Query Templating


### PR DESCRIPTION
## Summary
- Adds a "Creating custom qualifiers" subsection to the Qualified Types section
- Shows the three steps: define the `@Qualifier` annotation, implement qualified `ArgumentFactory` and `ColumnMapper`, register and use with `QualifiedType`
- Uses a `@Reversed` string example consistent with existing test code in `TestCustomQualifier`

Addresses #1436.

## Test plan
- [x] `make install-fast` passes (AsciiDoc compiles to `docs/target/generated-docs/index.html`)
- [ ] Review rendered HTML for correct formatting

[Generated by AI]