### PR TITLE
fix: DefaultJdbiCache retries after a throwing loader instead of corrupting the cache

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCache.java
+++ b/core/src/main/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCache.java
@@ -16,12 +16,14 @@ package org.jdbi.v3.core.cache.internal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.jdbi.v3.core.cache.JdbiCache;
 import org.jdbi.v3.core.cache.JdbiCacheLoader;
+import org.jdbi.v3.core.internal.exceptions.Sneaky;
 
 final class DefaultJdbiCache<K, V> implements JdbiCache<K, V> {
 
@@ -67,7 +69,7 @@ final class DefaultJdbiCache<K, V> implements JdbiCache<K, V> {
             if (!node.value.isCompletedExceptionally()) {
                 refresh(node);
             }
-            return node.value.join();
+            return join(node);
         }
 
         // Node with Future atomically loaded into cache, but needs a value still
@@ -77,14 +79,43 @@ final class DefaultJdbiCache<K, V> implements JdbiCache<K, V> {
         synchronized (node) {
             // Double-check in case of race
             if (!node.value.isDone()) {
+                final V value;
+                try {
+                    value = loader == null ? null : loader.create(key);
+                } catch (Throwable e) {
+                    // The loader failed. Complete the placeholder exceptionally so a racing caller that
+                    // already holds this node observes the same failure instead of re-running the loader,
+                    // then drop the node so a later call retries with a fresh one. Without this the
+                    // permanently-incomplete node would be found again and re-added to the expunge queue
+                    // (which would throw "Can not add node twice!"). The node was never added to the
+                    // expunge queue, since the value is computed first.
+                    node.value.completeExceptionally(e);
+                    cache.remove(key, node);
+                    throw e;
+                }
                 if (maxSize > 0) {
                     synchronized (expungeQueue) {
                         expungeQueue.addHead(node);
                     }
                 }
-                node.value.complete(loader == null ? null : loader.create(key));
+                node.value.complete(value);
             }
+            return join(node);
+        }
+    }
+
+    /**
+     * Join on a node's value, discarding the {@link CompletionException} wrapper that
+     * {@link CompletableFuture#join()} adds around a loader failure. Every caller then sees the same
+     * exception the loader threw, regardless of which thread won the race to compute the key.
+     */
+    // PreserveStackTrace: the wrapper carries only CompletableFuture plumbing; the rethrown cause keeps its own stack.
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    private V join(DoubleLinkedList.Node<K, CompletableFuture<V>> node) {
+        try {
             return node.value.join();
+        } catch (CompletionException e) {
+            throw Sneaky.throwAnyway(e.getCause());
         }
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/cache/internal/DefaultJdbiCacheTest.java
@@ -14,6 +14,9 @@
 package org.jdbi.v3.core.cache.internal;
 
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.jdbi.v3.core.cache.JdbiCache;
 import org.jdbi.v3.core.cache.JdbiCacheBuilder;
@@ -21,6 +24,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class DefaultJdbiCacheTest extends JdbiCacheTest {
 
@@ -155,6 +159,94 @@ public class DefaultJdbiCacheTest extends JdbiCacheTest {
     static void refresh(int max, JdbiCache<String, String> cache, String[] keys) {
         for (int i = 0; i < max; i++) {
             cache.get(keys[i]);
+        }
+    }
+
+    /**
+     * A loader that throws must not corrupt the cache: the placeholder node is dropped so a later call
+     * for the same key retries the loader instead of failing with "Can not add node twice!".
+     */
+    @Test
+    void testThrowingLoaderDoesNotCorruptCache() {
+        JdbiCache<String, String> cache = setupBuilder().maxSize(10).build();
+
+        assertThatThrownBy(() -> cache.getWithLoader("key", k -> {
+            throw new IllegalStateException("first");
+        })).isInstanceOf(IllegalStateException.class).hasMessage("first");
+
+        // Same key again: the loader runs again (the cache was not corrupted by the first failure).
+        assertThatThrownBy(() -> cache.getWithLoader("key", k -> {
+            throw new IllegalStateException("second");
+        })).isInstanceOf(IllegalStateException.class).hasMessage("second");
+
+        // A subsequent successful load for the same key populates and returns the value.
+        assertThat(cache.getWithLoader("key", k -> "value")).isEqualTo("value");
+        assertThat(cache.getWithLoader("key", k -> "ignored")).isEqualTo("value");
+    }
+
+    /**
+     * When a loader throws while another thread is already waiting on the same node, the waiter must observe the
+     * failure rather than re-run its loader and complete a node the failed loader already removed from the cache.
+     * Such a resurrected node would be orphaned in the expunge queue and could later evict the live entry.
+     */
+    @Test
+    void testThrowingLoaderDoesNotResurrectNodeForConcurrentWaiter() throws Exception {
+        JdbiCache<String, String> cache = setupBuilder().maxSize(10).build();
+        Assumptions.assumeTrue(cache instanceof DefaultJdbiCache);
+
+        final CountDownLatch loaderEntered = new CountDownLatch(1);
+        final CountDownLatch releaseLoader = new CountDownLatch(1);
+
+        // Thread A holds the node's monitor inside its loader, then fails.
+        final Thread a = new Thread(() -> {
+            try {
+                cache.getWithLoader("key", k -> {
+                    loaderEntered.countDown();
+                    awaitUninterruptibly(releaseLoader);
+                    throw new IllegalStateException("boom");
+                });
+            } catch (RuntimeException expected) {
+                // A's load fails by design.
+            }
+        }, "loader-A");
+
+        // Thread B waits on the same node's monitor while A holds it; when it wakes it must not "win".
+        final AtomicReference<Object> bOutcome = new AtomicReference<>();
+        final Thread b = new Thread(() -> {
+            try {
+                bOutcome.set(cache.getWithLoader("key", k -> "resurrected"));
+            } catch (RuntimeException failed) {
+                bOutcome.set(failed);
+            }
+        }, "loader-B");
+
+        a.start();
+        assertThat(loaderEntered.await(5, TimeUnit.SECONDS)).isTrue();
+        b.start();
+        // Deterministically wait until B is blocked entering the monitor A holds, then let A fail.
+        while (b.getState() != Thread.State.BLOCKED) {
+            Thread.sleep(1);
+        }
+        releaseLoader.countDown();
+        a.join(TimeUnit.SECONDS.toMillis(5));
+        b.join(TimeUnit.SECONDS.toMillis(5));
+
+        // B observed the loader's failure (unwrapped, not a CompletionException); it did not resurrect the
+        // removed node with a value.
+        assertThat(bOutcome.get()).isInstanceOf(IllegalStateException.class);
+
+        // The cache holds no orphaned entry: a fresh successful load is the only cached value.
+        assertThat(cache.getWithLoader("key", k -> "value")).isEqualTo("value");
+        DefaultJdbiCacheStats stats = cache.getStats();
+        assertThat(stats.cacheSize()).isOne();
+    }
+
+    private static void awaitUninterruptibly(final CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
         }
     }
 


### PR DESCRIPTION
A JdbiCacheLoader that threw left the placeholder node in the backing map and already added to the expunge queue, so the next get() for the same key threw IllegalStateException("Can not add node twice!") instead of retrying the loader.

Compute the value before adding the node to the expunge queue, and remove the node from the map on loader failure, so a later call for the same key retries with a fresh node. Adds a regression test.