### PR TITLE
Restore package-info.java files

### DIFF
--- a/commons-text/src/main/java/org/jdbi/v3/commonstext/package-info.java
+++ b/commons-text/src/main/java/org/jdbi/v3/commonstext/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * A template engine implementation using Apache Commons Text
+ * {@link org.apache.commons.text.StringSubstitutor}. This allows
+ * configurable variable delimiters in SQL templates, such as
+ * {@code ${foo}}, {@code <foo>}, or {@code %foo%}.
+ * </p>
+ */
+package org.jdbi.v3.commonstext;

--- a/core/src/main/java/org/jdbi/v3/core/annotation/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/core/annotation/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Annotations that control the behavior of reflective property mapping,
+ * such as {@link org.jdbi.v3.core.annotation.JdbiProperty}.
+ * </p>
+ */
+package org.jdbi.v3.core.annotation;

--- a/core/src/main/java/org/jdbi/v3/core/async/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/core/async/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Provides asynchronous execution of Jdbi operations.
+ * The {@link org.jdbi.v3.core.async.JdbiExecutor} wraps a
+ * {@link org.jdbi.v3.core.Jdbi} instance and an {@link java.util.concurrent.Executor}
+ * to run callbacks asynchronously, returning
+ * {@link java.util.concurrent.CompletionStage} results.
+ * </p>
+ */
+package org.jdbi.v3.core.async;

--- a/core/src/main/java/org/jdbi/v3/core/codec/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/core/codec/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Bidirectional mapping between Java types and database columns.
+ * A {@link org.jdbi.v3.core.codec.Codec} combines a
+ * {@link org.jdbi.v3.core.mapper.ColumnMapper} and an
+ * {@link org.jdbi.v3.core.argument.Argument} mapping function.
+ * The {@link org.jdbi.v3.core.codec.CodecFactory} manages codec
+ * registration and lookup.
+ * </p>
+ */
+package org.jdbi.v3.core.codec;

--- a/core/src/main/java/org/jdbi/v3/core/enums/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/core/enums/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Configuration and annotations for binding and mapping Java
+ * {@link java.lang.Enum} types. Enums can be persisted by name or by
+ * ordinal, controlled through the {@link org.jdbi.v3.core.enums.Enums}
+ * configuration class or the {@link org.jdbi.v3.core.enums.EnumByName}
+ * and {@link org.jdbi.v3.core.enums.EnumByOrdinal} annotations.
+ * </p>
+ */
+package org.jdbi.v3.core.enums;

--- a/core/src/main/java/org/jdbi/v3/core/extension/annotation/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/annotation/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Meta-annotations for the extension framework. These annotations are
+ * used to mark other annotations that configure, customize, or provide
+ * handlers for extension types such as SQL Objects.
+ * </p>
+ */
+package org.jdbi.v3.core.extension.annotation;

--- a/core/src/main/java/org/jdbi/v3/core/interceptor/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/core/interceptor/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Generic interception chain for transformation operations.
+ * A {@link org.jdbi.v3.core.interceptor.JdbiInterceptor} can process
+ * or pass on a value through a
+ * {@link org.jdbi.v3.core.interceptor.JdbiInterceptionChain}.
+ * </p>
+ */
+package org.jdbi.v3.core.interceptor;

--- a/core/src/main/java/org/jdbi/v3/core/mapper/immutables/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/immutables/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Support for mapping to and from
+ * <a href="https://immutables.github.io">Immutables</a> generated value
+ * types. Register value types through the
+ * {@link org.jdbi.v3.core.mapper.immutables.JdbiImmutables} configuration
+ * class.
+ * </p>
+ */
+package org.jdbi.v3.core.mapper.immutables;

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Qualified types add context to Java types for database mapping.
+ * The {@link org.jdbi.v3.core.qualifier.Qualifier} meta-annotation
+ * marks custom qualifying annotations, and
+ * {@link org.jdbi.v3.core.qualifier.QualifiedType} pairs a Java type
+ * with its qualifiers for use in argument binding and column mapping.
+ * </p>
+ */
+package org.jdbi.v3.core.qualifier;

--- a/core/src/main/java/org/jdbi/v3/meta/package-info.java
+++ b/core/src/main/java/org/jdbi/v3/meta/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Annotations that provide metadata about the Jdbi API itself,
+ * such as stability guarantees.
+ * </p>
+ */
+package org.jdbi.v3.meta;

