### PR TITLE
Add the Jdbi.builder() assembly API and the JdbiPlugin.configure(Builder) SPI

### DIFF
--- a/core/src/main/java/org/jdbi/core/Handle.java
+++ b/core/src/main/java/org/jdbi/core/Handle.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.jdbi.core.config.ConfigRegistry;
@@ -84,12 +85,24 @@ public class Handle implements Closeable, Configurable<Handle> {
 
     private final AtomicBoolean closed = new AtomicBoolean();
 
+    /** A no-op per-handle config scope: the handle uses an unmodified copy of the Jdbi config. */
+    private static final Consumer<ConfigRegistry> NO_CONFIG_SCOPE = config -> {};
+
     static Handle createHandle(final Jdbi jdbi,
             final Cleanable connectionCleaner,
             final TransactionHandler transactionHandler,
             final StatementBuilder statementBuilder,
             final Connection connection) throws SQLException {
-        final Handle handle = new Handle(jdbi, connectionCleaner, transactionHandler, statementBuilder, connection);
+        return createHandle(jdbi, connectionCleaner, transactionHandler, statementBuilder, connection, NO_CONFIG_SCOPE);
+    }
+
+    static Handle createHandle(final Jdbi jdbi,
+            final Cleanable connectionCleaner,
+            final TransactionHandler transactionHandler,
+            final StatementBuilder statementBuilder,
+            final Connection connection,
+            final Consumer<ConfigRegistry> configScope) throws SQLException {
+        final Handle handle = new Handle(jdbi, connectionCleaner, transactionHandler, statementBuilder, connection, configScope);
 
         handle.notifyHandleCreated();
         return handle;
@@ -99,13 +112,17 @@ public class Handle implements Closeable, Configurable<Handle> {
             final Cleanable connectionCleaner,
             final TransactionHandler transactionHandler,
             final StatementBuilder statementBuilder,
-            final Connection connection) throws SQLException {
+            final Connection connection,
+            final Consumer<ConfigRegistry> configScope) throws SQLException {
         this.jdbi = jdbi;
         this.connectionCleaner = connectionCleaner;
         this.connection = connection;
 
-        // create a copy to detach config from the jdbi to allow local changes.
-        this.defaultExtensionContext = ExtensionContext.forConfig(jdbi.getConfig().createCopy());
+        // create a copy to detach config from the jdbi to allow local changes, then apply any per-handle scope
+        // before the extension context and handle listeners are derived from it.
+        final ConfigRegistry handleConfig = jdbi.getConfig().createCopy();
+        configScope.accept(handleConfig);
+        this.defaultExtensionContext = ExtensionContext.forConfig(handleConfig);
         this.currentExtensionContext = defaultExtensionContext;
 
         this.statementBuilder = statementBuilder;

--- a/core/src/main/java/org/jdbi/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/core/Jdbi.java
@@ -703,7 +703,10 @@ public class Jdbi implements Configurable<Jdbi> {
          * @return this builder
          */
         public Builder installPlugin(final JdbiPlugin plugin) {
-            plugins.add(Objects.requireNonNull(plugin, "null plugin"));
+            Objects.requireNonNull(plugin, "null plugin");
+            if (!plugins.contains(plugin)) {
+                plugins.add(plugin);
+            }
             return this;
         }
 
@@ -758,11 +761,17 @@ public class Jdbi implements Configurable<Jdbi> {
         /**
          * Applies the installed plugins and returns the assembled {@link Jdbi}. Each plugin's
          * {@link JdbiPlugin#configure(Builder)} runs, then its {@link JdbiPlugin#customizeJdbi(Jdbi)}, in install order.
+         * A plugin may itself install further plugins (via {@link #installPlugin(JdbiPlugin)} from its
+         * {@code configure}/{@code customizeJdbi} hook); those are drained and applied in turn, each at most once.
          *
          * @return the assembled {@code Jdbi}
          */
         public Jdbi build() {
-            for (final JdbiPlugin plugin : plugins) {
+            // Drain by index: a plugin's configure()/customizeJdbi() may install further plugins, growing the list
+            // mid-drain. installPlugin() dedups so a plugin pulled in by two others is still applied once.
+            int i = 0;
+            while (i < plugins.size()) {
+                final JdbiPlugin plugin = plugins.get(i++);
                 plugin.configure(this);
                 jdbi.installPlugin(plugin);
             }

--- a/core/src/main/java/org/jdbi/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/core/Jdbi.java
@@ -305,7 +305,10 @@ public class Jdbi implements Configurable<Jdbi> {
      * provided {@link Handle} instances.
      * @param plugin the plugin to install
      * @return this
+     * @deprecated assemble with {@link #builder(ConnectionFactory)} and {@link Builder#installPlugin(JdbiPlugin)};
+     *             post-construction plugin installation is going away.
      */
+    @Deprecated(since = "4.0.0", forRemoval = true)
     public Jdbi installPlugin(final JdbiPlugin plugin) {
         Objects.requireNonNull(plugin, "null plugin");
         // Bridge onto the assembly funnel so a plugin that contributes via configure(Builder) is applied even on
@@ -320,6 +323,7 @@ public class Jdbi implements Configurable<Jdbi> {
      * hooks run in that order. The install-if-absent guard makes a plugin pulled in more than once apply only once.
      * Shared by {@link Builder#build()} and the {@link #installPlugin(JdbiPlugin)} bridge.
      */
+    @SuppressWarnings("deprecation") // customizeJdbi is deprecated for removal but still honored during the window
     private void applyPlugin(final Builder builder, final JdbiPlugin plugin) {
         if (plugins.addIfAbsent(plugin)) {
             plugin.configure(builder);
@@ -335,7 +339,9 @@ public class Jdbi implements Configurable<Jdbi> {
      *
      * @param factory the new statement builder factory.
      * @return this
+     * @deprecated set this with {@link Builder#statementBuilderFactory(StatementBuilderFactory)} during assembly instead.
      */
+    @Deprecated(since = "4.0.0", forRemoval = true)
     public Jdbi setStatementBuilderFactory(final StatementBuilderFactory factory) {
         this.statementBuilderFactory.set(factory);
         return this;
@@ -367,7 +373,9 @@ public class Jdbi implements Configurable<Jdbi> {
      * @param handler The TransactionHandler to use for all Handle instances obtained
      *                from this Jdbi
      * @return this
+     * @deprecated set this with {@link Builder#transactionHandler(TransactionHandler)} during assembly instead.
      */
+    @Deprecated(since = "4.0.0", forRemoval = true)
     public Jdbi setTransactionHandler(final TransactionHandler handler) {
         Objects.requireNonNull(handler, "null transaction handler");
         this.transactionhandler.set(handler);
@@ -391,8 +399,10 @@ public class Jdbi implements Configurable<Jdbi> {
      * @param handleCallbackDecorator The {@link HandleCallbackDecorator} to use for all {@link #useHandle}, {@link #withHandle},
      *                {@link #useTransaction(HandleConsumer)} and {@link #inTransaction(HandleCallback)} from this Jdbi. Must not be null
      * @return this
+     * @deprecated set this with {@link Builder#handleCallbackDecorator(HandleCallbackDecorator)} during assembly instead.
      */
     @Alpha
+    @Deprecated(since = "4.0.0", forRemoval = true)
     public Jdbi setHandleCallbackDecorator(final HandleCallbackDecorator handleCallbackDecorator) {
         Objects.requireNonNull(handleCallbackDecorator, "null handler");
         this.handleCallbackDecorator.set(handleCallbackDecorator);
@@ -424,8 +434,10 @@ public class Jdbi implements Configurable<Jdbi> {
      * Set the {@link HandleScope} object. The Jdbi instance uses this to provide handles in a given scope.
      * <br>
      * @param handleScope A {@link HandleScope} object. Must not be null!
+     * @deprecated set this with {@link Builder#handleScope(HandleScope)} during assembly instead.
      */
     @Alpha
+    @Deprecated(since = "4.0.0", forRemoval = true)
     public final void setHandleScope(final HandleScope handleScope) {
         this.handleScope = handleScope;
     }

--- a/core/src/main/java/org/jdbi/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/core/Jdbi.java
@@ -307,10 +307,24 @@ public class Jdbi implements Configurable<Jdbi> {
      * @return this
      */
     public Jdbi installPlugin(final JdbiPlugin plugin) {
+        Objects.requireNonNull(plugin, "null plugin");
+        // Bridge onto the assembly funnel so a plugin that contributes via configure(Builder) is applied even on
+        // this post-construction path. The Builder is a facade over this same instance (shared config), so build()
+        // applies the plugin's hooks to this Jdbi and returns it. Removed wholesale when this method is dropped.
+        return new Builder(this).installPlugin(plugin).build();
+    }
+
+    /**
+     * Applies a single plugin to this instance during assembly: it is registered once for the per-handle and
+     * per-connection hooks, then its {@link JdbiPlugin#configure(Builder)} and {@link JdbiPlugin#customizeJdbi(Jdbi)}
+     * hooks run in that order. The install-if-absent guard makes a plugin pulled in more than once apply only once.
+     * Shared by {@link Builder#build()} and the {@link #installPlugin(JdbiPlugin)} bridge.
+     */
+    private void applyPlugin(final Builder builder, final JdbiPlugin plugin) {
         if (plugins.addIfAbsent(plugin)) {
+            plugin.configure(builder);
             Unchecked.consumer(plugin::customizeJdbi).accept(this);
         }
-        return this;
     }
 
     /**
@@ -768,12 +782,10 @@ public class Jdbi implements Configurable<Jdbi> {
          */
         public Jdbi build() {
             // Drain by index: a plugin's configure()/customizeJdbi() may install further plugins, growing the list
-            // mid-drain. installPlugin() dedups so a plugin pulled in by two others is still applied once.
+            // mid-drain. applyPlugin() installs-if-absent so a plugin pulled in by two others is still applied once.
             int i = 0;
             while (i < plugins.size()) {
-                final JdbiPlugin plugin = plugins.get(i++);
-                plugin.configure(this);
-                jdbi.installPlugin(plugin);
+                jdbi.applyPlugin(this, plugins.get(i++));
             }
             return jdbi;
         }

--- a/core/src/main/java/org/jdbi/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/core/Jdbi.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import javax.sql.DataSource;
 
@@ -58,6 +59,9 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  */
 public class Jdbi implements Configurable<Jdbi> {
     private static final Logger LOG = LoggerFactory.getLogger(Jdbi.class);
+
+    /** A no-op per-handle config scope: the opened handle uses an unmodified copy of this Jdbi's config. */
+    private static final Consumer<ConfigRegistry> NO_CONFIG_SCOPE = config -> {};
 
     private final ConfigRegistry config = new ConfigRegistry();
 
@@ -452,6 +456,29 @@ public class Jdbi implements Configurable<Jdbi> {
      * @see #withHandle(HandleCallback)
      */
     public Handle open() {
+        return open(NO_CONFIG_SCOPE);
+    }
+
+    /**
+     * Obtain a Handle whose configuration is a copy of this Jdbi's, with the given scope applied. Use this to run a
+     * unit of work against a handle that carries per-handle configuration (mappers, arguments, defines, and the like)
+     * without affecting this Jdbi or any other handle:
+     * <pre>{@code
+     * try (Handle h = jdbi.open(config -> config.configure(RowMappers.class, r -> r.register(myMapper)))) {
+     *     ...
+     * }
+     * }</pre>
+     * The scope receives a private copy of this Jdbi's config and configures it in place. You own the returned handle
+     * and are required to close it, ideally with a {@code try-with-resources} block.
+     *
+     * @param configScope applied to the new handle's private config copy during {@code open}
+     * @return an open Handle instance carrying the scoped configuration
+     * @see #open()
+     * @see #withHandle(Consumer, HandleCallback)
+     */
+    @Alpha
+    public Handle open(final Consumer<ConfigRegistry> configScope) {
+        Objects.requireNonNull(configScope, "null configScope");
         try {
             final long start = System.nanoTime();
             Connection conn = Objects.requireNonNull(connectionFactory.openConnection(),
@@ -469,7 +496,8 @@ public class Jdbi implements Configurable<Jdbi> {
                         connectionFactory.getCleanableFor(conn), // don't use conn::close, the cleanup must be done by the connection factory!
                         transactionhandler.get(),
                         cache,
-                        conn);
+                        conn,
+                        configScope);
 
                 for (final JdbiPlugin p : plugins) {
                     h = p.customizeHandle(h);
@@ -516,6 +544,42 @@ public class Jdbi implements Configurable<Jdbi> {
     }
 
     /**
+     * A convenience function which manages the lifecycle of a handle carrying the given per-handle configuration,
+     * and yields it to a callback. Unlike {@link #withHandle(HandleCallback)}, this always opens a <em>new</em> handle
+     * for the scoped configuration (a handle captures its config at {@code open}), so it does not join a handle already
+     * in scope; the scoped handle is in scope for the duration of the callback and is closed before returning.
+     *
+     * @param configScope applied to the new handle's private config copy during {@code open}
+     * @param callback A callback which will receive the scoped Handle
+     * @param <R> type returned by the callback
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @return the value returned by callback
+     *
+     * @throws X any exception thrown by the callback
+     * @see #open(Consumer)
+     */
+    @Alpha
+    public <R, X extends Exception> R withHandle(final Consumer<ConfigRegistry> configScope, final HandleCallback<R, X> callback) throws X {
+        Objects.requireNonNull(configScope, "null configScope");
+        final HandleCallback<R, X> decoratedCallback = handleCallbackDecorator.get().decorate(callback);
+
+        final var previous = handleScope.get();
+        try (Handle h = this.open(configScope)) {
+            h.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(c.isAttachCallbackStatementsForCleanup()));
+
+            handleScope.set(ConstantHandleSupplier.of(h));
+            return decoratedCallback.withHandle(h);
+        } finally {
+            if (previous == null) {
+                handleScope.clear();
+            } else {
+                handleScope.set(previous);
+            }
+        }
+    }
+
+    /**
      * A convenience function which manages the lifecycle of a handle and yields it to a callback
      * for use by clients.
      *
@@ -526,6 +590,22 @@ public class Jdbi implements Configurable<Jdbi> {
      */
     public <X extends Exception> void useHandle(final HandleConsumer<X> consumer) throws X {
         withHandle(consumer.asCallback());
+    }
+
+    /**
+     * A convenience function which manages the lifecycle of a handle carrying the given per-handle configuration,
+     * and yields it to a callback. Like {@link #withHandle(Consumer, HandleCallback)}, this always opens a new handle
+     * for the scoped configuration.
+     *
+     * @param configScope applied to the new handle's private config copy during {@code open}
+     * @param consumer A callback which will receive the scoped Handle
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @throws X any exception thrown by the callback
+     */
+    @Alpha
+    public <X extends Exception> void useHandle(final Consumer<ConfigRegistry> configScope, final HandleConsumer<X> consumer) throws X {
+        withHandle(configScope, consumer.asCallback());
     }
 
     /**
@@ -547,6 +627,26 @@ public class Jdbi implements Configurable<Jdbi> {
     }
 
     /**
+     * A convenience function which manages the lifecycle of a handle carrying the given per-handle configuration,
+     * and yields it to a callback in a transaction. The transaction is committed if the callback finishes normally,
+     * or rolled back if it raises an exception. Like {@link #withHandle(Consumer, HandleCallback)}, this always opens
+     * a new handle for the scoped configuration.
+     *
+     * @param configScope applied to the new handle's private config copy during {@code open}
+     * @param callback A callback which will receive the scoped Handle, in a transaction
+     * @param <R> type returned by the callback
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @return the value returned by callback
+     *
+     * @throws X any exception thrown by the callback
+     */
+    @Alpha
+    public <R, X extends Exception> R inTransaction(final Consumer<ConfigRegistry> configScope, final HandleCallback<R, X> callback) throws X {
+        return withHandle(configScope, handle -> handle.inTransaction(callback));
+    }
+
+    /**
      * A convenience function which manages the lifecycle of a handle and yields it to a callback
      * for use by clients. The handle will be in a transaction when the callback is invoked, and
      * that transaction will be committed if the callback finishes normally, or rolled back if the
@@ -559,6 +659,23 @@ public class Jdbi implements Configurable<Jdbi> {
      */
     public <X extends Exception> void useTransaction(final HandleConsumer<X> callback) throws X {
         useHandle(handle -> handle.useTransaction(callback));
+    }
+
+    /**
+     * A convenience function which manages the lifecycle of a handle carrying the given per-handle configuration,
+     * and yields it to a callback in a transaction. The transaction is committed if the callback finishes normally,
+     * or rolled back if it raises an exception. Like {@link #withHandle(Consumer, HandleCallback)}, this always opens
+     * a new handle for the scoped configuration.
+     *
+     * @param configScope applied to the new handle's private config copy during {@code open}
+     * @param callback A callback which will receive the scoped Handle, in a transaction
+     * @param <X> exception type thrown by the callback, if any.
+     *
+     * @throws X any exception thrown by the callback
+     */
+    @Alpha
+    public <X extends Exception> void useTransaction(final Consumer<ConfigRegistry> configScope, final HandleConsumer<X> callback) throws X {
+        useHandle(configScope, handle -> handle.useTransaction(callback));
     }
 
     /**

--- a/core/src/main/java/org/jdbi/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/core/Jdbi.java
@@ -16,6 +16,8 @@ package org.jdbi.core;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -150,6 +152,82 @@ public class Jdbi implements Configurable<Jdbi> {
         Objects.requireNonNull(username, "null username");
         Objects.requireNonNull(password, "null password");
         return create(() -> DriverManager.getConnection(url, username, password));
+    }
+
+    /**
+     * Returns a {@link Builder} that assembles a {@link Jdbi} against the given connection factory. The builder is
+     * the preferred way to configure a {@code Jdbi}: register mappers, arguments, and plugins, set the transaction
+     * handler and other knobs, then call {@link Builder#build()}.
+     *
+     * @param connectionFactory provides JDBC connections to {@link Handle} instances
+     * @return a builder for a {@code Jdbi} using the given connection factory
+     */
+    @Alpha
+    public static Builder builder(final ConnectionFactory connectionFactory) {
+        return new Builder(create(connectionFactory));
+    }
+
+    /**
+     * Returns a {@link Builder} that assembles a {@link Jdbi} against the given data source.
+     *
+     * @param dataSource the data source.
+     * @return a builder for a {@code Jdbi} using the given data source
+     * @see #builder(ConnectionFactory)
+     */
+    @Alpha
+    public static Builder builder(final DataSource dataSource) {
+        return new Builder(create(dataSource));
+    }
+
+    /**
+     * Returns a {@link Builder} that assembles a {@link Jdbi} against a single database connection.
+     *
+     * @param connection a {@link Connection} object.
+     * @return a builder for a {@code Jdbi} using the given connection
+     * @see #builder(ConnectionFactory)
+     */
+    @Alpha
+    public static Builder builder(final Connection connection) {
+        return new Builder(create(connection));
+    }
+
+    /**
+     * Returns a {@link Builder} that assembles a {@link Jdbi} against connections obtained from the given URL.
+     *
+     * @param url a JDBC URL for connections.
+     * @return a builder for a {@code Jdbi} using the given URL
+     * @see #builder(ConnectionFactory)
+     */
+    @Alpha
+    public static Builder builder(final String url) {
+        return new Builder(create(url));
+    }
+
+    /**
+     * Returns a {@link Builder} that assembles a {@link Jdbi} against connections obtained from the given URL and properties.
+     *
+     * @param url        a JDBC URL for connections.
+     * @param properties properties passed to {@link DriverManager#getConnection(String, Properties)} for each handle.
+     * @return a builder for a {@code Jdbi} using the given URL and properties
+     * @see #builder(ConnectionFactory)
+     */
+    @Alpha
+    public static Builder builder(final String url, final Properties properties) {
+        return new Builder(create(url, properties));
+    }
+
+    /**
+     * Returns a {@link Builder} that assembles a {@link Jdbi} against connections obtained from the given URL, user, and password.
+     *
+     * @param url      a JDBC URL for connections.
+     * @param username the username for the connection.
+     * @param password the password for the connection.
+     * @return a builder for a {@code Jdbi} using the given URL and credentials
+     * @see #builder(ConnectionFactory)
+     */
+    @Alpha
+    public static Builder builder(final String url, final String username, final String password) {
+        return new Builder(create(url, username, password));
     }
 
     /**
@@ -592,5 +670,103 @@ public class Jdbi implements Configurable<Jdbi> {
      */
     public StatementTemplate buildStatementTemplate(final CharSequence sql) {
         return new StatementTemplate(getConfig().createCopy(), sql);
+    }
+
+    /**
+     * Assembles a {@link Jdbi} instance. Obtain one from {@link Jdbi#builder(ConnectionFactory)} (or an overload),
+     * register mappers, arguments, and plugins, set the transaction handler and other knobs, then call
+     * {@link #build()}. The builder is {@link Configurable}, so all of the {@code register*}/{@code configure}
+     * convenience methods are available during assembly.
+     * <p>
+     * A builder is single-use: {@link #build()} returns the assembled {@code Jdbi} and should be called once.
+     */
+    @Alpha
+    public static final class Builder implements Configurable<Builder> {
+
+        private final Jdbi jdbi;
+        private final List<JdbiPlugin> plugins = new ArrayList<>();
+
+        Builder(final Jdbi jdbi) {
+            this.jdbi = jdbi;
+        }
+
+        @Override
+        public ConfigRegistry getConfig() {
+            return jdbi.getConfig();
+        }
+
+        /**
+         * Installs a {@link JdbiPlugin} to be applied when {@link #build()} is called. Plugins are applied in the
+         * order installed.
+         *
+         * @param plugin the plugin to install
+         * @return this builder
+         */
+        public Builder installPlugin(final JdbiPlugin plugin) {
+            plugins.add(Objects.requireNonNull(plugin, "null plugin"));
+            return this;
+        }
+
+        /**
+         * Sets the {@link TransactionHandler} for the assembled {@code Jdbi}.
+         *
+         * @param handler the transaction handler
+         * @return this builder
+         * @see Jdbi#setTransactionHandler(TransactionHandler)
+         */
+        public Builder transactionHandler(final TransactionHandler handler) {
+            jdbi.setTransactionHandler(handler);
+            return this;
+        }
+
+        /**
+         * Sets the {@link StatementBuilderFactory} for the assembled {@code Jdbi}.
+         *
+         * @param factory the statement builder factory
+         * @return this builder
+         * @see Jdbi#setStatementBuilderFactory(StatementBuilderFactory)
+         */
+        public Builder statementBuilderFactory(final StatementBuilderFactory factory) {
+            jdbi.setStatementBuilderFactory(factory);
+            return this;
+        }
+
+        /**
+         * Sets the {@link HandleCallbackDecorator} for the assembled {@code Jdbi}.
+         *
+         * @param handleCallbackDecorator the handle callback decorator
+         * @return this builder
+         * @see Jdbi#setHandleCallbackDecorator(HandleCallbackDecorator)
+         */
+        public Builder handleCallbackDecorator(final HandleCallbackDecorator handleCallbackDecorator) {
+            jdbi.setHandleCallbackDecorator(handleCallbackDecorator);
+            return this;
+        }
+
+        /**
+         * Sets the {@link HandleScope} for the assembled {@code Jdbi}.
+         *
+         * @param handleScope the handle scope
+         * @return this builder
+         * @see Jdbi#setHandleScope(HandleScope)
+         */
+        public Builder handleScope(final HandleScope handleScope) {
+            jdbi.setHandleScope(handleScope);
+            return this;
+        }
+
+        /**
+         * Applies the installed plugins and returns the assembled {@link Jdbi}. Each plugin's
+         * {@link JdbiPlugin#configure(Builder)} runs, then its {@link JdbiPlugin#customizeJdbi(Jdbi)}, in install order.
+         *
+         * @return the assembled {@code Jdbi}
+         */
+        public Jdbi build() {
+            for (final JdbiPlugin plugin : plugins) {
+                plugin.configure(this);
+                jdbi.installPlugin(plugin);
+            }
+            return jdbi;
+        }
     }
 }

--- a/core/src/main/java/org/jdbi/core/config/ConfiguringPlugin.java
+++ b/core/src/main/java/org/jdbi/core/config/ConfiguringPlugin.java
@@ -32,7 +32,7 @@ public final class ConfiguringPlugin<C extends JdbiConfig<C>> implements JdbiPlu
     }
 
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.configure(configClass, configurer);
+    public void configure(Jdbi.Builder builder) {
+        builder.configure(configClass, configurer);
     }
 }

--- a/core/src/main/java/org/jdbi/core/h2/H2DatabasePlugin.java
+++ b/core/src/main/java/org/jdbi/core/h2/H2DatabasePlugin.java
@@ -22,7 +22,7 @@ import org.jdbi.core.spi.JdbiPlugin;
  */
 public class H2DatabasePlugin extends JdbiPlugin.Singleton {
     @Override
-    public void customizeJdbi(Jdbi db) {
-        db.setSqlArrayArgumentStrategy(SqlArrayArgumentStrategy.OBJECT_ARRAY);
+    public void configure(Jdbi.Builder builder) {
+        builder.setSqlArrayArgumentStrategy(SqlArrayArgumentStrategy.OBJECT_ARRAY);
     }
 }

--- a/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
+++ b/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
@@ -63,7 +63,10 @@ public interface JdbiPlugin {
      * This method is invoked immediately when the plugin is installed.
      * @param jdbi the jdbi to customize
      * @throws SQLException something went wrong with the database
+     * @deprecated contribute configuration from {@link #configure(Jdbi.Builder)} instead; this hook is applied after
+     *             the {@code Jdbi} is constructed and is going away.
      */
+    @Deprecated(since = "4.0.0", forRemoval = true)
     default void customizeJdbi(Jdbi jdbi) throws SQLException {}
 
     /**

--- a/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
+++ b/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
@@ -15,6 +15,8 @@ package org.jdbi.core.spi;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jdbi.core.Handle;
@@ -25,6 +27,27 @@ import org.jdbi.core.Jdbi;
  * types before they are returned from their factories.
  */
 public interface JdbiPlugin {
+    /**
+     * Returns a plugin whose {@link #configure(Jdbi.Builder)} applies the given consumer to the builder. This is a
+     * lambda shorthand for bundling a bit of build-time configuration without declaring an anonymous {@code JdbiPlugin}:
+     * <pre>{@code
+     * builder.installPlugin(JdbiPlugin.of(b -> b.registerRowMapper(mapper).registerArgument(argument)));
+     * }</pre>
+     * The returned plugin implements only {@code configure(Builder)}; it does not customize handles or connections.
+     *
+     * @param configureConsumer applied to the {@link Jdbi.Builder} during assembly
+     * @return a plugin that runs the given consumer at build time
+     */
+    static JdbiPlugin of(Consumer<Jdbi.Builder> configureConsumer) {
+        Objects.requireNonNull(configureConsumer, "null configureConsumer");
+        return new JdbiPlugin() {
+            @Override
+            public void configure(Jdbi.Builder builder) {
+                configureConsumer.accept(builder);
+            }
+        };
+    }
+
     /**
      * Contributes configuration and knobs to a {@link Jdbi.Builder} during assembly. This method is invoked by
      * {@link Jdbi.Builder#build()} for each installed plugin, in install order, before {@link #customizeJdbi(Jdbi)}.

--- a/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
+++ b/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
@@ -26,6 +26,16 @@ import org.jdbi.core.Jdbi;
  */
 public interface JdbiPlugin {
     /**
+     * Contributes configuration and knobs to a {@link Jdbi.Builder} during assembly. This method is invoked by
+     * {@link Jdbi.Builder#build()} for each installed plugin, in install order, before {@link #customizeJdbi(Jdbi)}.
+     * It is the preferred hook for plugins that only add configuration (mappers, arguments, and the like), because
+     * it runs while the {@code Jdbi} is still being assembled rather than mutating it after construction.
+     *
+     * @param builder the builder to contribute to
+     */
+    default void configure(Jdbi.Builder builder) {}
+
+    /**
      * Configure customizations global to any object managed by this Jdbi.
      * This method is invoked immediately when the plugin is installed.
      * @param jdbi the jdbi to customize

--- a/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
+++ b/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// exercises the deprecated Jdbi.installPlugin bridge and the customizeJdbi hook on purpose
+@SuppressWarnings("deprecation")
 public class TestJdbiBuilder {
 
     private static String url() {

--- a/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
+++ b/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
@@ -126,6 +126,34 @@ public class TestJdbiBuilder {
     }
 
     @Test
+    public void installPluginBridgesConfigureHook() {
+        // A plugin that contributes only via configure(Builder) is still applied through the post-construction
+        // Jdbi.installPlugin path (the deprecation-window bridge onto the assembly funnel).
+        final RowMapper<String> mapper = (rs, ctx) -> "bridged";
+        final Jdbi jdbi = Jdbi.create(url())
+                .installPlugin(JdbiPlugin.of(b -> b.registerRowMapper(String.class, mapper)));
+
+        try (Handle h = jdbi.open()) {
+            assertThat(h.createQuery("select 1").mapTo(String.class).one()).isEqualTo("bridged");
+        }
+    }
+
+    @Test
+    public void installPluginAppliesPluginOnce() {
+        final AtomicInteger configureCount = new AtomicInteger();
+        final JdbiPlugin plugin = new JdbiPlugin.Singleton() {
+            @Override
+            public void configure(final Jdbi.Builder builder) {
+                configureCount.incrementAndGet();
+            }
+        };
+
+        Jdbi.create(url()).installPlugin(plugin).installPlugin(plugin);
+
+        assertThat(configureCount).hasValue(1);
+    }
+
+    @Test
     public void buildAppliesPluginPulledInByTwoOthersOnce() {
         final AtomicInteger configureCount = new AtomicInteger();
         final JdbiPlugin shared = new JdbiPlugin() {

--- a/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
+++ b/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
@@ -94,4 +94,61 @@ public class TestJdbiBuilder {
             assertThat(h.createQuery("select 1").mapTo(String.class).one()).isEqualTo("from-plugin");
         }
     }
+
+    @Test
+    public void ofRunsConsumerAtBuildTime() {
+        final RowMapper<String> mapper = (rs, ctx) -> "from-of";
+        final Jdbi jdbi = Jdbi.builder(url())
+                .installPlugin(JdbiPlugin.of(b -> b.registerRowMapper(String.class, mapper)))
+                .build();
+
+        try (Handle h = jdbi.open()) {
+            assertThat(h.createQuery("select 1").mapTo(String.class).one()).isEqualTo("from-of");
+        }
+    }
+
+    @Test
+    public void buildDrainsPluginsInstalledDuringConfigure() {
+        final RowMapper<String> mapper = (rs, ctx) -> "from-sub";
+        final JdbiPlugin sub = JdbiPlugin.of(b -> b.registerRowMapper(String.class, mapper));
+        final JdbiPlugin parent = new JdbiPlugin() {
+            @Override
+            public void configure(final Jdbi.Builder builder) {
+                builder.installPlugin(sub);
+            }
+        };
+
+        final Jdbi jdbi = Jdbi.builder(url()).installPlugin(parent).build();
+
+        try (Handle h = jdbi.open()) {
+            assertThat(h.createQuery("select 1").mapTo(String.class).one()).isEqualTo("from-sub");
+        }
+    }
+
+    @Test
+    public void buildAppliesPluginPulledInByTwoOthersOnce() {
+        final AtomicInteger configureCount = new AtomicInteger();
+        final JdbiPlugin shared = new JdbiPlugin() {
+            @Override
+            public void configure(final Jdbi.Builder builder) {
+                configureCount.incrementAndGet();
+            }
+        };
+        final JdbiPlugin first = new JdbiPlugin() {
+            @Override
+            public void configure(final Jdbi.Builder builder) {
+                builder.installPlugin(shared);
+            }
+        };
+        final JdbiPlugin second = new JdbiPlugin() {
+            @Override
+            public void configure(final Jdbi.Builder builder) {
+                builder.installPlugin(shared);
+            }
+        };
+
+        Jdbi.builder(url()).installPlugin(first).installPlugin(second).build();
+
+        assertThat(configureCount).hasValue(1);
+    }
 }

--- a/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
+++ b/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.core;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jdbi.core.mapper.RowMapper;
+import org.jdbi.core.spi.JdbiPlugin;
+import org.jdbi.core.transaction.LocalTransactionHandler;
+import org.jdbi.core.transaction.TransactionHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJdbiBuilder {
+
+    private static String url() {
+        return "jdbc:h2:mem:" + UUID.randomUUID();
+    }
+
+    @Test
+    public void buildAppliesConfiguration() {
+        final RowMapper<String> mapper = (rs, ctx) -> "mapped";
+        final Jdbi jdbi = Jdbi.builder(url())
+                .registerRowMapper(String.class, mapper)
+                .build();
+
+        try (Handle h = jdbi.open()) {
+            assertThat(h.createQuery("select 1").mapTo(String.class).one()).isEqualTo("mapped");
+        }
+    }
+
+    @Test
+    public void buildSetsKnobs() {
+        final TransactionHandler handler = LocalTransactionHandler.binding();
+        final Jdbi jdbi = Jdbi.builder(url())
+                .transactionHandler(handler)
+                .build();
+
+        assertThat(jdbi.getTransactionHandler()).isSameAs(handler);
+    }
+
+    @Test
+    public void buildAppliesBothPluginHooksInOrder() {
+        final AtomicInteger tick = new AtomicInteger();
+        final int[] configuredAt = {-1};
+        final int[] customizedAt = {-1};
+
+        final JdbiPlugin plugin = new JdbiPlugin() {
+            @Override
+            public void configure(final Jdbi.Builder builder) {
+                configuredAt[0] = tick.getAndIncrement();
+            }
+
+            @Override
+            public void customizeJdbi(final Jdbi jdbi) {
+                customizedAt[0] = tick.getAndIncrement();
+            }
+        };
+
+        final Jdbi jdbi = Jdbi.builder(url()).installPlugin(plugin).build();
+
+        assertThat(jdbi).isNotNull();
+        // both hooks run, configure() before customizeJdbi()
+        assertThat(configuredAt[0]).isZero();
+        assertThat(customizedAt[0]).isOne();
+    }
+
+    @Test
+    public void pluginConfigureContributesConfig() {
+        final RowMapper<String> mapper = (rs, ctx) -> "from-plugin";
+        final JdbiPlugin plugin = new JdbiPlugin() {
+            @Override
+            public void configure(final Jdbi.Builder builder) {
+                builder.registerRowMapper(String.class, mapper);
+            }
+        };
+
+        final Jdbi jdbi = Jdbi.builder(url()).installPlugin(plugin).build();
+
+        try (Handle h = jdbi.open()) {
+            assertThat(h.createQuery("select 1").mapTo(String.class).one()).isEqualTo("from-plugin");
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/core/TestOpenWithConfigScope.java
+++ b/core/src/test/java/org/jdbi/core/TestOpenWithConfigScope.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.core;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.mapper.ColumnMappers;
+import org.jdbi.core.mapper.NoSuchMapperException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestOpenWithConfigScope {
+
+    private static String url() {
+        return "jdbc:h2:mem:" + UUID.randomUUID();
+    }
+
+    static final class Widget {
+        final String name;
+
+        Widget(final String name) {
+            this.name = name;
+        }
+    }
+
+    // registers a column mapper for Widget, which has no built-in mapper
+    private static final Consumer<ConfigRegistry> WIDGET_MAPPER = config ->
+            config.configure(ColumnMappers.class, m -> m.register(Widget.class, (rs, col, ctx) -> new Widget(rs.getString(col))));
+
+    @Test
+    public void openScopeAppliesConfig() {
+        final Jdbi jdbi = Jdbi.create(url());
+        try (Handle h = jdbi.open(WIDGET_MAPPER)) {
+            assertThat(h.createQuery("select 'sprocket'").mapTo(Widget.class).one().name).isEqualTo("sprocket");
+        }
+    }
+
+    @Test
+    public void openScopeDoesNotAffectJdbi() {
+        final Jdbi jdbi = Jdbi.create(url());
+        try (Handle scoped = jdbi.open(WIDGET_MAPPER)) {
+            assertThat(scoped.createQuery("select 'x'").mapTo(Widget.class).one().name).isEqualTo("x");
+        }
+        // a plain handle from the same Jdbi never saw the scoped mapper
+        try (Handle plain = jdbi.open()) {
+            assertThatThrownBy(() -> plain.createQuery("select 'x'").mapTo(Widget.class).one())
+                    .isInstanceOf(NoSuchMapperException.class);
+        }
+    }
+
+    @Test
+    public void withHandleScopeAppliesConfig() {
+        final Jdbi jdbi = Jdbi.create(url());
+        final String name = jdbi.withHandle(WIDGET_MAPPER,
+                h -> h.createQuery("select 'gadget'").mapTo(Widget.class).one().name);
+        assertThat(name).isEqualTo("gadget");
+    }
+
+    @Test
+    public void inTransactionScopeAppliesConfig() {
+        final Jdbi jdbi = Jdbi.create(url());
+        final String name = jdbi.inTransaction(WIDGET_MAPPER,
+                h -> h.createQuery("select 'cog'").mapTo(Widget.class).one().name);
+        assertThat(name).isEqualTo("cog");
+    }
+
+    @Test
+    public void scopedHandleListenerSeesFullLifecycle() {
+        final Jdbi jdbi = Jdbi.create(url());
+        final AtomicInteger created = new AtomicInteger();
+        final AtomicInteger closed = new AtomicInteger();
+        // the scope is applied before the handle copies its listeners, so a handleCreated listener is honored
+        final Consumer<ConfigRegistry> listenerScope = config -> config.configure(Handles.class, h -> h.addListener(new HandleListener() {
+            @Override
+            public void handleCreated(final Handle handle) {
+                created.incrementAndGet();
+            }
+
+            @Override
+            public void handleClosed(final Handle handle) {
+                closed.incrementAndGet();
+            }
+        }));
+
+        try (Handle h = jdbi.open(listenerScope)) {
+            assertThat(created).hasValue(1);
+        }
+        assertThat(closed).hasValue(1);
+    }
+
+    @Test
+    public void nullScopeRejected() {
+        final Jdbi jdbi = Jdbi.create(url());
+        assertThatThrownBy(() -> jdbi.open((Consumer<ConfigRegistry>) null)).isInstanceOf(NullPointerException.class);
+    }
+}

--- a/core/src/test/java/org/jdbi/core/TestPlugins.java
+++ b/core/src/test/java/org/jdbi/core/TestPlugins.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// exercises the deprecated Jdbi.installPlugin path to verify the customizeHandle/customizeConnection hooks
+@SuppressWarnings("deprecation")
 public class TestPlugins {
 
     @RegisterExtension

--- a/core/src/test/java/org/jdbi/core/internal/testing/DatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/core/internal/testing/DatabaseExtension.java
@@ -44,13 +44,13 @@ public interface DatabaseExtension<T extends DatabaseExtension<T>> {
     }
 
     @SuppressWarnings("unchecked")
-    default void installTestPlugins(Jdbi jdbi) throws Exception {
+    default void installTestPlugins(Jdbi.Builder builder) throws Exception {
         // cache plugin tests
         String cachePluginName = System.getProperty("jdbi.test.cache-plugin");
         if (cachePluginName != null) {
             Class<? extends JdbiPlugin> cachePluginClass = (Class<? extends JdbiPlugin>) Class.forName(cachePluginName);
             JdbiPlugin cachePlugin = cachePluginClass.getConstructor().newInstance();
-            jdbi.installPlugin(cachePlugin);
+            builder.installPlugin(cachePlugin);
         }
     }
 

--- a/core/src/test/java/org/jdbi/core/internal/testing/H2DatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/core/internal/testing/H2DatabaseExtension.java
@@ -133,7 +133,7 @@ public final class H2DatabaseExtension implements DatabaseExtension<H2DatabaseEx
         if (jdbi != null) {
             throw new IllegalStateException("jdbi is not null!");
         }
-        jdbi = Jdbi.create(() -> {
+        final Jdbi.Builder builder = Jdbi.builder(() -> {
             final Connection connection = DriverManager.getConnection(uri);
             // this will only work reliably in single-threaded tests. Any multi-threaded
             // test will hand out the last connection used by the last thread calling this
@@ -142,14 +142,15 @@ public final class H2DatabaseExtension implements DatabaseExtension<H2DatabaseEx
             return connection;
         });
 
-        installTestPlugins(jdbi);
+        installTestPlugins(builder);
 
         if (enableLeakchecker) {
-            jdbi.configure(Handles.class, c -> c.addListener(leakChecker));
-            jdbi.configure(SqlStatements.class, c -> c.addContextListener(leakChecker));
+            builder.configure(Handles.class, c -> c.addListener(leakChecker));
+            builder.configure(SqlStatements.class, c -> c.addContextListener(leakChecker));
         }
 
-        plugins.forEach(jdbi::installPlugin);
+        plugins.forEach(builder::installPlugin);
+        jdbi = builder.build();
         sharedHandle = jdbi.open();
 
         initializerMaybe.ifPresent(i -> i.initialize(sharedHandle));

--- a/core/src/test/java/org/jdbi/core/internal/testing/PgDatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/core/internal/testing/PgDatabaseExtension.java
@@ -106,16 +106,17 @@ public final class PgDatabaseExtension implements DatabaseExtension<PgDatabaseEx
 
         info = pg.createDatabaseInfo();
 
-        jdbi = Jdbi.create(info.asDataSource());
+        final Jdbi.Builder builder = Jdbi.builder(info.asDataSource());
 
-        installTestPlugins(jdbi);
+        installTestPlugins(builder);
 
         if (enableLeakchecker) {
-            jdbi.configure(Handles.class, c -> c.addListener(leakChecker));
-            jdbi.configure(SqlStatements.class, c -> c.addContextListener(leakChecker));
+            builder.configure(Handles.class, c -> c.addListener(leakChecker));
+            builder.configure(SqlStatements.class, c -> c.addContextListener(leakChecker));
         }
 
-        plugins.forEach(jdbi::installPlugin);
+        plugins.forEach(builder::installPlugin);
+        jdbi = builder.build();
         sharedHandle = jdbi.open();
 
         initializerMaybe.ifPresent(i -> i.initialize(sharedHandle));

--- a/core/src/test/java/org/jdbi/core/internal/testing/SqliteDatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/core/internal/testing/SqliteDatabaseExtension.java
@@ -105,16 +105,17 @@ public final class SqliteDatabaseExtension implements DatabaseExtension<SqliteDa
         if (jdbi != null) {
             throw new IllegalStateException("jdbi is not null!");
         }
-        jdbi = Jdbi.create(uri);
+        final Jdbi.Builder builder = Jdbi.builder(uri);
 
-        installTestPlugins(jdbi);
+        installTestPlugins(builder);
 
         if (enableLeakchecker) {
-            jdbi.configure(Handles.class, c -> c.addListener(leakChecker));
-            jdbi.configure(SqlStatements.class, c -> c.addContextListener(leakChecker));
+            builder.configure(Handles.class, c -> c.addListener(leakChecker));
+            builder.configure(SqlStatements.class, c -> c.addContextListener(leakChecker));
         }
 
-        plugins.forEach(jdbi::installPlugin);
+        plugins.forEach(builder::installPlugin);
+        jdbi = builder.build();
         sharedHandle = jdbi.open();
 
         initializerMaybe.ifPresent(i -> i.initialize(sharedHandle));

--- a/gson2/src/main/java/org/jdbi/gson2/Gson2Plugin.java
+++ b/gson2/src/main/java/org/jdbi/gson2/Gson2Plugin.java
@@ -27,8 +27,8 @@ import org.jdbi.json.JsonPlugin;
  */
 public class Gson2Plugin extends JdbiPlugin.Singleton {
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.installPlugin(new JsonPlugin());
-        jdbi.configure(JsonConfig.class, c -> c.jsonMapper(new GsonJsonMapper()));
+    public void configure(Jdbi.Builder builder) {
+        builder.installPlugin(new JsonPlugin());
+        builder.configure(JsonConfig.class, c -> c.jsonMapper(new GsonJsonMapper()));
     }
 }

--- a/guava/src/main/java/org/jdbi/guava/GuavaPlugin.java
+++ b/guava/src/main/java/org/jdbi/guava/GuavaPlugin.java
@@ -21,8 +21,8 @@ import org.jdbi.core.spi.JdbiPlugin;
  */
 public class GuavaPlugin extends JdbiPlugin.Singleton {
     @Override
-    public void customizeJdbi(Jdbi db) {
-        db.registerArgument(GuavaArguments.factory());
-        db.registerCollector(GuavaCollectors.factory());
+    public void configure(Jdbi.Builder builder) {
+        builder.registerArgument(GuavaArguments.factory());
+        builder.registerCollector(GuavaCollectors.factory());
     }
 }

--- a/jackson2/src/main/java/org/jdbi/jackson2/Jackson2Plugin.java
+++ b/jackson2/src/main/java/org/jdbi/jackson2/Jackson2Plugin.java
@@ -27,8 +27,8 @@ import org.jdbi.json.JsonPlugin;
  */
 public class Jackson2Plugin extends JdbiPlugin.Singleton {
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.installPlugin(new JsonPlugin());
-        jdbi.configure(JsonConfig.class, c -> c.jsonMapper(new JacksonJsonMapper()));
+    public void configure(Jdbi.Builder builder) {
+        builder.installPlugin(new JsonPlugin());
+        builder.configure(JsonConfig.class, c -> c.jsonMapper(new JacksonJsonMapper()));
     }
 }

--- a/jackson3/src/main/java/org/jdbi/jackson3/Jackson3Plugin.java
+++ b/jackson3/src/main/java/org/jdbi/jackson3/Jackson3Plugin.java
@@ -27,8 +27,8 @@ import org.jdbi.json.JsonPlugin;
  */
 public class Jackson3Plugin extends JdbiPlugin.Singleton {
     @Override
-    public void customizeJdbi(final Jdbi jdbi) {
-        jdbi.installPlugin(new JsonPlugin());
-        jdbi.configure(JsonConfig.class, c -> c.jsonMapper(new JacksonJsonMapper()));
+    public void configure(final Jdbi.Builder builder) {
+        builder.installPlugin(new JsonPlugin());
+        builder.configure(JsonConfig.class, c -> c.jsonMapper(new JacksonJsonMapper()));
     }
 }

--- a/jodatime2/src/main/java/org/jdbi/jodatime2/JodaTimePlugin.java
+++ b/jodatime2/src/main/java/org/jdbi/jodatime2/JodaTimePlugin.java
@@ -21,8 +21,8 @@ import org.jdbi.core.spi.JdbiPlugin;
  */
 public class JodaTimePlugin implements JdbiPlugin {
     @Override
-    public void customizeJdbi(Jdbi db) {
-        db.registerArgument(new DateTimeArgumentFactory());
-        db.registerColumnMapper(new DateTimeMapper());
+    public void configure(Jdbi.Builder builder) {
+        builder.registerArgument(new DateTimeArgumentFactory());
+        builder.registerColumnMapper(new DateTimeMapper());
     }
 }

--- a/jpa/src/main/java/org/jdbi/jpa/JpaPlugin.java
+++ b/jpa/src/main/java/org/jdbi/jpa/JpaPlugin.java
@@ -22,7 +22,7 @@ import org.jdbi.core.spi.JdbiPlugin;
  */
 public class JpaPlugin implements JdbiPlugin {
     @Override
-    public void customizeJdbi(Jdbi db) {
-        db.registerRowMapper(new JpaMapperFactory());
+    public void configure(Jdbi.Builder builder) {
+        builder.registerRowMapper(new JpaMapperFactory());
     }
 }

--- a/json/src/main/java/org/jdbi/json/JsonPlugin.java
+++ b/json/src/main/java/org/jdbi/json/JsonPlugin.java
@@ -20,8 +20,8 @@ import org.jdbi.json.internal.JsonColumnMapperFactory;
 
 public class JsonPlugin extends JdbiPlugin.Singleton {
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.registerArgument(new JsonArgumentFactory());
-        jdbi.registerColumnMapper(new JsonColumnMapperFactory());
+    public void configure(Jdbi.Builder builder) {
+        builder.registerArgument(new JsonArgumentFactory());
+        builder.registerColumnMapper(new JsonColumnMapperFactory());
     }
 }

--- a/moshi/src/main/java/org/jdbi/moshi/MoshiPlugin.java
+++ b/moshi/src/main/java/org/jdbi/moshi/MoshiPlugin.java
@@ -28,8 +28,8 @@ import org.jdbi.json.JsonPlugin;
 public class MoshiPlugin extends JdbiPlugin.Singleton {
 
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.installPlugin(new JsonPlugin());
-        jdbi.configure(JsonConfig.class, c -> c.jsonMapper(new MoshiJsonMapper()));
+    public void configure(Jdbi.Builder builder) {
+        builder.installPlugin(new JsonPlugin());
+        builder.configure(JsonConfig.class, c -> c.jsonMapper(new MoshiJsonMapper()));
     }
 }

--- a/opentelemetry/src/main/java/org/jdbi/opentelemetry/JdbiOpenTelemetryPlugin.java
+++ b/opentelemetry/src/main/java/org/jdbi/opentelemetry/JdbiOpenTelemetryPlugin.java
@@ -13,8 +13,6 @@
  */
 package org.jdbi.opentelemetry;
 
-import java.sql.SQLException;
-
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -52,8 +50,8 @@ public class JdbiOpenTelemetryPlugin extends JdbiPlugin.Singleton {
     }
 
     @Override
-    public void customizeJdbi(final Jdbi jdbi) throws SQLException {
-        jdbi.configure(SqlStatements.class, c -> c.addContextListener(new TracingListener()));
+    public void configure(final Jdbi.Builder builder) {
+        builder.configure(SqlStatements.class, c -> c.addContextListener(new TracingListener()));
     }
 
     class TracingListener implements StatementContextListener {

--- a/oracle12/src/main/java/org/jdbi/oracle12/OraclePlugin.java
+++ b/oracle12/src/main/java/org/jdbi/oracle12/OraclePlugin.java
@@ -33,8 +33,8 @@ import org.jdbi.core.spi.JdbiPlugin;
 public class OraclePlugin extends JdbiPlugin.Singleton {
 
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.configure(Arguments.class, arguments ->
+    public void configure(Jdbi.Builder builder) {
+        builder.configure(Arguments.class, arguments ->
                 arguments.untypedNullArgument(new NullArgument(Types.NULL)));
     }
 }

--- a/postgis/src/main/java/org/jdbi/postgis/PostgisPlugin.java
+++ b/postgis/src/main/java/org/jdbi/postgis/PostgisPlugin.java
@@ -48,10 +48,10 @@ import org.locationtech.jts.geom.Polygon;
 public class PostgisPlugin extends JdbiPlugin.Singleton {
 
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
+    public void configure(Jdbi.Builder builder) {
         final Codec<Geometry> codec = new PostgisCodec();
 
-        jdbi.registerCodecFactory(CodecFactory.builder()
+        builder.registerCodecFactory(CodecFactory.builder()
             .addCodec(Geometry.class, codec)
             .addCodec(GeometryCollection.class, codec)
             .addCodec(LinearRing.class, codec)

--- a/postgres/src/main/java/org/jdbi/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/postgres/PostgresPlugin.java
@@ -117,53 +117,53 @@ public class PostgresPlugin extends JdbiPlugin.Singleton {
     }
 
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.registerArgument(new TypedEnumArgumentFactory());
-        jdbi.registerArgument(new JavaTimeArgumentFactory());
-        jdbi.registerArgument(new DurationArgumentFactory());
-        jdbi.registerArgument(new PeriodArgumentFactory());
-        jdbi.registerArgument(new InetArgumentFactory());
-        jdbi.registerArgument(new HStoreArgumentFactory());
-        jdbi.registerArgument(new MacAddrArgumentFactory());
-        jdbi.registerArgument(new UUIDArgumentFactory());
-        jdbi.registerArgument(new PGobjectArgumentFactory());
-        jdbi.registerArgument(new BitStringEnumSetArgumentFactory());
-        jdbi.registerArgument(new BlobInputStreamArgumentFactory());
-        jdbi.registerArgument(new ClobReaderArgumentFactory());
+    public void configure(Jdbi.Builder builder) {
+        builder.registerArgument(new TypedEnumArgumentFactory());
+        builder.registerArgument(new JavaTimeArgumentFactory());
+        builder.registerArgument(new DurationArgumentFactory());
+        builder.registerArgument(new PeriodArgumentFactory());
+        builder.registerArgument(new InetArgumentFactory());
+        builder.registerArgument(new HStoreArgumentFactory());
+        builder.registerArgument(new MacAddrArgumentFactory());
+        builder.registerArgument(new UUIDArgumentFactory());
+        builder.registerArgument(new PGobjectArgumentFactory());
+        builder.registerArgument(new BitStringEnumSetArgumentFactory());
+        builder.registerArgument(new BlobInputStreamArgumentFactory());
+        builder.registerArgument(new ClobReaderArgumentFactory());
 
         // built-in PGobject types
-        jdbi.registerArrayType(PGbox.class, "box");
-        jdbi.registerArrayType(PGcircle.class, "circle");
-        jdbi.registerArrayType(PGInterval.class, "interval");
-        jdbi.registerArrayType(PGline.class, "line");
-        jdbi.registerArrayType(PGlseg.class, "lseg");
-        jdbi.registerArrayType(PGmoney.class, "money");
-        jdbi.registerArrayType(PGpath.class, "path");
-        jdbi.registerArrayType(PGpoint.class, "point");
-        jdbi.registerArrayType(PGpolygon.class, "polygon");
-        jdbi.registerArrayType(new ByteaArrayType());
-        jdbi.registerArrayType(new PostgresCustomTypeArrayFactory());
+        builder.registerArrayType(PGbox.class, "box");
+        builder.registerArrayType(PGcircle.class, "circle");
+        builder.registerArrayType(PGInterval.class, "interval");
+        builder.registerArrayType(PGline.class, "line");
+        builder.registerArrayType(PGlseg.class, "lseg");
+        builder.registerArrayType(PGmoney.class, "money");
+        builder.registerArrayType(PGpath.class, "path");
+        builder.registerArrayType(PGpoint.class, "point");
+        builder.registerArrayType(PGpolygon.class, "polygon");
+        builder.registerArrayType(new ByteaArrayType());
+        builder.registerArrayType(new PostgresCustomTypeArrayFactory());
 
-        jdbi.registerColumnMapper(new JavaTimeMapperFactory());
-        jdbi.registerColumnMapper(new HStoreColumnMapper());
-        jdbi.registerColumnMapper(new MacAddrColumnMapper());
-        jdbi.registerColumnMapper(new DurationColumnMapperFactory());
-        jdbi.registerColumnMapper(new PeriodColumnMapperFactory());
-        jdbi.registerColumnMapper(new PGobjectColumnMapperFactory());
-        jdbi.registerColumnMapper(new BitStringEnumSetMapperFactory());
-        jdbi.registerColumnMapper(new BlobInputStreamColumnMapperFactory());
-        jdbi.registerColumnMapper(new ClobReaderColumnMapperFactory());
+        builder.registerColumnMapper(new JavaTimeMapperFactory());
+        builder.registerColumnMapper(new HStoreColumnMapper());
+        builder.registerColumnMapper(new MacAddrColumnMapper());
+        builder.registerColumnMapper(new DurationColumnMapperFactory());
+        builder.registerColumnMapper(new PeriodColumnMapperFactory());
+        builder.registerColumnMapper(new PGobjectColumnMapperFactory());
+        builder.registerColumnMapper(new BitStringEnumSetMapperFactory());
+        builder.registerColumnMapper(new BlobInputStreamColumnMapperFactory());
+        builder.registerColumnMapper(new ClobReaderColumnMapperFactory());
 
         if (installLegacy) {
             // legacy unqualified HSTORE
             // Do *NOT* replace with `new HStoreArgumentFactory()`, the AI/Intellij whatever hint is wrong.
-            jdbi.registerArgument((ArgumentFactory) new HStoreArgumentFactory()::build);
-            jdbi.registerColumnMapper(new GenericType<>() {}, new HStoreColumnMapper());
+            builder.registerArgument((ArgumentFactory) new HStoreArgumentFactory()::build);
+            builder.registerColumnMapper(new GenericType<>() {}, new HStoreColumnMapper());
         }
 
         // optional integration
         if (JdbiClassUtils.isPresent("org.jdbi.json.JsonConfig")) {
-            jdbi.registerArgument(new JsonArgumentFactory());
+            builder.registerArgument(new JsonArgumentFactory());
         }
     }
 

--- a/sqlite/src/main/java/org/jdbi/sqlite3/SQLitePlugin.java
+++ b/sqlite/src/main/java/org/jdbi/sqlite3/SQLitePlugin.java
@@ -21,8 +21,8 @@ import org.jdbi.core.spi.JdbiPlugin;
  */
 public class SQLitePlugin extends JdbiPlugin.Singleton {
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.registerArgument(new URLArgumentFactory());
-        jdbi.registerColumnMapper(new URLColumnMapper());
+    public void configure(Jdbi.Builder builder) {
+        builder.registerArgument(new URLArgumentFactory());
+        builder.registerColumnMapper(new URLColumnMapper());
     }
 }

--- a/sqlobject/src/main/java/org/jdbi/sqlobject/SqlObjectPlugin.java
+++ b/sqlobject/src/main/java/org/jdbi/sqlobject/SqlObjectPlugin.java
@@ -22,14 +22,14 @@ import org.jdbi.core.spi.JdbiPlugin;
  */
 public class SqlObjectPlugin extends JdbiPlugin.Singleton {
     @Override
-    public void customizeJdbi(Jdbi db) {
+    public void configure(Jdbi.Builder builder) {
 
         // support for generated classes (jdbi-generator)
         GeneratorSqlObjectFactory generatorSqlObjectFactory = new GeneratorSqlObjectFactory();
-        db.registerExtension(generatorSqlObjectFactory);
-        db.configure(OnDemandExtensions.class, c -> c.factory(generatorSqlObjectFactory));
+        builder.registerExtension(generatorSqlObjectFactory);
+        builder.configure(OnDemandExtensions.class, c -> c.factory(generatorSqlObjectFactory));
 
         // register SQL object proxy factory
-        db.registerExtension(new SqlObjectFactory());
+        builder.registerExtension(new SqlObjectFactory());
     }
 }

--- a/testing/src/main/java/org/jdbi/testing/junit/JdbiExtension.java
+++ b/testing/src/main/java/org/jdbi/testing/junit/JdbiExtension.java
@@ -321,9 +321,10 @@ public abstract class JdbiExtension implements BeforeAllCallback, AfterAllCallba
             withConfig(SqlStatements.class, s -> s.addContextListener(leakChecker));
         }
 
-        final Jdbi jdbiInstance = Jdbi.create(ds);
+        final Jdbi.Builder builder = Jdbi.builder(ds);
+        plugins.forEach(builder::installPlugin);
+        final Jdbi jdbiInstance = builder.build();
 
-        plugins.forEach(jdbiInstance::installPlugin);
         final Handle sharedHandleInstance = jdbiInstance.open();
 
         this.jdbi = jdbiInstance;

--- a/vavr/src/main/java/org/jdbi/vavr/VavrPlugin.java
+++ b/vavr/src/main/java/org/jdbi/vavr/VavrPlugin.java
@@ -28,11 +28,11 @@ import org.jdbi.core.spi.JdbiPlugin;
  */
 public class VavrPlugin extends JdbiPlugin.Singleton {
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.registerCollector(new VavrCollectorFactory());
-        jdbi.registerRowMapper(new VavrTupleRowMapperFactory());
-        jdbi.registerRowMapper(new VavrOptionRowMapperFactory());
-        jdbi.registerArgument(new VavrValueArgumentFactory());
-        jdbi.registerColumnMapper(new VavrOptionColumnMapperFactory());
+    public void configure(Jdbi.Builder builder) {
+        builder.registerCollector(new VavrCollectorFactory());
+        builder.registerRowMapper(new VavrTupleRowMapperFactory());
+        builder.registerRowMapper(new VavrOptionRowMapperFactory());
+        builder.registerArgument(new VavrValueArgumentFactory());
+        builder.registerColumnMapper(new VavrOptionColumnMapperFactory());
     }
 }


### PR DESCRIPTION
Third feature PR of the stack, on top of pr3. It introduces the build-time assembly model — configure a Jdbi through a builder, and let plugins configure that builder — and deprecates post-construction mutation ahead of the read-only Jdbi in the next PR. Additive and deprecation-only; nothing is removed yet.

What's here:
  
 - Jdbi.builder() assembly API. A builder assembles a configured Jdbi: register mappers, arguments, and config on the builder, install plugins, then build(). Since config is immutable (pr3), the builder is where configuration happens.
 - JdbiPlugin.configure(Jdbi.Builder) SPI. The build-time plugin hook. build() drains and applies installed plugins, installPlugin de-duplicates, and JdbiPlugin.of(builder -> ...) is a lambda shorthand for a one-off plugin. In-repo plugins migrate to configure(Builder), with a bridge that keeps legacy installPlugin working.
 - Post-construction mutation is deprecated. The directly-owned mutating surface on a built Jdbi (transaction handler, statement-builder factory, and the like) is deprecated — a built Jdbi is meant to be assembled once, not reconfigured afterward.
  
Scope note: this PR only adds the new API and marks the old surface deprecated; the read-only Jdbi/Handle split and the removals land in pr5.