### PR TITLE
refactor(testcontainers): move the JUnit 5 extension to org.jdbi.testing.junit

### DIFF
--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -6165,7 +6165,7 @@ While Jdbi makes an effort to support all databases provided by the Testcontaine
 - Using a custom docker image that is incompatible with the default Jdbi testcontainer support.
 - Require specific behavior in tests that is different from the Jdbi testcontainer support.
 
-The link:{jdbidocs}/testing/junit/tc/TestcontainersDatabaseInformation.html#of(java.lang.String,java.lang.String,java.lang.String,java.util.function.BiFunction)[TestcontainersDatabaseInformation#of()^] method allows creation of custom database information instances which then can be passed into link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html#instance(org.jdbi.testing.junit.tc.TestcontainersDatabaseInformation,org.testcontainers.containers.JdbcDatabaseContainer)[JdbiTestcontainersExtension#instance(TestcontainersDatabaseInformation, JdbcDatabaseContainer)^] to create extensions with custom behavior.
+The link:{jdbidocs}/testing/junit/tc/TestcontainersDatabaseInformation.html#of(java.lang.String,java.lang.String,java.lang.String,java.util.function.BiFunction)[TestcontainersDatabaseInformation#of()^] method allows creation of custom database information instances which then can be passed into link:{jdbidocs}/testing/junit/tc/JdbiTestcontainersExtension.html#instance(org.jdbi.testing.junit.tc.TestcontainersDatabaseInformation,org.testcontainers.containers.JdbcDatabaseContainer)[JdbiTestcontainersExtension#instance(TestcontainersDatabaseInformation, JdbcDatabaseContainer)^] to create extensions with custom behavior.
 
 This is an example that uses a custom user with a special database image:
 
@@ -6193,11 +6193,11 @@ private static final TestcontainersDatabaseInformation CUSTOM_MYSQL =
 }
 ----
 
-The Javadoc for the link:{jdbidocs}/testing/junit/tc/TestcontainersDatabaseInformation.html[TestcontainersDatabaseInformation^] class has additional details on how to create custom link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] instances.
+The Javadoc for the link:{jdbidocs}/testing/junit/tc/TestcontainersDatabaseInformation.html[TestcontainersDatabaseInformation^] class has additional details on how to create custom link:{jdbidocs}/testing/junit/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] instances.
 
 ==== Controlling the extension shutdown timeout
 
-Some testcontainer based database may take a long time to create a new schema so when tests run very fast, shutting down the link:{jdbidocs}/testing/junit5/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] at the end of a test may interrupt this process and log spurious messages in the logs.
+Some testcontainer based database may take a long time to create a new schema so when tests run very fast, shutting down the link:{jdbidocs}/testing/junit/tc/JdbiTestcontainersExtension.html[JdbiTestcontainersExtension^] at the end of a test may interrupt this process and log spurious messages in the logs.
 Those messages are benign and can be safely ignored.
 If it is necessary (e.g. because there is a "no messages" policy in place at your organization), the shutdown time can be extended by setting the wait time to a higher value than the default of 10 seconds:
 

--- a/oracle12/src/test/java/org/jdbi/oracle12/TestGetGeneratedKeysOracle.java
+++ b/oracle12/src/test/java/org/jdbi/oracle12/TestGetGeneratedKeysOracle.java
@@ -25,7 +25,7 @@ import org.jdbi.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.sqlobject.statement.SqlQuery;
 import org.jdbi.sqlobject.statement.SqlUpdate;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/oracle12/src/test/java/org/jdbi/oracle12/TestOracleInOutParameter.java
+++ b/oracle12/src/test/java/org/jdbi/oracle12/TestOracleInOutParameter.java
@@ -18,7 +18,7 @@ import java.sql.Types;
 import org.jdbi.core.statement.Call;
 import org.jdbi.core.statement.OutParameters;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;

--- a/oracle12/src/test/java/org/jdbi/oracle12/TestOraclePluginIntegration.java
+++ b/oracle12/src/test/java/org/jdbi/oracle12/TestOraclePluginIntegration.java
@@ -15,7 +15,7 @@ package org.jdbi.oracle12;
 
 import org.jdbi.core.Handle;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/oracle12/src/test/java/org/jdbi/oracle12/TestOracleReturning.java
