### PR TITLE
spring: stop excluding spring-jcl from consumers of jdbi3-spring

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix jdbi3-spring excluding spring-jcl from consumers since 3.51.0, which broke Spring Boot 3
+  applications at startup with `NoClassDefFoundError: org.apache.commons.logging.LogFactory` (#2990)
 - Fix PreparedBatch NPE when rows bind different runtime types, e.g. mixed bean subclasses (#2974, thanks @arimu1!)
 - Fix DefaultJdbiCache pinning entries when loader throws an exception (#2995)
 - Fix GraalVM native image missing entries and update metadata to new format, support 25.2 (#2994)

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -252,12 +252,6 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${dep.spring.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.springframework</groupId>
-                        <artifactId>spring-jcl</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -254,12 +254,6 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${dep.spring.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.springframework</groupId>
-                        <artifactId>spring-jcl</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/native-tests/pom.xml
+++ b/native-tests/pom.xml
@@ -137,6 +137,14 @@
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-spring</artifactId>
             <scope>test</scope>
+            <!-- spring-jcl duplicates the commons-logging classes that jcl-over-slf4j
+                 (via pg-embedded's maven-loader) provides on the test classpath. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
@@ -280,6 +288,12 @@
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -62,18 +62,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-testing</artifactId>
             <scope>test</scope>

--- a/spring5/pom.xml
+++ b/spring5/pom.xml
@@ -74,18 +74,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Commit 8bba170d1 added a spring-jcl exclusion to the managed spring-core dependency so that the spring and spring5 test classpaths could route commons-logging through jcl-over-slf4j without the duplicate-class clash between spring-jcl and jcl-over-slf4j.

That management entry is inherited by the published jdbi3-build-parent POM, so the exclusion reached every downstream consumer of jdbi3-spring: since 3.51.0, spring-core no longer brought spring-jcl transitively. Spring Boot 3 applications that rely on it (anything using org.apache.commons.logging, e.g. OncePerRequestFilter) fail at startup with
NoClassDefFoundError: org/apache/commons/logging/LogFactory. Boot 4 dropped spring-jcl, so only Boot 3 is affected.

The jcl-over-slf4j swap was a build-internal logging preference, not a functional test requirement: the spring tests pass with spring-jcl on the classpath (as they did before 3.51.0), and slf4j-simple is already inherited as a global test dependency. Revert the change in both modules: drop the managed exclusion and the test-scoped jcl-over-slf4j/slf4j-simple, restoring the pre-3.51.0 behavior where spring-jcl flows to consumers transitively via spring-core. Consumers that do not want it can still exclude it themselves.

Fixes #2990.