### PR TITLE
Multiple prefixed mappers for a single type

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/internal/PrefixedMapperKey.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/PrefixedMapperKey.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.internal;
+
+import java.lang.reflect.Type;
+
+public record PrefixedMapperKey(Type type, String prefix) {
+}

--- a/core/src/main/java/org/jdbi/v3/core/internal/PrefixedMapperKey.java
+++ b/core/src/main/java/org/jdbi/v3/core/internal/PrefixedMapperKey.java
@@ -15,5 +15,4 @@ package org.jdbi.v3.core.internal;
 
 import java.lang.reflect.Type;
 
-public record PrefixedMapperKey(Type type, String prefix) {
-}
+public record PrefixedMapperKey(Type type, String prefix) {}

--- a/core/src/main/java/org/jdbi/v3/core/mapper/PrefixedRowMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/PrefixedRowMapper.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+public interface PrefixedRowMapper<T> extends RowMapper<T> {
+    String getPrefix();
+}

--- a/core/src/main/java/org/jdbi/v3/core/mapper/RowMappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/RowMappers.java
@@ -208,10 +208,8 @@ public class RowMappers implements JdbiConfig<RowMappers> {
         for (RowMapperFactory factory : factories) {
             Optional<RowMapper<?>> maybeMapper = factory.build(type, registry);
             RowMapper<?> mapper = maybeMapper.orElse(null);
-            if (mapper instanceof PrefixedRowMapper prefixedRowMapper) {
-                if (prefix != null && !prefix.equals(prefixedRowMapper.getPrefix())) {
-                    mapper = null;
-                }
+            if (mapper instanceof PrefixedRowMapper prefixedRowMapper && prefix != null && !prefix.equals(prefixedRowMapper.getPrefix())) {
+                mapper = null;
             }
             if (mapper != null) {
                 mapper.init(registry);

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -231,10 +231,10 @@ public final class ConstructorMapper<T> implements PrefixedRowMapper<T> {
         return specialize(rs, ctx).map(rs, ctx);
     }
 
-	@Override
-	public String getPrefix() {
+    @Override
+    public String getPrefix() {
         return this.prefix;
-	}
+    }
 
     @Override
     public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.mapper.Nested;
+import org.jdbi.v3.core.mapper.PrefixedRowMapper;
 import org.jdbi.v3.core.mapper.PropagateNull;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
@@ -60,7 +61,7 @@ import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnName
  * Constructor parameters annotated as {@code @Nullable} may be omitted from the result set without error. Any annotation named "Nullable" can be used, no
  * matter which package it is from.
  */
-public final class ConstructorMapper<T> implements RowMapper<T> {
+public final class ConstructorMapper<T> implements PrefixedRowMapper<T> {
     private static final String DEFAULT_PREFIX = "";
 
     @SuppressWarnings("InlineFormatString")
@@ -229,6 +230,11 @@ public final class ConstructorMapper<T> implements RowMapper<T> {
     public T map(ResultSet rs, StatementContext ctx) throws SQLException {
         return specialize(rs, ctx).map(rs, ctx);
     }
+
+	@Override
+	public String getPrefix() {
+        return this.prefix;
+	}
 
     @Override
     public RowMapper<T> specialize(ResultSet rs, StatementContext ctx) throws SQLException {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -33,6 +33,7 @@ import org.jdbi.v3.core.annotation.internal.JdbiAnnotations;
 import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.Nested;
+import org.jdbi.v3.core.mapper.PrefixedRowMapper;
 import org.jdbi.v3.core.mapper.PropagateNull;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
@@ -57,7 +58,7 @@ import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnName
  *
  * The mapped class must have a default constructor.
  */
-public final class FieldMapper<T> implements RowMapper<T> {
+public final class FieldMapper<T> implements PrefixedRowMapper<T> {
     private static final String DEFAULT_PREFIX = "";
 
     /**
@@ -136,6 +137,11 @@ public final class FieldMapper<T> implements RowMapper<T> {
 
         return mapper;
     }
+
+	@Override
+	public String getPrefix() {
+        return this.prefix;
+	}
 
     private <R> Optional<RowMapper<R>> createSpecializedRowMapper(StatementContext ctx,
                                                List<String> columnNames,

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -138,10 +138,10 @@ public final class FieldMapper<T> implements PrefixedRowMapper<T> {
         return mapper;
     }
 
-	@Override
-	public String getPrefix() {
+    @Override
+    public String getPrefix() {
         return this.prefix;
-	}
+    }
 
     private <R> Optional<RowMapper<R>> createSpecializedRowMapper(StatementContext ctx,
                                                List<String> columnNames,

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
@@ -34,6 +34,7 @@ import org.jdbi.v3.core.generic.GenericTypes;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;
+import org.jdbi.v3.core.mapper.PrefixedRowMapper;
 import org.jdbi.v3.core.mapper.PropagateNull;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.SingleColumnMapper;
@@ -53,7 +54,7 @@ import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.findColumnInd
 import static org.jdbi.v3.core.mapper.reflect.ReflectionMapperUtil.getColumnNames;
 
 /** This class is the future home of BeanMapper functionality. */
-public class PojoMapper<T> implements RowMapper<T> {
+public class PojoMapper<T> implements PrefixedRowMapper<T> {
 
     protected boolean strictColumnTypeMapping = true; // this should be default (only?) behavior but that's a breaking change
     protected final Type type;
@@ -187,6 +188,10 @@ public class PojoMapper<T> implements RowMapper<T> {
         return new PojoMapper<>(rawType, nestedPrefix);
     }
 
+	@Override
+	public String getPrefix() {
+        return this.prefix;
+	}
 
     private String getName(PojoProperty<T> property) {
         return property.getAnnotation(ColumnName.class)

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
@@ -188,10 +188,10 @@ public class PojoMapper<T> implements PrefixedRowMapper<T> {
         return new PojoMapper<>(rawType, nestedPrefix);
     }
 
-	@Override
-	public String getPrefix() {
+    @Override
+    public String getPrefix() {
         return this.prefix;
-	}
+    }
 
     private String getName(PojoProperty<T> property) {
         return property.getAnnotation(ColumnName.class)

--- a/core/src/main/java/org/jdbi/v3/core/result/RowView.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/RowView.java
@@ -74,7 +74,7 @@ public abstract class RowView {
      */
     public Object getRow(Type type) {
         return getRow(type, null);
-    };
+    }
 
     /**
      * Use a row mapper to extract a type from the current ResultSet row.

--- a/core/src/main/java/org/jdbi/v3/core/result/RowView.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/RowView.java
@@ -32,7 +32,17 @@ public abstract class RowView {
      * @return the materialized T
      */
     public <T> T getRow(Class<T> rowType) {
-        return rowType.cast(getRow((Type) rowType));
+        return rowType.cast(getRow((Type) rowType, null));
+    }
+
+    /**
+     * Use a row mapper to extract a type from the current ResultSet row.
+     * @param <T> the type to map
+     * @param rowType the Class of the type
+     * @return the materialized T
+     */
+    public <T> T getRow(Class<T> rowType, String prefix) {
+        return rowType.cast(getRow((Type) rowType, prefix));
     }
 
     /**
@@ -43,7 +53,18 @@ public abstract class RowView {
      */
     @SuppressWarnings("unchecked")
     public <T> T getRow(GenericType<T> rowType) {
-        return (T) getRow(rowType.getType());
+        return (T) getRow(rowType.getType(), null);
+    }
+
+    /**
+     * Use a row mapper to extract a type from the current ResultSet row.
+     * @param <T> the type to map
+     * @param rowType the GenericType of the type
+     * @return the materialized T
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getRow(GenericType<T> rowType, String prefix) {
+        return (T) getRow(rowType.getType(), prefix);
     }
 
     /**
@@ -51,7 +72,16 @@ public abstract class RowView {
      * @param type the type to map
      * @return the materialized object
      */
-    public abstract Object getRow(Type type);
+    public Object getRow(Type type) {
+        return getRow(type, null);
+    };
+
+    /**
+     * Use a row mapper to extract a type from the current ResultSet row.
+     * @param type the type to map
+     * @return the materialized object
+     */
+    public abstract Object getRow(Type type, String prefix);
 
     /**
      * Use a column mapper to extract a type from the current ResultSet row.

--- a/core/src/main/java/org/jdbi/v3/core/result/internal/RowViewImpl.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/internal/RowViewImpl.java
@@ -61,7 +61,7 @@ public class RowViewImpl extends RowView {
         }
 
         RowMapper<?> mapper = ctx.findRowMapperFor(type, prefix)
-                .orElseThrow(() -> new NoSuchMapperException("No row mapper registered for " + type))
+                .orElseThrow(() -> new NoSuchMapperException("No row mapper registered for " + type + " and prefix " + prefix))
                 .specialize(rs, ctx);
         rowMappers.put(key, mapper);
 

--- a/core/src/main/java/org/jdbi/v3/core/result/internal/RowViewImpl.java
+++ b/core/src/main/java/org/jdbi/v3/core/result/internal/RowViewImpl.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jdbi.v3.core.internal.PrefixedMapperKey;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.MappingException;
 import org.jdbi.v3.core.mapper.NoSuchMapperException;
@@ -31,7 +32,7 @@ public class RowViewImpl extends RowView {
     private final StatementContext ctx;
     private final ResultSet rs;
 
-    private final Map<Type, RowMapper<?>> rowMappers = new ConcurrentHashMap<>();
+    private final Map<PrefixedMapperKey, RowMapper<?>> rowMappers = new ConcurrentHashMap<>();
     private final Map<QualifiedType<?>, ColumnMapper<?>> columnMappers = new ConcurrentHashMap<>();
 
     public RowViewImpl(ResultSet rs, StatementContext ctx) {
@@ -45,23 +46,24 @@ public class RowViewImpl extends RowView {
      * @return the materialized object
      */
     @Override
-    public Object getRow(Type type) {
+    public Object getRow(Type type, String prefix) {
         try {
-            return rowMapperFor(type).map(rs, ctx);
+            return rowMapperFor(type, prefix).map(rs, ctx);
         } catch (SQLException e) {
             throw new MappingException(e);
         }
     }
 
-    private RowMapper<?> rowMapperFor(Type type) throws SQLException {
-        if (rowMappers.containsKey(type)) {
-            return rowMappers.get(type);
+    private RowMapper<?> rowMapperFor(Type type, String prefix) throws SQLException {
+        var key = new PrefixedMapperKey(type, prefix);
+        if (rowMappers.containsKey(key)) {
+            return rowMappers.get(key);
         }
 
-        RowMapper<?> mapper = ctx.findRowMapperFor(type)
+        RowMapper<?> mapper = ctx.findRowMapperFor(type, prefix)
                 .orElseThrow(() -> new NoSuchMapperException("No row mapper registered for " + type))
                 .specialize(rs, ctx);
-        rowMappers.put(type, mapper);
+        rowMappers.put(key, mapper);
 
         return mapper;
     }

--- a/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/StatementContext.java
@@ -310,7 +310,17 @@ public class StatementContext implements Closeable {
      * @return a RowMapper for the given type, or empty if no row mapper is registered for the given type.
      */
     public Optional<RowMapper<?>> findRowMapperFor(Type type) {
-        return getConfig(RowMappers.class).findFor(type);
+        return getConfig(RowMappers.class).findFor(type, null);
+    }
+
+    /**
+     * Obtain a row mapper for the given type in this context.
+     *
+     * @param type the target type to map to
+     * @return a RowMapper for the given type, or empty if no row mapper is registered for the given type.
+     */
+    public Optional<RowMapper<?>> findRowMapperFor(Type type, String prefix) {
+        return getConfig(RowMappers.class).findFor(type, prefix);
     }
 
     /**
@@ -321,7 +331,18 @@ public class StatementContext implements Closeable {
      * @return a RowMapper for the given type, or empty if no row mapper is registered for the given type.
      */
     public <T> Optional<RowMapper<T>> findRowMapperFor(Class<T> type) {
-        return getConfig(RowMappers.class).findFor(type);
+        return getConfig(RowMappers.class).findFor(type, null);
+    }
+
+    /**
+     * Obtain a row mapper for the given type in this context.
+     *
+     * @param <T> the type to map
+     * @param type the target type to map to
+     * @return a RowMapper for the given type, or empty if no row mapper is registered for the given type.
+     */
+    public <T> Optional<RowMapper<T>> findRowMapperFor(Class<T> type, String prefix) {
+        return getConfig(RowMappers.class).findFor(type, prefix);
     }
 
     /**
@@ -332,7 +353,18 @@ public class StatementContext implements Closeable {
      * @return a RowMapper for the given type, or empty if no row mapper is registered for the given type.
      */
     public <T> Optional<RowMapper<T>> findRowMapperFor(GenericType<T> type) {
-        return getConfig(RowMappers.class).findFor(type);
+        return getConfig(RowMappers.class).findFor(type, null);
+    }
+
+    /**
+     * Obtain a row mapper for the given type in this context.
+     *
+     * @param <T> the type to map
+     * @param type the target type to map to
+     * @return a RowMapper for the given type, or empty if no row mapper is registered for the given type.
+     */
+    public <T> Optional<RowMapper<T>> findRowMapperFor(GenericType<T> type, String prefix) {
+        return getConfig(RowMappers.class).findFor(type, prefix);
     }
 
     /**


### PR DESCRIPTION
In any case where a table has two foreign key references to the same table and you have a query that joins with both, it's not possible to use a RowMapper for both of those objects because, even if you register a mapper twice with different prefixes, the `rowView.getObject(Class<?>)` method will just use the last registered mapper for the type. #2445 is a ticket someone opened for the same problem, and this PR allows users to access row mappers by type _and_ prefix, making this possible.

The basic idea is to make sure mapper prefixes are accessible and even part of the mapper cache key, and add new `RowView` overload methods that allow `String prefix` as a second argument; if that argument is present, it will only return use a mapper that was created with that prefix.

I've provided a single test in `TestBeanMapper` that gives a good idea of what this looks like in a RowReducer. I realize more tests are probably necessary, but I just wanted to create the pull request and get some feedback on implementation before I go write more tests. How does this look? Is my implementation good, or should I make some changes?