+++ b/oracle12/src/test/java/org/jdbi/oracle12/TestOracleReturning.java
@@ -21,7 +21,7 @@ import org.jdbi.core.Something;
 import org.jdbi.core.statement.Update;
 import org.jdbi.sqlobject.SqlObjectPlugin;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/oracle12/src/test/java/org/jdbi/oracle12/TestOutparameterCursor.java
+++ b/oracle12/src/test/java/org/jdbi/oracle12/TestOutparameterCursor.java
@@ -21,7 +21,7 @@ import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.core.statement.Call;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;

--- a/oracle12/src/test/java/org/jdbi/oracle12/TestScript.java
+++ b/oracle12/src/test/java/org/jdbi/oracle12/TestScript.java
@@ -25,7 +25,7 @@ import org.jdbi.core.statement.Query;
 import org.jdbi.core.statement.Script;
 import org.jdbi.core.statement.StatementContext;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;

--- a/postgis/src/test/java/org/jdbi/postgis/PostgisPluginTest.java
+++ b/postgis/src/test/java/org/jdbi/postgis/PostgisPluginTest.java
@@ -18,7 +18,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.postgres.PostgresPlugin;
 import org.jdbi.sqlobject.SqlObjectPlugin;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;

--- a/postgres/src/test/java/org/jdbi/postgres/TestVectorExtension.java
+++ b/postgres/src/test/java/org/jdbi/postgres/TestVectorExtension.java
@@ -17,7 +17,7 @@ import com.pgvector.PGhalfvec;
 import com.pgvector.PGsparsevec;
 import com.pgvector.PGvector;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/testcontainers/src/main/java/org/jdbi/testing/junit/tc/EmbeddedUtil.java
+++ b/testcontainers/src/main/java/org/jdbi/testing/junit/tc/EmbeddedUtil.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import java.util.concurrent.ThreadLocalRandom;
 

--- a/testcontainers/src/main/java/org/jdbi/testing/junit/tc/JdbiTestcontainersExtension.java
+++ b/testcontainers/src/main/java/org/jdbi/testing/junit/tc/JdbiTestcontainersExtension.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import javax.sql.DataSource;
 

--- a/testcontainers/src/main/java/org/jdbi/testing/junit/tc/TestcontainersDatabaseInformation.java
+++ b/testcontainers/src/main/java/org/jdbi/testing/junit/tc/TestcontainersDatabaseInformation.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/testcontainers/src/main/java/org/jdbi/testing/junit/tc/TestcontainersDatabaseInformationSupplier.java
+++ b/testcontainers/src/main/java/org/jdbi/testing/junit/tc/TestcontainersDatabaseInformationSupplier.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/testcontainers/src/main/java/org/jdbi/testing/junit/tc/package-info.java
+++ b/testcontainers/src/main/java/org/jdbi/testing/junit/tc/package-info.java
@@ -15,4 +15,4 @@
  * Jdbi test support for <a href="https://testcontainers.org/">Testcontainer based JDBC containers</a>. Any
  * database that is supported can be used as a test database in <a href="https://junit.org/junit5/">JUnit 5</a> tests.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;

--- a/testcontainers/src/test/java/org/jdbi/testcontainers/TestMSSQLStoredProcedure.java
+++ b/testcontainers/src/test/java/org/jdbi/testcontainers/TestMSSQLStoredProcedure.java
@@ -21,7 +21,7 @@ import org.jdbi.core.statement.Call;
 import org.jdbi.core.statement.OutParameters;
 import org.jdbi.sqlobject.SqlObjectPlugin;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;

--- a/testcontainers/src/test/java/org/jdbi/testcontainers/mysql/TestMySQL.java
+++ b/testcontainers/src/test/java/org/jdbi/testcontainers/mysql/TestMySQL.java
@@ -23,7 +23,7 @@ import org.jdbi.sqlobject.customizer.Bind;
 import org.jdbi.sqlobject.customizer.Define;
 import org.jdbi.sqlobject.statement.SqlQuery;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;

