### PR TITLE
Share ExtensionMetadata cache across forked configs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- share the extension metadata cache across handles so `handle.attach()`-only workloads no longer
+  recompute `ExtensionMetadata` on every handle (#2991)
+
 # 3.54.0
 
 - fix deadlock in configuration caching (#2980)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,8 @@
   must also override `parse`, most simply to return `Optional.empty()`, which keeps the core on
   its `render` path.
   `Batch` and `Script` now render through the statement cache as well. (#2997)
+- Share the extension metadata cache across handles so `handle.attach()`-only workloads no longer
+  recompute `ExtensionMetadata` on every handle (#2991)
 
 # 3.54.0
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionFactory.java
@@ -90,6 +90,10 @@ public interface ExtensionFactory {
      * addition to the factories that have been registered with {@link Extensions#registerHandlerFactory}.
      * <br>
      * Handler factories returned here can customize the behavior of the Extension factory itself.
+     * <br>
+     * The result is baked into the cached {@link ExtensionMetadata}. If it depends on mutable {@code config}
+     * state, that state's mutators must call {@link Extensions#invalidateMetadataCache()} to avoid serving
+     * stale metadata after a change.
      *
      * @param config A Configuration registry object that can be used to look up additional information
      * @return A collection of {@link ExtensionHandlerFactory} objects. Can be empty, must not be null
@@ -106,6 +110,10 @@ public interface ExtensionFactory {
      * in addition to the customizers that have been registered with {@link Extensions#registerHandlerCustomizer}.
      * <br>
      * Handler customizers returned here can customize the behavior of the Handlers returned by the handler factories.
+     * <br>
+     * The result is baked into the cached {@link ExtensionMetadata}. If it depends on mutable {@code config}
+     * state, that state's mutators must call {@link Extensions#invalidateMetadataCache()} to avoid serving
+     * stale metadata after a change.
      *
      * @param config A Configuration registry object that can be used to look up additional information
      * @return A collection of {@link ExtensionHandlerCustomizer} objects. Can be empty, must not be null
@@ -123,6 +131,11 @@ public interface ExtensionFactory {
      * Each factory is called once for every type that is attached by the factory and once for each method in the
      * type. They can return {@link ConfigCustomizer} instances that will affect the specific configuration for
      * each method and extension type.
+     * <br>
+     * Which factories are returned is baked into the cached {@link ExtensionMetadata} (though the per-instance
+     * configuration a {@link ConfigCustomizer} applies at attach time is not). If the set depends on mutable
+     * {@code config} state, that state's mutators must call {@link Extensions#invalidateMetadataCache()} to
+     * avoid serving stale metadata after a change.
      *
      * @param config A Configuration registry object that can be used to look up additional information
      * @return A collection of {@link ConfigCustomizerFactory} objects. Can be empty, must not be null

--- a/core/src/main/java/org/jdbi/v3/core/extension/Extensions.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/Extensions.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -36,13 +37,27 @@ import static org.jdbi.v3.core.extension.ExtensionFactory.FactoryFlag.NON_VIRTUA
 public class Extensions implements JdbiConfig<Extensions> {
 
     private final List<ExtensionFactoryDelegate> extensionFactories;
-    private final Map<Class<?>, ExtensionMetadata> extensionMetadataCache;
+
+    // Shared with the config this instance was copied from, so metadata computed inside a forked config (e.g.
+    // a per-request Handle via handle.attach()) is reused by every other config forked from the same root.
+    // Deep-copying it, as every other field is, left an attach()-only workload recomputing metadata on every
+    // fresh Handle (jdbi/jdbi#2991). Metadata depends on the registrations here and on other config types read
+    // through the registry while building it (e.g. Handlers, HandlerDecorators in sqlobject); any change to
+    // such an input must invalidateMetadataCache() first so stale metadata is not served afterwards.
+    // Annotation-driven config (e.g. @RegisterRowMapper) is exempt: it is a config customizer replayed per
+    // instance at attach time, not baked into cached metadata.
+    private volatile Map<Class<?>, ExtensionMetadata> extensionMetadataCache;
+
     private final List<ExtensionHandlerCustomizer> extensionHandlerCustomizers;
     private final List<ExtensionHandlerFactory> extensionHandlerFactories;
     private final List<ConfigCustomizerFactory> configCustomizerFactories;
 
-    private boolean allowProxy;
-    private boolean failFast;
+    // Read while computing metadata (see ExtensionMetadata.isFailFast) on handle threads other than the one
+    // that configured this instance, now that findMetadata runs against the shared cache. AtomicBoolean gives
+    // the needed safe publication (a plain field trips SpotBugs AT_STALE_THREAD_WRITE_OF_PRIMITIVE). They are
+    // final so the reference publishes safely via the copy constructor.
+    private final AtomicBoolean allowProxy = new AtomicBoolean();
+    private final AtomicBoolean failFast = new AtomicBoolean();
 
     private ConfigRegistry registry;
 
@@ -61,8 +76,8 @@ public class Extensions implements JdbiConfig<Extensions> {
         extensionHandlerFactories = new CopyOnWriteArrayList<>();
         configCustomizerFactories = new CopyOnWriteArrayList<>();
 
-        allowProxy = true;
-        failFast = false;
+        allowProxy.set(true);
+        failFast.set(false);
 
         // default handler factories for bridge and default methods
         internalRegisterHandlerFactory(DefaultMethodExtensionHandlerFactory.INSTANCE);
@@ -84,13 +99,14 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     private Extensions(Extensions that) {
         extensionFactories = new CopyOnWriteArrayList<>(that.extensionFactories);
-        extensionMetadataCache = new CopyOnWriteHashMap<>(that.extensionMetadataCache);
+        // Share the parent's cache reference rather than copying it. See the field comment.
+        extensionMetadataCache = that.extensionMetadataCache;
         extensionHandlerCustomizers = new CopyOnWriteArrayList<>(that.extensionHandlerCustomizers);
         extensionHandlerFactories = new CopyOnWriteArrayList<>(that.extensionHandlerFactories);
         configCustomizerFactories = new CopyOnWriteArrayList<>(that.configCustomizerFactories);
 
-        allowProxy = that.allowProxy;
-        failFast = that.failFast;
+        allowProxy.set(that.allowProxy.get());
+        failFast.set(that.failFast.get());
     }
 
     @Override
@@ -105,6 +121,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      * @return This instance
      */
     public Extensions register(ExtensionFactory factory) {
+        invalidateMetadataCache();
         extensionFactories.add(0, new ExtensionFactoryDelegate(factory));
         return this;
     }
@@ -119,6 +136,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public Extensions registerHandlerFactory(ExtensionHandlerFactory extensionHandlerFactory) {
+        invalidateMetadataCache();
         return internalRegisterHandlerFactory(FilteringExtensionHandlerFactory.forDelegate(extensionHandlerFactory));
     }
 
@@ -132,6 +150,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public Extensions registerHandlerCustomizer(ExtensionHandlerCustomizer extensionHandlerCustomizer) {
+        invalidateMetadataCache();
         extensionHandlerCustomizers.add(0, extensionHandlerCustomizer);
         return this;
     }
@@ -146,8 +165,32 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public Extensions registerConfigCustomizerFactory(ConfigCustomizerFactory configCustomizerFactory) {
+        invalidateMetadataCache();
         configCustomizerFactories.add(0, configCustomizerFactory);
         return this;
+    }
+
+    /**
+     * Invalidates this configuration's extension metadata cache. Call this before mutating any state that
+     * {@linkplain #findMetadata computed metadata} depends on, so that metadata computed under the previous
+     * configuration is not served afterwards.
+     * <p>
+     * The cache is shared across copies of this configuration (see {@link #findMetadata}). Copies made before
+     * this call keep their existing cache — a valid snapshot as of their creation — so a handle still sees
+     * configuration as of the moment it was opened; this configuration and later copies recompute.
+     * <p>
+     * The {@code register*} methods here call this for their own registrations. A configuration type in
+     * another module whose contents feed metadata computation must call it from its own mutators, via
+     * {@code registry.get(Extensions.class).invalidateMetadataCache()} (the sqlobject {@code Handlers} and
+     * {@code HandlerDecorators} do so).
+     *
+     * @since 3.55.0
+     */
+    @Alpha
+    public void invalidateMetadataCache() {
+        // Replace, don't clear: copies share this map reference and must keep their snapshot, so it must not
+        // be mutated in place.
+        extensionMetadataCache = new CopyOnWriteHashMap<>();
     }
 
     /**
@@ -215,6 +258,8 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public ExtensionMetadata findMetadata(Class<?> extensionType, ExtensionFactory extensionFactory) {
+        // Racing first-computations may build metadata more than once (computeIfAbsent runs the mapping
+        // function under a retry loop), which is harmless because metadata is a pure function of the config.
         return extensionMetadataCache.computeIfAbsent(extensionType, createMetadata(extensionFactory));
     }
 
@@ -260,7 +305,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Beta
     public Extensions setAllowProxy(boolean allowProxy) {
-        this.allowProxy = allowProxy;
+        this.allowProxy.set(allowProxy);
         return this;
     }
 
@@ -271,7 +316,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Beta
     public boolean isAllowProxy() {
-        return allowProxy;
+        return allowProxy.get();
     }
 
     /**
@@ -283,7 +328,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public Extensions failFast() {
-        this.failFast = true;
+        this.failFast.set(true);
 
         return this;
     }
@@ -296,7 +341,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public boolean isFailFast() {
-        return failFast;
+        return failFast.get();
     }
 
 

--- a/core/src/main/java/org/jdbi/v3/core/extension/Extensions.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/Extensions.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -36,13 +37,27 @@ import static org.jdbi.v3.core.extension.ExtensionFactory.FactoryFlag.NON_VIRTUA
 public class Extensions implements JdbiConfig<Extensions> {
 
     private final List<ExtensionFactoryDelegate> extensionFactories;
-    private final Map<Class<?>, ExtensionMetadata> extensionMetadataCache;
+
+    // Shared with the config this instance was copied from, so metadata computed inside a forked config (e.g.
+    // a per-request Handle via handle.attach()) is reused by every other config forked from the same root.
+    // Deep-copying it, as every other field is, left an attach()-only workload recomputing metadata on every
+    // fresh Handle (jdbi/jdbi#2991). Metadata depends on the registrations here and on other config types read
+    // through the registry while building it (e.g. Handlers, HandlerDecorators in sqlobject); any change to
+    // such an input must invalidateMetadataCache() first so stale metadata is not served afterwards.
+    // Annotation-driven config (e.g. @RegisterRowMapper) is exempt: it is a config customizer replayed per
+    // instance at attach time, not baked into cached metadata.
+    private volatile Map<Class<?>, ExtensionMetadata> extensionMetadataCache;
+
     private final List<ExtensionHandlerCustomizer> extensionHandlerCustomizers;
     private final List<ExtensionHandlerFactory> extensionHandlerFactories;
     private final List<ConfigCustomizerFactory> configCustomizerFactories;
 
-    private boolean allowProxy;
-    private boolean failFast;
+    // Only the metadata cache is shared across copies; these flags are still read from the copy that owns them,
+    // as before. AtomicBoolean is here because the volatile cache field makes SpotBugs treat the class as
+    // concurrent and flag plain primitive fields (AT_STALE_THREAD_WRITE_OF_PRIMITIVE), while volatile booleans
+    // trip SonarCloud S3078.
+    private final AtomicBoolean allowProxy = new AtomicBoolean();
+    private final AtomicBoolean failFast = new AtomicBoolean();
 
     private ConfigRegistry registry;
 
@@ -61,8 +76,8 @@ public class Extensions implements JdbiConfig<Extensions> {
         extensionHandlerFactories = new CopyOnWriteArrayList<>();
         configCustomizerFactories = new CopyOnWriteArrayList<>();
 
-        allowProxy = true;
-        failFast = false;
+        allowProxy.set(true);
+        failFast.set(false);
 
         // default handler factories for bridge and default methods
         internalRegisterHandlerFactory(DefaultMethodExtensionHandlerFactory.INSTANCE);
@@ -84,13 +99,14 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     private Extensions(Extensions that) {
         extensionFactories = new CopyOnWriteArrayList<>(that.extensionFactories);
-        extensionMetadataCache = new CopyOnWriteHashMap<>(that.extensionMetadataCache);
+        // Share the parent's cache reference rather than copying it. See the field comment.
+        extensionMetadataCache = that.extensionMetadataCache;
         extensionHandlerCustomizers = new CopyOnWriteArrayList<>(that.extensionHandlerCustomizers);
         extensionHandlerFactories = new CopyOnWriteArrayList<>(that.extensionHandlerFactories);
         configCustomizerFactories = new CopyOnWriteArrayList<>(that.configCustomizerFactories);
 
-        allowProxy = that.allowProxy;
-        failFast = that.failFast;
+        allowProxy.set(that.allowProxy.get());
+        failFast.set(that.failFast.get());
     }
 
     @Override
@@ -105,6 +121,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      * @return This instance
      */
     public Extensions register(ExtensionFactory factory) {
+        invalidateMetadataCache();
         extensionFactories.add(0, new ExtensionFactoryDelegate(factory));
         return this;
     }
@@ -119,6 +136,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public Extensions registerHandlerFactory(ExtensionHandlerFactory extensionHandlerFactory) {
+        invalidateMetadataCache();
         return internalRegisterHandlerFactory(FilteringExtensionHandlerFactory.forDelegate(extensionHandlerFactory));
     }
 
@@ -132,6 +150,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public Extensions registerHandlerCustomizer(ExtensionHandlerCustomizer extensionHandlerCustomizer) {
+        invalidateMetadataCache();
         extensionHandlerCustomizers.add(0, extensionHandlerCustomizer);
         return this;
     }
@@ -146,8 +165,32 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public Extensions registerConfigCustomizerFactory(ConfigCustomizerFactory configCustomizerFactory) {
+        invalidateMetadataCache();
         configCustomizerFactories.add(0, configCustomizerFactory);
         return this;
+    }
+
+    /**
+     * Invalidates this configuration's extension metadata cache. Call this before mutating any state that
+     * {@linkplain #findMetadata computed metadata} depends on, so that metadata computed under the previous
+     * configuration is not served afterwards.
+     * <p>
+     * The cache is shared across copies of this configuration (see {@link #findMetadata}). Copies made before
+     * this call keep their existing cache — a valid snapshot as of their creation — so a handle still sees
+     * configuration as of the moment it was opened; this configuration and later copies recompute.
+     * <p>
+     * The {@code register*} methods here call this for their own registrations. A configuration type in
+     * another module whose contents feed metadata computation must call it from its own mutators, via
+     * {@code registry.get(Extensions.class).invalidateMetadataCache()} (the sqlobject {@code Handlers} and
+     * {@code HandlerDecorators} do so).
+     *
+     * @since 3.55.0
+     */
+    @Alpha
+    public void invalidateMetadataCache() {
+        // Replace, don't clear: copies share this map reference and must keep their snapshot, so it must not
+        // be mutated in place.
+        extensionMetadataCache = new CopyOnWriteHashMap<>();
     }
 
     /**
@@ -215,6 +258,8 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public ExtensionMetadata findMetadata(Class<?> extensionType, ExtensionFactory extensionFactory) {
+        // Racing first-computations may build metadata more than once (computeIfAbsent runs the mapping
+        // function under a retry loop), which is harmless because metadata is a pure function of the config.
         return extensionMetadataCache.computeIfAbsent(extensionType, createMetadata(extensionFactory));
     }
 
@@ -260,7 +305,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Beta
     public Extensions setAllowProxy(boolean allowProxy) {
-        this.allowProxy = allowProxy;
+        this.allowProxy.set(allowProxy);
         return this;
     }
 
@@ -271,7 +316,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Beta
     public boolean isAllowProxy() {
-        return allowProxy;
+        return allowProxy.get();
     }
 
     /**
@@ -283,7 +328,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public Extensions failFast() {
-        this.failFast = true;
+        this.failFast.set(true);
 
         return this;
     }
@@ -296,7 +341,7 @@ public class Extensions implements JdbiConfig<Extensions> {
      */
     @Alpha
     public boolean isFailFast() {
-        return failFast;
+        return failFast.get();
     }
 
 

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionMetadataCaching.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionMetadataCaching.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for jdbi/jdbi#2991.
+ *
+ * <p>Each {@link Handle} receives a copy of the root {@link org.jdbi.v3.core.config.ConfigRegistry}.
+ * The {@link Extensions} metadata cache is shared across those copies, so metadata computed inside a
+ * handle obtained via {@code handle.attach()} is visible to every other handle forked from the same root.
+ * Before the fix, the cache was deep-copied per handle, so an {@code attach()}-only workload recomputed
+ * {@link ExtensionMetadata} on every fresh handle.
+ *
+ * <p>{@link ExtensionFactory#buildExtensionMetadata} is invoked exactly once per metadata computation
+ * (see {@code Extensions.createMetadata}), so counting its invocations counts cache misses without
+ * touching production code.
+ */
+public class TestExtensionMetadataCaching {
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+
+    public interface CountingExtension {
+        default String ping() {
+            return "pong";
+        }
+    }
+
+    static class CountingExtensionFactory implements ExtensionFactory {
+
+        final AtomicInteger metadataComputations = new AtomicInteger();
+
+        @Override
+        public boolean accepts(Class<?> extensionType) {
+            return CountingExtension.class.equals(extensionType);
+        }
+
+        @Override
+        public Set<FactoryFlag> getFactoryFlags() {
+            return EnumSet.noneOf(FactoryFlag.class);
+        }
+
+        @Override
+        public void buildExtensionMetadata(ExtensionMetadata.Builder builder) {
+            metadataComputations.incrementAndGet();
+        }
+    }
+
+    @Test
+    public void attachOnlyComputesMetadataOnce() {
+        CountingExtensionFactory factory = new CountingExtensionFactory();
+        Jdbi jdbi = h2Extension.getJdbi().registerExtension(factory);
+
+        for (int i = 0; i < 5; i++) {
+            try (Handle handle = jdbi.open()) {
+                handle.attach(CountingExtension.class);
+            }
+        }
+
+        // The metadata cache is shared across handles forked from the same root, so the first attach
+        // computes metadata and every later handle hits the shared cache (#2991).
+        assertThat(factory.metadataComputations)
+                .as("attach()-only workloads compute ExtensionMetadata once across all handles (#2991)")
+                .hasValue(1);
+    }
+
+    @Test
+    public void repeatedAttachOnSameHandleUsesHandleLocalCache() {
+        CountingExtensionFactory factory = new CountingExtensionFactory();
+        Jdbi jdbi = h2Extension.getJdbi().registerExtension(factory);
+
+        try (Handle handle = jdbi.open()) {
+            handle.attach(CountingExtension.class);
+            handle.attach(CountingExtension.class);
+            handle.attach(CountingExtension.class);
+        }
+
+        // Within a single handle the forked cache does its job.
+        assertThat(factory.metadataComputations)
+                .as("repeated attach on one handle hits the handle-local cache")
+                .hasValue(1);
+    }
+
+    @Test
+    public void primingRootCacheAvoidsPerHandleRecomputation() {
+        CountingExtensionFactory factory = new CountingExtensionFactory();
+        Jdbi jdbi = h2Extension.getJdbi().registerExtension(factory);
+
+        // The documented workaround: prime the root config's cache before opening per-request handles.
+        jdbi.withExtension(CountingExtension.class, CountingExtension::ping);
+        int primed = factory.metadataComputations.get();
+        assertThat(primed).isEqualTo(1);
+
+        for (int i = 0; i < 5; i++) {
+            try (Handle handle = jdbi.open()) {
+                handle.attach(CountingExtension.class);
+            }
+        }
+
+        // Forked handles inherit the pre-populated cache, so no further computation occurs.
+        assertThat(factory.metadataComputations)
+                .as("handles forked after priming inherit the warm root cache")
+                .hasValue(1);
+    }
+
+    @Test
+    public void reconfiguringACopyDoesNotShareMetadataWithSiblings() {
+        CountingExtensionFactory rootFactory = new CountingExtensionFactory();
+        Jdbi jdbi = h2Extension.getJdbi().registerExtension(rootFactory);
+
+        // A copy that registers an extension of its own must not read metadata from, or write metadata to,
+        // the shared cache: its metadata is computed from a different set of factories. Registering
+        // invalidates the copy's cache, so it computes against its own configuration and the root cache is
+        // untouched.
+        CountingExtensionFactory copyFactory = new CountingExtensionFactory();
+        try (Handle reconfigured = jdbi.open()) {
+            reconfigured.registerExtension(copyFactory);
+            reconfigured.attach(CountingExtension.class);
+        }
+        // The copy's own factory (registered at the front) handled the attach and computed metadata once.
+        assertThat(copyFactory.metadataComputations)
+                .as("a reconfigured copy computes metadata against its own configuration")
+                .hasValue(1);
+        // The root factory was never consulted, so the shared cache holds no entry for the copy's metadata.
+        assertThat(rootFactory.metadataComputations)
+                .as("reconfiguring a copy does not pollute the shared root cache")
+                .hasValue(0);
+
+        // Plain handles forked from the untouched root share the root cache: the first computes, the rest hit.
+        for (int i = 0; i < 3; i++) {
+            try (Handle plain = jdbi.open()) {
+                plain.attach(CountingExtension.class);
+            }
+        }
+        assertThat(rootFactory.metadataComputations)
+                .as("the root cache is uncorrupted and shared across plain handles after a sibling reconfigured")
+                .hasValue(1);
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionMetadataCaching.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionMetadataCaching.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for jdbi/jdbi#2991.
+ *
+ * <p>Each {@link Handle} receives a copy of the root {@link org.jdbi.v3.core.config.ConfigRegistry}.
+ * The {@link Extensions} metadata cache is shared across those copies, so metadata computed inside a
+ * handle obtained via {@code handle.attach()} is visible to every other handle forked from the same root.
+ * Before the fix, the cache was deep-copied per handle, so an {@code attach()}-only workload recomputed
+ * {@link ExtensionMetadata} on every fresh handle.
+ *
+ * <p>{@link ExtensionFactory#buildExtensionMetadata} is invoked exactly once per metadata computation
+ * (see {@code Extensions.createMetadata}), so counting its invocations counts cache misses without
+ * touching production code.
+ */
+public class TestExtensionMetadataCaching {
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+
+    public interface CountingExtension {
+        default String ping() {
+            return "pong";
+        }
+    }
+
+    static class CountingExtensionFactory implements ExtensionFactory {
+
+        final AtomicInteger metadataComputations = new AtomicInteger();
+
+        @Override
+        public boolean accepts(Class<?> extensionType) {
+            return CountingExtension.class.equals(extensionType);
+        }
+
+        @Override
+        public Set<FactoryFlag> getFactoryFlags() {
+            return EnumSet.noneOf(FactoryFlag.class);
+        }
+
+        @Override
+        public void buildExtensionMetadata(ExtensionMetadata.Builder builder) {
+            metadataComputations.incrementAndGet();
+        }
+    }
+
+    @Test
+    public void attachOnlyComputesMetadataOnce() {
+        CountingExtensionFactory factory = new CountingExtensionFactory();
+        Jdbi jdbi = h2Extension.getJdbi().registerExtension(factory);
+
+        for (int i = 0; i < 5; i++) {
+            try (Handle handle = jdbi.open()) {
+                handle.attach(CountingExtension.class);
+            }
+        }
+
+        // The metadata cache is shared across handles forked from the same root, so the first attach
+        // computes metadata and every later handle hits the shared cache (#2991).
+        assertThat(factory.metadataComputations)
+                .as("attach()-only workloads compute ExtensionMetadata once across all handles (#2991)")
+                .hasValue(1);
+    }
+
+    @Test
+    public void repeatedAttachOnSameHandleComputesOnce() {
+        CountingExtensionFactory factory = new CountingExtensionFactory();
+        Jdbi jdbi = h2Extension.getJdbi().registerExtension(factory);
+
+        try (Handle handle = jdbi.open()) {
+            handle.attach(CountingExtension.class);
+            handle.attach(CountingExtension.class);
+            handle.attach(CountingExtension.class);
+        }
+
+        assertThat(factory.metadataComputations)
+                .as("repeated attach on one handle hits the cache")
+                .hasValue(1);
+    }
+
+    @Test
+    public void openHandleKeepsSnapshotWhenRootIsReconfigured() {
+        CountingExtensionFactory rootFactory = new CountingExtensionFactory();
+        Jdbi jdbi = h2Extension.getJdbi().registerExtension(rootFactory);
+
+        try (Handle opened = jdbi.open()) {
+            opened.attach(CountingExtension.class);
+            assertThat(rootFactory.metadataComputations).hasValue(1);
+
+            // Registering on the root detaches the root's cache. The handle opened earlier keeps its snapshot
+            // and never consults the new factory, so a repeated attach on it hits the cache and does not
+            // recompute.
+            CountingExtensionFactory lateFactory = new CountingExtensionFactory();
+            jdbi.registerExtension(lateFactory);
+
+            opened.attach(CountingExtension.class);
+            assertThat(rootFactory.metadataComputations)
+                    .as("a handle opened before a root reconfiguration keeps its metadata snapshot")
+                    .hasValue(1);
+            assertThat(lateFactory.metadataComputations)
+                    .as("a handle opened before a root reconfiguration does not see the new factory")
+                    .hasValue(0);
+
+            // A handle opened after the reconfiguration computes against the new configuration, where the
+            // late factory (registered at the front) handles the type.
+            try (Handle later = jdbi.open()) {
+                later.attach(CountingExtension.class);
+            }
+            assertThat(lateFactory.metadataComputations)
+                    .as("a handle opened after a root reconfiguration computes against the new configuration")
+                    .hasValue(1);
+            assertThat(rootFactory.metadataComputations).hasValue(1);
+        }
+    }
+
+    @Test
+    public void primingRootCacheAvoidsPerHandleRecomputation() {
+        CountingExtensionFactory factory = new CountingExtensionFactory();
+        Jdbi jdbi = h2Extension.getJdbi().registerExtension(factory);
+
+        // The documented workaround: prime the root config's cache before opening per-request handles.
+        jdbi.withExtension(CountingExtension.class, CountingExtension::ping);
+        int primed = factory.metadataComputations.get();
+        assertThat(primed).isEqualTo(1);
+
+        for (int i = 0; i < 5; i++) {
+            try (Handle handle = jdbi.open()) {
+                handle.attach(CountingExtension.class);
+            }
+        }
+
+        // Forked handles inherit the pre-populated cache, so no further computation occurs.
+        assertThat(factory.metadataComputations)
+                .as("handles forked after priming inherit the warm root cache")
+                .hasValue(1);
+    }
+
+    @Test
+    public void reconfiguringACopyDoesNotShareMetadataWithSiblings() {
+        CountingExtensionFactory rootFactory = new CountingExtensionFactory();
+        Jdbi jdbi = h2Extension.getJdbi().registerExtension(rootFactory);
+
+        // A copy that registers an extension of its own must not read metadata from, or write metadata to,
+        // the shared cache: its metadata is computed from a different set of factories. Registering
+        // invalidates the copy's cache, so it computes against its own configuration and the root cache is
+        // untouched.
+        CountingExtensionFactory copyFactory = new CountingExtensionFactory();
+        try (Handle reconfigured = jdbi.open()) {
+            reconfigured.registerExtension(copyFactory);
+            reconfigured.attach(CountingExtension.class);
+        }
+        // The copy's own factory (registered at the front) handled the attach and computed metadata once.
+        assertThat(copyFactory.metadataComputations)
+                .as("a reconfigured copy computes metadata against its own configuration")
+                .hasValue(1);
+        // The root factory was never consulted, so the shared cache holds no entry for the copy's metadata.
+        assertThat(rootFactory.metadataComputations)
+                .as("reconfiguring a copy does not pollute the shared root cache")
+                .hasValue(0);
+
+        // Plain handles forked from the untouched root share the root cache: the first computes, the rest hit.
+        for (int i = 0; i < 3; i++) {
+            try (Handle plain = jdbi.open()) {
+                plain.attach(CountingExtension.class);
+            }
+        }
+        assertThat(rootFactory.metadataComputations)
+                .as("the root cache is uncorrupted and shared across plain handles after a sibling reconfigured")
+                .hasValue(1);
+    }
+}

--- a/core/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-core/reachability-metadata.json
+++ b/core/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-core/reachability-metadata.json
@@ -17,6 +17,7 @@
     {"type":{"proxy":["org.jdbi.v3.core.extension.TestExtensionCustomizers$Dao"]}},
     {"type":{"proxy":["org.jdbi.v3.core.extension.TestExtensionCustomizers$OrderedOnType"]}},
     {"type":{"proxy":["org.jdbi.v3.core.extension.TestExtensionCustomizers$TypeDecorator"]}},
+    {"type":{"proxy":["org.jdbi.v3.core.extension.TestExtensionMetadataCaching$CountingExtension"]}},
     {"type":{"proxy":["org.jdbi.v3.core.extension.TestUseCustomExtensionHandlerFactory$SomethingDao"]}},
     {"type":{"proxy":["org.jdbi.v3.core.mapper.RowMapper"]}},
     {"type":{"proxy":["org.jdbi.v3.meta.Beta"]}},

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -9025,6 +9025,12 @@ link:{jdbidocs}/core/extension/ExtensionFactory.html#getConfigCustomizerFactorie
 getters that a factory can implement.
 By default, each returns an empty collection.
 
+[NOTE]
+What these getters return is baked into the per-type link:{jdbidocs}/core/extension/ExtensionMetadata.html[ExtensionMetadata^], which Jdbi caches and shares across handles.
+If a getter's result depends on mutable configuration read from the `ConfigRegistry` (for example the contents of another config object), that configuration's mutators must call
+link:{jdbidocs}/core/extension/Extensions.html#invalidateMetadataCache()[Extensions#invalidateMetadataCache()^] so that a later change is not masked by stale cached metadata.
+Configuration applied per instance at attach time (such as through a `ConfigCustomizer`) is not cached and needs no invalidation.
+
 ===== Java Object methods
 
 When the extension framework returns an implementation of an extension type, it usually returns a link:{jdkdocs}/java.base/java/lang/reflect/Proxy.html[Java proxy^]

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -9055,6 +9055,12 @@ link:{jdbidocs}/core/extension/ExtensionFactory.html#getConfigCustomizerFactorie
 getters that a factory can implement.
 By default, each returns an empty collection.
 
+[NOTE]
+What these getters return is baked into the per-type link:{jdbidocs}/core/extension/ExtensionMetadata.html[ExtensionMetadata^], which Jdbi caches and shares across handles.
+If a getter's result depends on mutable configuration read from the `ConfigRegistry` (for example the contents of another config object), that configuration's mutators must call
+link:{jdbidocs}/core/extension/Extensions.html#invalidateMetadataCache()[Extensions#invalidateMetadataCache()^] so that a later change is not masked by stale cached metadata.
+Configuration applied per instance at attach time (such as through a `ConfigCustomizer`) is not cached and needs no invalidation.
+
 ===== Java Object methods
 
 When the extension framework returns an implementation of an extension type, it usually returns a link:{jdkdocs}/java.base/java/lang/reflect/Proxy.html[Java proxy^]

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorators.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/HandlerDecorators.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.core.extension.ExtensionHandler;
+import org.jdbi.v3.core.extension.Extensions;
 
 /**
  * Registry for {@link HandlerDecorator handler decorators}. Decorators may modify or augment the behavior of a method
@@ -36,6 +37,8 @@ import org.jdbi.v3.core.extension.ExtensionHandler;
 public class HandlerDecorators implements JdbiConfig<HandlerDecorators> {
     private final List<HandlerDecorator> decorators;
 
+    private ConfigRegistry registry;
+
     public HandlerDecorators() {
         decorators = new CopyOnWriteArrayList<>();
         register(new SqlMethodAnnotatedHandlerDecorator());
@@ -45,6 +48,11 @@ public class HandlerDecorators implements JdbiConfig<HandlerDecorators> {
         decorators = new CopyOnWriteArrayList<>(that.decorators);
     }
 
+    @Override
+    public void setRegistry(ConfigRegistry registry) {
+        this.registry = registry;
+    }
+
     /**
      * Registers the given handler decorator with the registry.
      *
@@ -52,6 +60,12 @@ public class HandlerDecorators implements JdbiConfig<HandlerDecorators> {
      * @return this
      */
     public HandlerDecorators register(HandlerDecorator decorator) {
+        // The registered decorators feed ExtensionMetadata computation, so detach this config's shared
+        // metadata cache before mutating them (jdbi/jdbi#2991). No-op until the registry is wired up,
+        // which covers the construction-time registration below before any metadata could have been cached.
+        if (registry != null) {
+            registry.get(Extensions.class).invalidateMetadataCache();
+        }
         decorators.add(decorator);
         return this;
     }

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handlers.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/Handlers.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.config.JdbiConfig;
 import org.jdbi.v3.core.extension.ExtensionHandlerFactory;
+import org.jdbi.v3.core.extension.Extensions;
 
 /**
  * Registry for {@link HandlerFactory handler factories}, which produce {@link Handler handlers} for SQL object methods.
@@ -36,12 +37,19 @@ import org.jdbi.v3.core.extension.ExtensionHandlerFactory;
 public class Handlers implements JdbiConfig<Handlers> {
     private final List<HandlerFactory> factories;
 
+    private ConfigRegistry registry;
+
     public Handlers() {
         factories = new CopyOnWriteArrayList<>();
     }
 
     private Handlers(Handlers that) {
         factories = new CopyOnWriteArrayList<>(that.factories);
+    }
+
+    @Override
+    public void setRegistry(ConfigRegistry registry) {
+        this.registry = registry;
     }
 
     List<HandlerFactory> getFactories() {
@@ -54,6 +62,12 @@ public class Handlers implements JdbiConfig<Handlers> {
      * @return this
      */
     public Handlers register(HandlerFactory factory) {
+        // The registered factories feed ExtensionMetadata computation, so detach this config's shared
+        // metadata cache before mutating them (jdbi/jdbi#2991). No-op until the registry is wired up,
+        // which covers construction-time registration before any metadata could have been cached.
+        if (registry != null) {
+            registry.get(Extensions.class).invalidateMetadataCache();
+        }
         factories.add(0, factory);
         return this;
     }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestHandlerRegistrationAfterAttach.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestHandlerRegistrationAfterAttach.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.extension.ExtensionHandler;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for jdbi/jdbi#2991: the shared {@code ExtensionMetadata} cache must not serve metadata
+ * computed before a metadata-relevant configuration change. {@code Handlers} and {@code HandlerDecorators}
+ * feed metadata computation but live outside {@code Extensions}, so their {@code register} methods invalidate
+ * the shared cache (via {@code Extensions.invalidateMetadataCache()}) exactly as the {@code Extensions}
+ * registrations do. Without that invalidation, a handle that attaches a type after a sibling handle warmed the
+ * shared cache would receive stale metadata computed without the newly registered handler.
+ *
+ * <p>A {@link HandlerFactory}'s {@code buildHandler} is invoked while metadata is computed for a type, so a
+ * counting factory reveals whether a given attach recomputed metadata or reused a cached value.
+ */
+public class TestHandlerRegistrationAfterAttach {
+
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin());
+
+    public interface WarmDao extends SqlObject {
+        default String warm() {
+            return "warm";
+        }
+    }
+
+    // Counts how many times metadata is computed for WarmDao (buildHandler is consulted per method during
+    // metadata computation). Returns empty so it never actually supplies a handler, leaving stock resolution
+    // of the default method intact.
+    static final class CountingHandlerFactory implements HandlerFactory {
+        final AtomicInteger buildHandlerCalls = new AtomicInteger();
+
+        @Override
+        public Optional<Handler> buildHandler(Class<?> sqlObjectType, Method method) {
+            if (sqlObjectType == WarmDao.class) {
+                buildHandlerCalls.incrementAndGet();
+            }
+            return Optional.empty();
+        }
+    }
+
+    @Test
+    public void handlerRegisteredAfterSiblingAttachForcesRecompute() {
+        Jdbi jdbi = h2Extension.getJdbi();
+        CountingHandlerFactory counter = new CountingHandlerFactory();
+        jdbi.configure(Handlers.class, c -> c.register(counter));
+
+        // Warm the shared metadata cache for WarmDao from one handle.
+        try (Handle warm = jdbi.open()) {
+            warm.attach(WarmDao.class);
+        }
+        int afterWarm = counter.buildHandlerCalls.get();
+        assertThat(afterWarm).as("warming computes WarmDao metadata once").isPositive();
+
+        // A sibling handle attaching the same type reuses the shared cache: no recomputation.
+        try (Handle cached = jdbi.open()) {
+            cached.attach(WarmDao.class);
+        }
+        assertThat(counter.buildHandlerCalls)
+                .as("a sibling handle hits the shared cache without recomputing")
+                .hasValue(afterWarm);
+
+        // Register another handler factory imperatively AFTER the cache was warmed. This must invalidate the
+        // shared cache so that WarmDao's metadata is recomputed against the new configuration on the next attach.
+        jdbi.configure(Handlers.class, c -> c.register(new CountingHandlerFactory()));
+
+        try (Handle afterRegister = jdbi.open()) {
+            afterRegister.attach(WarmDao.class);
+        }
+        assertThat(counter.buildHandlerCalls.get())
+                .as("registering a handler factory after warming forces metadata recomputation (#2991)")
+                .isGreaterThan(afterWarm);
+    }
+
+    // Counts how many times the decorator is consulted while metadata is built for WarmDao, without changing
+    // the handler it decorates. customize() is the method invoked at metadata-build time (decorateHandler is
+    // only reached for handlers that are sqlobject Handler instances), so counting here is build-accurate.
+    static final class CountingHandlerDecorator implements HandlerDecorator {
+        final AtomicInteger decorateCalls = new AtomicInteger();
+
+        @Override
+        public ExtensionHandler customize(ExtensionHandler defaultHandler, Class<?> extensionType, Method method) {
+            if (extensionType == WarmDao.class) {
+                decorateCalls.incrementAndGet();
+            }
+            return defaultHandler;
+        }
+
+        @Override
+        public Handler decorateHandler(Handler base, Class<?> sqlObjectType, Method method) {
+            return base;
+        }
+    }
+
+    @Test
+    public void decoratorRegisteredAfterSiblingAttachForcesRecompute() {
+        Jdbi jdbi = h2Extension.getJdbi();
+        CountingHandlerDecorator counter = new CountingHandlerDecorator();
+        jdbi.configure(HandlerDecorators.class, c -> c.register(counter));
+
+        try (Handle warm = jdbi.open()) {
+            warm.attach(WarmDao.class);
+        }
+        int afterWarm = counter.decorateCalls.get();
+        assertThat(afterWarm).as("warming computes WarmDao metadata once").isPositive();
+
+        try (Handle cached = jdbi.open()) {
+            cached.attach(WarmDao.class);
+        }
+        assertThat(counter.decorateCalls)
+                .as("a sibling handle hits the shared cache without recomputing")
+                .hasValue(afterWarm);
+
+        // Registering a decorator after warming must invalidate the shared cache, exactly as a handler
+        // factory does; decorators change handler behavior, so a stale decorator cache is user-visible.
+        jdbi.configure(HandlerDecorators.class, c -> c.register(new CountingHandlerDecorator()));
+
+        try (Handle afterRegister = jdbi.open()) {
+            afterRegister.attach(WarmDao.class);
+        }
+        assertThat(counter.decorateCalls.get())
+                .as("registering a handler decorator after warming forces metadata recomputation (#2991)")
+                .isGreaterThan(afterWarm);
+    }
+
+    @Test
+    public void handlerRegisteredOnHandleDoesNotLeakToSiblings() {
+        Jdbi jdbi = h2Extension.getJdbi();
+        CountingHandlerFactory rootCounter = new CountingHandlerFactory();
+        jdbi.configure(Handlers.class, c -> c.register(rootCounter));
+
+        // One handle registers a factory locally, then attaches WarmDao. Its local registration invalidates
+        // only its own cache; the root cache stays empty.
+        try (Handle local = jdbi.open()) {
+            local.configure(Handlers.class, c -> c.register(new CountingHandlerFactory()));
+            local.attach(WarmDao.class);
+        }
+        int afterLocal = rootCounter.buildHandlerCalls.get();
+
+        // A sibling that never registered the local factory must not inherit its metadata from a shared
+        // cache: the first sibling attach still computes WarmDao metadata from the root configuration.
+        try (Handle sibling = jdbi.open()) {
+            sibling.attach(WarmDao.class);
+        }
+        assertThat(rootCounter.buildHandlerCalls.get())
+                .as("a sibling does not inherit metadata computed under a handle-local registration")
+                .isGreaterThan(afterLocal);
+    }
+}

--- a/sqlobject/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-sqlobject/reachability-metadata.json
+++ b/sqlobject/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-sqlobject/reachability-metadata.json
@@ -88,6 +88,7 @@
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestGetGeneratedKeysPostgres$RegisterRowMapperInterfaceDao"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestGetGeneratedKeysPostgres$UseRowMapperDao"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestGuavaCollectors$UserDao"]}},
+    {"type":{"proxy":["org.jdbi.v3.sqlobject.TestHandlerRegistrationAfterAttach$WarmDao"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestInClauseExpansion$DAO"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestInheritedAnnotations$CharacterDao"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestInheritedAnnotations$CharacterDao","org.jdbi.v3.sqlobject.TestInheritedAnnotations$CrudDao"]}},


### PR DESCRIPTION
Each Handle received a deep copy of the root Jdbi config, including a
separate extensionMetadataCache. Metadata computed inside a Handle's
forked cache never propagated back, so a service obtaining SqlObjects
exclusively via handle.attach() recomputed ExtensionMetadata on every
request and the cache stayed permanently cold (https://github.com/jdbi/jdbi/issues/2991).

Extensions now shares the metadata cache reference across config copies
instead of deep-copying it, so the first attach of a type populates a
cache that every sibling Handle reuses.

Sharing is only correct if a configuration change invalidates entries
computed under the old configuration. Computed metadata depends both on
the registrations in Extensions and on other config types read through
the registry while building metadata (Handlers, HandlerDecorators in the
sqlobject module). invalidateMetadataCache() replaces the shared map with
a fresh empty one; copies made earlier keep their snapshot, so a Handle
still sees configuration as of the moment it was opened. The Extensions
register* methods call it directly, and Handlers/HandlerDecorators call
it through registry.get(Extensions.class) from their own register methods.
Annotation-driven config such as @RegisterRowMapper needs no invalidation
because it is captured as a config customizer replayed against each
instance's own config copy at attach time rather than baked into metadata.

allowProxy/failFast become AtomicBoolean: they are now read from threads
other than the one that configured them once the config is shared, so they
need safe publication. A plain field trips SpotBugs
AT_STALE_THREAD_WRITE_OF_PRIMITIVE; AtomicBoolean publishes safely and,
unlike volatile, does not trip SonarCloud's S3078 gate. The public
boolean-typed accessors are unchanged, so this is not an API change.