### PR TITLE
Cache derived attach configurations per source registry

### DIFF
--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/OnDemandAttachBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/OnDemandAttachBenchmark.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Exercises the per-{@code attach} configuration derivation cost.
+ *
+ * <p>{@link Jdbi#onDemand(Class)} (and {@link Jdbi#withExtension}) re-attaches the extension on every
+ * method call against the same, stable {@code Jdbi}-level configuration. Each attach derives an
+ * instance configuration plus one configuration per extension method, each a full
+ * {@code ConfigRegistry.createCopy()}. The {@code ManyMethodDao} below has many methods so that the
+ * {@code 1 + methodCount} copies dominate, making the effect of caching the derived configurations
+ * visible. {@link #handleAttach()} attaches against a per-{@link Handle} configuration (a one-shot
+ * attach source that does not benefit from the cache) and is included to confirm there is no
+ * regression on that path.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@Measurement(time = 5, iterations = 5)
+@Warmup(time = 5, iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+public class OnDemandAttachBenchmark {
+
+    private Jdbi jdbi;
+    private Handle handle;
+
+    @Setup(Level.Iteration)
+    public void setUp() {
+        jdbi = Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10");
+        jdbi.installPlugin(new SqlObjectPlugin());
+        jdbi.registerRowMapper(Data.class, new DataMapper());
+
+        handle = jdbi.open();
+        handle.execute("drop table if exists tbl");
+        handle.execute("create table tbl (id identity, name varchar, description varchar)");
+        handle.execute("insert into tbl (id, name, description) values (0, 'name', 'description')");
+    }
+
+    @TearDown(Level.Iteration)
+    public void close() {
+        if (handle != null) {
+            handle.close();
+            handle = null;
+        }
+        jdbi = null;
+    }
+
+    /**
+     * On-demand style attach: re-attaches against the stable {@code Jdbi} configuration on every call,
+     * so the derived configurations can be cached and reused.
+     */
+    @Benchmark
+    public Data onDemandAttach() {
+        return jdbi.withExtension(ManyMethodDao.class, dao -> dao.getById(0));
+    }
+
+    /**
+     * Opens a fresh {@link Handle} per call and attaches against its per-handle configuration — a
+     * one-shot attach source (a new configuration each call) that does <em>not</em> reuse cached
+     * configurations. This mirrors the typical open-handle-per-unit-of-work pattern and confirms there
+     * is no regression on the path the cache cannot help.
+     */
+    @Benchmark
+    public Data handleAttach() {
+        try (Handle h = jdbi.open()) {
+            return h.attach(ManyMethodDao.class).getById(0);
+        }
+    }
+
+    @RegisterRowMapper(DataMapper.class)
+    public interface ManyMethodDao {
+
+        @SqlQuery("select * from tbl where id = :id")
+        Data getById(@Bind("id") long id);
+
+        @SqlQuery("select * from tbl order by id")
+        List<Data> listAll();
+
+        @SqlQuery("select * from tbl where name = :name")
+        Data getByName(@Bind("name") String name);
+
+        @SqlQuery("select * from tbl where description = :description")
+        Data getByDescription(@Bind("description") String description);
+
+        @SqlQuery("select count(*) from tbl")
+        long count();
+
+        @SqlQuery("select name from tbl where id = :id")
+        String nameById(@Bind("id") long id);
+
+        @SqlQuery("select description from tbl where id = :id")
+        String descriptionById(@Bind("id") long id);
+
+        @SqlQuery("select id from tbl order by id")
+        List<Long> listIds();
+
+        @SqlQuery("select * from tbl where id > :id")
+        List<Data> listAfter(@Bind("id") long id);
+
+        @SqlQuery("select * from tbl where id < :id")
+        List<Data> listBefore(@Bind("id") long id);
+    }
+
+    public static class Data {
+
+        private final int id;
+        private final String name;
+        private final String description;
+
+        public Data(int id, String name, String description) {
+            this.id = id;
+            this.name = name;
+            this.description = description;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public String description() {
+            return description;
+        }
+    }
+
+    public static class DataMapper implements RowMapper<Data> {
+
+        @Override
+        public Data map(final ResultSet r, final StatementContext ctx) throws SQLException {
+            return new Data(r.getInt("id"), r.getString("name"), r.getString("description"));
+        }
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import org.jdbi.v3.core.config.ConfigCustomizer;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.internal.ConfigCustomizerChain;
+import org.jdbi.v3.core.extension.internal.ExtensionConfigCache;
 import org.jdbi.v3.core.internal.JdbiClassUtils;
 import org.jdbi.v3.core.internal.JdbiClassUtils.MethodKey;
 import org.jdbi.v3.core.internal.exceptions.Sneaky;
@@ -80,30 +81,41 @@ public final class ExtensionMetadata {
      * Create an instance specific configuration based on all instance customizers. The instance configuration holds all
      * custom configuration that was applied e.g. through instance annotations.
      *
+     * <p>The derived configuration is cached per source registry (see {@link ExtensionConfigCache}), so repeated
+     * attaches against the same registry — notably {@link org.jdbi.v3.core.Jdbi#onDemand(Class)}, which
+     * re-attaches on every method call — reuse it instead of copying the registry every time.
+     *
      * @param config A configuration object. The object is not changed
-     * @return A new configuration object with all changes applied
+     * @return A configuration object with all changes applied; shared across attaches from the same source registry
      */
     public ConfigRegistry createInstanceConfiguration(ConfigRegistry config) {
-        ConfigRegistry instanceConfiguration = config.createCopy();
-        instanceConfigCustomizer.customize(instanceConfiguration);
-        return instanceConfiguration;
+        return config.get(ExtensionConfigCache.class).instanceConfiguration(extensionType, () -> {
+            ConfigRegistry instanceConfiguration = config.createCopy();
+            instanceConfigCustomizer.customize(instanceConfiguration);
+            return instanceConfiguration;
+        });
     }
 
     /**
      * Create an method specific configuration based on all method customizers. The method configuration holds all
      * custom configuration that was applied e.g. through method annotations.
      *
+     * <p>The derived configuration is cached per source registry (see {@link ExtensionConfigCache}), so repeated
+     * attaches against the same instance configuration reuse it instead of copying the registry every time.
+     *
      * @param method The method that is about to be called
      * @param config A configuration object. The object is not changed
-     * @return A new configuration object with all changes applied
+     * @return A configuration object with all changes applied; shared across attaches from the same source registry
      */
     public ConfigRegistry createMethodConfiguration(Method method, ConfigRegistry config) {
-        ConfigRegistry methodConfiguration = config.createCopy();
-        ConfigCustomizer methodConfigCustomizer = methodConfigCustomizers.get(method);
-        if (methodConfigCustomizer != null) {
-            methodConfigCustomizer.customize(methodConfiguration);
-        }
-        return methodConfiguration;
+        return config.get(ExtensionConfigCache.class).methodConfiguration(method, () -> {
+            ConfigRegistry methodConfiguration = config.createCopy();
+            ConfigCustomizer methodConfigCustomizer = methodConfigCustomizers.get(method);
+            if (methodConfigCustomizer != null) {
+                methodConfigCustomizer.customize(methodConfiguration);
+            }
+            return methodConfiguration;
+        });
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/extension/internal/ExtensionConfigCache.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/internal/ExtensionConfigCache.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension.internal;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.config.JdbiConfig;
+
+/**
+ * Per-{@link ConfigRegistry} cache of the derived configurations produced when an extension is
+ * attached: the instance configuration and the per-method configurations.
+ *
+ * <p>Deriving those configurations performs a full {@link ConfigRegistry#createCopy()} — one
+ * for the instance configuration plus one per extension method — on every {@code attach}.
+ * {@link org.jdbi.v3.core.Jdbi#onDemand(Class)} re-attaches on <em>every</em> method call against
+ * the same, stable {@code Jdbi}-level configuration, so without caching it repeats
+ * {@code 1 + methodCount} registry copies per call. For on-demand-heavy workloads those copies
+ * dominate allocation.
+ *
+ * <p>The derived configuration depends on the identity of the source registry, so this cache is
+ * deliberately <b>not</b> shared across copies: {@link #createCopy()} returns a fresh, empty
+ * instance. Consequences:
+ * <ul>
+ *   <li>A registry only ever used as an attach source once — e.g. the per-{@link
+ *       org.jdbi.v3.core.Handle} configuration in {@link org.jdbi.v3.core.Handle#attach(Class)}
+ *       — caches nothing reusable and behaves exactly as before (no regression).</li>
+ *   <li>A long-lived registry reused as an attach source — the {@code Jdbi} root
+ *       configuration used by on-demand — amortizes the copies to a one-time cost.</li>
+ * </ul>
+ * Entries live and die with their owning registry, so there is no unbounded growth.
+ *
+ * <p><b>Reconfiguration semantics:</b> this cache assumes that a registry reused as an attach
+ * source is effectively immutable once it has been attached against. Reconfiguring the {@code Jdbi}
+ * root configuration after an on-demand extension has been used will not retroactively change that
+ * extension's already-derived configuration. {@code Jdbi} configuration is expected to be finalized
+ * before use, so this matches the existing contract. (The shared, Jdbi-level
+ * {@link org.jdbi.v3.core.config.internal.ConfigCaches} makes the same "do not respect
+ * reconfiguration" assumption, though it differs in that it is shared across copies rather than
+ * derived per registry.)
+ */
+public final class ExtensionConfigCache implements JdbiConfig<ExtensionConfigCache> {
+
+    private final Map<Class<?>, ConfigRegistry> instanceConfigurations = new ConcurrentHashMap<>();
+    private final Map<Method, ConfigRegistry> methodConfigurations = new ConcurrentHashMap<>();
+
+    /**
+     * Returns the cached instance configuration for the given extension type, computing and caching
+     * it on first request.
+     */
+    public ConfigRegistry instanceConfiguration(Class<?> extensionType, Supplier<ConfigRegistry> factory) {
+        return instanceConfigurations.computeIfAbsent(extensionType, type -> factory.get());
+    }
+
+    /**
+     * Returns the cached method configuration for the given method, computing and caching it on first
+     * request.
+     */
+    public ConfigRegistry methodConfiguration(Method method, Supplier<ConfigRegistry> factory) {
+        return methodConfigurations.computeIfAbsent(method, m -> factory.get());
+    }
+
+    @Override
+    public ExtensionConfigCache createCopy() {
+        return new ExtensionConfigCache();
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionConfigCache.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionConfigCache.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.extension.annotation.UseExtensionHandler;
+import org.jdbi.v3.core.extension.internal.ExtensionConfigCache;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestExtensionConfigCache {
+
+    // --- ExtensionConfigCache unit behavior -------------------------------------------------
+
+    @Test
+    public void memoizesInstanceConfigurationPerType() {
+        ExtensionConfigCache cache = new ExtensionConfigCache();
+        AtomicInteger calls = new AtomicInteger();
+        Supplier<ConfigRegistry> factory = () -> {
+            calls.incrementAndGet();
+            return new ConfigRegistry();
+        };
+
+        ConfigRegistry first = cache.instanceConfiguration(String.class, factory);
+        ConfigRegistry second = cache.instanceConfiguration(String.class, factory);
+
+        assertThat(second).isSameAs(first);
+        assertThat(calls).hasValue(1);
+
+        ConfigRegistry other = cache.instanceConfiguration(Integer.class, factory);
+        assertThat(other).isNotSameAs(first);
+        assertThat(calls).hasValue(2);
+    }
+
+    @Test
+    public void memoizesMethodConfigurationPerMethod() throws Exception {
+        ExtensionConfigCache cache = new ExtensionConfigCache();
+        AtomicInteger calls = new AtomicInteger();
+        Supplier<ConfigRegistry> factory = () -> {
+            calls.incrementAndGet();
+            return new ConfigRegistry();
+        };
+        Method toString = Object.class.getMethod("toString");
+        Method hashCode = Object.class.getMethod("hashCode");
+
+        ConfigRegistry first = cache.methodConfiguration(toString, factory);
+        assertThat(cache.methodConfiguration(toString, factory)).isSameAs(first);
+        assertThat(calls).hasValue(1);
+
+        assertThat(cache.methodConfiguration(hashCode, factory)).isNotSameAs(first);
+        assertThat(calls).hasValue(2);
+    }
+
+    @Test
+    public void createCopyStartsEmptyAndIndependent() {
+        ExtensionConfigCache cache = new ExtensionConfigCache();
+        ConfigRegistry cached = cache.instanceConfiguration(String.class, ConfigRegistry::new);
+
+        ExtensionConfigCache copy = cache.createCopy();
+        assertThat(copy).isNotSameAs(cache);
+
+        AtomicInteger calls = new AtomicInteger();
+        ConfigRegistry inCopy = copy.instanceConfiguration(String.class, () -> {
+            calls.incrementAndGet();
+            return new ConfigRegistry();
+        });
+        // the copy did not inherit the original entry: the factory runs again and yields a new instance
+        assertThat(calls).hasValue(1);
+        assertThat(inCopy).isNotSameAs(cached);
+    }
+
+    // --- wiring through ExtensionMetadata ---------------------------------------------------
+
+    @Test
+    public void derivedConfigurationsAreCachedPerSourceRegistry() throws Exception {
+        ConfigRegistry root = new ConfigRegistry();
+        Extensions extensions = root.get(Extensions.class);
+        extensions.register(new ExtensionFrameworkTestFactory());
+        ExtensionMetadata metadata = extensions.findMetadata(Dao.class, new ExtensionFrameworkTestFactory());
+
+        // repeated attaches against the same registry (the on-demand case) reuse the derived configuration
+        ConfigRegistry instance1 = metadata.createInstanceConfiguration(root);
+        ConfigRegistry instance2 = metadata.createInstanceConfiguration(root);
+        assertThat(instance2).isSameAs(instance1);
+
+        // a different source registry (e.g. a per-Handle config in Handle#attach) derives its own copy
+        ConfigRegistry fromCopy = metadata.createInstanceConfiguration(root.createCopy());
+        assertThat(fromCopy).isNotSameAs(instance1);
+
+        Method doThing = Dao.class.getMethod("doThing");
+        ConfigRegistry method1 = metadata.createMethodConfiguration(doThing, instance1);
+        ConfigRegistry method2 = metadata.createMethodConfiguration(doThing, instance1);
+        assertThat(method2).isSameAs(method1);
+        assertThat(metadata.createMethodConfiguration(doThing, instance1.createCopy())).isNotSameAs(method1);
+    }
+
+    public interface Dao {
+        @TestHandler
+        void doThing();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @UseExtensionHandler(id = "test", value = NoOpHandler.class)
+    public @interface TestHandler {}
+
+    public static class NoOpHandler implements ExtensionHandler.Simple {
+        @Override
+        public Object invoke(HandleSupplier handleSupplier, Object... args) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
# Cache derived attach configurations per source registry

## Summary

Deriving an extension's configuration on `attach` performs a full
`ConfigRegistry.createCopy()` for the instance configuration **plus one copy per
extension method**. `Jdbi#onDemand(Class)` (and `Jdbi#withExtension`) re-attaches
the extension on **every** method call against the same, stable `Jdbi`-level
configuration, so without caching it repeats `1 + methodCount` registry copies on
every single call. For on-demand-heavy workloads those copies dominate allocation.

This PR introduces `ExtensionConfigCache`, a per-`ConfigRegistry` `JdbiConfig`
(placed in `org.jdbi.v3.core.extension.internal`, mirroring
`org.jdbi.v3.core.config.internal.ConfigCaches`) that memoizes the derived
instance and method configurations, keyed by extension type and by method.

## Why this is safe

The derived configuration depends on the **identity of the source registry**, so
the cache is deliberately **not** shared across copies — `createCopy()` returns a
fresh, empty instance. This gives two clean behaviors:

- **One-shot attach sources** (e.g. the per-`Handle` configuration used by
  `Handle#attach(Class)`) cache nothing reusable and behave **as before — no
  meaningful regression** (see benchmark below).
- **Long-lived attach sources** (the `Jdbi` root configuration used by on-demand)
  amortize the `1 + methodCount` copies to a **one-time cost**.

Entries live and die with their owning registry, so there is no unbounded growth.

I verified the on-demand path actually hits the cache:
`onDemand` → proxy → `Jdbi#withExtension` → `LazyHandleSupplier.getConfig()` returns
`jdbi.getConfig()` (the **stable root registry**, same instance on every call) →
`ExtensionFactoryDelegate.attach()` derives from it. The instance key
(`extensionType`) and method key (`Method`) cannot collide because
`Extensions#findMetadata` memoizes one `ExtensionMetadata` per type, so a given
source registry yields exactly one derived configuration per type/method.

## Behavior change worth calling out

Because the derived configuration is now frozen at first use, **reconfiguring the
`Jdbi` root configuration after an on-demand extension has already been used will
no longer be picked up** by that extension. Previously each call re-copied the
live root config, so a late `jdbi.registerRowMapper(...)` between two on-demand
calls would have been observed.

This matches the documented configuration contract — "a new context inherits a
copy of its parent configuration **at the time of creation**" and Jdbi
configuration is expected to be finalized before use. The shared, Jdbi-level
`ConfigCaches` already makes the same "do not respect reconfiguration" assumption.

## Related

This is the same hotspot discussed in #1103 (monitor contention in
`ConfigRegistry.createCopy()` under load), where lazily/once deriving config from
the parent registry to "amortize the cost of cloning" was suggested.

## Tests & benchmark

- `TestExtensionConfigCache` — unit tests for per-type / per-method memoization
  and the fresh-on-copy semantics, plus a wiring test through `ExtensionMetadata`
  asserting that repeated attaches against the same source registry reuse the
  derived configuration while a different source registry derives its own.
- `OnDemandAttachBenchmark` (JMH) — exercises the attach configuration-derivation
  cost with a many-method DAO (so the `1 + methodCount` copies dominate). The
  `onDemandAttach` benchmark drives the cached path; `handleAttach` opens a fresh
  `Handle` per call (a one-shot attach source, mirroring open-handle-per-unit-of-work)
  to confirm no regression on the path the cache cannot help.

## Benchmark results

`OnDemandAttachBenchmark` (JMH, H2, 10-method DAO), allocation via `-prof gc`:

| Benchmark | before (no cache) | after (cache) | allocation | throughput |
| --- | --- | --- | --- | --- |
| `onDemandAttach` (stable config, cache hit) | 90,574 B/op @ 42.0 ops/ms | 34,425 B/op @ 83.7 ops/ms | **−62%** | **~2×** |
| `handleAttach` (fresh handle/call, cache miss) | 258,366 B/op @ 12.6 ops/ms | 261,814 B/op @ 12.0 ops/ms | +1.3% | within noise |

The on-demand path allocates **~62% less per call** and roughly doubles throughput.
The cache-miss path shows no meaningful regression: the ~1% allocation delta is the
empty cache holder allocated on each fresh registry, dwarfed by the per-call
connection open (~258 KB here), and it turns positive for any handle reused more
than once.

(Reduced JMH settings — 1 fork × 3 warmup + 4 measurement iterations — for
turnaround; allocation norms were stable to within ±200 B/op. A full default run
reproduces the same ratios.)

## Notes for reviewers

- `ExtensionConfigCache` is intentionally in an `.internal` package so it is not
  part of the public API (excluded from japicmp / Javadoc), consistent with
  `ConfigCaches`.