--- a/testcontainers/src/test/java/org/jdbi/testcontainers/mysql/TestScript.java
+++ b/testcontainers/src/test/java/org/jdbi/testcontainers/mysql/TestScript.java
@@ -20,7 +20,7 @@ import org.jdbi.core.locator.ClasspathSqlLocator;
 import org.jdbi.core.statement.Script;
 import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.testing.junit.JdbiExtension;
-import org.jdbi.testing.junit5.tc.JdbiTestcontainersExtension;
+import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/AbstractJdbiTestcontainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/AbstractJdbiTestcontainersExtensionTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import java.util.List;
 

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/ClickhouseJdbiTestContainerExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/ClickhouseJdbiTestContainerExtensionTest.java
@@ -11,31 +11,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.TrinoContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Tag("slow")
 @Testcontainers
-class TrinoJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+class ClickhouseJdbiTestContainerExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new TrinoContainer("trinodb/trino");
+    static JdbcDatabaseContainer<?> dbContainer = new ClickHouseContainer("clickhouse/clickhouse-server:latest")
+        .withUsername("test")
+        .withPassword("test");
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {
         return dbContainer;
     }
 
-    @BeforeEach
-    public void beforeEach() throws Exception {
-        // we still love you, trino. But you are a mess.
-        Thread.sleep(5_000);
+    @Override
+    protected String getTableCreateStatement() {
+        // I'm different!
+        return super.getTableCreateStatement() + " Engine = Memory";
     }
 }

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/CockroachJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/CockroachJdbiTestContainersExtensionTest.java
@@ -11,25 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
-
+package org.jdbi.testing.junit.tc;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.testcontainers.containers.CockroachContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = { "x86_64", "amd64" })
-class PostGisJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+class CockroachJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new PostgreSQLContainer<>(
-        DockerImageName.parse("postgis/postgis:13-3.3-alpine").asCompatibleSubstituteFor("postgres"));
+    static JdbcDatabaseContainer<?> dbContainer = new CockroachContainer("cockroachdb/cockroach:latest");
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/DB2JdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/DB2JdbiTestContainersExtensionTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import java.nio.charset.Charset;
 

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/MSSQLJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/MSSQLJdbiTestContainersExtensionTest.java
@@ -11,20 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import org.junit.jupiter.api.Tag;
-import org.testcontainers.containers.CockroachContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Tag("slow")
 @Testcontainers
-class CockroachJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+class MSSQLJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new CockroachContainer("cockroachdb/cockroach:latest");
+    static JdbcDatabaseContainer<?> dbContainer = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2022-latest")
+        .acceptLicense();
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/MySQLJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/MySQLJdbiTestContainersExtensionTest.java
@@ -11,22 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
+
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = {"x86_64", "amd64"})
-class OracleXeJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+class MySQLJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+    static final String MYSQL_VERSION = System.getProperty("jdbi.test.mysql-version", "mysql");
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new OracleContainer("gvenzl/oracle-xe:slim-faststart");
+    static JdbcDatabaseContainer<?> dbContainer = new MySQLContainer<>(MYSQL_VERSION);
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/OracleFreeJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/OracleFreeJdbiTestContainersExtensionTest.java
@@ -11,22 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Tag("slow")
 @Testcontainers
-public class TimescaleJdbiTestContainerExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+class OracleFreeJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new PostgreSQLContainer<>(
-        DockerImageName.parse("timescale/timescaledb:latest-pg13").asCompatibleSubstituteFor("postgres"));
+    static JdbcDatabaseContainer<?> dbContainer = new OracleContainer(
+        DockerImageName.parse("gvenzl/oracle-free:slim-faststart"));
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/OracleXeJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/OracleXeJdbiTestContainersExtensionTest.java
@@ -11,22 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
-
+package org.jdbi.testing.junit.tc;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.tidb.TiDBContainer;
 
 @Tag("slow")
 @Testcontainers
-class TiDBJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+@EnabledOnOs(architectures = {"x86_64", "amd64"})
+class OracleXeJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new TiDBContainer("pingcap/tidb");
-
+    static JdbcDatabaseContainer<?> dbContainer = new OracleContainer("gvenzl/oracle-xe:slim-faststart");
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/PostGisJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/PostGisJdbiTestContainersExtensionTest.java
@@ -11,22 +11,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 @Tag("slow")
 @Testcontainers
