### PR TITLE
perf(stringtemplate4): cache StringTemplate compilation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 - Fix DefaultJdbiCache pinning entries when loader throws an exception (#2995)
 - Fix GraalVM native image missing entries and update metadata to new format, support 25.2 (#2994)
+- stringtemplate4: `StringTemplateEngine` now caches template compilation through the core statement
+  cache instead of recompiling on every render, with compiled templates pooled for thread safety.
+  The cached path bypasses `render(String, StatementContext)`: a subclass that overrides `render`
+  must also override `parse`, most simply to return `Optional.empty()`, which keeps the core on
+  its `render` path.
+  `Batch` and `Script` now render through the statement cache as well. (#2997)
 
 # 3.54.0
 

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -54,6 +54,14 @@
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-stringtemplate4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-postgres</artifactId>
         </dependency>
         <dependency>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/StringTemplateQueryBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/StringTemplateQueryBenchmark.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.h2.Driver;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.TemplateEngine;
+import org.jdbi.v3.stringtemplate4.StringTemplateEngine;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.STGroup;
+
+/**
+ * End-to-end effect of caching StringTemplate compilation: both arms run the same conditional query,
+ * differing only in the engine. {@code recompiling} recompiles the template every render, as the engine did
+ * before this change; {@code cached} is the current engine, which caches compilation.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+public class StringTemplateQueryBenchmark {
+
+    private static final String SQL =
+            "select id from tbl where id = :id"
+            + " <if(byName)> and name = :nm <endif>"
+            + " order by <sortCol>";
+
+    private Handle recompilingHandle;
+    private Handle cachedHandle;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        Driver.load();
+        recompilingHandle = open(new RecompilingStringTemplateEngine());
+        cachedHandle = open(new StringTemplateEngine());
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        recompilingHandle.close();
+        cachedHandle.close();
+    }
+
+    private static Handle open(TemplateEngine engine) {
+        Jdbi jdbi = Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10");
+        jdbi.setTemplateEngine(engine);
+        Handle handle = jdbi.open();
+        handle.execute("create table tbl (id integer primary key, name varchar)");
+        handle.execute("insert into tbl (id, name) values (1, 'row one')");
+        return handle;
+    }
+
+    private static Integer run(Handle handle) {
+        return handle.createQuery(SQL)
+                .define("byName", Boolean.TRUE)
+                .define("sortCol", "id")
+                .bind("id", 1)
+                .bind("nm", "row one")
+                .mapTo(Integer.class)
+                .one();
+    }
+
+    @Benchmark
+    public Integer recompiling() {
+        return run(recompilingHandle);
+    }
+
+    @Benchmark
+    public Integer cached() {
+        return run(cachedHandle);
+    }
+
+    /** Recompiles a fresh StringTemplate every render, as the engine did before it cached compilation. */
+    static final class RecompilingStringTemplateEngine implements TemplateEngine {
+        @Override
+        public String render(String sql, StatementContext ctx) {
+            ST template = new ST(new STGroup(), sql);
+            ctx.getAttributes().forEach(template::add);
+            return template.render();
+        }
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/StringTemplateQueryBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/StringTemplateQueryBenchmark.java
@@ -13,19 +13,18 @@
  */
 package org.jdbi.v3.benchmark;
 
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import org.h2.Driver;
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.TemplateEngine;
+import org.jdbi.v3.core.statement.UnableToCreateStatementException;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.jdbi.v3.stringtemplate4.StringTemplateEngine;
+import org.jdbi.v3.testing.JdbiRule;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -35,7 +34,9 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.STErrorListener;
 import org.stringtemplate.v4.STGroup;
+import org.stringtemplate.v4.misc.STMessage;
 
 /**
  * End-to-end effect of caching StringTemplate compilation: both arms run the same conditional query,
@@ -55,26 +56,29 @@ public class StringTemplateQueryBenchmark {
             + " <if(byName)> and name = :nm <endif>"
             + " order by <sortCol>";
 
+    private JdbiRule recompilingDb;
+    private JdbiRule cachedDb;
     private Handle recompilingHandle;
     private Handle cachedHandle;
 
-    @Setup(Level.Trial)
-    public void setup() {
-        Driver.load();
-        recompilingHandle = open(new RecompilingStringTemplateEngine());
-        cachedHandle = open(new StringTemplateEngine());
+    @Setup
+    public void setup() throws Throwable {
+        recompilingDb = JdbiRule.h2();
+        cachedDb = JdbiRule.h2();
+        recompilingHandle = open(recompilingDb, new RecompilingStringTemplateEngine());
+        cachedHandle = open(cachedDb, new StringTemplateEngine());
     }
 
-    @TearDown(Level.Trial)
+    @TearDown
     public void tearDown() {
-        recompilingHandle.close();
-        cachedHandle.close();
+        recompilingDb.after();
+        cachedDb.after();
     }
 
-    private static Handle open(TemplateEngine engine) {
-        Jdbi jdbi = Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10");
-        jdbi.setTemplateEngine(engine);
-        Handle handle = jdbi.open();
+    private static Handle open(JdbiRule db, TemplateEngine engine) throws Throwable {
+        db.before();
+        Handle handle = db.getHandle();
+        handle.setTemplateEngine(engine);
         handle.execute("create table tbl (id integer primary key, name varchar)");
         handle.execute("insert into tbl (id, name) values (1, 'row one')");
         return handle;
@@ -100,13 +104,47 @@ public class StringTemplateQueryBenchmark {
         return run(cachedHandle);
     }
 
-    /** Recompiles a fresh StringTemplate every render, as the engine did before it cached compilation. */
+    /**
+     * Recompiles a fresh StringTemplate every render, as the engine did before it cached compilation,
+     * including the per-render group and error-listener setup.
+     */
     static final class RecompilingStringTemplateEngine implements TemplateEngine {
         @Override
         public String render(String sql, StatementContext ctx) {
-            ST template = new ST(new STGroup(), sql);
+            STGroup group = new STGroup();
+            group.setListener(new ThrowingListener(ctx));
+            ST template = new ST(group, sql);
             ctx.getAttributes().forEach(template::add);
             return template.render();
+        }
+    }
+
+    /** Fails loudly like the real engine's listener; the benchmark template never errors. */
+    static final class ThrowingListener implements STErrorListener {
+        private final StatementContext ctx;
+
+        ThrowingListener(StatementContext ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void compileTimeError(STMessage msg) {
+            throw new UnableToCreateStatementException("Compiling StringTemplate failed: " + msg, msg.cause, ctx);
+        }
+
+        @Override
+        public void runTimeError(STMessage msg) {
+            throw new UnableToExecuteStatementException("Executing StringTemplate failed: " + msg, msg.cause, ctx);
+        }
+
+        @Override
+        public void IOError(STMessage msg) {
+            runTimeError(msg);
+        }
+
+        @Override
+        public void internalError(STMessage msg) {
+            runTimeError(msg);
         }
     }
 }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-build-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
         <relativePath>../internal/build</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
     <description>Jdbi Bill of Materials (BOM). Import this module into a project to get a list of all public modules with a specific version.</description>
 
     <properties>
-        <dep.jdbi3.version>3.54.1-SNAPSHOT</dep.jdbi3.version>
+        <dep.jdbi3.version>3.55.0-SNAPSHOT</dep.jdbi3.version>
         <moduleName>org.jdbi.v3.bom</moduleName>
     </properties>
 

--- a/cache/caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/cache/noop-cache/pom.xml
+++ b/cache/noop-cache/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-internal-cache-parent</artifactId>

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Batch.java
@@ -74,7 +74,7 @@ public class Batch extends BaseStatement<Batch> {
 
             try {
                 for (String part : parts) {
-                    final String sql = stmtConfig.getTemplateEngine().render(part, getContext());
+                    final String sql = stmtConfig.preparedRender(part, getContext());
                     LOG.trace(" {}", sql);
                     stmt.addBatch(sql);
                 }

--- a/core/src/main/java/org/jdbi/v3/core/statement/Script.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Script.java
@@ -68,8 +68,7 @@ public class Script extends SqlStatement<Script> {
      * @return the split statements
      */
     public List<String> getStatements() {
-        var templateEngine = getConfig(SqlStatements.class).getTemplateEngine();
-        return splitToStatements(templateEngine.render(getSql(), getContext()));
+        return splitToStatements(getConfig(SqlStatements.class).preparedRender(getSql(), getContext()));
     }
 
     private List<String> splitToStatements(String script) {

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/gson2/pom.xml
+++ b/gson2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-root</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
         <relativePath>../root</relativePath>
     </parent>
 
@@ -72,7 +72,7 @@
         <dep.jakarta-annotation-api.version>3.0.0</dep.jakarta-annotation-api.version>
         <dep.jakarta-inject-api.version>2.0.1.MR</dep.jakarta-inject-api.version>
         <dep.javax-inject.version>1</dep.javax-inject.version>
-        <dep.jdbi-policy.version>3.54.1-SNAPSHOT</dep.jdbi-policy.version>
+        <dep.jdbi-policy.version>3.55.0-SNAPSHOT</dep.jdbi-policy.version>
         <dep.jetbrainsAnnotations.version>26.1.0</dep.jetbrainsAnnotations.version>
         <dep.jfrunit.version>1.0.0.Alpha2</dep.jfrunit.version>
         <dep.joda-time.version>2.14.1</dep.joda-time.version>

--- a/internal/policy/pom.xml
+++ b/internal/policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-root</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
         <relativePath>../root</relativePath>
     </parent>
 

--- a/internal/pom.xml
+++ b/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-internal-parent</artifactId>

--- a/internal/root/pom.xml
+++ b/internal/root/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.jdbi.internal</groupId>
     <artifactId>jdbi3-root</artifactId>
-    <version>3.54.1-SNAPSHOT</version>
+    <version>3.55.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>jdbi3 - internal - root</name>

--- a/jackson2/pom.xml
+++ b/jackson2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/jackson3/pom.xml
+++ b/jackson3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/java21/pom.xml
+++ b/java21/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/moshi/pom.xml
+++ b/moshi/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/native-tests/pom.xml
+++ b/native-tests/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbi3-native-tests</artifactId>

--- a/noparameters/pom.xml
+++ b/noparameters/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/opentelemetry/pom.xml
+++ b/opentelemetry/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi3-build-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
         <relativePath>internal/build</relativePath>
     </parent>
 

--- a/postgis/pom.xml
+++ b/postgis/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/spring5/pom.xml
+++ b/spring5/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
@@ -15,7 +15,7 @@ package org.jdbi.v3.stringtemplate4;
 
 import java.util.Optional;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.config.ConfigRegistry;
@@ -26,6 +26,7 @@ import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STErrorListener;
 import org.stringtemplate.v4.STGroup;
+import org.stringtemplate.v4.compiler.CompiledST;
 import org.stringtemplate.v4.misc.STMessage;
 
 /**
@@ -35,6 +36,13 @@ import org.stringtemplate.v4.misc.STMessage;
 public class StringTemplateEngine implements TemplateEngine.Parsing {
     /** Installed on an idle pooled prototype so it holds no execution context between renders. */
     private static final STErrorListener IDLE_LISTENER = new IdleListener();
+
+    /**
+     * Caps how many compiled prototypes one cache entry retains. Rendering is normally CPU-bound, so
+     * concurrency rarely exceeds the processor count; a blocking attribute renderer (especially on virtual
+     * threads) can, and then a render past the cap recompiles instead of growing the pool forever.
+     */
+    private static final int POOL_CAPACITY = 2 * Runtime.getRuntime().availableProcessors();
 
     /** Non-cached render, for direct callers; the core uses {@link #parse(String, ConfigRegistry)}. */
     @Override
@@ -47,13 +55,16 @@ public class StringTemplateEngine implements TemplateEngine.Parsing {
      * not thread-safe, so a compiled template must not be rendered by two threads at once. Compiled prototypes
      * are pooled rather than bound to a thread, so compilation is reused across platform and virtual threads
      * alike: a render checks a prototype out of the pool (compiling one only if the pool is empty), renders a
-     * copy, and returns the prototype. Rendering is fast, non-blocking, and CPU-bound, so no more prototypes
-     * are checked out at once than there are threads actually rendering; the pool self-bounds without a
-     * capacity limit, holding its high-water mark of concurrent renders for the life of the cache entry.
+     * copy, and returns the prototype. The pool holds at most {@link #POOL_CAPACITY} prototypes; a render that
+     * finds it empty compiles its own, and a return that finds it full discards.
+     *
+     * <p>The cached function bypasses {@link #render(String, StatementContext)}. A subclass that overrides
+     * render() must also override this method so the two agree: either return {@link Optional#empty()} to
+     * keep the core on the render() path, or return a function with the subclass's semantics.
      */
     @Override
     public Optional<Function<StatementContext, String>> parse(String sql, ConfigRegistry config) {
-        final Queue<ST> pool = new ConcurrentLinkedQueue<>();
+        final Queue<ST> pool = new LinkedBlockingQueue<>(POOL_CAPACITY);
         return Optional.of(ctx -> {
             ST proto = pool.poll();
             if (proto == null) {
@@ -63,6 +74,9 @@ public class StringTemplateEngine implements TemplateEngine.Parsing {
             final STGroup group = proto.groupThatCreatedThisInstance;
             try {
                 group.setListener(new ErrorListener(ctx));
+                // The copy must finish rendering before the prototype returns to the pool: ST4's
+                // CompiledST.clone() hands the copy the formalArguments map the prototype held and gives the
+                // prototype a fresh one, so an in-progress render would share that map with the next checkout.
                 return renderInstance(new ST(proto), ctx);
             } finally {
                 // Drop the execution context so an idle pooled prototype retains no StatementContext.
@@ -72,8 +86,24 @@ public class StringTemplateEngine implements TemplateEngine.Parsing {
         });
     }
 
+    /**
+     * The engine is stateless, so all instances of the same class are interchangeable. Equality by class lets
+     * the core statement cache reuse compiled templates across instances, e.g. one created per statement or
+     * by each {@code @UseStringTemplateEngine} annotation. A stateful subclass must override equals and
+     * hashCode to keep differently-configured instances apart in the cache.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && getClass() == obj.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
     private static ST compile(String sql, StatementContext ctx) {
-        STGroup group = new STGroup();
+        STGroup group = new StatementGroup();
         group.setListener(new ErrorListener(ctx));
         return new ST(group, sql);
     }
@@ -81,6 +111,22 @@ public class StringTemplateEngine implements TemplateEngine.Parsing {
     private static String renderInstance(ST template, StatementContext ctx) {
         ctx.getAttributes().forEach(template::add);
         return template.render();
+    }
+
+    /**
+     * STGroup that retains no negative lookup results. {@link STGroup#lookupTemplate} caches a not-found
+     * marker per name, and a dynamic include such as {@code <(name)()>} derives names from attribute values,
+     * so a pooled group's marker map would grow by one entry per distinct value for the life of the pool.
+     */
+    static final class StatementGroup extends STGroup {
+        @Override
+        public CompiledST lookupTemplate(String name) {
+            CompiledST code = super.lookupTemplate(name);
+            if (code == null) {
+                templates.remove(name.charAt(0) == '/' ? name : "/" + name);
+            }
+            return code;
+        }
     }
 
     static class ErrorListener implements STErrorListener {

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
@@ -167,18 +167,33 @@ public class StringTemplateEngine implements TemplateEngine.Parsing {
         }
     }
 
-    /** No-op listener for a pooled prototype at rest; a render always installs an {@link ErrorListener} first. */
+    /**
+     * Listener for a pooled prototype at rest. A render installs an {@link ErrorListener} before it touches the
+     * group, so a callback here means a template executed outside a checkout, which is a bug in the caller.
+     */
     private static final class IdleListener implements STErrorListener {
         @Override
-        public void compileTimeError(STMessage msg) {}
+        public void compileTimeError(STMessage msg) {
+            idle(msg);
+        }
 
         @Override
-        public void runTimeError(STMessage msg) {}
+        public void runTimeError(STMessage msg) {
+            idle(msg);
+        }
 
         @Override
-        public void IOError(STMessage msg) {}
+        public void IOError(STMessage msg) {
+            idle(msg);
+        }
 
         @Override
-        public void internalError(STMessage msg) {}
+        public void internalError(STMessage msg) {
+            idle(msg);
+        }
+
+        private static void idle(STMessage msg) {
+            throw new IllegalStateException("StringTemplate reported an error on an idle pooled template: " + msg, msg.cause);
+        }
     }
 }

--- a/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
+++ b/stringtemplate4/src/main/java/org/jdbi/v3/stringtemplate4/StringTemplateEngine.java
@@ -13,6 +13,12 @@
  */
 package org.jdbi.v3.stringtemplate4;
 
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.TemplateEngine;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
@@ -26,15 +32,54 @@ import org.stringtemplate.v4.misc.STMessage;
  * Rewrites a StringTemplate template, using the attributes on the {@link StatementContext} as template parameters.
  * For configuration, see {@link StringTemplates}.
  */
-public class StringTemplateEngine implements TemplateEngine {
+public class StringTemplateEngine implements TemplateEngine.Parsing {
+    /** Installed on an idle pooled prototype so it holds no execution context between renders. */
+    private static final STErrorListener IDLE_LISTENER = new IdleListener();
+
+    /** Non-cached render, for direct callers; the core uses {@link #parse(String, ConfigRegistry)}. */
     @Override
     public String render(String sql, StatementContext ctx) {
+        return renderInstance(compile(sql, ctx), ctx);
+    }
+
+    /**
+     * Caches compilation. StringTemplate is expensive to compile, and its {@link STGroup} and {@link ST} are
+     * not thread-safe, so a compiled template must not be rendered by two threads at once. Compiled prototypes
+     * are pooled rather than bound to a thread, so compilation is reused across platform and virtual threads
+     * alike: a render checks a prototype out of the pool (compiling one only if the pool is empty), renders a
+     * copy, and returns the prototype. Rendering is fast, non-blocking, and CPU-bound, so no more prototypes
+     * are checked out at once than there are threads actually rendering; the pool self-bounds without a
+     * capacity limit, holding its high-water mark of concurrent renders for the life of the cache entry.
+     */
+    @Override
+    public Optional<Function<StatementContext, String>> parse(String sql, ConfigRegistry config) {
+        final Queue<ST> pool = new ConcurrentLinkedQueue<>();
+        return Optional.of(ctx -> {
+            ST proto = pool.poll();
+            if (proto == null) {
+                proto = compile(sql, ctx);
+            }
+            // The prototype is checked out exclusively, so its group is not shared while in use.
+            final STGroup group = proto.groupThatCreatedThisInstance;
+            try {
+                group.setListener(new ErrorListener(ctx));
+                return renderInstance(new ST(proto), ctx);
+            } finally {
+                // Drop the execution context so an idle pooled prototype retains no StatementContext.
+                group.setListener(IDLE_LISTENER);
+                pool.offer(proto);
+            }
+        });
+    }
+
+    private static ST compile(String sql, StatementContext ctx) {
         STGroup group = new STGroup();
         group.setListener(new ErrorListener(ctx));
-        ST template = new ST(group, sql);
+        return new ST(group, sql);
+    }
 
+    private static String renderInstance(ST template, StatementContext ctx) {
         ctx.getAttributes().forEach(template::add);
-
         return template.render();
     }
 
@@ -74,5 +119,20 @@ public class StringTemplateEngine implements TemplateEngine {
         public void internalError(STMessage msg) {
             runTimeError(msg);
         }
+    }
+
+    /** No-op listener for a pooled prototype at rest; a render always installs an {@link ErrorListener} first. */
+    private static final class IdleListener implements STErrorListener {
+        @Override
+        public void compileTimeError(STMessage msg) {}
+
+        @Override
+        public void runTimeError(STMessage msg) {}
+
+        @Override
+        public void IOError(STMessage msg) {}
+
+        @Override
+        public void internalError(STMessage msg) {}
     }
 }

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateEngineCaching.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateEngineCaching.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.stringtemplate4;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.cache.internal.DefaultJdbiCacheStats;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Covers the caching behavior of {@link StringTemplateEngine#parse}. */
+public class TestStringTemplateEngineCaching {
+
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2();
+
+    Handle handle;
+
+    @BeforeEach
+    void setup() {
+        handle = h2Extension.getSharedHandle();
+        handle.execute("create table tbl (id int, name varchar)");
+        handle.execute("insert into tbl (id, name) values (1, 'a')");
+    }
+
+    /** The documented pattern for a render() override: also override parse() to opt out of caching. */
+    @Test
+    void subclassOptsOutOfCachingToKeepRenderOverride() {
+        handle.setTemplateEngine(new StringTemplateEngine() {
+            @Override
+            public String render(String sql, StatementContext ctx) {
+                return super.render(sql, ctx).replace("__TBL__", "tbl");
+            }
+
+            @Override
+            public Optional<Function<StatementContext, String>> parse(String sql, ConfigRegistry config) {
+                return Optional.empty();
+            }
+        });
+        for (int i = 0; i < 3; i++) {
+            assertThat(handle.createQuery("select count(*) from __TBL__ where id = <id>")
+                    .define("id", 1)
+                    .mapTo(Long.class)
+                    .one()).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void statelessEnginesAreEqualByClass() {
+        assertThat(new StringTemplateEngine())
+                .isEqualTo(new StringTemplateEngine())
+                .hasSameHashCodeAs(new StringTemplateEngine());
+    }
+
+    /** A fresh engine instance per statement must reuse the shared cache entry, not add new ones. */
+    @Test
+    void freshEngineInstancesShareOneCacheEntry() {
+        String sql = "select count(*) from tbl where id = <id>";
+        assertThat(query(sql)).isEqualTo(1L);
+        DefaultJdbiCacheStats before = handle.getConfig(SqlStatements.class).cacheStats();
+        assertThat(query(sql)).isEqualTo(1L);
+        assertThat(query(sql)).isEqualTo(1L);
+        DefaultJdbiCacheStats after = handle.getConfig(SqlStatements.class).cacheStats();
+        assertThat(after.cacheSize()).isEqualTo(before.cacheSize());
+    }
+
+    @Test
+    void dynamicIncludeOfMissingTemplateThrowsEveryRender() {
+        handle.setTemplateEngine(new StringTemplateEngine());
+        for (String tname : List.of("alpha", "beta", "alpha")) {
+            assertThatThrownBy(() -> handle.createQuery("select <(tname)()> from tbl")
+                    .define("tname", tname)
+                    .mapTo(String.class)
+                    .one())
+                    .isInstanceOf(UnableToExecuteStatementException.class);
+        }
+    }
+
+    @Test
+    void negativeTemplateLookupIsNotRetained() {
+        StringTemplateEngine.StatementGroup group = new StringTemplateEngine.StatementGroup();
+        assertThat(group.lookupTemplate("missing")).isNull();
+        assertThat(group.rawGetTemplate("/missing")).isNull();
+    }
+
+    private long query(String sql) {
+        return handle.createQuery(sql)
+                .setTemplateEngine(new StringTemplateEngine())
+                .define("id", 1)
+                .mapTo(Long.class)
+                .one();
+    }
+}

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateEngineConcurrency.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateEngineConcurrency.java
@@ -15,11 +15,13 @@ package org.jdbi.v3.stringtemplate4;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
@@ -52,12 +54,15 @@ public class TestStringTemplateEngineConcurrency {
         int threads = 8;
         int iterations = 2000;
         ExecutorService pool = Executors.newFixedThreadPool(threads);
-        AtomicInteger wrong = new AtomicInteger();
+        CyclicBarrier start = new CyclicBarrier(threads);
+        Queue<String> mismatches = new ConcurrentLinkedQueue<>();
         List<Future<?>> futures = new ArrayList<>();
 
         for (int t = 0; t < threads; t++) {
             final int seed = t;
             futures.add(pool.submit(() -> {
+                // Line up all workers so the first renders are guaranteed to contend.
+                start.await();
                 for (int i = 0; i < iterations; i++) {
                     // Vary the rendered shape and the bound name per call.
                     boolean byName = ((seed + i) & 1) == 0;
@@ -70,17 +75,21 @@ public class TestStringTemplateEngineConcurrency {
                             .mapTo(Long.class)
                             .one());
                     if (count != expected) {
-                        wrong.incrementAndGet();
+                        mismatches.add("byName=" + byName + " name=" + name + " expected=" + expected + " got=" + count);
                     }
                 }
+                return null;
             }));
         }
 
-        for (Future<?> f : futures) {
-            f.get(60, TimeUnit.SECONDS);
+        try {
+            for (Future<?> f : futures) {
+                f.get(60, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
         }
-        pool.shutdown();
 
-        assertThat(wrong).hasValue(0);
+        assertThat(mismatches).isEmpty();
     }
 }

--- a/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateEngineConcurrency.java
+++ b/stringtemplate4/src/test/java/org/jdbi/v3/stringtemplate4/TestStringTemplateEngineConcurrency.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.stringtemplate4;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Renders one cached template from many threads at once, each with different per-call attributes, to confirm
+ * the pooled compiled prototypes are never used by two threads at once and every render is correct.
+ */
+public class TestStringTemplateEngineConcurrency {
+
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2();
+
+    private static final String SQL =
+            "select count(*) from tbl where id = :id <if(byName)> and name = :nm <endif>";
+
+    @Test
+    public void concurrentRendersOfOneTemplateAreIsolated() throws Exception {
+        Jdbi jdbi = h2Extension.getJdbi();
+        jdbi.setTemplateEngine(new StringTemplateEngine());
+        jdbi.useHandle(h -> {
+            h.execute("create table tbl (id int, name varchar)");
+            h.execute("insert into tbl (id, name) values (1, 'a')");
+        });
+
+        int threads = 8;
+        int iterations = 2000;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        AtomicInteger wrong = new AtomicInteger();
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int t = 0; t < threads; t++) {
+            final int seed = t;
+            futures.add(pool.submit(() -> {
+                for (int i = 0; i < iterations; i++) {
+                    // Vary the rendered shape and the bound name per call.
+                    boolean byName = ((seed + i) & 1) == 0;
+                    String name = ((seed + i) & 2) == 0 ? "a" : "z";
+                    long expected = !byName ? 1 : ("a".equals(name) ? 1 : 0);
+                    long count = jdbi.withHandle(h -> h.createQuery(SQL)
+                            .define("byName", byName)
+                            .bind("id", 1)
+                            .bind("nm", name)
+                            .mapTo(Long.class)
+                            .one());
+                    if (count != expected) {
+                        wrong.incrementAndGet();
+                    }
+                }
+            }));
+        }
+
+        for (Future<?> f : futures) {
+            f.get(60, TimeUnit.SECONDS);
+        }
+        pool.shutdown();
+
+        assertThat(wrong).hasValue(0);
+    }
+}

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jdbi.internal</groupId>
         <artifactId>jdbi3-parent</artifactId>
-        <version>3.54.1-SNAPSHOT</version>
+        <version>3.55.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jdbi</groupId>


### PR DESCRIPTION
StringTemplateEngine recompiled the template on every render, because it
implemented TemplateEngine rather than TemplateEngine.Parsing, so the core's
template cache could not hold a reusable render function for it. Compilation
dominated the render cost.
    
Implement TemplateEngine.Parsing to cache compilation. StringTemplate's
STGroup and ST are not thread-safe, so a compiled template must not be
rendered by two threads at once. Compiled prototypes are pooled (checked out
exclusively, copied via the ST copy constructor, returned after render)
rather than bound to a thread, so compilation is reused across platform and
virtual threads alike. Rendering is fast, non-blocking, and CPU-bound, so the
pool usually holds no more prototypes than there are threads rendering at once.
A returned prototype's error listener is reset so an
idle pooled prototype retains no StatementContext. A new concurrency test
renders one cached template from 8 threads x 2000 iterations with varying
attributes and checks every render.
