### PR TITLE
ConfigCaches: run cache computers without holding the bin monitor to fix ABBA deadlock

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
@@ -105,7 +105,8 @@ public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
                 final Object computed;
                 try {
                     computed = computer.apply(config, key);
-                } catch (RuntimeException | Error e) {
+                } catch (Throwable e) {
+                    // Clean up on ANY throwable, since otherwise we leave waiting threads blocked forever
                     fail(cache, normalizedKey, entry, e);
                     throw e;
                 }
@@ -117,7 +118,7 @@ public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
                     fail(cache, normalizedKey, entry, e);
                     throw e;
                 }
-                entry.value.complete(computed);
+                entry.complete(computed);
                 return (V) computed;
             }
         };
@@ -129,16 +130,31 @@ public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
      */
     private static void fail(Map<Object, Object> cache, Object normalizedKey, CacheEntry entry, Throwable cause) {
         cache.remove(normalizedKey, entry);
-        entry.value.completeExceptionally(cause);
+        entry.completeExceptionally(cause);
     }
 
     /**
      * A cache slot. {@code value} is completed exactly once by the thread that installed the entry;
      * {@code owner} is that thread, retained only to detect a computer re-entering the cache for the key
      * it is itself computing (an unsatisfiable self-dependency we must reject rather than deadlock on).
+     * The owner reference is meaningful only while the computation is in flight, so it is cleared on
+     * completion: the cache is unbounded and lives for the life of the Jdbi instance, and a retained
+     * Thread would pin that thread (and its thread-locals and context classloader) from collection.
      */
     private static final class CacheEntry {
-        final Thread owner = Thread.currentThread();
+        // No synchronization needed: a thread always sees its own writes, and any other thread that reads a
+        // stale owner fails the identity check and falls through to join() — the correct path.
+        Thread owner = Thread.currentThread();
         final CompletableFuture<Object> value = new CompletableFuture<>();
+
+        void complete(Object computed) {
+            owner = null;
+            value.complete(computed);
+        }
+
+        void completeExceptionally(Throwable cause) {
+            owner = null;
+            value.completeExceptionally(cause);
+        }
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.config.internal;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -59,10 +60,75 @@ public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
             @SuppressWarnings("unchecked")
             @Override
             public V get(K key, ConfigRegistry config) {
-                return (V) config.get(ConfigCaches.class).caches
-                    .computeIfAbsent(this, x -> new ConcurrentHashMap<>())
-                    .computeIfAbsent(keyNormalizer.apply(key), x -> computer.apply(config, key));
+                // The per-cache map allocation below runs a trivial, non-reentrant mapping function, so
+                // holding the bin monitor for it is harmless.
+                final Map<Object, Object> cache = config.get(ConfigCaches.class).caches
+                    .computeIfAbsent(this, x -> new ConcurrentHashMap<>());
+
+                final Object normalizedKey = keyNormalizer.apply(key);
+
+                // Deliberately not computeIfAbsent: that holds the ConcurrentHashMap bin monitor for the
+                // duration of the mapping function, and our computers routinely recurse into other caches
+                // (and other bins of this same map) to resolve qualifiers, column mappers, and the like.
+                // Two threads warming such mappers concurrently can take bin monitors in opposite order and
+                // deadlock (ABBA). See https://github.com/jdbi/jdbi/issues/2980.
+                //
+                // Instead we install an incomplete entry under the key with an atomic putIfAbsent (whose
+                // bin monitor is never held across user code), then run the computer with no lock held. The
+                // thread that wins the race computes exactly once; everyone else joins its result.
+                final CacheEntry entry = new CacheEntry();
+                final CacheEntry existing = (CacheEntry) cache.putIfAbsent(normalizedKey, entry);
+                if (existing != null) {
+                    if (Thread.currentThread().equals(existing.owner) && !existing.value.isDone()) {
+                        // A computer on this thread re-entered the same cache for the same key it is still
+                        // computing. The value depends on itself; no caching strategy can satisfy it. Fail
+                        // fast with a useful message instead of self-deadlocking on the join below. This
+                        // mirrors ConcurrentHashMap.computeIfAbsent, which throws on recursive same-key updates.
+                        throw new IllegalStateException("Recursive cache computation for key " + key);
+                    }
+                    // The winning thread has already run the computer and completed (or failed) the future,
+                    // so join() does not block on user code while holding any lock. A failed computation
+                    // surfaces here as a CompletionException wrapping the original cause.
+                    return (V) existing.value.join();
+                }
+
+                final Object computed;
+                try {
+                    computed = computer.apply(config, key);
+                } catch (RuntimeException | Error e) {
+                    fail(cache, normalizedKey, entry, e);
+                    throw e;
+                }
+                if (computed == null) {
+                    // These caches map JVM constants to a derived form; "no value" is not a meaningful
+                    // result. Reject null rather than cache it and risk an NPE far downstream. A computer
+                    // that needs to express absence should return an Optional or a sentinel, not null.
+                    final IllegalStateException e = new IllegalStateException("Cache computer returned null for key " + key);
+                    fail(cache, normalizedKey, entry, e);
+                    throw e;
+                }
+                entry.value.complete(computed);
+                return (V) computed;
             }
         };