-class MySQLJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
-    static final String MYSQL_VERSION = System.getProperty("jdbi.test.mysql-version", "mysql");
+@EnabledOnOs(architectures = { "x86_64", "amd64" })
+class PostGisJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new MySQLContainer<>(MYSQL_VERSION);
+    static JdbcDatabaseContainer<?> dbContainer = new PostgreSQLContainer<>(
+        DockerImageName.parse("postgis/postgis:13-3.3-alpine").asCompatibleSubstituteFor("postgres"));
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/TiDBJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/TiDBJdbiTestContainersExtensionTest.java
@@ -11,22 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
+
 
 import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.oracle.OracleContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.tidb.TiDBContainer;
 
 @Tag("slow")
 @Testcontainers
-class OracleFreeJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+class TiDBJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new OracleContainer(
-        DockerImageName.parse("gvenzl/oracle-free:slim-faststart"));
+    static JdbcDatabaseContainer<?> dbContainer = new TiDBContainer("pingcap/tidb");
+
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/TimescaleJdbiTestContainerExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/TimescaleJdbiTestContainerExtensionTest.java
@@ -11,22 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.YugabyteDBYSQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 @Tag("slow")
 @Testcontainers
-@EnabledOnOs(architectures = { "x86_64", "amd64" })
-class YugabyteJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+public class TimescaleJdbiTestContainerExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new YugabyteDBYSQLContainer("yugabytedb/yugabyte");
+    static JdbcDatabaseContainer<?> dbContainer = new PostgreSQLContainer<>(
+        DockerImageName.parse("timescale/timescaledb:latest-pg13").asCompatibleSubstituteFor("postgres"));
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/TrinoJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/TrinoJdbiTestContainersExtensionTest.java
@@ -11,24 +11,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.TrinoContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Tag("slow")
 @Testcontainers
-class MSSQLJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+class TrinoJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2022-latest")
-        .acceptLicense();
+    static JdbcDatabaseContainer<?> dbContainer = new TrinoContainer("trinodb/trino");
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {
         return dbContainer;
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        // we still love you, trino. But you are a mess.
+        Thread.sleep(5_000);
     }
 }

--- a/testcontainers/src/test/java/org/jdbi/testing/junit/tc/YugabyteJdbiTestContainersExtensionTest.java
+++ b/testcontainers/src/test/java/org/jdbi/testing/junit/tc/YugabyteJdbiTestContainersExtensionTest.java
@@ -11,31 +11,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.testing.junit5.tc;
+package org.jdbi.testing.junit.tc;
 
 import org.junit.jupiter.api.Tag;
-import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.YugabyteDBYSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Tag("slow")
 @Testcontainers
-class ClickhouseJdbiTestContainerExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
+@EnabledOnOs(architectures = { "x86_64", "amd64" })
+class YugabyteJdbiTestContainersExtensionTest extends AbstractJdbiTestcontainersExtensionTest {
 
     @Container
-    static JdbcDatabaseContainer<?> dbContainer = new ClickHouseContainer("clickhouse/clickhouse-server:latest")
-        .withUsername("test")
-        .withPassword("test");
+    static JdbcDatabaseContainer<?> dbContainer = new YugabyteDBYSQLContainer("yugabytedb/yugabyte");
 
     @Override
     JdbcDatabaseContainer<?> getDbContainer() {
         return dbContainer;
-    }
-
-    @Override
-    protected String getTableCreateStatement() {
-        // I'm different!
-        return super.getTableCreateStatement() + " Engine = Memory";
     }
 }


### PR DESCRIPTION
The v4 rename moved the core testing extensions from org.jdbi.v3.testing.junit5 to org.jdbi.testing.junit (JUnit 4 support is gone, so the '5' is redundant), but the Testcontainers extension was left behind at org.jdbi.testing.junit5.tc. Align it to org.jdbi.testing.junit.tc so the whole testing surface lives under one package and the v4 upgrade is a uniform junit5 -> junit move. Pre-release and riding the existing package-rename churn, so it costs migrators nothing extra. Also fixes stale testing/junit5/tc javadoc links in the guide (one sentence already mixed junit/tc and junit5/tc).