--- a/generator/src/main/java/org/jdbi/v3/generator/package-info.java
+++ b/generator/src/main/java/org/jdbi/v3/generator/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Annotation processor that generates concrete implementations of SQL
+ * Object interfaces at compile time, avoiding the runtime cost of
+ * reflective proxy generation.
+ * </p>
+ */
+package org.jdbi.v3.generator;

--- a/gson2/src/main/java/org/jdbi/v3/gson2/package-info.java
+++ b/gson2/src/main/java/org/jdbi/v3/gson2/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * JSON support using the <a href="https://github.com/google/gson">Gson</a>
+ * library. Install the {@link org.jdbi.v3.gson2.Gson2Plugin} to provide
+ * Gson-backed JSON serialization for {@code @Json} qualified types.
+ * </p>
+ */
+package org.jdbi.v3.gson2;

--- a/guava/src/main/java/org/jdbi/v3/guava/codec/package-info.java
+++ b/guava/src/main/java/org/jdbi/v3/guava/codec/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * Provides codec implementations for some Guava types.
+ * The {@link org.jdbi.v3.guava.codec.TypeResolvingCodecFactory} extends
+ * the codec framework with Guava's {@code TypeToken} to resolve codecs
+ * for subtypes of registered types.
+ * </p>
+ */
+package org.jdbi.v3.guava.codec;

--- a/jackson2/src/main/java/org/jdbi/v3/jackson2/package-info.java
+++ b/jackson2/src/main/java/org/jdbi/v3/jackson2/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * JSON support using the
+ * <a href="https://github.com/FasterXML/jackson">Jackson 2</a> library.
+ * Install the {@link org.jdbi.v3.jackson2.Jackson2Plugin} to provide
+ * Jackson-backed JSON serialization for {@code @Json} qualified types.
+ * </p>
+ */
+package org.jdbi.v3.jackson2;

--- a/jackson3/src/main/java/org/jdbi/v3/jackson3/package-info.java
+++ b/jackson3/src/main/java/org/jdbi/v3/jackson3/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * JSON support using the
+ * <a href="https://github.com/FasterXML/jackson">Jackson 3</a> library.
+ * Install the {@link org.jdbi.v3.jackson3.Jackson3Plugin} to provide
+ * Jackson-backed JSON serialization for {@code @Json} qualified types.
+ * </p>
+ */
+package org.jdbi.v3.jackson3;

--- a/json/src/main/java/org/jdbi/v3/json/package-info.java
+++ b/json/src/main/java/org/jdbi/v3/json/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * JSON mapping SPI and the {@link org.jdbi.v3.json.Json} qualifier.
+ * The {@link org.jdbi.v3.json.JsonPlugin} registers argument and column
+ * mapper factories for {@code @Json} qualified types. A concrete JSON
+ * library implementation (such as Gson, Jackson, or Moshi) must be
+ * installed to provide the actual serialization.
+ * </p>
+ */
+package org.jdbi.v3.json;

--- a/moshi/src/main/java/org/jdbi/v3/moshi/package-info.java
+++ b/moshi/src/main/java/org/jdbi/v3/moshi/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * JSON support using the
+ * <a href="https://github.com/square/moshi">Moshi</a> library.
+ * Install the {@link org.jdbi.v3.moshi.MoshiPlugin} to provide
+ * Moshi-backed JSON serialization for {@code @Json} qualified types.
+ * </p>
+ */
+package org.jdbi.v3.moshi;

--- a/opentelemetry/src/main/java/org/jdbi/v3/opentelemetry/package-info.java
+++ b/opentelemetry/src/main/java/org/jdbi/v3/opentelemetry/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * OpenTelemetry integration for Jdbi. Install the
+ * {@link org.jdbi.v3.opentelemetry.JdbiOpenTelemetryPlugin} to emit
+ * a trace span for every SQL statement executed by Jdbi.
+ * </p>
+ */
+package org.jdbi.v3.opentelemetry;

--- a/postgis/src/main/java/org/jdbi/v3/postgis/package-info.java
+++ b/postgis/src/main/java/org/jdbi/v3/postgis/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>
+ * PostGIS support for Jdbi. Install the
+ * {@link org.jdbi.v3.postgis.PostgisPlugin} to bind and map JTS
+ * geometry types such as {@code Point}, {@code Polygon}, and
+ * {@code LineString} to PostGIS columns.
+ * </p>
+ */
+package org.jdbi.v3.postgis;


### PR DESCRIPTION
## Summary
- Re-add 19 package-info.java files that were accidentally deleted by the squashed PR #2930 commit
- These files were originally added in PR #2932

## Test plan
- [x] Files match the originals from PR #2932 commit `6057cd175`

Generated with [Claude Code](https://claude.com/claude-code)