+    }
+
+    /**
+     * Abandon a computation that did not produce a usable value: drop the entry so a later call retries
+     * (we deliberately do not memoize failures), and hand the cause to any threads already joining the key.
+     */
+    private static void fail(Map<Object, Object> cache, Object normalizedKey, CacheEntry entry, Throwable cause) {
+        cache.remove(normalizedKey, entry);
+        entry.value.completeExceptionally(cause);
+    }
+
+    /**
+     * A cache slot. {@code value} is completed exactly once by the thread that installed the entry;
+     * {@code owner} is that thread, retained only to detect a computer re-entering the cache for the key
+     * it is itself computing (an unsatisfiable self-dependency we must reject rather than deadlock on).
+     */
+    private static final class CacheEntry {
+        final Thread owner = Thread.currentThread();
+        final CompletableFuture<Object> value = new CompletableFuture<>();
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/internal/ConfigCaches.java
@@ -15,12 +15,14 @@ package org.jdbi.v3.core.config.internal;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.core.internal.exceptions.Sneaky;
 
 /**
  * Hold metadata caches which maps various JVM constants into pre-parsed forms.
@@ -57,7 +59,10 @@ public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
 
     public static <K, V> ConfigCache<K, V> declare(Function<K, ?> keyNormalizer, BiFunction<ConfigRegistry, K, V> computer) {
         return new ConfigCache<>() {
-            @SuppressWarnings("unchecked")
+            // PreserveStackTrace: the join() path deliberately discards the CompletionException wrapper and
+            // rethrows its cause; the wrapper carries only CompletableFuture plumbing, and the cause keeps
+            // its own stack. See the comment at the throw site.
+            @SuppressWarnings({"unchecked", "PMD.PreserveStackTrace"})
             @Override
             public V get(K key, ConfigRegistry config) {
                 // The per-cache map allocation below runs a trivial, non-reentrant mapping function, so
@@ -87,9 +92,14 @@ public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
                         throw new IllegalStateException("Recursive cache computation for key " + key);
                     }
                     // The winning thread has already run the computer and completed (or failed) the future,
-                    // so join() does not block on user code while holding any lock. A failed computation
-                    // surfaces here as a CompletionException wrapping the original cause.
-                    return (V) existing.value.join();
+                    // so join() does not block on user code while holding any lock. On failure, unwrap the
+                    // CompletionException so a thread that lost the race sees the same exception the computing
+                    // thread would throw: the type a caller catches must not depend on who won the race.
+                    try {
+                        return (V) existing.value.join();
+                    } catch (CompletionException e) {
+                        throw Sneaky.throwAnyway(e.getCause());
+                    }
                 }
 
                 final Object computed;

--- a/core/src/test/java/org/jdbi/v3/core/config/internal/TestConfigCaches.java
+++ b/core/src/test/java/org/jdbi/v3/core/config/internal/TestConfigCaches.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.config.internal;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.junit.jupiter.api.Test;
+
+import static java.util.stream.Collectors.toList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+class TestConfigCaches {
+
+    // Every test runs under a hard timeout: a regression in the cache's locking discipline shows up as a
+    // failing (timed-out) test, never as a hung build. See https://github.com/jdbi/jdbi/issues/2980.
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    @Test
+    void computesValueOnce() {
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            final AtomicInteger computations = new AtomicInteger();
+            final ConfigCache<String, String> cache =
+                ConfigCaches.declare(key -> {
+                    computations.incrementAndGet();
+                    return key.toUpperCase();
+                });
+            final ConfigRegistry config = new ConfigRegistry();
+
+            assertThat(cache.get("a", config)).isEqualTo("A");
+            assertThat(cache.get("a", config)).isEqualTo("A");
+
+            assertThat(computations).hasValue(1);
+        });
+    }
+
+    @Test
+    void rejectsNullValue() {
+        // A null result is rejected, and like any failed computation it is not memoized, so a later
+        // (non-null) call still succeeds.
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            final AtomicInteger computations = new AtomicInteger();
+            final ConfigCache<String, String> cache =
+                ConfigCaches.declare(key -> computations.incrementAndGet() == 1 ? null : key.toUpperCase());
+            final ConfigRegistry config = new ConfigRegistry();
+
+            assertThatThrownBy(() -> cache.get("a", config))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("null");
+
+            assertThat(cache.get("a", config)).isEqualTo("A");
+            assertThat(computations).hasValue(2);
+        });
+    }
+
+    @Test
+    void doesNotCacheComputationFailure() {
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            final AtomicInteger attempts = new AtomicInteger();
+            final ConfigCache<String, String> cache =
+                ConfigCaches.declare(key -> {
+                    if (attempts.incrementAndGet() == 1) {
+                        throw new IllegalStateException("boom");
+                    }
+                    return key.toUpperCase();
+                });
+            final ConfigRegistry config = new ConfigRegistry();
+
+            assertThatThrownBy(() -> cache.get("a", config))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("boom");
+
+            // A failure is not memoized: a subsequent call retries and succeeds.
+            assertThat(cache.get("a", config)).isEqualTo("A");
+            assertThat(attempts).hasValue(2);
+        });
+    }
+
+    @Test
+    void reentrantDifferentKeyComputationSucceeds() {
+        // A computer recursing into the same cache for a different key (the mapper-warming pattern from
+        // #2980) must not throw "Recursive update" or deadlock.
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            final ConfigRegistry config = new ConfigRegistry();
+
+            @SuppressWarnings("unchecked")
+            final ConfigCache<Integer, Integer>[] holder = new ConfigCache[1];
+            // fib(n) recurses into fib(n-1) and fib(n-2) through the same cache. Many distinct keys are
+            // populated reentrantly, so at least one pair collides into a shared bin on any realistic table.
+            holder[0] = ConfigCaches.declare(n ->
+                n < 2 ? n : holder[0].get(n - 1, config) + holder[0].get(n - 2, config));
+
+            assertThat(holder[0].get(30, config)).isEqualTo(832040);
+        });
+    }
+
+    @Test
+    void concurrentReentrantComputationDoesNotDeadlock() {
+        // Many threads warming overlapping reentrant entries from distinct starting keys, so they acquire
+        // bin monitors in opposite orders — the ABBA hazard from #2980.
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            final ConfigRegistry config = new ConfigRegistry();
+
+            @SuppressWarnings("unchecked")
+            final ConfigCache<Integer, Integer>[] holder = new ConfigCache[1];
+            final CountDownLatch start = new CountDownLatch(1);
+            holder[0] = ConfigCaches.declare(n ->
+                n < 2 ? n : holder[0].get(n - 1, config) + holder[0].get(n - 2, config));
+
+            final int threads = 8;
+            final ExecutorService pool = Executors.newFixedThreadPool(threads);
+            try {
+                final List<Future<Integer>> results = IntStream.range(0, threads)
+                    .mapToObj(i -> pool.submit(() -> {
+                        await(start);
+                        return holder[0].get(25 + i, config);
+                    }))
+                    .collect(toList());
+
+                start.countDown();
+                for (Future<Integer> result : results) {
+                    assertThat(result.get()).isPositive();
+                }
+            } finally {
+                pool.shutdownNow();
+            }
+        });
+    }
+
+    @Test
+    void concurrentGetsComputeOnce() {
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            final int threads = 16;
+            final AtomicInteger computations = new AtomicInteger();
+            final CountDownLatch start = new CountDownLatch(1);
+            final ConfigCache<String, String> cache =
+                ConfigCaches.declare(key -> {
+                    computations.incrementAndGet();
+                    return key.toUpperCase();
+                });
+            final ConfigRegistry config = new ConfigRegistry();
+
+            final ExecutorService pool = Executors.newFixedThreadPool(threads);
+            try {
+                final List<Future<String>> results = IntStream.range(0, threads)
+                    .mapToObj(i -> pool.submit(() -> {
+                        await(start);
+                        return cache.get("key", config);
+                    }))
+                    .collect(toList());
+
+                start.countDown();
+                for (Future<String> result : results) {
+                    assertThat(result.get()).isEqualTo("KEY");
+                }
+            } finally {
+                pool.shutdownNow();
+            }
+
+            assertThat(computations).hasValue(1);
+        });
+    }
+
+    @Test
+    void selfRecursiveComputationFailsFast() {
+        // A computer that re-enters the same cache for the key it is computing describes a value that
+        // depends on itself. We reject it rather than self-deadlock on the join, mirroring
+        // ConcurrentHashMap.computeIfAbsent's behavior for recursive same-key updates.
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            final ConfigRegistry config = new ConfigRegistry();
+            @SuppressWarnings("rawtypes")
+            final ConfigCache[] holder = new ConfigCache[1];
+            final ConfigCache<String, String> cache =
+                ConfigCaches.declare(key -> (String) holder[0].get(key, config));
+            holder[0] = cache;
+
+            assertThatThrownBy(() -> cache.get("a", config))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Recursive");
+        });
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("interrupted", e);
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/config/internal/TestConfigCaches.java
+++ b/core/src/test/java/org/jdbi/v3/core/config/internal/TestConfigCaches.java
@@ -15,6 +15,7 @@ package org.jdbi.v3.core.config.internal;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -183,6 +184,56 @@ class TestConfigCaches {
     }
 
     @Test
+    void concurrentLoserSeesOriginalException() {
+        // A thread that lost the race and joined the in-flight entry must see the computer's original
+        // exception type, not a CompletionException wrapping it. (E.g. EnumMapper's computer throws
+        // UnableToProduceResultException for an unmatched name; a concurrent caller must still see that.)
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            final ConfigRegistry config = new ConfigRegistry();
+            final CountDownLatch computing = new CountDownLatch(1);
+            final CountDownLatch loserArrived = new CountDownLatch(1);
+
+            final ConfigCache<String, String> cache =
+                ConfigCaches.declare(key -> {
+                    // Announce that this thread owns the in-flight entry, then wait until the loser is stalled
+                    // on the entry before failing. This makes the loser deterministically observe a failure
+                    // produced by another thread rather than computing the value itself.
+                    computing.countDown();
+                    await(loserArrived);
+                    throw new CustomException("boom");
+                });
+
+            final ExecutorService pool = Executors.newFixedThreadPool(2);
+            try {
+                final Future<String> winner = pool.submit(() -> cache.get("a", config));
+                await(computing);
+
+                // Capture the loser's thread so we can observe when it stalls inside get() waiting on the
+                // winner, instead of guessing with a fixed sleep.
+                final CompletableFuture<Thread> loserThread = new CompletableFuture<>();
+                final Future<String> loser = pool.submit(() -> {
+                    loserThread.complete(Thread.currentThread());
+                    return cache.get("a", config);
+                });
+
+                // Wait until the loser is stalled inside get() waiting on the winner, then release the winner
+                // to fail. This guarantees the loser is committed to this computation rather than racing to a
+                // fresh one, so its observed exception reflects the shared failure.
+                final Thread t = loserThread.join();
+                awaitThreadStalled(t);
+                loserArrived.countDown();
+
+                assertThatThrownBy(winner::get)
+                    .hasCauseInstanceOf(CustomException.class);
+                assertThatThrownBy(loser::get)
+                    .hasCauseInstanceOf(CustomException.class);
+            } finally {
+                pool.shutdownNow();
+            }
+        });
+    }
+
+    @Test
     void selfRecursiveComputationFailsFast() {
         // A computer that re-enters the same cache for the key it is computing describes a value that
         // depends on itself. We reject it rather than self-deadlock on the join, mirroring
@@ -199,6 +250,31 @@ class TestConfigCaches {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Recursive");
         });
+    }
+
+    private static final class CustomException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        CustomException(String message) {
+            super(message);
+        }
+    }
+
+    // Spin until the thread is stalled inside get() waiting on the winner — parked on the future (WAITING)
+    // or blocked on a bin monitor (BLOCKED). Either way it is committed to the lookup and cannot recompute
+    // before the winner is released, which makes the race outcome deterministic; accepting both states keeps
+    // the handshake independent of get()'s locking strategy. The enclosing timeout bounds the spin.
+    private static void awaitThreadStalled(Thread thread) {
+        while (true) {
+            final Thread.State state = thread.getState();
+            if (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING || state == Thread.State.BLOCKED) {
+                return;
+            }
+            if (state == Thread.State.TERMINATED) {
+                throw new IllegalStateException("thread terminated before stalling on the cache entry");
+            }
+            Thread.onSpinWait();
+        }
     }
 
     private static void await(CountDownLatch latch) {


### PR DESCRIPTION
Claude says:

ConcurrentHashMap.computeIfAbsent holds the bin monitor for the duration of the
mapping function. Our cache computers routinely recurse into other caches (and
other bins of the same map) to resolve qualifiers and column mappers, so two
threads warming such mappers concurrently could take bin monitors in opposite
order and deadlock (ABBA).

Install an incomplete CompletableFuture-backed entry via an atomic putIfAbsent,
then run the computer with no lock held; late arrivals join the winner's result.
The computer runs exactly once per key. Failures are not memoized: the entry is
dropped so a later call retries, and the cause is handed to any joining threads.
A computer that re-enters the cache for the key it is itself computing describes
an unsatisfiable self-dependency, so we reject it rather than self-deadlock on
the join, mirroring computeIfAbsent's recursive-update behavior.

Null results are rejected rather than cached. The old computeIfAbsent silently
never stored null and recomputed every call; no production computer returns null,
so caching one is not a needed feature. Rejecting it at the computer fails loudly
there instead of NPE-ing downstream.

Fixes https://github.com/jdbi/jdbi/issues/2980