### PR TITLE
Add option to not export bindings with OpenTelemetry

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -64,6 +64,8 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     private volatile int jfrSqlMaxLength = 512;
     private volatile int jfrParamMaxLength = 512;
 
+    private volatile boolean includeBindingsInTelemetry = true;
+
     public SqlStatements() {
         attributes = Collections.synchronizedMap(new HashMap<>());
         templateEngine = new DefinedAttributeTemplateEngine();
@@ -90,6 +92,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
         this.templateCache = that.templateCache;
         this.jfrSqlMaxLength = that.jfrSqlMaxLength;
         this.jfrParamMaxLength = that.jfrParamMaxLength;
+        this.includeBindingsInTelemetry = that.includeBindingsInTelemetry;
     }
 
     /**
@@ -391,6 +394,14 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     }
 
     /**
+     * Toggle whether to include potentially sensitive bindins in telemetry data.
+     */
+    @Beta
+    public boolean getIncludeBindingsInTelemetry() {
+        return includeBindingsInTelemetry;
+    }
+
+    /**
      * When recording JFR events, the maximum length of rendered parameters to store in the event record.
      */
     @Beta
@@ -405,6 +416,14 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     @Beta
     public int getJfrParamMaxLength() {
         return jfrParamMaxLength;
+    }
+
+    /**
+     * Toggle whether to include potentially sensitive bindins in telemetry data.
+     */
+    public SqlStatements setIncludeBindingsInTelemetry(boolean includeBindingsInTelemetry) {
+        this.includeBindingsInTelemetry = includeBindingsInTelemetry;
+        return this;
     }
 
     /**

--- a/opentelemetry/src/main/java/org/jdbi/v3/opentelemetry/JdbiOpenTelemetryPlugin.java
+++ b/opentelemetry/src/main/java/org/jdbi/v3/opentelemetry/JdbiOpenTelemetryPlugin.java
@@ -71,7 +71,9 @@ public class JdbiOpenTelemetryPlugin extends JdbiPlugin.Singleton {
                         span.setAttribute(SQL, renderedSql.substring(0,
                                 Math.min(renderedSql.length(), stmtConfig.getJfrSqlMaxLength())));
                     }
-                    span.setAttribute(BINDING, ctx.getBinding().describe(stmtConfig.getJfrParamMaxLength()));
+                    if (stmtConfig.getIncludeBindingsInTelemetry()) {
+                        span.setAttribute(BINDING, ctx.getBinding().describe(stmtConfig.getJfrParamMaxLength()));
+                    }
                     span.setAttribute(NUM_ROWS, ctx.getMappedRows());
                     span.end();
                 });


### PR DESCRIPTION
For our system the data in bindings is sensitive and should not be shown in telemetry data. The Java OpenTelemetry library does not seem to include any option to filter out attributes.

This PR lets you change a setting in SqlStatements.java in order to not add the binding attributes. I have also added a test to verify that no binding data is being exported.