### PR TITLE
Fix StringTemplate rendering for @BindMethodsList with @DefineNamedBindings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,6 +34,7 @@ documentation at https://jdbi.org/ for details.
 - Support INOUT parameters for stored procedure Call statements (#1606)
 - Map java.time types according to JDBC 4.2 spec (using setObject) (#988)
 - Add `@Legacy` annotation to restore old timestamp mapping behavior
+- Make `@BindMethodsList` work with the String template engine (fixes #2917, reported by @agavrilov76, fixed by @JScodeconcise)
 
 # 3.51.0
 

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -1683,7 +1683,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
                 }
 
                 final String methodName = methodNames.get(methodIndex);
-                final String name = key + valueIndex + '.' + methodName;
+                final String name = key + valueIndex + "_" + methodName;
                 names.append(':').append(name);
                 final Argument argument = beanMethods.find(methodName, ctx)
                     .orElseThrow(() -> new UnableToCreateStatementException("Unable to get " + methodName + " argument for " + bean, ctx));

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestBindMethodsListWithStringTemplate.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestBindMethodsListWithStringTemplate.java
@@ -1,0 +1,42 @@
+package org.jdbi.v3.stringtemplate4;
+
+import java.util.List;
+
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.BindMethodsList;
+import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestBindMethodsListWithStringTemplate {
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2()
+        .withPlugin(new SqlObjectPlugin());
+
+    public record Boo(String a, String b) {}
+
+    public interface Dao {
+        @UseStringTemplateEngine
+        @DefineNamedBindings
+        @SqlQuery("SELECT <if(flag)>('c', 'd') IN (<list>)<else>TRUE<endif>")
+        boolean test2(@Define boolean flag,
+            @BindMethodsList(methodNames = { "a", "b" }) List<Boo> list);
+    }
+
+    @Test
+    public void reproduceIssue() {
+        Dao dao = h2Extension.getJdbi().onDemand(Dao.class);
+
+        List<Boo> list = List.of(
+            new Boo("c", "d"),
+            new Boo("e", "f")
+        );
+
+        assertTrue(dao.test2(true, list));
+    }
+}


### PR DESCRIPTION
Fixes a StringTemplate rendering issue when `@BindMethodsList` is used together with `@DefineNamedBindings`.

`bindMethodsList()` generated binding names like `list0.a`, which are invalid StringTemplate attribute names and caused rendering to fail with `cannot have '.' in attribute names`.

This change updates the generated binding names to avoid `.` so the query can render correctly.

Added a regression test that failed before the fix and now passes.