### PR TITLE
Make Jdbi and Handle read-only; move all configuration off the Handle

### DIFF
--- a/4.0_TODO
+++ b/4.0_TODO
@@ -8,3 +8,14 @@
 * Throwables throwOnlyException only exists because of the above <X extends Exception> issue, so clean that up too
 * BeanMapper should throw if it can't find a nested type rather than default to `rs.getObject` (strictColumnMapping)
 * use the with/use pattern everywhere. Replace `inTransaction` with `withTransaction`
+* Improve builder/plugin registration ordering for interceptor-dependent registrations.
+  JdbiPlugin.configure(Builder) hooks run at build() time, and a plugin that installs further
+  plugins appends them to the drain queue. So a register* call made from a builder/withConfig hook
+  can execute BEFORE a plugin that installs the interceptor it needs. Concretely, registering a
+  KotlinMapper via the inferring registerRowMapper(RowMapper) overload from a withConfig hook throws
+  "Must use a concretely typed RowMapper here" because KotlinPlugin's KotlinRowMapperInterceptor is
+  not installed yet (KotlinSqlObjectPlugin installs KotlinPlugin as a nested plugin, drained later).
+  Workarounds today: register on a built Jdbi's handle, or use an explicit-type overload that skips
+  inference. Consider making nested-plugin configuration eager (or two-phase: install all plugins,
+  then run their config hooks) so registration order within a hook no longer depends on drain timing.
+  See Issue1944Test / TestIssue1577 for the affected patterns.

--- a/benchmark/src/main/java/org/jdbi/benchmark/BeanBindingBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/benchmark/BeanBindingBenchmark.java
@@ -79,7 +79,8 @@ public class BeanBindingBenchmark {
     public void setup() throws Throwable {
 
         db = BenchmarkSupport.h2()
-                .installPlugin(new SqlObjectPlugin());
+                .installPlugin(new SqlObjectPlugin())
+                .build();
         dao = db.open()
                 .attach(Dao.class);
         dao.create();

--- a/benchmark/src/main/java/org/jdbi/benchmark/BenchmarkSupport.java
+++ b/benchmark/src/main/java/org/jdbi/benchmark/BenchmarkSupport.java
@@ -23,7 +23,7 @@ final class BenchmarkSupport {
         throw new UtilityClassException();
     }
 
-    static Jdbi h2() {
-        return Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID());
+    static Jdbi.Builder h2() {
+        return Jdbi.builder("jdbc:h2:mem:" + UUID.randomUUID());
     }
 }

--- a/benchmark/src/main/java/org/jdbi/benchmark/EnumBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/benchmark/EnumBenchmark.java
@@ -43,7 +43,7 @@ public class EnumBenchmark {
 
     @Setup
     public void setup() throws Throwable {
-        jdbi = BenchmarkSupport.h2();
+        jdbi = BenchmarkSupport.h2().build();
         jdbi.useHandle(h -> {
             h.execute("create table sensitive (value varchar)");
             h.execute("create table insensitive (value varchar)");

--- a/benchmark/src/main/java/org/jdbi/benchmark/QualifiersBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/benchmark/QualifiersBenchmark.java
@@ -49,12 +49,13 @@ public class QualifiersBenchmark {
 
     @Setup
     public void setup() throws Throwable {
-        jdbi = Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID());
-        jdbi.registerRowMapper(BeanMapper.factory(UnqualifiedBean.class));
-        jdbi.registerRowMapper(BeanMapper.factory(QualifiedBean1.class));
-        jdbi.registerRowMapper(BeanMapper.factory(QualifiedBean2.class));
-        jdbi.registerRowMapper(BeanMapper.factory(QualifiedBean3.class));
-        jdbi.registerRowMapper(BeanMapper.factory(QualifiedBean4.class));
+        jdbi = Jdbi.builder("jdbc:h2:mem:" + UUID.randomUUID())
+                .registerRowMapper(BeanMapper.factory(UnqualifiedBean.class))
+                .registerRowMapper(BeanMapper.factory(QualifiedBean1.class))
+                .registerRowMapper(BeanMapper.factory(QualifiedBean2.class))
+                .registerRowMapper(BeanMapper.factory(QualifiedBean3.class))
+                .registerRowMapper(BeanMapper.factory(QualifiedBean4.class))
+                .build();
         qualifiers = new Qualifiers(new ConfigRegistry());
     }
 

--- a/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/BaseSqlObjectV3Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/BaseSqlObjectV3Benchmark.java
@@ -37,7 +37,7 @@ public abstract class BaseSqlObjectV3Benchmark extends AbstractSqlObjectBenchmar
     private DaoV3 dao;
     private long rowOne;
 
-    protected abstract Jdbi createJdbi();
+    protected abstract Jdbi.Builder createJdbi();
     protected abstract void createTable();
 
     private void insertRow() {
@@ -47,9 +47,10 @@ public abstract class BaseSqlObjectV3Benchmark extends AbstractSqlObjectBenchmar
 
     @Setup(Level.Iteration)
     public void setup() throws Throwable {
-        jdbi = createJdbi();
-        jdbi.installPlugin(new SqlObjectPlugin());
-        jdbi.registerRowMapper(new DaoV3.TestDataMapper());
+        jdbi = createJdbi()
+                .installPlugin(new SqlObjectPlugin())
+                .registerRowMapper(new DaoV3.TestDataMapper())
+                .build();
 
         handle = jdbi.open();
         dao = handle.attach(DaoV3.class);

--- a/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/H2SqlObjectV3Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/H2SqlObjectV3Benchmark.java
@@ -24,8 +24,8 @@ public class H2SqlObjectV3Benchmark extends BaseSqlObjectV3Benchmark {
     }
 
     @Override
-    protected Jdbi createJdbi() {
-        return Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10");
+    protected Jdbi.Builder createJdbi() {
+        return Jdbi.builder("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10");
     }
 
     @Override

--- a/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/HandlePerOpV3Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/HandlePerOpV3Benchmark.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.benchmark.sqlobject;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.h2.Driver;
+import org.jdbi.benchmark.sqlobject.BaseSqlObjectV3Benchmark.DaoV3;
+import org.jdbi.core.Handle;
+import org.jdbi.core.Jdbi;
+import org.jdbi.sqlobject.SqlObjectPlugin;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Opens a <em>fresh handle per invocation</em> (the jdbi/jdbi#2992 "one handle per request" scenario) and
+ * measures the cost of the handle-boundary configuration copy. With the handle config as a copy-on-write child
+ * of the frozen Jdbi root, an unmodified handle shares the root's warm resolvers (mappers, extension metadata)
+ * instead of paying a cold {@code createCopy()} on every open. The deterministic metric is
+ * {@code gc.alloc.rate.norm} (bytes per operation); A/B the same build with the handle-COW change in vs out.
+ * <p>
+ * The {@code withHandle} variants matter specifically: the per-callback attach-for-cleanup scope was moved off
+ * per-handle config, so a callback handle no longer forks the shared config and now shares the warm resolvers too.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+public class HandlePerOpV3Benchmark {
+
+    private static final String CREATE = "create table tbl (id identity, name varchar, description varchar)";
+    private static final String INSERT = "INSERT INTO tbl (name, description) VALUES (:name, :description)";
+    private static final String SELECT = "SELECT id, name, description FROM tbl WHERE id = :id";
+
+    static {
+        Driver.load();
+    }
+
+    private Jdbi jdbi;
+    private long rowOne;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        jdbi = Jdbi.builder("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10")
+                .installPlugin(new SqlObjectPlugin())
+                .registerRowMapper(new DaoV3.TestDataMapper())
+                .build();
+
+        try (Handle h = jdbi.open()) {
+            h.execute(CREATE);
+            rowOne = h.createUpdate(INSERT)
+                    .bind("name", "row one")
+                    .bind("description", "the first row")
+                    .executeAndReturnGeneratedKeys()
+                    .mapTo(long.class)
+                    .one();
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        jdbi = null;
+    }
+
+    @Benchmark
+    public TestData openFluentSelect() {
+        try (Handle h = jdbi.open()) {
+            return h.createQuery(SELECT)
+                    .bind("id", rowOne)
+                    .mapTo(TestData.class)
+                    .one();
+        }
+    }
+
+    @Benchmark
+    public TestData withHandleFluentSelect() {
+        return jdbi.withHandle(h -> h.createQuery(SELECT)
+                .bind("id", rowOne)
+                .mapTo(TestData.class)
+                .one());
+    }
+
+    @Benchmark
+    public TestData openAttachSelect() {
+        try (Handle h = jdbi.open()) {
+            return h.attach(DaoV3.class).getTestData(rowOne);
+        }
+    }
+
+    @Benchmark
+    public TestData withHandleAttachSelect() {
+        return jdbi.withHandle(h -> h.attach(DaoV3.class).getTestData(rowOne));
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/PGSqlObjectV3Benchmark.java
+++ b/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/PGSqlObjectV3Benchmark.java
@@ -19,8 +19,8 @@ import org.jdbi.postgres.PostgresPlugin;
 
 public class PGSqlObjectV3Benchmark extends BaseSqlObjectV3Benchmark {
     @Override
-    protected Jdbi createJdbi() {
-        return Unchecked.supplier(() -> Jdbi.create(PGSqlObjectV2Benchmark.PROVIDER.createDefaultDataSource())
+    protected Jdbi.Builder createJdbi() {
+        return Unchecked.supplier(() -> Jdbi.builder(PGSqlObjectV2Benchmark.PROVIDER.createDefaultDataSource())
             .installPlugin(new PostgresPlugin())).get();
     }
 

--- a/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/SqlObjectOperationBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/benchmark/sqlobject/SqlObjectOperationBenchmark.java
@@ -54,9 +54,10 @@ public class SqlObjectOperationBenchmark {
 
     @Setup(Level.Iteration)
     public void setUp() {
-        jdbi = Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10");
-        jdbi.installPlugin(new SqlObjectPlugin());
-        jdbi.registerRowMapper(Data.class, new DataMapper());
+        jdbi = Jdbi.builder("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10")
+                .installPlugin(new SqlObjectPlugin())
+                .registerRowMapper(Data.class, new DataMapper())
+                .build();
 
         handle = jdbi.open();
         handle.execute("drop table if exists tbl");

--- a/cache/noop-cache/src/main/java/org/jdbi/cache/noop/NoopCachePlugin.java
+++ b/cache/noop-cache/src/main/java/org/jdbi/cache/noop/NoopCachePlugin.java
@@ -24,8 +24,8 @@ import org.jdbi.core.statement.SqlStatements;
 public final class NoopCachePlugin implements JdbiPlugin {
 
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.configure(SqlStatements.class, config -> config
+    public void configure(Jdbi.Builder builder) {
+        builder.configure(SqlStatements.class, config -> config
                 .templateCache(NoopCache.builder())
                 .sqlParser(new ColonPrefixSqlParser(NoopCache.builder())));
     }

--- a/commons-text/src/test/java/org/jdbi/commonstext/TestUseStringSubstitutorTemplateEngine.java
+++ b/commons-text/src/test/java/org/jdbi/commonstext/TestUseStringSubstitutorTemplateEngine.java
@@ -29,13 +29,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestUseStringSubstitutorTemplateEngine {
 
     @RegisterExtension
-    public JdbiExtension sqliteExtension = JdbiExtension.sqlite().withPlugin(new SqlObjectPlugin());
+    public JdbiExtension sqliteExtension = JdbiExtension.sqlite().withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.setTemplateEngine(TemplateEngine.NOP));
 
     private Jdbi jdbi;
 
     @BeforeEach
     public void before() {
-        jdbi = sqliteExtension.getJdbi().setTemplateEngine(TemplateEngine.NOP);
+        jdbi = sqliteExtension.getJdbi();
     }
 
     @Test

--- a/core/src/main/java/org/jdbi/core/ConstantHandleSupplier.java
+++ b/core/src/main/java/org/jdbi/core/ConstantHandleSupplier.java
@@ -37,7 +37,7 @@ final class ConstantHandleSupplier extends AbstractHandleSupplier {
 
     @Override
     public ConfigRegistry getConfig() {
-        return handle.getConfig();
+        return handle.configRegistry();
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/core/Handle.java
+++ b/core/src/main/java/org/jdbi/core/Handle.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jdbi.core.config.ConfigRegistry;
-import org.jdbi.core.config.Configurable;
 import org.jdbi.core.extension.ExtensionContext;
 import org.jdbi.core.extension.ExtensionMethod;
 import org.jdbi.core.extension.Extensions;
@@ -38,6 +37,7 @@ import org.jdbi.core.result.ResultBearing;
 import org.jdbi.core.statement.Batch;
 import org.jdbi.core.statement.Call;
 import org.jdbi.core.statement.Cleanable;
+import org.jdbi.core.statement.ConfigReader;
 import org.jdbi.core.statement.MetaData;
 import org.jdbi.core.statement.PreparedBatch;
 import org.jdbi.core.statement.Query;
@@ -61,7 +61,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * a JDBC Connection object.  Handle provides essential methods for transaction
  * management, statement creation, and other operations tied to the database session.
  */
-public class Handle implements Closeable, Configurable<Handle> {
+public class Handle implements Closeable, ConfigReader {
 
     private static final Logger LOG = LoggerFactory.getLogger(Handle.class);
 
@@ -130,11 +130,14 @@ public class Handle implements Closeable, Configurable<Handle> {
         this.connection = connection;
 
         // A copy-on-write child of the (frozen post-build) Jdbi config: an unmodified handle shares the root's
-        // warm resolver views instead of paying a cold copy, and a local change (a per-handle scope, or later
-        // handle.configure) forks a private snapshot without touching the root. The scope is applied before the
-        // extension context and handle listeners are derived from it.
+        // warm resolver views instead of paying a cold copy, and a local change (a per-handle config scope, or a
+        // plugin's customizeHandleConfig) forks a private snapshot without touching the root. Both are applied
+        // during construction, before the extension context and handle listeners are derived from the config.
         final ConfigRegistry handleConfig = jdbi.getConfig().createChild();
         configScope.accept(handleConfig);
+        // Plugins contribute per-connection config (e.g. binding database types to this connection) during
+        // construction, after the caller's scope and before the extension context is derived from the config.
+        jdbi.customizeHandleConfig(connection, handleConfig);
         this.defaultExtensionContext = ExtensionContext.forConfig(handleConfig);
         this.currentExtensionContext = defaultExtensionContext;
 

--- a/core/src/main/java/org/jdbi/core/Handle.java
+++ b/core/src/main/java/org/jdbi/core/Handle.java
@@ -41,6 +41,7 @@ import org.jdbi.core.statement.MetaData;
 import org.jdbi.core.statement.PreparedBatch;
 import org.jdbi.core.statement.Query;
 import org.jdbi.core.statement.Script;
+import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.core.statement.StatementBuilder;
 import org.jdbi.core.statement.Update;
 import org.jdbi.core.transaction.TransactionException;
@@ -70,6 +71,12 @@ public class Handle implements Closeable, Configurable<Handle> {
     private final boolean forceEndTransactions;
 
     private StatementBuilder statementBuilder;
+
+    // Set for a managed callback handle (withHandle/useHandle/inTransaction/useTransaction): statements created
+    // on this handle are attached to it for cleanup, regardless of the SqlStatements.attachAllStatementsForCleanup
+    // policy. Held here rather than as per-handle config so an unmodified callback handle keeps sharing the Jdbi
+    // root's copy-on-write config (and its warm resolvers) instead of forking a private copy on open.
+    private volatile boolean forceAttachStatements;
 
     // the fallback context. It is used when resetting the Handle state.
     private final ExtensionContext defaultExtensionContext;
@@ -118,9 +125,11 @@ public class Handle implements Closeable, Configurable<Handle> {
         this.connectionCleaner = connectionCleaner;
         this.connection = connection;
 
-        // create a copy to detach config from the jdbi to allow local changes, then apply any per-handle scope
-        // before the extension context and handle listeners are derived from it.
-        final ConfigRegistry handleConfig = jdbi.getConfig().createCopy();
+        // A copy-on-write child of the (frozen post-build) Jdbi config: an unmodified handle shares the root's
+        // warm resolver views instead of paying a cold copy, and a local change (a per-handle scope, or later
+        // handle.configure) forks a private snapshot without touching the root. The scope is applied before the
+        // extension context and handle listeners are derived from it.
+        final ConfigRegistry handleConfig = jdbi.getConfig().createChild();
         configScope.accept(handleConfig);
         this.defaultExtensionContext = ExtensionContext.forConfig(handleConfig);
         this.currentExtensionContext = defaultExtensionContext;
@@ -898,6 +907,22 @@ public class Handle implements Closeable, Configurable<Handle> {
         this.currentExtensionContext = extensionContext == null ? defaultExtensionContext : extensionContext;
 
         return this;
+    }
+
+    /**
+     * Whether statements created on this handle are attached to it for cleanup when the handle closes. This is the
+     * case when either this is a managed callback handle (see {@link Jdbi#withHandle}) whose callback-cleanup policy
+     * is enabled, or the {@link SqlStatements#isAttachAllStatementsForCleanup()} policy is set on this handle's config.
+     *
+     * @return {@code true} if new statements are attached to this handle for cleanup
+     */
+    public boolean isAttachStatementsForCleanup() {
+        return forceAttachStatements || getConfig().get(SqlStatements.class).isAttachAllStatementsForCleanup();
+    }
+
+    // package-private: set by the Jdbi callback methods to mark this as a managed callback handle.
+    void setForceAttachStatements(final boolean forceAttachStatements) {
+        this.forceAttachStatements = forceAttachStatements;
     }
 
     private void notifyHandleCreated() {

--- a/core/src/main/java/org/jdbi/core/Handle.java
+++ b/core/src/main/java/org/jdbi/core/Handle.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.config.Configurable;
 import org.jdbi.core.extension.ExtensionContext;
@@ -75,8 +76,11 @@ public class Handle implements Closeable, Configurable<Handle> {
     // Set for a managed callback handle (withHandle/useHandle/inTransaction/useTransaction): statements created
     // on this handle are attached to it for cleanup, regardless of the SqlStatements.attachAllStatementsForCleanup
     // policy. Held here rather than as per-handle config so an unmodified callback handle keeps sharing the Jdbi
-    // root's copy-on-write config (and its warm resolvers) instead of forking a private copy on open.
-    private volatile boolean forceAttachStatements;
+    // root's copy-on-write config (and its warm resolvers) instead of forking a private copy on open. A plain
+    // field like the handle's other mutable state (statementBuilder, currentExtensionContext): a Handle wraps a
+    // JDBC Connection and is not thread-safe, so it is confined to one thread or handed off with a barrier that
+    // publishes this write along with the rest of its state.
+    private boolean forceAttachStatements;
 
     // the fallback context. It is used when resetting the Handle state.
     private final ExtensionContext defaultExtensionContext;
@@ -921,6 +925,8 @@ public class Handle implements Closeable, Configurable<Handle> {
     }
 
     // package-private: set by the Jdbi callback methods to mark this as a managed callback handle.
+    @SuppressFBWarnings(value = "AT_STALE_THREAD_WRITE_OF_PRIMITIVE",
+            justification = "Handle is thread-confined (wraps a JDBC Connection); set once right after open, before the callback runs")
     void setForceAttachStatements(final boolean forceAttachStatements) {
         this.forceAttachStatements = forceAttachStatements;
     }

--- a/core/src/main/java/org/jdbi/core/Handle.java
+++ b/core/src/main/java/org/jdbi/core/Handle.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.extension.ExtensionContext;
 import org.jdbi.core.extension.ExtensionMethod;
 import org.jdbi.core.extension.Extensions;
@@ -86,6 +87,12 @@ public class Handle implements Closeable, ConfigReader {
     private final ExtensionContext defaultExtensionContext;
 
     private ExtensionContext currentExtensionContext;
+
+    // Read-only view handed to callers via getConfig(): a distinct delegate that cannot be cast back to the mutable
+    // ConfigRegistry, so a handle's config is not mutable post-open. It reads through to the current extension
+    // context's config, so it tracks context switches during extension invocation. Statements derive their own
+    // (copy-on-write) config from it via createChild().
+    private final ConfigView configView = ConfigView.readOnly(this::configRegistry);
 
     @GuardedBy("transactionCallbacks")
     private final List<TransactionCallback> transactionCallbacks = new ArrayList<>();
@@ -162,12 +169,23 @@ public class Handle implements Closeable, ConfigReader {
     }
 
     /**
-     * The current configuration object associated with this handle.
+     * A read-only view of the configuration associated with this handle. It is a {@link ConfigView}, not a
+     * {@link ConfigRegistry}: a handle's configuration is fixed at open time. To configure a handle, open it with a
+     * config scope ({@link Jdbi#open(Consumer)}) or configure individual statements (which are copy-on-write).
      *
-     * @return A {@link ConfigRegistry} object that is associated with the handle.
+     * @return the read-only configuration view associated with the handle.
      */
     @Override
-    public ConfigRegistry getConfig() {
+    public ConfigView getConfig() {
+        return configView;
+    }
+
+    /**
+     * The mutable registry backing {@link #getConfig()} (the current extension context's config). Package-private,
+     * for framework code (handle suppliers, the extension machinery) that must reach the live registry; the public
+     * surface is read-only.
+     */
+    ConfigRegistry configRegistry() {
         return currentExtensionContext.getConfig();
     }
 

--- a/core/src/main/java/org/jdbi/core/Handles.java
+++ b/core/src/main/java/org/jdbi/core/Handles.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.internal.RegistrationLists;
 
@@ -69,6 +70,7 @@ public final class Handles implements JdbiConfig<Handles> {
      *                             discipline.
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Handles forceEndTransactions(boolean forceEndTransactions) {
         return new Handles(forceEndTransactions, handleListeners);
     }
@@ -81,6 +83,7 @@ public final class Handles implements JdbiConfig<Handles> {
      *
      * @return a copy of this configuration with the listener registered
      */
+    @CheckReturnValue
     public Handles addListener(final HandleListener handleListener) {
         return new Handles(forceEndTransactions, RegistrationLists.appendDistinct(handleListeners, handleListener));
     }
@@ -92,6 +95,7 @@ public final class Handles implements JdbiConfig<Handles> {
      *
      * @return a copy of this configuration with the listener removed
      */
+    @CheckReturnValue
     public Handles removeListener(final HandleListener handleListener) {
         if (!handleListeners.contains(handleListener)) {
             return this;

--- a/core/src/main/java/org/jdbi/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/core/Jdbi.java
@@ -447,7 +447,7 @@ public class Jdbi implements ConfigReader {
         }
 
         try (Handle h = this.open()) {
-            h.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(c.isAttachCallbackStatementsForCleanup()));
+            h.setForceAttachStatements(h.getConfig().get(SqlStatements.class).isAttachCallbackStatementsForCleanup());
 
             handleScope.set(ConstantHandleSupplier.of(h));
             return decoratedCallback.withHandle(h);
@@ -479,7 +479,7 @@ public class Jdbi implements ConfigReader {
 
         final var previous = handleScope.get();
         try (Handle h = this.open(configScope)) {
-            h.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(c.isAttachCallbackStatementsForCleanup()));
+            h.setForceAttachStatements(h.getConfig().get(SqlStatements.class).isAttachCallbackStatementsForCleanup());
 
             handleScope.set(ConstantHandleSupplier.of(h));
             return decoratedCallback.withHandle(h);

--- a/core/src/main/java/org/jdbi/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/core/Jdbi.java
@@ -427,6 +427,16 @@ public class Jdbi implements ConfigReader {
     }
 
     /**
+     * Applies each installed plugin's {@link JdbiPlugin#customizeHandleConfig} to a new handle's config during
+     * construction, in install order. Called from the {@link Handle} constructor.
+     */
+    void customizeHandleConfig(final Connection connection, final ConfigRegistry config) throws SQLException {
+        for (final JdbiPlugin p : plugins) {
+            p.customizeHandleConfig(connection, config);
+        }
+    }
+
+    /**
      * A convenience function which manages the lifecycle of a handle and yields it to a callback
      * for use by clients.
      *

--- a/core/src/main/java/org/jdbi/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/core/Jdbi.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import javax.sql.DataSource;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.config.Configurable;
 import org.jdbi.core.extension.ExtensionCallback;
 import org.jdbi.core.extension.ExtensionConsumer;
@@ -64,6 +65,9 @@ public class Jdbi implements ConfigReader {
     private static final Consumer<ConfigRegistry> NO_CONFIG_SCOPE = config -> {};
 
     private final ConfigRegistry config = new ConfigRegistry();
+    // Read-only view handed to callers via getConfig(): a distinct delegate that cannot be cast back to the mutable
+    // ConfigRegistry, so post-build configuration must go through the builder. Internal code uses `config` directly.
+    private final ConfigView configView = ConfigView.readOnly(this::configRegistry);
 
     private final ConnectionFactory connectionFactory;
     private final AtomicReference<TransactionHandler> transactionhandler = new AtomicReference<>(LocalTransactionHandler.binding());
@@ -325,7 +329,15 @@ public class Jdbi implements ConfigReader {
     }
 
     @Override
-    public ConfigRegistry getConfig() {
+    public ConfigView getConfig() {
+        return configView;
+    }
+
+    /**
+     * The mutable registry backing {@link #getConfig()}. Package-private, for framework code (the extension
+     * machinery, handle suppliers) that must reach the live registry; the public surface is read-only.
+     */
+    ConfigRegistry configRegistry() {
         return config;
     }
 
@@ -735,7 +747,7 @@ public class Jdbi implements ConfigReader {
      * @return a reusable query template
      */
     public StatementTemplate buildStatementTemplate(final CharSequence sql) {
-        return new StatementTemplate(getConfig().createCopy(), sql);
+        return new StatementTemplate(config.createCopy(), sql);
     }
 
     /**
@@ -758,7 +770,9 @@ public class Jdbi implements ConfigReader {
 
         @Override
         public ConfigRegistry getConfig() {
-            return jdbi.getConfig();
+            // The builder configures the Jdbi's registry in place during assembly, so it returns the mutable
+            // registry directly rather than the read-only view exposed by Jdbi.getConfig().
+            return jdbi.config;
         }
 
         /**

--- a/core/src/main/java/org/jdbi/core/Jdbi.java
+++ b/core/src/main/java/org/jdbi/core/Jdbi.java
@@ -35,8 +35,8 @@ import org.jdbi.core.extension.Extensions;
 import org.jdbi.core.extension.HandleSupplier;
 import org.jdbi.core.extension.NoSuchExtensionException;
 import org.jdbi.core.internal.OnDemandExtensions;
-import org.jdbi.core.internal.exceptions.Unchecked;
 import org.jdbi.core.spi.JdbiPlugin;
+import org.jdbi.core.statement.ConfigReader;
 import org.jdbi.core.statement.DefaultStatementBuilder;
 import org.jdbi.core.statement.StatementTemplate;
 import org.jdbi.core.statement.SqlStatements;
@@ -57,7 +57,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * Use it to obtain Handle instances and provide configuration
  * for all handles obtained from it.
  */
-public class Jdbi implements Configurable<Jdbi> {
+public class Jdbi implements ConfigReader {
     private static final Logger LOG = LoggerFactory.getLogger(Jdbi.class);
 
     /** A no-op per-handle config scope: the opened handle uses an unmodified copy of this Jdbi's config. */
@@ -305,50 +305,14 @@ public class Jdbi implements Configurable<Jdbi> {
     }
 
     /**
-     * Install a given {@link JdbiPlugin} instance that will configure any
-     * provided {@link Handle} instances.
-     * @param plugin the plugin to install
-     * @return this
-     * @deprecated assemble with {@link #builder(ConnectionFactory)} and {@link Builder#installPlugin(JdbiPlugin)};
-     *             post-construction plugin installation is going away.
-     */
-    @Deprecated(since = "4.0.0", forRemoval = true)
-    public Jdbi installPlugin(final JdbiPlugin plugin) {
-        Objects.requireNonNull(plugin, "null plugin");
-        // Bridge onto the assembly funnel so a plugin that contributes via configure(Builder) is applied even on
-        // this post-construction path. The Builder is a facade over this same instance (shared config), so build()
-        // applies the plugin's hooks to this Jdbi and returns it. Removed wholesale when this method is dropped.
-        return new Builder(this).installPlugin(plugin).build();
-    }
-
-    /**
      * Applies a single plugin to this instance during assembly: it is registered once for the per-handle and
-     * per-connection hooks, then its {@link JdbiPlugin#configure(Builder)} and {@link JdbiPlugin#customizeJdbi(Jdbi)}
-     * hooks run in that order. The install-if-absent guard makes a plugin pulled in more than once apply only once.
-     * Shared by {@link Builder#build()} and the {@link #installPlugin(JdbiPlugin)} bridge.
+     * per-connection hooks, then its {@link JdbiPlugin#configure(Builder)} hook runs. The install-if-absent guard
+     * makes a plugin pulled in more than once apply only once. Shared by {@link Builder#build()}.
      */
-    @SuppressWarnings("deprecation") // customizeJdbi is deprecated for removal but still honored during the window
     private void applyPlugin(final Builder builder, final JdbiPlugin plugin) {
         if (plugins.addIfAbsent(plugin)) {
             plugin.configure(builder);
-            Unchecked.consumer(plugin::customizeJdbi).accept(this);
         }
-    }
-
-    /**
-     * Allows customization of how prepared statements are created. When a Handle is created
-     * against this Jdbi instance the factory will be used to create a StatementBuilder for
-     * that specific handle. When the handle is closed, the StatementBuilder's close method
-     * will be invoked.
-     *
-     * @param factory the new statement builder factory.
-     * @return this
-     * @deprecated set this with {@link Builder#statementBuilderFactory(StatementBuilderFactory)} during assembly instead.
-     */
-    @Deprecated(since = "4.0.0", forRemoval = true)
-    public Jdbi setStatementBuilderFactory(final StatementBuilderFactory factory) {
-        this.statementBuilderFactory.set(factory);
-        return this;
     }
 
     /**
@@ -366,51 +330,12 @@ public class Jdbi implements Configurable<Jdbi> {
     }
 
     /**
-     * Specify the TransactionHandler instance to use. This allows overriding
-     * transaction semantics, or mapping into different transaction
-     * management systems.
-     * <p>
-     * The default version uses local transactions on the database Connection
-     * instances obtained.
-     * </p>
-     *
-     * @param handler The TransactionHandler to use for all Handle instances obtained
-     *                from this Jdbi
-     * @return this
-     * @deprecated set this with {@link Builder#transactionHandler(TransactionHandler)} during assembly instead.
-     */
-    @Deprecated(since = "4.0.0", forRemoval = true)
-    public Jdbi setTransactionHandler(final TransactionHandler handler) {
-        Objects.requireNonNull(handler, "null transaction handler");
-        this.transactionhandler.set(handler);
-        return this;
-    }
-
-    /**
      * Returns the {@link TransactionHandler}.
      *
      * @return the {@link TransactionHandler}
      */
     public TransactionHandler getTransactionHandler() {
         return this.transactionhandler.get();
-    }
-
-    /**
-     * Specify the {@link HandleCallbackDecorator} instance to use. This allows overriding
-     * callbacks for {@link #useHandle}, {@link #withHandle}, {@link #useTransaction(HandleConsumer)} and
-     * {@link #inTransaction(HandleCallback)}. The default version is a pass-through that returns the callback unchanged.
-     *
-     * @param handleCallbackDecorator The {@link HandleCallbackDecorator} to use for all {@link #useHandle}, {@link #withHandle},
-     *                {@link #useTransaction(HandleConsumer)} and {@link #inTransaction(HandleCallback)} from this Jdbi. Must not be null
-     * @return this
-     * @deprecated set this with {@link Builder#handleCallbackDecorator(HandleCallbackDecorator)} during assembly instead.
-     */
-    @Alpha
-    @Deprecated(since = "4.0.0", forRemoval = true)
-    public Jdbi setHandleCallbackDecorator(final HandleCallbackDecorator handleCallbackDecorator) {
-        Objects.requireNonNull(handleCallbackDecorator, "null handler");
-        this.handleCallbackDecorator.set(handleCallbackDecorator);
-        return this;
     }
 
     /**
@@ -432,18 +357,6 @@ public class Jdbi implements Configurable<Jdbi> {
      */
     public final HandleScope getHandleScope() {
         return handleScope;
-    }
-
-    /**
-     * Set the {@link HandleScope} object. The Jdbi instance uses this to provide handles in a given scope.
-     * <br>
-     * @param handleScope A {@link HandleScope} object. Must not be null!
-     * @deprecated set this with {@link Builder#handleScope(HandleScope)} during assembly instead.
-     */
-    @Alpha
-    @Deprecated(since = "4.0.0", forRemoval = true)
-    public final void setHandleScope(final HandleScope handleScope) {
-        this.handleScope = handleScope;
     }
 
     /**
@@ -858,10 +771,9 @@ public class Jdbi implements Configurable<Jdbi> {
          *
          * @param handler the transaction handler
          * @return this builder
-         * @see Jdbi#setTransactionHandler(TransactionHandler)
          */
         public Builder transactionHandler(final TransactionHandler handler) {
-            jdbi.setTransactionHandler(handler);
+            jdbi.transactionhandler.set(Objects.requireNonNull(handler, "null transaction handler"));
             return this;
         }
 
@@ -870,10 +782,9 @@ public class Jdbi implements Configurable<Jdbi> {
          *
          * @param factory the statement builder factory
          * @return this builder
-         * @see Jdbi#setStatementBuilderFactory(StatementBuilderFactory)
          */
         public Builder statementBuilderFactory(final StatementBuilderFactory factory) {
-            jdbi.setStatementBuilderFactory(factory);
+            jdbi.statementBuilderFactory.set(factory);
             return this;
         }
 
@@ -882,10 +793,9 @@ public class Jdbi implements Configurable<Jdbi> {
          *
          * @param handleCallbackDecorator the handle callback decorator
          * @return this builder
-         * @see Jdbi#setHandleCallbackDecorator(HandleCallbackDecorator)
          */
         public Builder handleCallbackDecorator(final HandleCallbackDecorator handleCallbackDecorator) {
-            jdbi.setHandleCallbackDecorator(handleCallbackDecorator);
+            jdbi.handleCallbackDecorator.set(Objects.requireNonNull(handleCallbackDecorator, "null handler"));
             return this;
         }
 
@@ -894,24 +804,23 @@ public class Jdbi implements Configurable<Jdbi> {
          *
          * @param handleScope the handle scope
          * @return this builder
-         * @see Jdbi#setHandleScope(HandleScope)
          */
         public Builder handleScope(final HandleScope handleScope) {
-            jdbi.setHandleScope(handleScope);
+            jdbi.handleScope = handleScope;
             return this;
         }
 
         /**
          * Applies the installed plugins and returns the assembled {@link Jdbi}. Each plugin's
-         * {@link JdbiPlugin#configure(Builder)} runs, then its {@link JdbiPlugin#customizeJdbi(Jdbi)}, in install order.
-         * A plugin may itself install further plugins (via {@link #installPlugin(JdbiPlugin)} from its
-         * {@code configure}/{@code customizeJdbi} hook); those are drained and applied in turn, each at most once.
+         * {@link JdbiPlugin#configure(Builder)} runs, in install order. A plugin may itself install further plugins
+         * (via {@link #installPlugin(JdbiPlugin)} from its {@code configure} hook); those are drained and applied in
+         * turn, each at most once.
          *
          * @return the assembled {@code Jdbi}
          */
         public Jdbi build() {
-            // Drain by index: a plugin's configure()/customizeJdbi() may install further plugins, growing the list
-            // mid-drain. applyPlugin() installs-if-absent so a plugin pulled in by two others is still applied once.
+            // Drain by index: a plugin's configure() may install further plugins, growing the list mid-drain.
+            // applyPlugin() installs-if-absent so a plugin pulled in by two others is still applied once.
             int i = 0;
             while (i < plugins.size()) {
                 jdbi.applyPlugin(this, plugins.get(i++));

--- a/core/src/main/java/org/jdbi/core/LazyHandleSupplier.java
+++ b/core/src/main/java/org/jdbi/core/LazyHandleSupplier.java
@@ -32,7 +32,7 @@ final class LazyHandleSupplier extends AbstractHandleSupplier implements OnDeman
     @Override
     public ConfigRegistry getConfig() {
         ExtensionContext extensionContext = currentExtensionContext();
-        return extensionContext != null ? extensionContext.getConfig() : jdbi.getConfig();
+        return extensionContext != null ? extensionContext.getConfig() : jdbi.configRegistry();
     }
 
     @Override

--- a/core/src/main/java/org/jdbi/core/argument/AbstractArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/AbstractArgumentFactory.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.UnableToCreateStatementException;
 
 import static org.jdbi.core.generic.GenericTypes.findGenericParameter;
@@ -26,7 +26,7 @@ import static org.jdbi.core.generic.GenericTypes.isSuperType;
 
 /**
  * An {@link ArgumentFactory} base class for arguments of type {@code T}. For values of type {@code T}, factories
- * produces arguments from the {@link #build(Object, ConfigRegistry)} method. For null values with a known expected type
+ * produces arguments from the {@link #build(Object, ConfigView)} method. For null values with a known expected type
  * of {@code T}, produces null arguments for the {@code sqlType} passed to the constructor.
  * <pre>
  * class ValueType {
@@ -39,7 +39,7 @@ import static org.jdbi.core.generic.GenericTypes.isSuperType;
  *     }
  *
  *     &#64;Override
- *     protected Argument build(ValueType valueType, ConfigRegistry config) {
+ *     protected Argument build(ValueType valueType, ConfigView config) {
  *         return (pos, stmt, ctx) -&gt; stmt.setString(pos, valueType.value);
  *     }
  * }
@@ -75,21 +75,21 @@ public abstract class AbstractArgumentFactory<T> implements ArgumentFactory.Prep
     }
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         return isInstance.test(type, null)
                 ? Optional.of(value -> innerBuild(type, value, config))
                 : Optional.empty();
     }
 
     @Override
-    public final Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
+    public final Optional<Argument> build(Type type, Object value, ConfigView config) {
         return isInstance.test(type, value)
                 ? Optional.of(innerBuild(type, value, config))
                 : Optional.empty();
     }
 
     @SuppressWarnings("unchecked")
-    private Argument innerBuild(Type type, Object value, ConfigRegistry config) {
+    private Argument innerBuild(Type type, Object value, ConfigView config) {
         if (value == null) {
             return new NullArgument(sqlType);
         }
@@ -111,7 +111,7 @@ public abstract class AbstractArgumentFactory<T> implements ArgumentFactory.Prep
      * @param config the config registry
      * @return An {@link Argument} for the given {@code value}. Must not be null!
      */
-    protected abstract Argument build(T value, ConfigRegistry config);
+    protected abstract Argument build(T value, ConfigView config);
 
     @FunctionalInterface
     private interface ArgumentPredicate {

--- a/core/src/main/java/org/jdbi/core/argument/ArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/ArgumentFactory.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 import org.jdbi.meta.Beta;
 
@@ -41,7 +41,7 @@ public interface ArgumentFactory {
      * @see StatementContext#findArgumentFor(Type, Object)
      * @see Arguments#findFor(Type, Object)
      */
-    Optional<Argument> build(Type type, Object value, ConfigRegistry config);
+    Optional<Argument> build(Type type, Object value, ConfigView config);
 
     /**
      * ArgumentFactory extension interface that allows preparing arguments for efficient batch binding.
@@ -50,10 +50,10 @@ public interface ArgumentFactory {
     @SuppressWarnings("PMD.ImplicitFunctionalInterface")
     interface Preparable extends ArgumentFactory {
         @Override
-        default Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
+        default Optional<Argument> build(Type type, Object value, ConfigView config) {
             return prepare(type, config).map(p -> p.apply(value));
         }
 
-        Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config);
+        Optional<Function<Object, Argument>> prepare(Type type, ConfigView config);
     }
 }

--- a/core/src/main/java/org/jdbi/core/argument/ArgumentResolver.java
+++ b/core/src/main/java/org/jdbi/core/argument/ArgumentResolver.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.meta.Beta;
@@ -48,7 +47,7 @@ public final class ArgumentResolver {
         return config.readAs(ArgumentResolver.class, ArgumentResolver::new);
     }
 
-    private final ConfigRegistry registry;
+    private final ConfigView registry;
     private final Map<QualifiedType<?>, Function<Object, Argument>> preparedFactories = new ConcurrentHashMap<>();
     private final Set<QualifiedType<?>> didPrepare = ConcurrentHashMap.newKeySet();
 
@@ -57,7 +56,7 @@ public final class ArgumentResolver {
     // registry (immutable-config step), each fork has its own fresh resolver and this guard is moot.
     private volatile int factoryCount = -1;
 
-    private ArgumentResolver(final ConfigRegistry registry) {
+    private ArgumentResolver(final ConfigView registry) {
         this.registry = registry;
     }
 

--- a/core/src/main/java/org/jdbi/core/argument/ArgumentResolver.java
+++ b/core/src/main/java/org/jdbi/core/argument/ArgumentResolver.java
@@ -22,15 +22,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.meta.Beta;
 
 /**
- * Resolves arguments for a specific {@link ConfigRegistry}, caching the results.
+ * Resolves arguments for a specific {@link ConfigView}, caching the results.
  * <p>
  * A resolver reads the registered factories from the registry's {@link Arguments} (which holds only
  * registration data) and turns a bound value into an {@link Argument}, memoizing the prepared factory
- * function per type. It is obtained per registry via {@link #forRegistry(ConfigRegistry)} and is scoped
+ * function per type. It is obtained per registry via {@link #forRegistry(ConfigView)} and is scoped
  * to that registry: because it is never shared across registry copies, it safely holds the registry
  * reference, and its prepared-factory cache is warm across the many statements executed against a shared
  * registry, yet a forked registry starts with an empty cache and re-resolves against its own factories.
@@ -43,7 +44,7 @@ public final class ArgumentResolver {
      * @param config the configuration registry to resolve against
      * @return the registry's memoized argument resolver
      */
-    public static ArgumentResolver forRegistry(final ConfigRegistry config) {
+    public static ArgumentResolver forRegistry(final ConfigView config) {
         return config.readAs(ArgumentResolver.class, ArgumentResolver::new);
     }
 

--- a/core/src/main/java/org/jdbi/core/argument/Arguments.java
+++ b/core/src/main/java/org/jdbi/core/argument/Arguments.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.array.SqlArrayArgumentFactory;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.internal.RegistrationLists;
@@ -88,6 +89,7 @@ public final class Arguments implements JdbiConfig<Arguments> {
      * @param factory the factory to add
      * @return a copy of this configuration with the factory registered
      */
+    @CheckReturnValue
     public Arguments register(final ArgumentFactory factory) {
         return register(QualifiedArgumentFactory.adapt(factory));
     }
@@ -98,6 +100,7 @@ public final class Arguments implements JdbiConfig<Arguments> {
      * @param factory the qualified factory to add
      * @return a copy of this configuration with the factory registered
      */
+    @CheckReturnValue
     public Arguments register(final QualifiedArgumentFactory factory) {
         return new Arguments(RegistrationLists.prepend(factories, factory),
                 untypedNullArgument, bindingNullToPrimitivesPermitted, preparedArgumentsEnabled);
@@ -111,6 +114,7 @@ public final class Arguments implements JdbiConfig<Arguments> {
      * @param factories the factories to add
      * @return a copy of this configuration with the factories registered
      */
+    @CheckReturnValue
     public Arguments register(final Collection<? extends ArgumentFactory> factories) {
         if (factories.isEmpty()) {
             return this;
@@ -134,6 +138,7 @@ public final class Arguments implements JdbiConfig<Arguments> {
      * @param untypedNullArgument the argument to bind
      * @return a copy of this configuration with the untyped null argument set
      */
+    @CheckReturnValue
     public Arguments untypedNullArgument(final Argument untypedNullArgument) {
         if (untypedNullArgument == null) {
             throw new IllegalArgumentException("the Argument itself may not be null");
@@ -165,6 +170,7 @@ public final class Arguments implements JdbiConfig<Arguments> {
      * @param bindingNullToPrimitivesPermitted if true, {@code null} can be bound to a variable declared as a primitive type.
      * @return a copy of this configuration with the policy set
      */
+    @CheckReturnValue
     public Arguments bindingNullToPrimitivesPermitted(final boolean bindingNullToPrimitivesPermitted) {
         return new Arguments(factories, untypedNullArgument, bindingNullToPrimitivesPermitted, preparedArgumentsEnabled);
     }
@@ -185,6 +191,7 @@ public final class Arguments implements JdbiConfig<Arguments> {
      * @param preparedArgumentsEnabled whether to enable preparable argument factories
      * @return a copy of this configuration with the policy set
      */
+    @CheckReturnValue
     public Arguments preparedArgumentsEnabled(final boolean preparedArgumentsEnabled) {
         return new Arguments(factories, untypedNullArgument, bindingNullToPrimitivesPermitted, preparedArgumentsEnabled);
     }

--- a/core/src/main/java/org/jdbi/core/argument/BuiltInArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/BuiltInArgumentFactory.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.enums.EnumByName;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.core.statement.SqlStatement;
@@ -51,14 +51,14 @@ public class BuiltInArgumentFactory implements ArgumentFactory.Preparable {
     );
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         return FACTORIES.stream()
             .flatMap(factory -> factory.prepare(type, config).stream())
             .findFirst();
     }
 
     @Override
-    public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+    public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
         return FACTORIES.stream()
             .flatMap(factory -> factory.build(expectedType, value, config).stream())
             .findFirst();
@@ -67,13 +67,13 @@ public class BuiltInArgumentFactory implements ArgumentFactory.Preparable {
     private static class LegacyEnumByNameArgumentFactory implements ArgumentFactory.Preparable {
         private final EnumArgumentFactory delegate = new EnumArgumentFactory();
         @Override
-        public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+        public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
             return EnumArgumentFactory.ifEnum(type).map(clazz ->
                     value -> build(type, value, config)
                         .orElseThrow(() -> new UnableToCreateStatementException("No enum value to bind after prepare")));
         }
         @Override
-        public Optional<Argument> build(Type expectedType, Object rawValue, ConfigRegistry config) {
+        public Optional<Argument> build(Type expectedType, Object rawValue, ConfigView config) {
             return delegate.build(QualifiedType.of(expectedType).with(EnumByName.class), rawValue, config);
         }
     }

--- a/core/src/main/java/org/jdbi/core/argument/CharSequenceArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/CharSequenceArgumentFactory.java
@@ -16,7 +16,7 @@ package org.jdbi.core.argument;
 import java.sql.Types;
 import java.util.Objects;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * An {@link ArgumentFactory} for arguments that implement {@link CharSequence}.<p>
@@ -36,7 +36,7 @@ public class CharSequenceArgumentFactory extends AbstractArgumentFactory<CharSeq
     }
 
     @Override
-    protected Argument build(CharSequence value, ConfigRegistry config) {
+    protected Argument build(CharSequence value, ConfigView config) {
         return (position, statement, ctx) -> statement.setString(position, Objects.toString(value, null));
     }
 

--- a/core/src/main/java/org/jdbi/core/argument/DelegatingArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/DelegatingArgumentFactory.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 
 import org.jdbi.core.argument.internal.StatementBinder;
 import org.jdbi.core.argument.internal.strategies.LoggableBinderArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
 
@@ -28,12 +28,12 @@ abstract class DelegatingArgumentFactory implements ArgumentFactory.Preparable {
     private final IdentityHashMap<Class<?>, Function<Object, Argument>> builders = new IdentityHashMap<>();
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         return Optional.ofNullable(builders.get(getErasedType(type)));
     }
 
     @Override
-    public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+    public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
         Class<?> expectedClass = getErasedType(expectedType);
 
         if (value != null && expectedClass == Object.class) {

--- a/core/src/main/java/org/jdbi/core/argument/DirectArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/DirectArgumentFactory.java
@@ -16,11 +16,11 @@ package org.jdbi.core.argument;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 public class DirectArgumentFactory implements ArgumentFactory {
     @Override
-    public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+    public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
         return value instanceof Argument argument
                 ? Optional.of(argument)
                 : Optional.empty();

--- a/core/src/main/java/org/jdbi/core/argument/EnumArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/EnumArgumentFactory.java
@@ -18,7 +18,7 @@ import java.sql.Types;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.enums.DatabaseValue;
 import org.jdbi.core.enums.EnumStrategy;
 import org.jdbi.core.internal.EnumStrategyResolver;
@@ -28,7 +28,7 @@ import org.jdbi.core.qualifier.QualifiedType;
 class EnumArgumentFactory implements QualifiedArgumentFactory {
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public Optional<Argument> build(QualifiedType<?> givenType, Object value, ConfigRegistry config) {
+    public Optional<Argument> build(QualifiedType<?> givenType, Object value, ConfigView config) {
         return ifEnum(givenType.getType())
             .flatMap(clazz -> makeEnumArgument((QualifiedType<Enum>) givenType, (Enum) value, config));
     }
@@ -41,7 +41,7 @@ class EnumArgumentFactory implements QualifiedArgumentFactory {
         return Optional.empty();
     }
 
-    private static <E extends Enum<E>> Optional<Argument> makeEnumArgument(QualifiedType<E> givenType, E value, ConfigRegistry config) {
+    private static <E extends Enum<E>> Optional<Argument> makeEnumArgument(QualifiedType<E> givenType, E value, ConfigView config) {
         boolean byName = EnumStrategy.BY_NAME == EnumStrategyResolver.forRegistry(config).findStrategy(givenType);
 
         return byName
@@ -49,7 +49,7 @@ class EnumArgumentFactory implements QualifiedArgumentFactory {
             : byOrdinal(value, config);
     }
 
-    private static <E extends Enum<E>> Optional<Argument> byName(E value, ConfigRegistry config) {
+    private static <E extends Enum<E>> Optional<Argument> byName(E value, ConfigView config) {
         return makeArgument(Types.VARCHAR, String.class, value, EnumArgumentFactory::annotatedValue, config);
     }
 
@@ -61,7 +61,7 @@ class EnumArgumentFactory implements QualifiedArgumentFactory {
                 .orElse(e.name());
     }
 
-    private static <E extends Enum<E>> Optional<Argument> byOrdinal(E value, ConfigRegistry config) {
+    private static <E extends Enum<E>> Optional<Argument> byOrdinal(E value, ConfigView config) {
         return makeArgument(Types.INTEGER, Integer.class, value, E::ordinal, config);
     }
 
@@ -69,7 +69,7 @@ class EnumArgumentFactory implements QualifiedArgumentFactory {
                                                                           Class<A> attributeType,
                                                                           E value,
                                                                           Function<E, A> transform,
-                                                                          ConfigRegistry config) {
+                                                                          ConfigView config) {
         if (value == null) {
             return Optional.of(new NullArgument(nullType));
         }

--- a/core/src/main/java/org/jdbi/core/argument/JavaTimeZoneIdArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/JavaTimeZoneIdArgumentFactory.java
@@ -17,7 +17,7 @@ import java.sql.Types;
 import java.time.ZoneId;
 
 import org.jdbi.core.argument.internal.strategies.LoggableBinderArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 public class JavaTimeZoneIdArgumentFactory extends AbstractArgumentFactory<ZoneId> {
     public JavaTimeZoneIdArgumentFactory() {
@@ -25,7 +25,7 @@ public class JavaTimeZoneIdArgumentFactory extends AbstractArgumentFactory<ZoneI
     }
 
     @Override
-    protected Argument build(ZoneId value, ConfigRegistry config) {
+    protected Argument build(ZoneId value, ConfigView config) {
         return LoggableBinderArgument.bindAsString(value);
     }
 }

--- a/core/src/main/java/org/jdbi/core/argument/NVarcharArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/NVarcharArgumentFactory.java
@@ -15,7 +15,7 @@ package org.jdbi.core.argument;
 
 import java.sql.Types;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.qualifier.NVarchar;
 
 /**
@@ -28,7 +28,7 @@ class NVarcharArgumentFactory extends AbstractArgumentFactory<String> {
     }
 
     @Override
-    protected Argument build(String value, ConfigRegistry config) {
+    protected Argument build(String value, ConfigView config) {
         return (pos, stmt, ctx) -> stmt.setNString(pos, value);
     }
 }

--- a/core/src/main/java/org/jdbi/core/argument/ObjectArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/ObjectArgumentFactory.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * Argument factory that matches a specified type and binds
@@ -54,14 +54,14 @@ public class ObjectArgumentFactory implements ArgumentFactory.Preparable {
     }
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type expectedType, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type expectedType, ConfigView config) {
         return Optional.of(expectedType)
                 .filter(type::equals)
                 .map(t -> o -> ObjectArgument.of(o, sqlType));
     }
 
     @Override
-    public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+    public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
         return Objects.equals(type, expectedType) || type.isInstance(value)
                 ? Optional.of(ObjectArgument.of(value, sqlType))
                 : Optional.empty();

--- a/core/src/main/java/org/jdbi/core/argument/ObjectMethodArguments.java
+++ b/core/src/main/java/org/jdbi/core/argument/ObjectMethodArguments.java
@@ -28,6 +28,7 @@ import org.jdbi.core.annotation.internal.JdbiAnnotations;
 import org.jdbi.core.argument.internal.ObjectPropertyNamedArgumentFinder;
 import org.jdbi.core.argument.internal.TypedValue;
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.config.internal.ConfigCache;
 import org.jdbi.core.config.internal.ConfigCaches;
 import org.jdbi.core.internal.exceptions.Unchecked;
@@ -50,7 +51,7 @@ public class ObjectMethodArguments extends ObjectPropertyNamedArgumentFinder {
         super(prefix, object);
     }
 
-    private static Map<String, Function<Object, TypedValue>> load(ConfigRegistry config, Class<?> type) {
+    private static Map<String, Function<Object, TypedValue>> load(ConfigView config, Class<?> type) {
         final HashMap<String, Function<Object, TypedValue>> methodMap = new HashMap<>();
         if (Modifier.isPublic(type.getModifiers())) {
             Arrays.stream(type.getMethods())

--- a/core/src/main/java/org/jdbi/core/argument/OptionalArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/OptionalArgumentFactory.java
@@ -21,7 +21,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 import static org.jdbi.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
@@ -52,7 +52,7 @@ class OptionalArgumentFactory extends DelegatingArgumentFactory {
     }
 
     @Override
-    public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+    public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
         if (value instanceof Optional<?> maybeValue) {
             Object nestedValue = maybeValue.orElse(null);
             Type nestedType = findOptionalType(expectedType, nestedValue);
@@ -63,7 +63,7 @@ class OptionalArgumentFactory extends DelegatingArgumentFactory {
     }
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         if (Optional.class.equals(getErasedType(type))) {
             return ArgumentResolver.forRegistry(config)
                     .prepareFor(findOptionalType(type, null))

--- a/core/src/main/java/org/jdbi/core/argument/PrimitivesArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/PrimitivesArgumentFactory.java
@@ -19,7 +19,7 @@ import java.sql.Types;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 class PrimitivesArgumentFactory extends DelegatingArgumentFactory {
     PrimitivesArgumentFactory() {
@@ -34,16 +34,16 @@ class PrimitivesArgumentFactory extends DelegatingArgumentFactory {
     }
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         return super.prepare(type, config)
                 .map(prepared -> value -> prepared.apply(checkForNull(config, type, value)));
     }
     @Override
-    public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+    public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
         return super.build(expectedType, checkForNull(config, expectedType, value), config);
     }
 
-    private Object checkForNull(ConfigRegistry cfg, Type type, Object value) {
+    private Object checkForNull(ConfigView cfg, Type type, Object value) {
         if (value == null || value instanceof NullArgument) {
             if (cfg.get(Arguments.class).isBindingNullToPrimitivesPermitted()) {
                 return null;

--- a/core/src/main/java/org/jdbi/core/argument/QualifiedArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/QualifiedArgumentFactory.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.core.qualifier.Qualifiers;
 import org.jdbi.meta.Beta;
@@ -49,7 +50,7 @@ public interface QualifiedArgumentFactory {
      * @see Arguments#findFor(QualifiedType, Object)
      * @see QualifiedType
      */
-    Optional<Argument> build(QualifiedType<?> type, Object value, ConfigRegistry config);
+    Optional<Argument> build(QualifiedType<?> type, Object value, ConfigView config);
 
     /**
      * Adapts an {@link ArgumentFactory} into a QualifiedArgumentFactory. The returned factory only
@@ -66,7 +67,7 @@ public interface QualifiedArgumentFactory {
         return new QualifiedArgumentFactory() {
             private volatile Set<Annotation> qualifiers;
 
-            private Set<Annotation> qualifiers(ConfigRegistry cfg) {
+            private Set<Annotation> qualifiers(ConfigView cfg) {
                 Set<Annotation> q = qualifiers;
                 if (q == null) {
                     q = cfg.get(Qualifiers.class).findFor(factory.getClass());
@@ -76,7 +77,7 @@ public interface QualifiedArgumentFactory {
             }
 
             @Override
-            public Optional<Argument> build(QualifiedType<?> type, Object value, ConfigRegistry cfg) {
+            public Optional<Argument> build(QualifiedType<?> type, Object value, ConfigView cfg) {
                 return type.getQualifiers().equals(qualifiers(cfg))
                     ? factory.build(type.getType(), value, cfg)
                     : Optional.empty();
@@ -99,7 +100,7 @@ public interface QualifiedArgumentFactory {
      */
     @Beta
     interface Preparable extends QualifiedArgumentFactory {
-        Optional<Function<Object, Argument>> prepare(QualifiedType<?> type, ConfigRegistry config);
+        Optional<Function<Object, Argument>> prepare(QualifiedType<?> type, ConfigView config);
 
         /**
          * Adapts an {@link ArgumentFactory.Preparable} into a QualifiedArgumentFactory.Preparable.
@@ -113,7 +114,7 @@ public interface QualifiedArgumentFactory {
             return new Preparable() {
                 private volatile Set<Annotation> qualifiers;
 
-                private Set<Annotation> qualifiers(ConfigRegistry cfg) {
+                private Set<Annotation> qualifiers(ConfigView cfg) {
                     Set<Annotation> q = qualifiers;
                     if (q == null) {
                         q = cfg.get(Qualifiers.class).findFor(factory.getClass());
@@ -123,14 +124,14 @@ public interface QualifiedArgumentFactory {
                 }
 
                 @Override
-                public Optional<Argument> build(QualifiedType<?> type, Object value, ConfigRegistry cfg) {
+                public Optional<Argument> build(QualifiedType<?> type, Object value, ConfigView cfg) {
                     return type.getQualifiers().equals(qualifiers(cfg))
                             ? factory.build(type.getType(), value, cfg)
                             : Optional.empty();
                 }
 
                 @Override
-                public Optional<Function<Object, Argument>> prepare(QualifiedType<?> type, ConfigRegistry cfg) {
+                public Optional<Function<Object, Argument>> prepare(QualifiedType<?> type, ConfigView cfg) {
                     return type.getQualifiers().equals(qualifiers(cfg))
                             ? factory.prepare(type.getType(), cfg)
                             : Optional.empty();

--- a/core/src/main/java/org/jdbi/core/argument/SetObjectArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/SetObjectArgumentFactory.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * Factory that uses {@link java.sql.PreparedStatement#setObject(int, Object, int)} to bind values.
@@ -43,7 +43,7 @@ public class SetObjectArgumentFactory implements ArgumentFactory.Preparable {
     }
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         return Optional.of(type)
             .filter(Class.class::isInstance)
             .map(Class.class::cast)

--- a/core/src/main/java/org/jdbi/core/argument/UntypedNullArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/argument/UntypedNullArgumentFactory.java
@@ -17,16 +17,16 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 class UntypedNullArgumentFactory implements ArgumentFactory.Preparable {
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         return Optional.empty(); // always dynamic
     }
 
     @Override
-    public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+    public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
         return value == null
                 ? Optional.of(config.get(Arguments.class).getUntypedNullArgument())
                 : Optional.empty();

--- a/core/src/main/java/org/jdbi/core/array/ArrayTypeResolver.java
+++ b/core/src/main/java/org/jdbi/core/array/ArrayTypeResolver.java
@@ -16,7 +16,6 @@ package org.jdbi.core.array;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.config.ConfigView;
 
 /**
@@ -39,9 +38,9 @@ public final class ArrayTypeResolver {
         return config.readAs(ArrayTypeResolver.class, ArrayTypeResolver::new);
     }
 
-    private final ConfigRegistry registry;
+    private final ConfigView registry;
 
-    private ArrayTypeResolver(final ConfigRegistry registry) {
+    private ArrayTypeResolver(final ConfigView registry) {
         this.registry = registry;
     }
 

--- a/core/src/main/java/org/jdbi/core/array/ArrayTypeResolver.java
+++ b/core/src/main/java/org/jdbi/core/array/ArrayTypeResolver.java
@@ -17,13 +17,14 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
- * Resolves {@link SqlArrayType}s for a specific {@link ConfigRegistry}.
+ * Resolves {@link SqlArrayType}s for a specific {@link ConfigView}.
  * <p>
  * A resolver reads the registered factories from the registry's {@link SqlArrayTypes} (which holds only
  * registration data) and turns an array element type into a {@link SqlArrayType}. It is obtained per registry
- * via {@link #forRegistry(ConfigRegistry)} and holds the registry reference the factories need; because it is
+ * via {@link #forRegistry(ConfigView)} and holds the registry reference the factories need; because it is
  * never shared across registry copies, that reference is always the one this resolver resolves against.
  */
 public final class ArrayTypeResolver {
@@ -34,7 +35,7 @@ public final class ArrayTypeResolver {
      * @param config the configuration registry to resolve against
      * @return the registry's memoized array-type resolver
      */
-    public static ArrayTypeResolver forRegistry(final ConfigRegistry config) {
+    public static ArrayTypeResolver forRegistry(final ConfigView config) {
         return config.readAs(ArrayTypeResolver.class, ArrayTypeResolver::new);
     }
 

--- a/core/src/main/java/org/jdbi/core/array/InferredSqlArrayTypeFactory.java
+++ b/core/src/main/java/org/jdbi/core/array/InferredSqlArrayTypeFactory.java
@@ -16,7 +16,7 @@ package org.jdbi.core.array;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 import static org.jdbi.core.generic.GenericTypes.findGenericParameter;
 
@@ -36,7 +36,7 @@ class InferredSqlArrayTypeFactory implements SqlArrayTypeFactory {
     }
 
     @Override
-    public Optional<SqlArrayType<?>> build(Type elementType, ConfigRegistry config) {
+    public Optional<SqlArrayType<?>> build(Type elementType, ConfigView config) {
         return inferredElementType.equals(elementType)
                 ? Optional.of(arrayType)
                 : Optional.empty();

--- a/core/src/main/java/org/jdbi/core/array/SqlArrayArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/core/array/SqlArrayArgumentFactory.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
 import org.jdbi.core.argument.NullArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.IterableLike;
 
 /**
@@ -40,7 +40,7 @@ import org.jdbi.core.internal.IterableLike;
  */
 public class SqlArrayArgumentFactory implements ArgumentFactory.Preparable {
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         return IterableLike.elementTypeOf(type)
             .flatMap(ArrayTypeResolver.forRegistry(config)::findFor)
             .map(arrayType -> value -> arrayArgument(value, arrayType));

--- a/core/src/main/java/org/jdbi/core/array/SqlArrayMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/array/SqlArrayMapperFactory.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 
 import org.jdbi.core.collector.CollectorResolver;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
@@ -32,7 +32,7 @@ import org.jdbi.core.mapper.ColumnMapperFactory;
 public class SqlArrayMapperFactory implements ColumnMapperFactory {
     @Override
     @SuppressWarnings("unchecked")
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         final Class<?> erasedType = GenericTypes.getErasedType(type);
 
         if (erasedType.isArray()) {
@@ -48,7 +48,7 @@ public class SqlArrayMapperFactory implements ColumnMapperFactory {
                         .map(elementMapper -> new CollectorColumnMapper(elementMapper, collector)));
     }
 
-    private Optional<ColumnMapper<?>> elementTypeMapper(Type elementType, ConfigRegistry config) {
+    private Optional<ColumnMapper<?>> elementTypeMapper(Type elementType, ConfigView config) {
         Optional<ColumnMapper<?>> mapper = config.findColumnMapperFor(elementType);
 
         if (!mapper.isPresent() && elementType == Object.class) {

--- a/core/src/main/java/org/jdbi/core/array/SqlArrayTypeFactory.java
+++ b/core/src/main/java/org/jdbi/core/array/SqlArrayTypeFactory.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 
 /**
@@ -33,7 +33,7 @@ public interface SqlArrayTypeFactory {
      * @return an {@link SqlArrayType} for the given {@code elementType} if this factory supports it; empty otherwise.
      * @see ArrayTypeResolver#findFor(Type)
      */
-    Optional<SqlArrayType<?>> build(Type elementType, ConfigRegistry config);
+    Optional<SqlArrayType<?>> build(Type elementType, ConfigView config);
 
     /**
      * Create a SqlArrayTypeFactory for the given {@code elementType} that binds using a

--- a/core/src/main/java/org/jdbi/core/array/SqlArrayTypes.java
+++ b/core/src/main/java/org/jdbi/core/array/SqlArrayTypes.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.enums.internal.EnumSqlArrayTypeFactory;
 import org.jdbi.core.interceptor.JdbiInterceptionChainHolder;
@@ -94,6 +95,7 @@ public final class SqlArrayTypes implements JdbiConfig<SqlArrayTypes> {
      * @param argumentStrategy the argument strategy to set
      * @return the derived configuration
      */
+    @CheckReturnValue
     public SqlArrayTypes argumentStrategy(SqlArrayArgumentStrategy argumentStrategy) {
         return new SqlArrayTypes(factories, inferenceInterceptors, argumentStrategy);
     }
@@ -105,6 +107,7 @@ public final class SqlArrayTypes implements JdbiConfig<SqlArrayTypes> {
      * @param interceptor the inference interceptor to add
      * @return the derived configuration
      */
+    @CheckReturnValue
     @Alpha
     public SqlArrayTypes withInferenceInterceptor(final JdbiInterceptor<SqlArrayType<?>, SqlArrayTypeFactory> interceptor) {
         final JdbiInterceptionChainHolder<SqlArrayType<?>, SqlArrayTypeFactory> newInterceptors = new JdbiInterceptionChainHolder<>(inferenceInterceptors);
@@ -120,6 +123,7 @@ public final class SqlArrayTypes implements JdbiConfig<SqlArrayTypes> {
      *                    {@link java.sql.Connection#createArrayOf(String, Object[])} to create SQL arrays.
      * @return a copy of this configuration with the array type registered
      */
+    @CheckReturnValue
     public SqlArrayTypes register(Class<?> elementType, String sqlTypeName) {
         return register(SqlArrayTypeFactory.of(elementType, sqlTypeName, Function.identity()));
     }
@@ -135,6 +139,7 @@ public final class SqlArrayTypes implements JdbiConfig<SqlArrayTypes> {
      * @return a copy of this configuration with the array type registered
      * @throws UnsupportedOperationException if the argument is not a concretely parameterized type
      */
+    @CheckReturnValue
     public SqlArrayTypes register(SqlArrayType<?> arrayType) {
         SqlArrayTypeFactory factory = inferenceInterceptors.process(arrayType);
 
@@ -148,6 +153,7 @@ public final class SqlArrayTypes implements JdbiConfig<SqlArrayTypes> {
      * @param factory the factory
      * @return a copy of this configuration with the factory registered
      */
+    @CheckReturnValue
     public SqlArrayTypes register(SqlArrayTypeFactory factory) {
         return new SqlArrayTypes(RegistrationLists.prepend(factories, factory), inferenceInterceptors, argumentStrategy);
     }

--- a/core/src/main/java/org/jdbi/core/codec/Codec.java
+++ b/core/src/main/java/org/jdbi/core/codec/Codec.java
@@ -16,7 +16,7 @@ package org.jdbi.core.codec;
 import java.util.function.Function;
 
 import org.jdbi.core.argument.Argument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.meta.Beta;
 
@@ -33,7 +33,7 @@ public interface Codec<T> {
     /**
      * Returns a {@link ColumnMapper} that creates an attribute value from a database column.
      * <p>
-     * Either this method or {@link #getColumnMapper(ConfigRegistry)} must be implemented.
+     * Either this method or {@link #getColumnMapper(ConfigView)} must be implemented.
      */
     default ColumnMapper<T> getColumnMapper() {
         throw new UnsupportedOperationException("getColumnMapper");
@@ -44,16 +44,16 @@ public interface Codec<T> {
      * <p>
      * This method is optional. If it is not implemented, the result of {@link #getColumnMapper()} is returned.
      *
-     * @param configRegistry The {@link ConfigRegistry} that this argument belongs to.
+     * @param configRegistry The {@link ConfigView} that this argument belongs to.
      */
-    default ColumnMapper<T> getColumnMapper(ConfigRegistry configRegistry) {
+    default ColumnMapper<T> getColumnMapper(ConfigView configRegistry) {
         return getColumnMapper();
     }
 
     /**
      * Returns a {@link Function} that creates an {@link Argument} to map an attribute value onto the database column.
      * <p>
-     * Either this method or {@link #getArgumentFunction(ConfigRegistry)} must be implemented.
+     * Either this method or {@link #getArgumentFunction(ConfigView)} must be implemented.
      */
     default Function<T, Argument> getArgumentFunction() {
         throw new UnsupportedOperationException("getArgumentFunction");
@@ -64,9 +64,9 @@ public interface Codec<T> {
      * <p>
      * This method is optional. If it is not implemented, the result of {@link #getArgumentFunction()} is returned.
      *
-     * @param configRegistry The {@link ConfigRegistry} that this argument belongs to.
+     * @param configRegistry The {@link ConfigView} that this argument belongs to.
      */
-    default Function<T, Argument> getArgumentFunction(ConfigRegistry configRegistry) {
+    default Function<T, Argument> getArgumentFunction(ConfigView configRegistry) {
         return getArgumentFunction();
     }
 }

--- a/core/src/main/java/org/jdbi/core/codec/CodecFactory.java
+++ b/core/src/main/java/org/jdbi/core/codec/CodecFactory.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import com.google.errorprone.annotations.ThreadSafe;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.QualifiedArgumentFactory;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.QualifiedColumnMapperFactory;
@@ -82,17 +82,17 @@ public class CodecFactory implements QualifiedColumnMapperFactory, QualifiedArgu
 
     @Override
     @SuppressWarnings("unchecked")
-    public final Optional<Function<Object, Argument>> prepare(final QualifiedType<?> type, final ConfigRegistry config) {
+    public final Optional<Function<Object, Argument>> prepare(final QualifiedType<?> type, final ConfigView config) {
         return Optional.of(type).map(this::resolveType).map(key -> (Function<Object, Argument>) key.getArgumentFunction(config));
     }
 
     @Override
-    public final Optional<Argument> build(final QualifiedType<?> type, final Object value, final ConfigRegistry config) {
+    public final Optional<Argument> build(final QualifiedType<?> type, final Object value, final ConfigView config) {
         return prepare(type, config).map(f -> f.apply(value));
     }
 
     @Override
-    public final Optional<ColumnMapper<?>> build(final QualifiedType<?> type, final ConfigRegistry config) {
+    public final Optional<ColumnMapper<?>> build(final QualifiedType<?> type, final ConfigView config) {
         return Optional.of(type).map(this::resolveType).map(c -> c.getColumnMapper(config));
     }
 

--- a/core/src/main/java/org/jdbi/core/collector/CollectorResolver.java
+++ b/core/src/main/java/org/jdbi/core/collector/CollectorResolver.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collector;
 
-import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.CopyOnWriteHashMap;
 
@@ -44,7 +43,7 @@ public final class CollectorResolver {
         return config.readAs(CollectorResolver.class, CollectorResolver::new);
     }
 
-    private final ConfigRegistry registry;
+    private final ConfigView registry;
     private final Map<Type, Optional<CollectorFactory>> factoryCache = new CopyOnWriteHashMap<>();
 
     // Registration only ever adds factories, so a change in factory count means a factory was registered
@@ -52,7 +51,7 @@ public final class CollectorResolver {
     // registry (immutable-config step), each fork has its own fresh resolver and this guard is moot.
     private volatile int factoryCount = -1;
 
-    private CollectorResolver(final ConfigRegistry registry) {
+    private CollectorResolver(final ConfigView registry) {
         this.registry = registry;
     }
 

--- a/core/src/main/java/org/jdbi/core/collector/CollectorResolver.java
+++ b/core/src/main/java/org/jdbi/core/collector/CollectorResolver.java
@@ -20,14 +20,15 @@ import java.util.Optional;
 import java.util.stream.Collector;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.CopyOnWriteHashMap;
 
 /**
- * Resolves collectors for a specific {@link ConfigRegistry}, caching the results.
+ * Resolves collectors for a specific {@link ConfigView}, caching the results.
  * <p>
  * A resolver reads the registered factories from the registry's {@link JdbiCollectors} (which holds only
  * registration data) and turns a container type into a {@link Collector}, memoizing the outcome. It is
- * obtained per registry via {@link #forRegistry(ConfigRegistry)} and is scoped to that registry: its cache
+ * obtained per registry via {@link #forRegistry(ConfigView)} and is scoped to that registry: its cache
  * is warm across the many statements executed against a shared registry, yet a forked registry starts with
  * an empty cache and re-resolves against its own factories.
  */
@@ -39,7 +40,7 @@ public final class CollectorResolver {
      * @param config the configuration registry to resolve against
      * @return the registry's memoized collector resolver
      */
-    public static CollectorResolver forRegistry(final ConfigRegistry config) {
+    public static CollectorResolver forRegistry(final ConfigView config) {
         return config.readAs(CollectorResolver.class, CollectorResolver::new);
     }
 

--- a/core/src/main/java/org/jdbi/core/collector/JdbiCollectors.java
+++ b/core/src/main/java/org/jdbi/core/collector/JdbiCollectors.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collector;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.internal.RegistrationLists;
 
@@ -61,6 +62,7 @@ public final class JdbiCollectors implements JdbiConfig<JdbiCollectors> {
      * @param factory A collector factory
      * @return a copy of this configuration with the factory registered
      */
+    @CheckReturnValue
     public JdbiCollectors register(final CollectorFactory factory) {
         return new JdbiCollectors(RegistrationLists.prepend(factories, factory));
     }
@@ -73,6 +75,7 @@ public final class JdbiCollectors implements JdbiConfig<JdbiCollectors> {
      * @since 3.38.0
      * @see org.jdbi.core.config.Configurable#registerCollector(CollectorFactory)
      */
+    @CheckReturnValue
     public JdbiCollectors registerCollector(final Type collectionType, final Collector<?, ?, ?> collector) {
         return register(CollectorFactory.collectorFactory(collectionType, collector));
     }

--- a/core/src/main/java/org/jdbi/core/config/ConfigRegistry.java
+++ b/core/src/main/java/org/jdbi/core/config/ConfigRegistry.java
@@ -25,7 +25,6 @@ import org.jdbi.core.config.internal.ConfigCaches;
 import org.jdbi.core.internal.JdbiClassUtils;
 import org.jdbi.core.mapper.ColumnMappers;
 import org.jdbi.core.mapper.RowMappers;
-import org.jdbi.core.statement.ConfigReader;
 import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.meta.Alpha;
 
@@ -34,7 +33,7 @@ import org.jdbi.meta.Alpha;
  *
  * @see Configurable
  */
-public final class ConfigRegistry implements ConfigReader {
+public final class ConfigRegistry implements ConfigView {
 
     private static final Class<?>[] JDBI_CONFIG_TYPES = {ConfigRegistry.class};
 
@@ -86,6 +85,7 @@ public final class ConfigRegistry implements ConfigReader {
      * @param <C>         the config class type.
      * @return the given config class instance that belongs to this registry.
      */
+    @Override
     public <C extends JdbiConfig<C>> C get(Class<C> configClass) {
         // we would computeIfAbsent if not for JDK-8062841 >:(
         final JdbiConfig<?> lookup = configs.get(configClass);
@@ -160,6 +160,7 @@ public final class ConfigRegistry implements ConfigReader {
      * @return the memoized view of the given type for this registry
      */
     @Alpha
+    @Override
     public <T> T readAs(final Class<T> asType, final Function<ConfigRegistry, T> create) {
         if (parent != null) {
             // Un-forked child: its effective config equals the parent's, so reuse the parent's (warm) view.
@@ -189,6 +190,7 @@ public final class ConfigRegistry implements ConfigReader {
      * @see JdbiConfig#createCopy() config objects in the returned registry are copies of the corresponding
      * config objects from this registry.
      */
+    @Override
     public ConfigRegistry createCopy() {
         return new ConfigRegistry(this, false);
     }
@@ -208,6 +210,7 @@ public final class ConfigRegistry implements ConfigReader {
      * @return a copy-on-write child of this registry
      */
     @Alpha
+    @Override
     public ConfigRegistry createChild() {
         return new ConfigRegistry(this, true);
     }

--- a/core/src/main/java/org/jdbi/core/config/ConfigRegistry.java
+++ b/core/src/main/java/org/jdbi/core/config/ConfigRegistry.java
@@ -49,6 +49,11 @@ public final class ConfigRegistry implements ConfigView {
     // until the child's first install(), at which point the child materialises its own configs and detaches.
     private ConfigRegistry parent;
 
+    // Cached read-only view of this registry, handed to readAs create-functions (e.g. resolvers) so a resolver
+    // passes a ConfigView -- never this mutable registry -- to the factory SPIs it invokes. Lazily created; the
+    // wrapper is stateless (it forwards to this), so a benign race that builds two equivalent wrappers is harmless.
+    private ConfigView readOnlyView;
+
     /**
      * Creates a new config registry.
      */
@@ -161,7 +166,7 @@ public final class ConfigRegistry implements ConfigView {
      */
     @Alpha
     @Override
-    public <T> T readAs(final Class<T> asType, final Function<ConfigRegistry, T> create) {
+    public <T> T readAs(final Class<T> asType, final Function<ConfigView, T> create) {
         if (parent != null) {
             // Un-forked child: its effective config equals the parent's, so reuse the parent's (warm) view.
             return parent.readAs(asType, create);
@@ -171,9 +176,20 @@ public final class ConfigRegistry implements ConfigView {
         if (existing != null) {
             return existing;
         }
-        final T created = create.apply(this);
+        // Hand the create-function a read-only view, not this registry, so a view (e.g. a resolver) cannot reach
+        // in-place mutation, and readAs cannot be abused to extract the mutable registry from a read-only context.
+        final T created = create.apply(asReadOnlyView());
         final T previous = asType.cast(views.putIfAbsent(asType, created));
         return previous != null ? previous : created;
+    }
+
+    // Package-private: the read-only view handed to readAs create-functions. Exposed to same-package tests
+    // that assert readAs binds a view to the intended registry.
+    ConfigView asReadOnlyView() {
+        if (readOnlyView == null) {
+            readOnlyView = ConfigView.readOnly(() -> this);
+        }
+        return readOnlyView;
     }
 
     private Function<ConfigRegistry, JdbiConfig<?>> configFactory(Class<? extends JdbiConfig<?>> configClass) {

--- a/core/src/main/java/org/jdbi/core/config/ConfigView.java
+++ b/core/src/main/java/org/jdbi/core/config/ConfigView.java
@@ -44,17 +44,17 @@ public interface ConfigView extends ConfigReader {
     /**
      * Returns a memoized, read-only view of this registry of the given type (for example a resolver that carries
      * resolution caches), creating it on first request. See {@link ConfigRegistry#readAs} for the memoization and
-     * scoping semantics. This is an internal building block for resolvers, which need the mutable
-     * {@link ConfigRegistry} to pass to the factory SPIs; the {@code create} function must not retain or mutate the
-     * registry it is given.
+     * scoping semantics. This is an internal building block for resolvers; the {@code create} function is handed a
+     * read-only {@code ConfigView} (never the mutable registry) to pass to the factory SPIs, and must not retain it
+     * beyond the view it builds.
      *
      * @param asType the view type, which also keys the memo
-     * @param create builds the view from the registry, if not already present
+     * @param create builds the view from a read-only view of the registry, if not already present
      * @param <T>    the view type
      * @return the memoized view of the given type for this registry
      */
     @Alpha
-    <T> T readAs(Class<T> asType, Function<ConfigRegistry, T> create);
+    <T> T readAs(Class<T> asType, Function<ConfigView, T> create);
 
     /**
      * Returns a copy-on-write child of this registry (see {@link ConfigRegistry#createChild()}). The returned child

--- a/core/src/main/java/org/jdbi/core/config/ConfigView.java
+++ b/core/src/main/java/org/jdbi/core/config/ConfigView.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.core.config;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.jdbi.core.statement.ConfigReader;
+import org.jdbi.meta.Alpha;
+
+/**
+ * A read-only view of a {@link ConfigRegistry}. It can read configuration values and derive new registries, but it
+ * cannot mutate a registry in place. {@link ConfigReader#getConfig()} returns a {@code ConfigView} so that read-only
+ * contexts (a {@link org.jdbi.core.Jdbi Jdbi} or a {@link org.jdbi.core.Handle Handle}) do not expose configuration
+ * mutation: the in-place mutation surface ({@link ConfigRegistry#configure}) lives only on {@link ConfigRegistry}.
+ * <p>
+ * A {@code ConfigView} obtained from a read-only context is a distinct read-only delegate, not the underlying
+ * {@code ConfigRegistry}, so it cannot be cast back to one to reach {@code configure}. To apply configuration, build
+ * the {@code Jdbi} with {@link org.jdbi.core.Jdbi#builder}, open a handle with a config scope
+ * ({@link org.jdbi.core.Jdbi#open(java.util.function.Consumer)}), or configure a statement (which is copy-on-write).
+ */
+public interface ConfigView extends ConfigReader {
+
+    /**
+     * Returns this registry's instance of the given config class, creating it on demand if absent.
+     *
+     * @param configClass the config class type
+     * @param <C>         the config class type
+     * @return the config value of the given type
+     */
+    <C extends JdbiConfig<C>> C get(Class<C> configClass);
+
+    /**
+     * Returns a memoized, read-only view of this registry of the given type (for example a resolver that carries
+     * resolution caches), creating it on first request. See {@link ConfigRegistry#readAs} for the memoization and
+     * scoping semantics. This is an internal building block for resolvers, which need the mutable
+     * {@link ConfigRegistry} to pass to the factory SPIs; the {@code create} function must not retain or mutate the
+     * registry it is given.
+     *
+     * @param asType the view type, which also keys the memo
+     * @param create builds the view from the registry, if not already present
+     * @param <T>    the view type
+     * @return the memoized view of the given type for this registry
+     */
+    @Alpha
+    <T> T readAs(Class<T> asType, Function<ConfigRegistry, T> create);
+
+    /**
+     * Returns a copy-on-write child of this registry (see {@link ConfigRegistry#createChild()}). The returned child
+     * is a new registry; mutating it does not affect this view's registry.
+     *
+     * @return a copy-on-write child registry
+     */
+    @Alpha
+    ConfigRegistry createChild();
+
+    /**
+     * Returns an isolated copy of this registry (see {@link ConfigRegistry#createCopy()}). Mutating the copy does not
+     * affect this view's registry.
+     *
+     * @return a copy of this registry
+     */
+    ConfigRegistry createCopy();
+
+    /**
+     * Returns a read-only view that forwards reads to the registry supplied on each access. The returned view is not
+     * a {@link ConfigRegistry} and cannot be cast to one, so it never exposes in-place mutation. The supplier is read
+     * on each call, so a caller whose effective registry changes over time (for example a handle switching extension
+     * contexts) always reads through to the current one.
+     *
+     * @param registry supplies the registry to read through to
+     * @return a read-only view over the supplied registry
+     */
+    static ConfigView readOnly(final Supplier<ConfigRegistry> registry) {
+        return new ReadOnlyConfigView(registry);
+    }
+}

--- a/core/src/main/java/org/jdbi/core/config/ReadOnlyConfigView.java
+++ b/core/src/main/java/org/jdbi/core/config/ReadOnlyConfigView.java
@@ -41,7 +41,7 @@ final class ReadOnlyConfigView implements ConfigView {
     }
 
     @Override
-    public <T> T readAs(final Class<T> asType, final Function<ConfigRegistry, T> create) {
+    public <T> T readAs(final Class<T> asType, final Function<ConfigView, T> create) {
         return registry.get().readAs(asType, create);
     }
 

--- a/core/src/main/java/org/jdbi/core/config/ReadOnlyConfigView.java
+++ b/core/src/main/java/org/jdbi/core/config/ReadOnlyConfigView.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.core.config;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * A read-only {@link ConfigView} that forwards reads to a {@link ConfigRegistry} supplied on each access. It is not a
+ * {@code ConfigRegistry}, so a caller cannot cast it back to reach the in-place mutation surface
+ * ({@link ConfigRegistry#configure}). See {@link ConfigView#readOnly}.
+ */
+final class ReadOnlyConfigView implements ConfigView {
+
+    private final Supplier<ConfigRegistry> registry;
+
+    ReadOnlyConfigView(final Supplier<ConfigRegistry> registry) {
+        this.registry = Objects.requireNonNull(registry, "null registry supplier");
+    }
+
+    @Override
+    public ConfigView getConfig() {
+        return this;
+    }
+
+    @Override
+    public <C extends JdbiConfig<C>> C get(final Class<C> configClass) {
+        return registry.get().get(configClass);
+    }
+
+    @Override
+    public <T> T readAs(final Class<T> asType, final Function<ConfigRegistry, T> create) {
+        return registry.get().readAs(asType, create);
+    }
+
+    @Override
+    public ConfigRegistry createChild() {
+        return registry.get().createChild();
+    }
+
+    @Override
+    public ConfigRegistry createCopy() {
+        return registry.get().createCopy();
+    }
+}

--- a/core/src/main/java/org/jdbi/core/config/internal/ConfigCache.java
+++ b/core/src/main/java/org/jdbi/core/config/internal/ConfigCache.java
@@ -13,7 +13,7 @@
  */
 package org.jdbi.core.config.internal;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.config.Configurable;
 import org.jdbi.core.statement.StatementContext;
 
@@ -25,7 +25,7 @@ import org.jdbi.core.statement.StatementContext;
 @SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface ConfigCache<K, V> {
 
-    V get(K key, ConfigRegistry config);
+    V get(K key, ConfigView config);
 
     default V get(K key, Configurable<?> configurable) {
         return get(key, configurable.getConfig());

--- a/core/src/main/java/org/jdbi/core/config/internal/ConfigCaches.java
+++ b/core/src/main/java/org/jdbi/core/config/internal/ConfigCaches.java
@@ -18,7 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.config.JdbiConfig;
 
 /**
@@ -50,15 +50,15 @@ public final class ConfigCaches implements JdbiConfig<ConfigCaches> {
         return declare(keyNormalizer, (config, k) -> computer.apply(k));
     }
 
-    public static <K, V> ConfigCache<K, V> declare(BiFunction<ConfigRegistry, K, V> computer) {
+    public static <K, V> ConfigCache<K, V> declare(BiFunction<ConfigView, K, V> computer) {
         return declare(Function.identity(), computer);
     }
 
-    public static <K, V> ConfigCache<K, V> declare(Function<K, ?> keyNormalizer, BiFunction<ConfigRegistry, K, V> computer) {
+    public static <K, V> ConfigCache<K, V> declare(Function<K, ?> keyNormalizer, BiFunction<ConfigView, K, V> computer) {
         return new ConfigCache<>() {
             @SuppressWarnings("unchecked")
             @Override
-            public V get(K key, ConfigRegistry config) {
+            public V get(K key, ConfigView config) {
                 return (V) config.get(ConfigCaches.class).caches
                     .computeIfAbsent(this, x -> new ConcurrentHashMap<>())
                     .computeIfAbsent(keyNormalizer.apply(key), x -> computer.apply(config, key));

--- a/core/src/main/java/org/jdbi/core/enums/Enums.java
+++ b/core/src/main/java/org/jdbi/core/enums/Enums.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.core.enums;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 
 /**
@@ -43,6 +44,7 @@ public final class Enums implements JdbiConfig<Enums> {
      * @param enumStrategy the new strategy
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Enums defaultStrategy(EnumStrategy enumStrategy) {
         return new Enums(enumStrategy);
     }

--- a/core/src/main/java/org/jdbi/core/enums/internal/EnumMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/enums/internal/EnumMapperFactory.java
@@ -15,7 +15,7 @@ package org.jdbi.core.enums.internal;
 
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.enums.EnumStrategy;
 import org.jdbi.core.generic.GenericTypes;
 import org.jdbi.core.internal.EnumStrategyResolver;
@@ -27,14 +27,14 @@ import org.jdbi.core.qualifier.QualifiedType;
 public class EnumMapperFactory implements QualifiedColumnMapperFactory {
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public Optional<ColumnMapper<?>> build(QualifiedType<?> givenType, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(QualifiedType<?> givenType, ConfigView config) {
         return Optional.of(givenType.getType())
             .map(GenericTypes::getErasedType)
             .filter(Enum.class::isAssignableFrom)
             .map(clazz -> makeEnumArgument((QualifiedType<Enum>) givenType, (Class<Enum>) clazz, config));
     }
 
-    private static <E extends Enum<E>> ColumnMapper<?> makeEnumArgument(QualifiedType<E> givenType, Class<E> enumClass, ConfigRegistry config) {
+    private static <E extends Enum<E>> ColumnMapper<?> makeEnumArgument(QualifiedType<E> givenType, Class<E> enumClass, ConfigView config) {
         boolean byName = EnumStrategy.BY_NAME == EnumStrategyResolver.forRegistry(config).findStrategy(givenType);
 
         return byName

--- a/core/src/main/java/org/jdbi/core/enums/internal/EnumSqlArrayTypeFactory.java
+++ b/core/src/main/java/org/jdbi/core/enums/internal/EnumSqlArrayTypeFactory.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import org.jdbi.core.array.SqlArrayType;
 import org.jdbi.core.array.SqlArrayTypeFactory;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.enums.EnumStrategy;
 import org.jdbi.core.generic.GenericTypes;
 import org.jdbi.core.internal.EnumStrategyResolver;
@@ -28,14 +28,14 @@ import org.jdbi.core.qualifier.QualifiedType;
 public class EnumSqlArrayTypeFactory implements SqlArrayTypeFactory {
     @Override
     @SuppressWarnings("unchecked")
-    public Optional<SqlArrayType<?>> build(Type elementType, ConfigRegistry config) {
+    public Optional<SqlArrayType<?>> build(Type elementType, ConfigView config) {
         return Optional.of(elementType)
             .map(GenericTypes::getErasedType)
             .filter(Enum.class::isAssignableFrom)
             .map(clazz -> makeSqlArrayType((Class<Enum>) clazz, config));
     }
 
-    private <E extends Enum<E>> SqlArrayType<E> makeSqlArrayType(Class<E> enumClass, ConfigRegistry config) {
+    private <E extends Enum<E>> SqlArrayType<E> makeSqlArrayType(Class<E> enumClass, ConfigView config) {
         boolean byName = EnumStrategy.BY_NAME == EnumStrategyResolver.forRegistry(config).findStrategy(QualifiedType.of(enumClass));
 
         return byName

--- a/core/src/main/java/org/jdbi/core/extension/ExtensionFactory.java
+++ b/core/src/main/java/org/jdbi/core/extension/ExtensionFactory.java
@@ -18,7 +18,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.jdbi.core.config.ConfigCustomizer;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.meta.Alpha;
 
 /**
@@ -97,7 +97,7 @@ public interface ExtensionFactory {
      * @since 3.38.0
      */
     @Alpha
-    default Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigRegistry config) {
+    default Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigView config) {
         return Collections.emptySet();
     }
 
@@ -113,7 +113,7 @@ public interface ExtensionFactory {
      * @since 3.38.0
      */
     @Alpha
-    default Collection<ExtensionHandlerCustomizer> getExtensionHandlerCustomizers(ConfigRegistry config) {
+    default Collection<ExtensionHandlerCustomizer> getExtensionHandlerCustomizers(ConfigView config) {
         return Collections.emptySet();
     }
 
@@ -130,7 +130,7 @@ public interface ExtensionFactory {
      * @since 3.38.0
      */
     @Alpha
-    default Collection<ConfigCustomizerFactory> getConfigCustomizerFactories(ConfigRegistry config) {
+    default Collection<ConfigCustomizerFactory> getConfigCustomizerFactories(ConfigView config) {
         return Collections.emptySet();
     }
 

--- a/core/src/main/java/org/jdbi/core/extension/ExtensionFactoryDelegate.java
+++ b/core/src/main/java/org/jdbi/core/extension/ExtensionFactoryDelegate.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.extension.ExtensionMetadata.ExtensionHandlerInvoker;
 import org.jdbi.core.internal.JdbiClassUtils.MethodKey;
 
@@ -54,19 +55,19 @@ final class ExtensionFactoryDelegate implements ExtensionFactory {
     }
 
     @Override
-    public Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(final ConfigRegistry config) {
+    public Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(final ConfigView config) {
         return Collections.unmodifiableCollection(delegatedFactory.getExtensionHandlerFactories(config).stream()
                 .map(FilteringExtensionHandlerFactory::forDelegate)
                 .toList());
     }
 
     @Override
-    public Collection<ExtensionHandlerCustomizer> getExtensionHandlerCustomizers(final ConfigRegistry config) {
+    public Collection<ExtensionHandlerCustomizer> getExtensionHandlerCustomizers(final ConfigView config) {
         return delegatedFactory.getExtensionHandlerCustomizers(config);
     }
 
     @Override
-    public Collection<ConfigCustomizerFactory> getConfigCustomizerFactories(final ConfigRegistry config) {
+    public Collection<ConfigCustomizerFactory> getConfigCustomizerFactories(final ConfigView config) {
         return delegatedFactory.getConfigCustomizerFactories(config);
     }
 

--- a/core/src/main/java/org/jdbi/core/extension/ExtensionMetadataResolver.java
+++ b/core/src/main/java/org/jdbi/core/extension/ExtensionMetadataResolver.java
@@ -17,16 +17,17 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.CopyOnWriteHashMap;
 
 import static org.jdbi.core.extension.ExtensionFactory.FactoryFlag.NON_VIRTUAL_FACTORY;
 
 /**
- * Resolves and caches {@link ExtensionMetadata} for a specific {@link ConfigRegistry}.
+ * Resolves and caches {@link ExtensionMetadata} for a specific {@link ConfigView}.
  * <p>
  * A resolver builds the metadata for an extension type from the passed {@link ExtensionFactory} and the
  * global handler/customizer factories registered on the registry's {@link Extensions} (which holds only
- * registration data), memoizing the outcome. It is obtained per registry via {@link #forRegistry(ConfigRegistry)}
+ * registration data), memoizing the outcome. It is obtained per registry via {@link #forRegistry(ConfigView)}
  * and is scoped to that registry: its cache is warm across the extensions attached against a shared registry,
  * yet a forked registry starts with an empty cache and re-resolves against its own registration data.
  * <p>
@@ -42,7 +43,7 @@ public final class ExtensionMetadataResolver {
      * @param config the configuration registry to resolve against
      * @return the registry's memoized extension-metadata resolver
      */
-    public static ExtensionMetadataResolver forRegistry(final ConfigRegistry config) {
+    public static ExtensionMetadataResolver forRegistry(final ConfigView config) {
         return config.readAs(ExtensionMetadataResolver.class, ExtensionMetadataResolver::new);
     }
 

--- a/core/src/main/java/org/jdbi/core/extension/ExtensionMetadataResolver.java
+++ b/core/src/main/java/org/jdbi/core/extension/ExtensionMetadataResolver.java
@@ -47,10 +47,10 @@ public final class ExtensionMetadataResolver {
         return config.readAs(ExtensionMetadataResolver.class, ExtensionMetadataResolver::new);
     }
 
-    private final ConfigRegistry registry;
+    private final ConfigView registry;
     private final Map<Class<?>, ExtensionMetadata> metadataCache = new CopyOnWriteHashMap<>();
 
-    private ExtensionMetadataResolver(final ConfigRegistry registry) {
+    private ExtensionMetadataResolver(final ConfigView registry) {
         this.registry = registry;
     }
 

--- a/core/src/main/java/org/jdbi/core/extension/Extensions.java
+++ b/core/src/main/java/org/jdbi/core/extension/Extensions.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.extension.annotation.UseExtensionHandler;
 import org.jdbi.core.extension.annotation.UseExtensionHandlerCustomizer;
@@ -89,6 +90,7 @@ public final class Extensions implements JdbiConfig<Extensions> {
      * @param factory the factory to register
      * @return a copy of this configuration with the factory registered
      */
+    @CheckReturnValue
     public Extensions register(ExtensionFactory factory) {
         return new Extensions(RegistrationLists.prepend(extensionFactories, new ExtensionFactoryDelegate(factory)),
                 extensionHandlerFactories, extensionHandlerCustomizers, configCustomizerFactories, allowProxy, failFast);
@@ -102,6 +104,7 @@ public final class Extensions implements JdbiConfig<Extensions> {
      *
      * @since 3.38.0
      */
+    @CheckReturnValue
     @Alpha
     public Extensions registerHandlerFactory(ExtensionHandlerFactory extensionHandlerFactory) {
         return internalRegisterHandlerFactory(FilteringExtensionHandlerFactory.forDelegate(extensionHandlerFactory));
@@ -115,6 +118,7 @@ public final class Extensions implements JdbiConfig<Extensions> {
      *
      * @since 3.38.0
      */
+    @CheckReturnValue
     @Alpha
     public Extensions registerHandlerCustomizer(ExtensionHandlerCustomizer extensionHandlerCustomizer) {
         return new Extensions(extensionFactories, extensionHandlerFactories,
@@ -130,6 +134,7 @@ public final class Extensions implements JdbiConfig<Extensions> {
      *
      * @since 3.38.0
      */
+    @CheckReturnValue
     @Alpha
     public Extensions registerConfigCustomizerFactory(ConfigCustomizerFactory configCustomizerFactory) {
         return new Extensions(extensionFactories, extensionHandlerFactories, extensionHandlerCustomizers,
@@ -233,6 +238,7 @@ public final class Extensions implements JdbiConfig<Extensions> {
      * @param allowProxy whether to allow use of Proxy types
      * @return the derived configuration
      */
+    @CheckReturnValue
     @Beta
     public Extensions allowProxy(boolean allowProxy) {
         return new Extensions(extensionFactories, extensionHandlerFactories, extensionHandlerCustomizers,
@@ -256,6 +262,7 @@ public final class Extensions implements JdbiConfig<Extensions> {
      * @return a copy of this configuration that fails fast
      * @since 3.39.0
      */
+    @CheckReturnValue
     @Alpha
     public Extensions failFast() {
         return new Extensions(extensionFactories, extensionHandlerFactories, extensionHandlerCustomizers,

--- a/core/src/main/java/org/jdbi/core/internal/EnumStrategyResolver.java
+++ b/core/src/main/java/org/jdbi/core/internal/EnumStrategyResolver.java
@@ -16,6 +16,7 @@ package org.jdbi.core.internal;
 import java.util.Optional;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.enums.EnumByName;
 import org.jdbi.core.enums.EnumByOrdinal;
 import org.jdbi.core.enums.EnumStrategy;
@@ -26,11 +27,11 @@ import org.jdbi.core.qualifier.Qualifiers;
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
 
 /**
- * Resolves the {@link EnumStrategy} to use for an enum type against a specific {@link ConfigRegistry}.
+ * Resolves the {@link EnumStrategy} to use for an enum type against a specific {@link ConfigView}.
  * <p>
  * This reads the registry's {@link Enums} default strategy and per-type strategy annotations (via
  * {@link Qualifiers}), so the outcome tracks the registry it is obtained from. It is obtained per registry via
- * {@link #forRegistry(ConfigRegistry)}; a forked registry resolves against its own {@code Enums} configuration.
+ * {@link #forRegistry(ConfigView)}; a forked registry resolves against its own {@code Enums} configuration.
  */
 public final class EnumStrategyResolver {
 
@@ -40,7 +41,7 @@ public final class EnumStrategyResolver {
      * @param config the configuration registry to resolve against
      * @return the registry's memoized enum-strategy resolver
      */
-    public static EnumStrategyResolver forRegistry(final ConfigRegistry config) {
+    public static EnumStrategyResolver forRegistry(final ConfigView config) {
         return config.readAs(EnumStrategyResolver.class, EnumStrategyResolver::new);
     }
 

--- a/core/src/main/java/org/jdbi/core/internal/EnumStrategyResolver.java
+++ b/core/src/main/java/org/jdbi/core/internal/EnumStrategyResolver.java
@@ -15,7 +15,6 @@ package org.jdbi.core.internal;
 
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.enums.EnumByName;
 import org.jdbi.core.enums.EnumByOrdinal;
@@ -45,9 +44,9 @@ public final class EnumStrategyResolver {
         return config.readAs(EnumStrategyResolver.class, EnumStrategyResolver::new);
     }
 
-    private final ConfigRegistry registry;
+    private final ConfigView registry;
 
-    private EnumStrategyResolver(final ConfigRegistry registry) {
+    private EnumStrategyResolver(final ConfigView registry) {
         this.registry = registry;
     }
 

--- a/core/src/main/java/org/jdbi/core/internal/OnDemandExtensions.java
+++ b/core/src/main/java/org/jdbi/core/internal/OnDemandExtensions.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.extension.Extensions;
@@ -41,6 +42,7 @@ public final class OnDemandExtensions implements JdbiConfig<OnDemandExtensions> 
         this.onDemandExtensionFactory = onDemandExtensionFactory;
     }
 
+    @CheckReturnValue
     public OnDemandExtensions factory(Factory onDemandExtensionFactory) {
         return new OnDemandExtensions(onDemandExtensionFactory);
     }

--- a/core/src/main/java/org/jdbi/core/mapper/BoxedMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/BoxedMapperFactory.java
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 import java.util.IdentityHashMap;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
 
@@ -51,7 +51,7 @@ class BoxedMapperFactory implements ColumnMapperFactory {
     }
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         Class<?> rawType = getErasedType(type);
 
         return Optional.ofNullable(mappers.get(rawType));

--- a/core/src/main/java/org/jdbi/core/mapper/BuiltInMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/BuiltInMapperFactory.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * @deprecated will be replaced by an opt-out plugin to give the core no hardwired behavior
@@ -38,7 +38,7 @@ public class BuiltInMapperFactory implements ColumnMapperFactory {
 
     @Deprecated
     @Override
-    public Optional<ColumnMapper<?>> build(final Type type, final ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(final Type type, final ConfigView config) {
         return FACTORIES.stream()
             .flatMap(factory -> factory.build(type, config).stream())
             .findFirst();

--- a/core/src/main/java/org/jdbi/core/mapper/ColumnMapper.java
+++ b/core/src/main/java/org/jdbi/core/mapper/ColumnMapper.java
@@ -16,7 +16,7 @@ package org.jdbi.core.mapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 
 /**
@@ -65,13 +65,13 @@ public interface ColumnMapper<T> {
     }
 
     /**
-     * Allows for initialization of the column mapper instance within a ConfigRegistry scope. This method is called once when the column mapper is first used from a
-     * ConfigRegistry.
+     * Allows for initialization of the column mapper instance within a config scope. This method is called once when the column mapper is first used from a
+     * config scope.
      * <p>
      * Note that a handle, and a statement or SQL object that changes its configuration, has its own registry, and this method is called once for each such registry.
      * A statement that does not change its configuration shares its handle's registry, so it reuses that registry's already-initialized mapper rather than initializing again.
      *
-     * @param registry A reference to the {@link ConfigRegistry} that this instance belongs to.
+     * @param registry A read-only view of the config that this instance belongs to.
      */
-    default void init(ConfigRegistry registry) {}
+    default void init(ConfigView registry) {}
 }

--- a/core/src/main/java/org/jdbi/core/mapper/ColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/ColumnMapperFactory.java
@@ -16,7 +16,7 @@ package org.jdbi.core.mapper;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * Factory interface used to produce column mappers.
@@ -31,7 +31,7 @@ public interface ColumnMapperFactory {
      * @return a column mapper for the given type if this factory supports it, or <code>Optional.empty()</code> otherwise.
      * @see ColumnMappers for composition
      */
-    Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config);
+    Optional<ColumnMapper<?>> build(Type type, ConfigView config);
 
     /**
      * Create a ColumnMapperFactory from a given {@link ColumnMapper} that

--- a/core/src/main/java/org/jdbi/core/mapper/ColumnMappers.java
+++ b/core/src/main/java/org/jdbi/core/mapper/ColumnMappers.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.array.SqlArrayMapperFactory;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.enums.internal.EnumMapperFactory;
@@ -88,6 +89,7 @@ public final class ColumnMappers implements JdbiConfig<ColumnMappers> {
      * @param interceptor the inference interceptor to add
      * @return the derived configuration
      */
+    @CheckReturnValue
     @Alpha
     public ColumnMappers withInferenceInterceptor(final JdbiInterceptor<ColumnMapper<?>, QualifiedColumnMapperFactory> interceptor) {
         final JdbiInterceptionChainHolder<ColumnMapper<?>, QualifiedColumnMapperFactory> newInterceptors = new JdbiInterceptionChainHolder<>(inferenceInterceptors);
@@ -106,6 +108,7 @@ public final class ColumnMappers implements JdbiConfig<ColumnMappers> {
      * @return a copy of this configuration with the mapper registered
      * @throws UnsupportedOperationException if the ColumnMapper is not a concretely parameterized type
      */
+    @CheckReturnValue
     public ColumnMappers register(ColumnMapper<?> mapper) {
         QualifiedColumnMapperFactory factory = inferenceInterceptors.process(mapper);
 
@@ -121,6 +124,7 @@ public final class ColumnMappers implements JdbiConfig<ColumnMappers> {
      * @param mapper the column mapper
      * @return this
      */
+    @CheckReturnValue
     public <T> ColumnMappers register(GenericType<T> type, ColumnMapper<T> mapper) {
         return this.register(ColumnMapperFactory.of(type.getType(), mapper));
     }
@@ -133,6 +137,7 @@ public final class ColumnMappers implements JdbiConfig<ColumnMappers> {
      * @param mapper the column mapper
      * @return this
      */
+    @CheckReturnValue
     public ColumnMappers register(Type type, ColumnMapper<?> mapper) {
         return this.register(ColumnMapperFactory.of(type, mapper));
     }
@@ -145,6 +150,7 @@ public final class ColumnMappers implements JdbiConfig<ColumnMappers> {
      * @param mapper the column mapper
      * @return this
      */
+    @CheckReturnValue
     public <T> ColumnMappers register(QualifiedType<T> type, ColumnMapper<T> mapper) {
         return this.register(QualifiedColumnMapperFactory.of(type, mapper));
     }
@@ -157,6 +163,7 @@ public final class ColumnMappers implements JdbiConfig<ColumnMappers> {
      * @param factory the column mapper factory
      * @return a copy of this configuration with the factory registered
      */
+    @CheckReturnValue
     public ColumnMappers register(ColumnMapperFactory factory) {
         return register(QualifiedColumnMapperFactory.adapt(factory));
     }
@@ -169,6 +176,7 @@ public final class ColumnMappers implements JdbiConfig<ColumnMappers> {
      * @param factory the qualified column mapper factory
      * @return a copy of this configuration with the factory registered
      */
+    @CheckReturnValue
     public ColumnMappers register(QualifiedColumnMapperFactory factory) {
         return new ColumnMappers(RegistrationLists.prepend(factories, factory), inferenceInterceptors, coalesceNullPrimitivesToDefaults);
     }
@@ -181,6 +189,7 @@ public final class ColumnMappers implements JdbiConfig<ColumnMappers> {
      * @param factories the column mapper factories to add
      * @return a copy of this configuration with the factories registered
      */
+    @CheckReturnValue
     public ColumnMappers register(Collection<? extends ColumnMapperFactory> factories) {
         if (factories.isEmpty()) {
             return this;
@@ -216,6 +225,7 @@ public final class ColumnMappers implements JdbiConfig<ColumnMappers> {
      * @param coalesceNullPrimitivesToDefaults If true, then use the JDBC default value, otherwise throw an exception.
      * @return a copy of this configuration with the policy set
      */
+    @CheckReturnValue
     public ColumnMappers coalesceNullPrimitivesToDefaults(boolean coalesceNullPrimitivesToDefaults) {
         return new ColumnMappers(factories, inferenceInterceptors, coalesceNullPrimitivesToDefaults);
     }

--- a/core/src/main/java/org/jdbi/core/mapper/EssentialsMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/EssentialsMapperFactory.java
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
@@ -46,7 +46,7 @@ class EssentialsMapperFactory implements ColumnMapperFactory {
     }
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         Class<?> rawType = getErasedType(type);
 
         return Optional.ofNullable(mappers.get(rawType));

--- a/core/src/main/java/org/jdbi/core/mapper/GenericMapMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/GenericMapMapperFactory.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.generic.GenericTypes;
 import org.jdbi.core.result.ResultBearing;
@@ -37,7 +37,7 @@ import org.jdbi.core.statement.StatementContext;
  * Factory for a RowMapper that can map resultset rows to column name/generic value {@link Map}s.
  * <p>
  * Each row in the resultset becomes a distinct {@link Map}, in which the keys are all distinct column names and the values are the corresponding cell contents.
- * All values are mapped to the same generic type {@code T} (e.g. {@link java.math.BigDecimal}) by a {@link ColumnMapper} from the {@link ConfigRegistry}.
+ * All values are mapped to the same generic type {@code T} (e.g. {@link java.math.BigDecimal}) by a {@link ColumnMapper} from the {@link ConfigView}.
  * <p>
  * This differs from {@link MapMapper} by supporting a concrete type instead of only {@link Object}, and from {@code collecting} into a {@link Map}
  * in that the latter maps an entire resultset to a single {@link Map} and can only keep 1 key and 1 value from each row.
@@ -53,7 +53,7 @@ import org.jdbi.core.statement.StatementContext;
 public class GenericMapMapperFactory implements RowMapperFactory {
 
     @Override
-    public Optional<RowMapper<?>> build(Type mapType, ConfigRegistry config) {
+    public Optional<RowMapper<?>> build(Type mapType, ConfigView config) {
         return Optional.of(mapType)
             .filter(ParameterizedType.class::isInstance)
             .map(ParameterizedType.class::cast)
@@ -69,11 +69,11 @@ public class GenericMapMapperFactory implements RowMapperFactory {
      * Returns a {@link RowMapper} for a map with the given value type. The key type is {@link String}.
      *
      * @param valueType A {@link Class} instance representing the value type for the {@link Map}
-     * @param config    A {@link ConfigRegistry} instance
+     * @param config    A {@link ConfigView} instance
      * @param <T>       The value type
      * @return A {@link RowMapper} for a map from string to the given value type
      */
-    public static <T> RowMapper<Map<String, T>> getMapperForValueType(Class<T> valueType, ConfigRegistry config) {
+    public static <T> RowMapper<Map<String, T>> getMapperForValueType(Class<T> valueType, ConfigView config) {
         return config.findColumnMapperFor(valueType)
             .map(GenericMapMapper::new)
             .orElseThrow(() -> new RuntimeException("no column mapper found for type " + valueType));
@@ -83,11 +83,11 @@ public class GenericMapMapperFactory implements RowMapperFactory {
      * Returns a {@link RowMapper} for a map with the given value type. The key type is {@link String}.
      *
      * @param valueType A {@link Class} instance representing the value type for the {@link Map}
-     * @param config    A {@link ConfigRegistry} instance
+     * @param config    A {@link ConfigView} instance
      * @param <T>       The value type
      * @return A {@link RowMapper} for a map from string to the given value type
      */
-    public static <T> RowMapper<Map<String, T>> getMapperForValueType(GenericType<T> valueType, ConfigRegistry config) {
+    public static <T> RowMapper<Map<String, T>> getMapperForValueType(GenericType<T> valueType, ConfigView config) {
         return config.findColumnMapperFor(valueType)
             .map(GenericMapMapper::new)
             .orElseThrow(() -> new RuntimeException("no column mapper found for type " + valueType));

--- a/core/src/main/java/org/jdbi/core/mapper/GetObjectColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/GetObjectColumnMapperFactory.java
@@ -22,7 +22,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 
 /**
@@ -61,7 +61,7 @@ public class GetObjectColumnMapperFactory implements ColumnMapperFactory {
     }
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         return Optional.of(type)
             .filter(Class.class::isInstance)
             .map(Class.class::cast)

--- a/core/src/main/java/org/jdbi/core/mapper/InferredColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/InferredColumnMapperFactory.java
@@ -15,7 +15,7 @@ package org.jdbi.core.mapper;
 
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.core.qualifier.Qualifiers;
 
@@ -42,7 +42,7 @@ class InferredColumnMapperFactory implements QualifiedColumnMapperFactory {
     }
 
     @Override
-    public Optional<ColumnMapper<?>> build(QualifiedType<?> type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(QualifiedType<?> type, ConfigView config) {
         return maps.equals(type)
                 ? Optional.of(mapper)
                 : Optional.empty();

--- a/core/src/main/java/org/jdbi/core/mapper/InferredRowMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/InferredRowMapperFactory.java
@@ -16,7 +16,7 @@ package org.jdbi.core.mapper;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 import static org.jdbi.core.generic.GenericTypes.findGenericParameter;
 
@@ -44,7 +44,7 @@ class InferredRowMapperFactory implements RowMapperFactory {
     }
 
     @Override
-    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<RowMapper<?>> build(Type type, ConfigView config) {
         return maps.equals(type)
                 ? Optional.of(mapper)
                 : Optional.empty();

--- a/core/src/main/java/org/jdbi/core/mapper/InternetMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/InternetMapperFactory.java
@@ -24,7 +24,7 @@ import java.sql.SQLException;
 import java.util.IdentityHashMap;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
@@ -47,7 +47,7 @@ class InternetMapperFactory implements ColumnMapperFactory {
     }
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         Class<?> rawType = getErasedType(type);
 
         return Optional.ofNullable(mappers.get(rawType));

--- a/core/src/main/java/org/jdbi/core/mapper/JavaTimeMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/JavaTimeMapperFactory.java
@@ -28,7 +28,7 @@ import java.time.ZonedDateTime;
 import java.util.IdentityHashMap;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
 
@@ -58,7 +58,7 @@ class JavaTimeMapperFactory implements ColumnMapperFactory {
     }
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         Class<?> rawType = getErasedType(type);
 
         return Optional.ofNullable(mappers.get(rawType));

--- a/core/src/main/java/org/jdbi/core/mapper/MapEntryMapper.java
+++ b/core/src/main/java/org/jdbi/core/mapper/MapEntryMapper.java
@@ -22,7 +22,7 @@ import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 
 import static java.lang.String.format;
@@ -65,7 +65,7 @@ public class MapEntryMapper<K, V> implements RowMapper<Map.Entry<K, V>> {
         };
     }
 
-    private static RowMapper<?> getKeyMapper(Type keyType, ConfigRegistry config) {
+    private static RowMapper<?> getKeyMapper(Type keyType, ConfigView config) {
         String column = config.get(MapEntryMappers.class).getKeyColumn();
         if (column == null) {
             return config.findRowMapperFor(keyType)
@@ -77,7 +77,7 @@ public class MapEntryMapper<K, V> implements RowMapper<Map.Entry<K, V>> {
         }
     }
 
-    private static RowMapper<?> getValueMapper(Type valueType, ConfigRegistry config) {
+    private static RowMapper<?> getValueMapper(Type valueType, ConfigView config) {
         String column = config.get(MapEntryMappers.class).getValueColumn();
         if (column == null) {
             return config.findRowMapperFor(valueType)

--- a/core/src/main/java/org/jdbi/core/mapper/MapEntryMappers.java
+++ b/core/src/main/java/org/jdbi/core/mapper/MapEntryMappers.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.core.mapper;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 
 /**
@@ -40,6 +41,7 @@ public final class MapEntryMappers implements JdbiConfig<MapEntryMappers>, MapEn
         return keyColumn;
     }
 
+    @CheckReturnValue
     @Override
     public MapEntryMappers keyColumn(String keyColumn) {
         return new MapEntryMappers(keyColumn, valueColumn);
@@ -50,6 +52,7 @@ public final class MapEntryMappers implements JdbiConfig<MapEntryMappers>, MapEn
         return valueColumn;
     }
 
+    @CheckReturnValue
     @Override
     public MapEntryMappers valueColumn(String valueColumn) {
         return new MapEntryMappers(keyColumn, valueColumn);

--- a/core/src/main/java/org/jdbi/core/mapper/MapMappers.java
+++ b/core/src/main/java/org/jdbi/core/mapper/MapMappers.java
@@ -15,6 +15,7 @@ package org.jdbi.core.mapper;
 
 import java.util.function.UnaryOperator;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 
 public final class MapMappers implements JdbiConfig<MapMappers> {
@@ -47,6 +48,7 @@ public final class MapMappers implements JdbiConfig<MapMappers> {
      * @return the derived configuration
      * @see CaseStrategy
      */
+    @CheckReturnValue
     public MapMappers caseChange(UnaryOperator<String> caseChange) {
         return new MapMappers(caseChange);
     }

--- a/core/src/main/java/org/jdbi/core/mapper/MapperResolver.java
+++ b/core/src/main/java/org/jdbi/core/mapper/MapperResolver.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.internal.CopyOnWriteHashMap;
@@ -47,7 +46,7 @@ public final class MapperResolver {
         return config.readAs(MapperResolver.class, MapperResolver::new);
     }
 
-    private final ConfigRegistry registry;
+    private final ConfigView registry;
     private final Map<Type, Optional<RowMapper<?>>> rowCache = new CopyOnWriteHashMap<>();
     private final Map<QualifiedType<?>, Optional<? extends ColumnMapper<?>>> columnCache = new CopyOnWriteHashMap<>();
 
@@ -57,7 +56,7 @@ public final class MapperResolver {
     private volatile int rowFactoryCount = -1;
     private volatile int columnFactoryCount = -1;
 
-    private MapperResolver(final ConfigRegistry registry) {
+    private MapperResolver(final ConfigView registry) {
         this.registry = registry;
     }
 

--- a/core/src/main/java/org/jdbi/core/mapper/MapperResolver.java
+++ b/core/src/main/java/org/jdbi/core/mapper/MapperResolver.java
@@ -20,16 +20,17 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.internal.CopyOnWriteHashMap;
 import org.jdbi.core.qualifier.QualifiedType;
 
 /**
- * Resolves row and column mappers for a specific {@link ConfigRegistry}, caching the results.
+ * Resolves row and column mappers for a specific {@link ConfigView}, caching the results.
  * <p>
  * A resolver reads the registered factories from the registry's {@link RowMappers} and
  * {@link ColumnMappers} (which hold only registration data) and turns them into mappers, memoizing the
- * outcome. It is obtained per registry via {@link #forRegistry(ConfigRegistry)} and is scoped to that
+ * outcome. It is obtained per registry via {@link #forRegistry(ConfigView)} and is scoped to that
  * registry: because it is never shared across registry copies, it safely holds the registry reference,
  * and its cache is warm across the many statements executed against a shared registry, yet a forked
  * registry starts with an empty cache and re-resolves against its own factories.
@@ -42,7 +43,7 @@ public final class MapperResolver {
      * @param config the configuration registry to resolve against
      * @return the registry's memoized mapper resolver
      */
-    public static MapperResolver forRegistry(final ConfigRegistry config) {
+    public static MapperResolver forRegistry(final ConfigView config) {
         return config.readAs(MapperResolver.class, MapperResolver::new);
     }
 

--- a/core/src/main/java/org/jdbi/core/mapper/OptionalColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/OptionalColumnMapperFactory.java
@@ -26,7 +26,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
@@ -41,10 +41,10 @@ import static org.jdbi.core.generic.GenericTypes.getErasedType;
  * </ul>
  */
 class OptionalColumnMapperFactory implements ColumnMapperFactory {
-    private static final Map<Class<?>, BiFunction<Type, ConfigRegistry, ColumnMapper<?>>> STRATEGIES;
+    private static final Map<Class<?>, BiFunction<Type, ConfigView, ColumnMapper<?>>> STRATEGIES;
 
     static {
-        Map<Class<?>, BiFunction<Type, ConfigRegistry, ColumnMapper<?>>> s = new HashMap<>();
+        Map<Class<?>, BiFunction<Type, ConfigView, ColumnMapper<?>>> s = new HashMap<>();
 
         s.put(Optional.class, OptionalColumnMapperFactory::create);
         s.put(OptionalInt.class, singleton(create(ResultSet::getInt, OptionalInt::empty, OptionalInt::of)));
@@ -55,12 +55,12 @@ class OptionalColumnMapperFactory implements ColumnMapperFactory {
     }
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         return Optional.ofNullable(STRATEGIES.get(getErasedType(type)))
                 .map(strategy -> strategy.apply(type, config));
     }
 
-    static BiFunction<Type, ConfigRegistry, ColumnMapper<?>> singleton(ColumnMapper<?> instance) {
+    static BiFunction<Type, ConfigView, ColumnMapper<?>> singleton(ColumnMapper<?> instance) {
         return (t, c) -> instance;
     }
 
@@ -70,7 +70,7 @@ class OptionalColumnMapperFactory implements ColumnMapperFactory {
                 .orElseGet(empty);
     }
 
-    private static ColumnMapper<?> create(Type type, ConfigRegistry config) {
+    private static ColumnMapper<?> create(Type type, ConfigView config) {
         final ColumnMapper<?> mapper = config.findColumnMapperFor(
                 GenericTypes.findGenericParameter(type, Optional.class)
                     .orElseThrow(() -> new NoSuchMapperException("No mapper for raw Optional type")))

--- a/core/src/main/java/org/jdbi/core/mapper/OptionalRowMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/OptionalRowMapperFactory.java
@@ -16,7 +16,7 @@ package org.jdbi.core.mapper;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
@@ -27,13 +27,13 @@ import static org.jdbi.core.generic.GenericTypes.getErasedType;
 class OptionalRowMapperFactory implements RowMapperFactory {
 
     @Override
-    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<RowMapper<?>> build(Type type, ConfigView config) {
         return Optional.of(type)
             .filter(t -> getErasedType(t) == Optional.class)
             .flatMap(t -> create(t, config));
     }
 
-    private static Optional<RowMapper<?>> create(Type type, ConfigRegistry config) {
+    private static Optional<RowMapper<?>> create(Type type, ConfigView config) {
         return config.findRowMapperFor(
                 GenericTypes.findGenericParameter(type, Optional.class)
                     .orElseThrow(() -> new NoSuchMapperException("No mapper for raw Optional type")))

--- a/core/src/main/java/org/jdbi/core/mapper/PrimitiveMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/PrimitiveMapperFactory.java
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 import java.util.IdentityHashMap;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.result.UnableToProduceResultException;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
@@ -52,7 +52,7 @@ class PrimitiveMapperFactory implements ColumnMapperFactory {
     }
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         Class<?> rawType = getErasedType(type);
 
         return Optional.ofNullable(mappers.get(rawType));

--- a/core/src/main/java/org/jdbi/core/mapper/QualifiedColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/QualifiedColumnMapperFactory.java
@@ -15,7 +15,7 @@ package org.jdbi.core.mapper;
 
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.core.qualifier.Qualifiers;
 
@@ -34,7 +34,7 @@ public interface QualifiedColumnMapperFactory {
      * @see ColumnMappers for composition
      * @see QualifiedType
      */
-    Optional<ColumnMapper<?>> build(QualifiedType<?> type, ConfigRegistry config);
+    Optional<ColumnMapper<?>> build(QualifiedType<?> type, ConfigView config);
 
     /**
      * Adapts a {@link ColumnMapperFactory} into a QualifiedColumnMapperFactory. The returned

--- a/core/src/main/java/org/jdbi/core/mapper/RowMapper.java
+++ b/core/src/main/java/org/jdbi/core/mapper/RowMapper.java
@@ -16,7 +16,7 @@ package org.jdbi.core.mapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 
 /**
@@ -63,13 +63,13 @@ public interface RowMapper<T> {
     }
 
     /**
-     * Allows for initialization of the row mapper instance within a ConfigRegistry scope. This method is called once when the row mapper is first used from a
-     * ConfigRegistry.
+     * Allows for initialization of the row mapper instance within a config scope. This method is called once when the row mapper is first used from a
+     * config scope.
      * <p>
      * Note that a handle, and a statement or SQL object that changes its configuration, has its own registry, and this method is called once for each such registry.
      * A statement that does not change its configuration shares its handle's registry, so it reuses that registry's already-initialized mapper rather than initializing again.
      *
-     * @param registry A reference to the {@link ConfigRegistry} that this instance belongs to.
+     * @param registry A read-only view of the config that this instance belongs to.
      */
-    default void init(ConfigRegistry registry) {}
+    default void init(ConfigView registry) {}
 }

--- a/core/src/main/java/org/jdbi/core/mapper/RowMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/RowMapperFactory.java
@@ -16,7 +16,7 @@ package org.jdbi.core.mapper;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * Factory interface used to produce row mappers.
@@ -31,7 +31,7 @@ public interface RowMapperFactory {
      * @return a row mapper for the given type if this factory supports it; <code>Optional.empty()</code> otherwise.
      * @see RowMappers for composition
      */
-    Optional<RowMapper<?>> build(Type type, ConfigRegistry config);
+    Optional<RowMapper<?>> build(Type type, ConfigView config);
 
     /**
      * Create a RowMapperFactory from a given {@link RowMapper} that matches

--- a/core/src/main/java/org/jdbi/core/mapper/RowMappers.java
+++ b/core/src/main/java/org/jdbi/core/mapper/RowMappers.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.interceptor.JdbiInterceptionChainHolder;
@@ -68,6 +69,7 @@ public final class RowMappers implements JdbiConfig<RowMappers> {
      * @param interceptor the inference interceptor to add
      * @return the derived configuration
      */
+    @CheckReturnValue
     @Alpha
     public RowMappers withInferenceInterceptor(final JdbiInterceptor<RowMapper<?>, RowMapperFactory> interceptor) {
         final JdbiInterceptionChainHolder<RowMapper<?>, RowMapperFactory> newInterceptors = new JdbiInterceptionChainHolder<>(inferenceInterceptors);
@@ -88,6 +90,7 @@ public final class RowMappers implements JdbiConfig<RowMappers> {
      * @return a copy of this configuration with the mapper registered
      * @throws UnsupportedOperationException if the RowMapper is not a concretely parameterized type
      */
+    @CheckReturnValue
     public RowMappers register(RowMapper<?> mapper) {
         RowMapperFactory factory = inferenceInterceptors.process(mapper);
 
@@ -102,6 +105,7 @@ public final class RowMappers implements JdbiConfig<RowMappers> {
      * @param mapper the row mapper
      * @return this
      */
+    @CheckReturnValue
     public <T> RowMappers register(GenericType<T> type, RowMapper<T> mapper) {
         return this.register(RowMapperFactory.of(type.getType(), mapper));
     }
@@ -113,6 +117,7 @@ public final class RowMappers implements JdbiConfig<RowMappers> {
      * @param mapper the row mapper
      * @return this
      */
+    @CheckReturnValue
     public RowMappers register(Type type, RowMapper<?> mapper) {
         return this.register(RowMapperFactory.of(type, mapper));
     }
@@ -125,6 +130,7 @@ public final class RowMappers implements JdbiConfig<RowMappers> {
      * @param factory the row mapper factory
      * @return a copy of this configuration with the factory registered
      */
+    @CheckReturnValue
     public RowMappers register(RowMapperFactory factory) {
         return new RowMappers(RegistrationLists.prepend(factories, factory), inferenceInterceptors);
     }
@@ -137,6 +143,7 @@ public final class RowMappers implements JdbiConfig<RowMappers> {
      * @param factories the row mapper factories to add
      * @return a copy of this configuration with the factories registered
      */
+    @CheckReturnValue
     public RowMappers register(Collection<? extends RowMapperFactory> factories) {
         if (factories.isEmpty()) {
             return this;

--- a/core/src/main/java/org/jdbi/core/mapper/SqlTimeMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/SqlTimeMapperFactory.java
@@ -19,7 +19,7 @@ import java.sql.Timestamp;
 import java.util.IdentityHashMap;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
 
@@ -37,7 +37,7 @@ class SqlTimeMapperFactory implements ColumnMapperFactory {
     }
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         Class<?> rawType = getErasedType(type);
 
         return Optional.ofNullable(mappers.get(rawType));

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/ReflectionMappers.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/ReflectionMappers.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.mapper.CaseStrategy;
 import org.jdbi.meta.Alpha;
@@ -72,6 +73,7 @@ public class ReflectionMappers implements JdbiConfig<ReflectionMappers> {
      * @param columnNameMatchers the column name matchers to use
      * @return the derived configuration
      */
+    @CheckReturnValue
     public ReflectionMappers columnNameMatchers(List<ColumnNameMatcher> columnNameMatchers) {
         return new ReflectionMappers(columnNameMatchers, strictMatching, caseChange, makeAccessible);
     }
@@ -95,6 +97,7 @@ public class ReflectionMappers implements JdbiConfig<ReflectionMappers> {
      * @param strictMatching whether to enable strict matching
      * @return the derived configuration
      */
+    @CheckReturnValue
     public ReflectionMappers strictMatching(boolean strictMatching) {
         return new ReflectionMappers(columnNameMatchers, strictMatching, caseChange, makeAccessible);
     }
@@ -117,6 +120,7 @@ public class ReflectionMappers implements JdbiConfig<ReflectionMappers> {
      * @return the derived configuration
      * @see CaseStrategy
      */
+    @CheckReturnValue
     public ReflectionMappers caseChange(UnaryOperator<String> caseChange) {
         return new ReflectionMappers(columnNameMatchers, strictMatching, caseChange, makeAccessible);
     }
@@ -131,6 +135,7 @@ public class ReflectionMappers implements JdbiConfig<ReflectionMappers> {
      * @see AccessibleObjectStrategy
      *
      */
+    @CheckReturnValue
     @Alpha
     public ReflectionMappers accessibleObjectStrategy(Consumer<AccessibleObject> makeAccessible) {
         return new ReflectionMappers(columnNameMatchers, strictMatching, caseChange, makeAccessible);
@@ -141,6 +146,7 @@ public class ReflectionMappers implements JdbiConfig<ReflectionMappers> {
      *
      * @return the derived configuration
      */
+    @CheckReturnValue
     @Alpha
     public ReflectionMappers disableAccessibleObjectStrategy() {
         return accessibleObjectStrategy(DO_NOT_MAKE_ACCESSIBLE);

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/BeanPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/BeanPropertiesFactory.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.leangen.geantyref.GenericTypeReflector;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.config.internal.ConfigCache;
 import org.jdbi.core.config.internal.ConfigCaches;
 import org.jdbi.core.generic.GenericTypes;
@@ -53,7 +53,7 @@ public class BeanPropertiesFactory {
 
     private BeanPropertiesFactory() {}
 
-    public static PojoProperties<?> propertiesFor(Type t, ConfigRegistry config) {
+    public static PojoProperties<?> propertiesFor(Type t, ConfigView config) {
         return new BeanPojoProperties<>(t, config);
     }
 
@@ -69,9 +69,9 @@ public class BeanPropertiesFactory {
 
     static class BeanPojoProperties<T> extends PojoProperties<T> {
 
-        private final ConfigRegistry config;
+        private final ConfigView config;
 
-        BeanPojoProperties(Type type, ConfigRegistry config) {
+        BeanPojoProperties(Type type, ConfigView config) {
             super(type);
             this.config = config;
         }

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/BuilderPojoProperties.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/BuilderPojoProperties.java
@@ -27,7 +27,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.leangen.geantyref.GenericTypeReflector;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.exceptions.Unchecked;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.core.qualifier.Qualifiers;
@@ -35,12 +35,12 @@ import org.jdbi.core.qualifier.Qualifiers;
 public class BuilderPojoProperties<T, B> extends PojoProperties<T> {
     protected MethodHandle builderBuild;
     private final Map<String, BuilderPojoProperty<T>> properties;
-    protected final ConfigRegistry config;
+    protected final ConfigView config;
     protected final Class<T> defn;
     protected final Class<?> impl;
     protected final Supplier<?> builder;
 
-    BuilderPojoProperties(Type type, ConfigRegistry config, Class<T> defn, Class<?> impl, Supplier<B> builder) {
+    BuilderPojoProperties(Type type, ConfigView config, Class<T> defn, Class<?> impl, Supplier<B> builder) {
         super(type);
         this.config = config;
         this.defn = defn;

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/BuilderSpec.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/BuilderSpec.java
@@ -16,15 +16,15 @@ package org.jdbi.core.mapper.reflect.internal;
 import java.lang.reflect.Type;
 import java.util.function.Supplier;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 public class BuilderSpec<T, B> {
     Type type;
-    ConfigRegistry config;
+    ConfigView config;
     Class<T> defn;
     Supplier<B> builder;
 
-    BuilderSpec(Type type, ConfigRegistry config, Class<T> defn, Supplier<B> builder) {
+    BuilderSpec(Type type, ConfigView config, Class<T> defn, Supplier<B> builder) {
         this.type = type;
         this.config = config;
         this.defn = defn;

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/ModifiablePojoPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/ModifiablePojoPropertiesFactory.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.function.Supplier;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.config.internal.ConfigCache;
 import org.jdbi.core.config.internal.ConfigCaches;
 import org.jdbi.core.generic.GenericTypes;
@@ -99,12 +99,12 @@ public interface ModifiablePojoPropertiesFactory extends PojoPropertiesFactory {
 
     class ModifiableSpec<T, M> {
         Type type;
-        ConfigRegistry config;
+        ConfigView config;
         Class<T> defn;
         Class<M> impl;
         Supplier<M> constructor;
 
-        ModifiableSpec(Type type, ConfigRegistry config, Class<T> defn, Class<M> impl, Supplier<M> constructor) {
+        ModifiableSpec(Type type, ConfigView config, Class<T> defn, Class<M> impl, Supplier<M> constructor) {
             this.type = type;
             this.config = config;
             this.defn = defn;

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/NullDelegatingMapper.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/NullDelegatingMapper.java
@@ -17,7 +17,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.StringJoiner;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.statement.StatementContext;
 
@@ -38,7 +38,7 @@ public final class NullDelegatingMapper<T> implements RowMapper<T> {
     }
 
     @Override
-    public void init(ConfigRegistry registry) {
+    public void init(ConfigView registry) {
         delegate.init(registry);
     }
 

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoMapperFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoMapperFactory.java
@@ -16,7 +16,7 @@ package org.jdbi.core.mapper.reflect.internal;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.mapper.RowMapperFactory;
 
@@ -26,7 +26,7 @@ import org.jdbi.core.mapper.RowMapperFactory;
  */
 public class PojoMapperFactory implements RowMapperFactory {
     @Override
-    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<RowMapper<?>> build(Type type, ConfigView config) {
         return PojoResolver.forRegistry(config).findFor(type)
                 .map(p -> new PojoMapper<>(type, ""));
     }

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoPropertiesFactory.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoPropertiesFactory.java
@@ -15,9 +15,9 @@ package org.jdbi.core.mapper.reflect.internal;
 
 import java.lang.reflect.Type;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 @FunctionalInterface
 public interface PojoPropertiesFactory {
-    PojoProperties<?> create(Type type, ConfigRegistry config);
+    PojoProperties<?> create(Type type, ConfigView config);
 }

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoResolver.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoResolver.java
@@ -17,14 +17,15 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 
 /**
- * Resolves {@link PojoProperties} for a specific {@link ConfigRegistry}.
+ * Resolves {@link PojoProperties} for a specific {@link ConfigView}.
  * <p>
  * A resolver reads the registered factories from the registry's {@link PojoTypes} (which holds only
  * registration data) and turns a type into its {@link PojoProperties}. It is obtained per registry via
- * {@link #forRegistry(ConfigRegistry)} and holds the registry reference the factories need; because it is
+ * {@link #forRegistry(ConfigView)} and holds the registry reference the factories need; because it is
  * never shared across registry copies, that reference is always the one this resolver resolves against.
  */
 public final class PojoResolver {
@@ -35,7 +36,7 @@ public final class PojoResolver {
      * @param config the configuration registry to resolve against
      * @return the registry's memoized pojo-properties resolver
      */
-    public static PojoResolver forRegistry(final ConfigRegistry config) {
+    public static PojoResolver forRegistry(final ConfigView config) {
         return config.readAs(PojoResolver.class, PojoResolver::new);
     }
 

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoResolver.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoResolver.java
@@ -16,7 +16,6 @@ package org.jdbi.core.mapper.reflect.internal;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 
@@ -40,9 +39,9 @@ public final class PojoResolver {
         return config.readAs(PojoResolver.class, PojoResolver::new);
     }
 
-    private final ConfigRegistry registry;
+    private final ConfigView registry;
 
-    private PojoResolver(final ConfigRegistry registry) {
+    private PojoResolver(final ConfigView registry) {
         this.registry = registry;
     }
 

--- a/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoTypes.java
+++ b/core/src/main/java/org/jdbi/core/mapper/reflect/internal/PojoTypes.java
@@ -16,6 +16,7 @@ package org.jdbi.core.mapper.reflect.internal;
 import java.util.HashMap;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 
 /**
@@ -35,6 +36,7 @@ public final class PojoTypes implements JdbiConfig<PojoTypes> {
         this.factories = factories;
     }
 
+    @CheckReturnValue
     public PojoTypes register(final Class<?> key, final PojoPropertiesFactory factory) {
         final Map<Class<?>, PojoPropertiesFactory> updated = new HashMap<>(factories);
         updated.put(key, factory);

--- a/core/src/main/java/org/jdbi/core/result/ResultIterable.java
+++ b/core/src/main/java/org/jdbi/core/result/ResultIterable.java
@@ -399,10 +399,6 @@ public interface ResultIterable<T> extends Iterable<T> {
      * <pre>{@code
      *     jdbi.registerCollector(List.class, Collectors.toCollection(LinkedList::new));
      * }</pre>
-     * or
-     * <pre>{@code
-     *     handle.registerCollector(List.class, Collectors.toCollection(LinkedList::new));
-     * }</pre>
      * <br>
      * If no collector is registered, then this method behaves like {@link #list()}.
      *
@@ -421,10 +417,6 @@ public interface ResultIterable<T> extends Iterable<T> {
      * <p>
      * <pre>{@code
      *     jdbi.registerCollector(Set.class, Collectors.toCollection(LinkedHashSet::new));
-     * }</pre>
-     * or
-     * <pre>{@code
-     *     handle.registerCollector(Set.class, Collectors.toCollection(LinkedHashSet::new));
      * }</pre>
      * <br>
      * If no collector is registered, then this method behaves like {@link #set()}.

--- a/core/src/main/java/org/jdbi/core/result/ResultProducers.java
+++ b/core/src/main/java/org/jdbi/core/result/ResultProducers.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.function.Supplier;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.result.internal.EmptyResultSet;
 import org.jdbi.core.statement.StatementContext;
@@ -140,6 +141,7 @@ public class ResultProducers implements JdbiConfig<ResultProducers> {
      * @param allowNoResults True if an empty {@link ResultSet} object should be returned, false if a {@link NoResultsException} should be thrown.
      * @return the derived configuration
      */
+    @CheckReturnValue
     public ResultProducers allowNoResults(boolean allowNoResults) {
         return new ResultProducers(allowNoResults);
     }

--- a/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
+++ b/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jdbi.core.Handle;
 import org.jdbi.core.Jdbi;
+import org.jdbi.core.config.ConfigRegistry;
 
 /**
  * A plugin is given an opportunity to customize instances of various {@code Jdbi}
@@ -56,6 +57,19 @@ public interface JdbiPlugin {
      * @param builder the builder to contribute to
      */
     default void configure(Jdbi.Builder builder) {}
+
+    /**
+     * Contributes per-connection configuration to a new handle's config while the handle is still being constructed.
+     * This is the hook for configuration that can only be computed once a JDBC {@link Connection} is available (for
+     * example, binding database types to the live connection), applied during construction rather than by mutating a
+     * finished handle. It runs after any caller-supplied config scope and before the handle's extension context is
+     * derived. Prefer this over {@link #customizeHandle(Handle)} for anything that modifies the handle's config.
+     *
+     * @param connection the JDBC connection backing the new handle
+     * @param config the new handle's config, still open for modification during construction
+     * @throws SQLException something went wrong with the database
+     */
+    default void customizeHandleConfig(Connection connection, ConfigRegistry config) throws SQLException {}
 
     /**
      * Configure customizations for a new Handle instance.

--- a/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
+++ b/core/src/main/java/org/jdbi/core/spi/JdbiPlugin.java
@@ -50,24 +50,12 @@ public interface JdbiPlugin {
 
     /**
      * Contributes configuration and knobs to a {@link Jdbi.Builder} during assembly. This method is invoked by
-     * {@link Jdbi.Builder#build()} for each installed plugin, in install order, before {@link #customizeJdbi(Jdbi)}.
-     * It is the preferred hook for plugins that only add configuration (mappers, arguments, and the like), because
-     * it runs while the {@code Jdbi} is still being assembled rather than mutating it after construction.
+     * {@link Jdbi.Builder#build()} for each installed plugin, in install order. It is the hook for plugins that add
+     * configuration (mappers, arguments, and the like), running while the {@code Jdbi} is still being assembled.
      *
      * @param builder the builder to contribute to
      */
     default void configure(Jdbi.Builder builder) {}
-
-    /**
-     * Configure customizations global to any object managed by this Jdbi.
-     * This method is invoked immediately when the plugin is installed.
-     * @param jdbi the jdbi to customize
-     * @throws SQLException something went wrong with the database
-     * @deprecated contribute configuration from {@link #configure(Jdbi.Builder)} instead; this hook is applied after
-     *             the {@code Jdbi} is constructed and is going away.
-     */
-    @Deprecated(since = "4.0.0", forRemoval = true)
-    default void customizeJdbi(Jdbi jdbi) throws SQLException {}
 
     /**
      * Configure customizations for a new Handle instance.

--- a/core/src/main/java/org/jdbi/core/statement/BaseStatement.java
+++ b/core/src/main/java/org/jdbi/core/statement/BaseStatement.java
@@ -38,7 +38,7 @@ abstract class BaseStatement<This> implements Closeable, Configurable<This> {
         final ConfigRegistry config = handle.getConfig().createChild();
         this.ctx = StatementContext.create(config, handle.getExtensionMethod(), getClass());
 
-        if (config.get(SqlStatements.class).isAttachAllStatementsForCleanup()) {
+        if (handle.isAttachStatementsForCleanup()) {
             attachToHandleForCleanup(this.handle, this.ctx);
         }
     }

--- a/core/src/main/java/org/jdbi/core/statement/ConfigReader.java
+++ b/core/src/main/java/org/jdbi/core/statement/ConfigReader.java
@@ -26,6 +26,7 @@ import org.jdbi.core.array.SqlArrayType;
 import org.jdbi.core.array.SqlArrayTypes;
 import org.jdbi.core.collector.CollectorResolver;
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.mapper.ColumnMapper;
@@ -47,11 +48,14 @@ public interface ConfigReader {
     }
 
     /**
-     * Returns the {@code ConfigRegistry}.
+     * Returns a read-only view of the configuration used by this context. It is a {@link ConfigView}, not a
+     * {@link ConfigRegistry}: read-only contexts (a {@code Jdbi} or a {@code Handle}) do not expose configuration
+     * mutation. Mutation lives on {@code ConfigRegistry}, which is available on {@link org.jdbi.core.config.Configurable
+     * Configurable} contexts (statements, the {@code Jdbi.Builder}) whose {@code getConfig()} covariantly returns it.
      *
-     * @return the {@code ConfigRegistry} used by this context.
+     * @return the read-only configuration view used by this context.
      */
-    ConfigRegistry getConfig();
+    ConfigView getConfig();
 
     /**
      * Obtain an argument for given value in this context

--- a/core/src/main/java/org/jdbi/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/core/statement/SqlStatements.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 
 import jakarta.annotation.Nullable;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.Handle;
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.cache.JdbiCache;
@@ -134,6 +135,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param value the value for the attribute
      * @return a copy of this configuration with the attribute defined
      */
+    @CheckReturnValue
     public SqlStatements define(final String key, final Object value) {
         final Map<String, Object> newAttributes = new HashMap<>(attributes);
         newAttributes.put(key, value);
@@ -146,6 +148,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param values map of attributes to define.
      * @return a copy of this configuration with the attributes defined, or this configuration if {@code values} is null or empty
      */
+    @CheckReturnValue
     public SqlStatements defineMap(final Map<String, ?> values) {
         if (values == null || values.isEmpty()) {
             return this;
@@ -190,6 +193,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param customizer instance to be used to customize a statement
      * @return a copy of this configuration with the customizer registered
      */
+    @CheckReturnValue
     public SqlStatements addCustomizer(final StatementCustomizer customizer) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
                 queryTimeout, allowUnusedBindings, attachAllStatementsForCleanup, attachCallbackStatementsForCleanup,
@@ -197,6 +201,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
                 contextListeners, jfrSqlMaxLength, jfrParamMaxLength, includeBindingsInTelemetry);
     }
 
+    @CheckReturnValue
     public SqlStatements addContextListener(final StatementContextListener listener) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
                 queryTimeout, allowUnusedBindings, attachAllStatementsForCleanup, attachCallbackStatementsForCleanup,
@@ -225,6 +230,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param templateEngine the new template engine.
      * @return the derived configuration
      */
+    @CheckReturnValue
     public SqlStatements templateEngine(final TemplateEngine templateEngine) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
                 queryTimeout, allowUnusedBindings, attachAllStatementsForCleanup, attachCallbackStatementsForCleanup,
@@ -239,6 +245,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param cacheBuilder the cache builder to use to create the cache.
      * @return the derived configuration
      */
+    @CheckReturnValue
     @Beta
     public SqlStatements templateCache(final JdbiCacheBuilder cacheBuilder) {
         return new SqlStatements(attributes, templateEngine, cacheBuilder.build(), sqlParser, sqlLogger,
@@ -259,6 +266,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param sqlParser the new SQL parser.
      * @return the derived configuration
      */
+    @CheckReturnValue
     public SqlStatements sqlParser(final SqlParser sqlParser) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
                 queryTimeout, allowUnusedBindings, attachAllStatementsForCleanup, attachCallbackStatementsForCleanup,
@@ -283,6 +291,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @return the derived configuration
      * @deprecated use {@link #sqlLogger} instead
      */
+    @CheckReturnValue
     @Deprecated(since = "3.2.0", forRemoval = true)
     public SqlStatements setTimingCollector(final TimingCollector timingCollector) {
         final SqlLogger logger = timingCollector == null ? SqlLogger.NOP_SQL_LOGGER : new SqlLogger() {
@@ -307,6 +316,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param sqlLogger The logger. Using <code>null</code> turns off all logging
      * @return the derived configuration
      */
+    @CheckReturnValue
     public SqlStatements sqlLogger(final SqlLogger sqlLogger) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser,
                 sqlLogger == null ? SqlLogger.NOP_SQL_LOGGER : sqlLogger,
@@ -328,6 +338,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      *                {@code setQueryTimeout(int)})
      * @return the derived configuration
      */
+    @CheckReturnValue
     @Beta
     public SqlStatements queryTimeout(@Nullable final Integer seconds) {
         if (seconds != null && seconds < 0) {
@@ -352,6 +363,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @return the derived configuration
      * @see org.jdbi.core.argument.Argument
      */
+    @CheckReturnValue
     public SqlStatements unusedBindingAllowed(final boolean unusedBindingAllowed) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
                 queryTimeout, unusedBindingAllowed, attachAllStatementsForCleanup, attachCallbackStatementsForCleanup,
@@ -381,6 +393,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      *
      * @since 3.38.0
      */
+    @CheckReturnValue
     @Beta
     public SqlStatements attachAllStatementsForCleanup(final boolean attachAllStatementsForCleanup) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
@@ -414,6 +427,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      *
      * @since 3.43.0
      */
+    @CheckReturnValue
     public SqlStatements scriptStatementsNeedSemicolon(final boolean scriptStatementsNeedSemicolon) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
                 queryTimeout, allowUnusedBindings, attachAllStatementsForCleanup, attachCallbackStatementsForCleanup,
@@ -445,6 +459,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      *
      * @since 3.38.0
      */
+    @CheckReturnValue
     public SqlStatements attachCallbackStatementsForCleanup(final boolean attachCallbackStatementsForCleanup) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
                 queryTimeout, allowUnusedBindings, attachAllStatementsForCleanup, attachCallbackStatementsForCleanup,
@@ -458,6 +473,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param jfrSqlMaxLength the maximum length of rendered SQL
      * @return the derived configuration
      */
+    @CheckReturnValue
     @Beta
     public SqlStatements jfrSqlMaxLength(final int jfrSqlMaxLength) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
@@ -488,6 +504,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param jfrParamMaxLength the maximum length of rendered parameters
      * @return the derived configuration
      */
+    @CheckReturnValue
     @Beta
     public SqlStatements jfrParamMaxLength(final int jfrParamMaxLength) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
@@ -510,6 +527,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param includeBindingsInTelemetry whether to include bindings in telemetry data
      * @return the derived configuration
      */
+    @CheckReturnValue
     public SqlStatements includeBindingsInTelemetry(final boolean includeBindingsInTelemetry) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,
                 queryTimeout, allowUnusedBindings, attachAllStatementsForCleanup, attachCallbackStatementsForCleanup,
@@ -524,6 +542,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      * @param handler the handler to register
      * @return a copy of this configuration with the handler registered
      */
+    @CheckReturnValue
     @Beta
     public SqlStatements addExceptionHandler(final SqlExceptionHandler handler) {
         return new SqlStatements(attributes, templateEngine, templateCache, sqlParser, sqlLogger,

--- a/core/src/main/java/org/jdbi/core/statement/StatementExceptions.java
+++ b/core/src/main/java/org/jdbi/core/statement/StatementExceptions.java
@@ -15,6 +15,7 @@ package org.jdbi.core.statement;
 
 import java.util.function.Function;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.meta.Beta;
 
@@ -51,6 +52,7 @@ public class StatementExceptions implements JdbiConfig<StatementExceptions> {
      * @param lengthLimit the limit hint.
      * @return the derived configuration
      */
+    @CheckReturnValue
     public StatementExceptions lengthLimit(int lengthLimit) {
         return new StatementExceptions(messageRendering, lengthLimit);
     }
@@ -71,6 +73,7 @@ public class StatementExceptions implements JdbiConfig<StatementExceptions> {
      * @return the derived configuration
      * @see MessageRendering
      */
+    @CheckReturnValue
     public StatementExceptions messageRendering(Function<StatementException, String> messageRendering) {
         return new StatementExceptions(messageRendering, lengthLimit);
     }

--- a/core/src/main/java/org/jdbi/core/transaction/SerializableTransactionRunner.java
+++ b/core/src/main/java/org/jdbi/core/transaction/SerializableTransactionRunner.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.Handle;
 import org.jdbi.core.HandleCallback;
 import org.jdbi.core.config.JdbiConfig;
@@ -158,6 +159,7 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
          * @param maxRetries The maximum number of retry attempts before aborting.
          * @return the derived configuration
          */
+        @CheckReturnValue
         public Configuration maxRetries(int maxRetries) {
             if (maxRetries < 0) {
                 throw new IllegalArgumentException("\"" + maxRetries + " retries\" makes no sense. Set a number >= 0 (default " + DEFAULT_MAX_RETRIES + ").");
@@ -171,6 +173,7 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
          * @param serializationFailureSqlState the SQL state to consider as a serialization failure.
          * @return the derived configuration
          */
+        @CheckReturnValue
         public Configuration serializationFailureSqlState(String serializationFailureSqlState) {
             return new Configuration(maxRetries, serializationFailureSqlState, onFailure, onSuccess);
         }
@@ -182,6 +185,7 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
          * @param onFailure A consumer to handle failures. Will never be called with Exceptions that have not been configured.
          * @return the derived configuration
          */
+        @CheckReturnValue
         public Configuration onFailure(Consumer<List<Exception>> onFailure) {
             return new Configuration(maxRetries, serializationFailureSqlState, onFailure, onSuccess);
         }
@@ -194,6 +198,7 @@ public class SerializableTransactionRunner extends DelegatingTransactionHandler 
          * @param onSuccess A consumer to handle the list of failures after the run has been completed successfully.
          * @return the derived configuration
          */
+        @CheckReturnValue
         public Configuration onSuccess(Consumer<List<Exception>> onSuccess) {
             return new Configuration(maxRetries, serializationFailureSqlState, onFailure, onSuccess);
         }

--- a/core/src/test/java/org/jdbi/core/EnumsConfigTest.java
+++ b/core/src/test/java/org/jdbi/core/EnumsConfigTest.java
@@ -117,9 +117,7 @@ public class EnumsConfigTest {
 
     @Test
     public void ordinalsAreBoundCorrectly() {
-        sqliteExtension.getJdbi().useHandle(h -> {
-            h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
-
+        sqliteExtension.getJdbi().useHandle(cfg -> cfg.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL)), h -> {
             h.createUpdate("create table enums(id int, ordinal int)").execute();
 
             h.createUpdate("insert into enums (id, ordinal) values (1, :ordinal)")
@@ -137,9 +135,7 @@ public class EnumsConfigTest {
 
     @Test
     public void ordinalsAreMappedCorrectly() {
-        sqliteExtension.getJdbi().useHandle(h -> {
-            h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
-
+        sqliteExtension.getJdbi().useHandle(cfg -> cfg.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL)), h -> {
             Foobar name = h.createQuery("select :ordinal")
                 .bind("ordinal", Foobar.FOO.ordinal())
                 .mapTo(Foobar.class)
@@ -161,9 +157,7 @@ public class EnumsConfigTest {
 
     @Test
     public void badOrdinalThrows() {
-        sqliteExtension.getJdbi().useHandle(h -> {
-            h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
-
+        sqliteExtension.getJdbi().useHandle(cfg -> cfg.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL)), h -> {
             assertThatThrownBy(h.createQuery("select 3").mapTo(Foobar.class)::one)
                 .isInstanceOf(UnableToProduceResultException.class)
                 .hasMessageContaining("no Foobar value could be matched to the ordinal 3");

--- a/core/src/test/java/org/jdbi/core/HandleExceptionTest.java
+++ b/core/src/test/java/org/jdbi/core/HandleExceptionTest.java
@@ -44,7 +44,7 @@ class HandleExceptionTest {
 
     @Test
     void handleException() {
-        h.configure(SqlStatements.class, c -> c
+        try (Handle h = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c
                 .addExceptionHandler(s -> null)
                 .addExceptionHandler(new SqlExceptionHandler() {
                         @Override
@@ -55,42 +55,43 @@ class HandleExceptionTest {
                             return null;
                         }
                 })
-                .addExceptionHandler(s -> null)); // simple chaining test
-        h.execute("create table exception_test(id int primary key)");
-        final String sql = "insert into exception_test (id) values(1)";
-        h.execute(sql);
-        assertThatThrownBy(() ->
-                h.execute(sql))
-            .isExactlyInstanceOf(RuntimeException.class)
-            .hasMessage("Wahoo");
+                .addExceptionHandler(s -> null)))) { // simple chaining test
+            h.execute("create table exception_test(id int primary key)");
+            final String sql = "insert into exception_test (id) values(1)";
+            h.execute(sql);
+            assertThatThrownBy(() ->
+                    h.execute(sql))
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("Wahoo");
 
-        assertThatThrownBy(() ->
-                h.createBatch()
-                        .add(sql)
-                        .execute())
-            .isExactlyInstanceOf(RuntimeException.class)
-            .hasMessage("Wahoo");
+            assertThatThrownBy(() ->
+                    h.createBatch()
+                            .add(sql)
+                            .execute())
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("Wahoo");
 
 
-        assertThatThrownBy(() ->
-                h.configure(SqlStatements.class, ss -> ss.unusedBindingAllowed(true))
-                        .prepareBatch(sql)
-                        .bind("unused", 1)
-                        .add()
-                        .execute())
-            .isExactlyInstanceOf(RuntimeException.class)
-            .hasMessage("Wahoo");
+            assertThatThrownBy(() ->
+                    h.prepareBatch(sql)
+                            .configure(SqlStatements.class, ss -> ss.unusedBindingAllowed(true))
+                            .bind("unused", 1)
+                            .add()
+                            .execute())
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("Wahoo");
 
-        assertThatThrownBy(() ->
-                h.createScript(sql)
-                        .execute())
-            .isExactlyInstanceOf(RuntimeException.class)
-            .hasMessage("Wahoo");
+            assertThatThrownBy(() ->
+                    h.createScript(sql)
+                            .execute())
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("Wahoo");
 
-        assertThatThrownBy(() ->
-                h.createCall(sql)
-                        .invoke())
-            .isExactlyInstanceOf(RuntimeException.class)
-            .hasMessage("Wahoo");
+            assertThatThrownBy(() ->
+                    h.createCall(sql)
+                            .invoke())
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("Wahoo");
+        }
     }
 }

--- a/core/src/test/java/org/jdbi/core/JdbiOpenLeakTest.java
+++ b/core/src/test/java/org/jdbi/core/JdbiOpenLeakTest.java
@@ -14,8 +14,10 @@
 package org.jdbi.core;
 
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.spi.JdbiPlugin;
@@ -45,14 +47,18 @@ public class JdbiOpenLeakTest {
             }
         };
 
-        h2Extension.getJdbi().installPlugin(jdbiPlugin);
+        final AtomicReference<Connection> lastConnection = new AtomicReference<>();
+        Jdbi jdbi = Jdbi.builder(() -> {
+            Connection conn = DriverManager.getConnection(h2Extension.getUri());
+            lastConnection.set(conn);
+            return conn;
+        }).installPlugin(jdbiPlugin).build();
 
-        h2Extension.clearLastConnection();
-        assertThatThrownBy(() -> h2Extension.getJdbi().open())
+        assertThatThrownBy(jdbi::open)
                 .isInstanceOf(CosmicRayException.class);
 
-        assertThat(h2Extension.getLastConnection()).isNotNull(); // has been created
-        assertThat(h2Extension.getLastConnection().isClosed()).isTrue(); // has been closed
+        assertThat(lastConnection.get()).isNotNull(); // has been created
+        assertThat(lastConnection.get().isClosed()).isTrue(); // has been closed
     }
 
     @Test
@@ -84,13 +90,16 @@ public class JdbiOpenLeakTest {
 
         h2Extension.getSharedHandle().execute("insert into something (id, name) values (1, 'Brian')");
 
-        Jdbi jdbi = h2Extension.getJdbi();
+        final AtomicReference<Connection> lastConnection = new AtomicReference<>();
         final ExplodeInSpecializeTransactionHandler handler = new ExplodeInSpecializeTransactionHandler();
-        h2Extension.getJdbi().setTransactionHandler(handler);
+        Jdbi jdbi = Jdbi.builder(() -> {
+            Connection conn = DriverManager.getConnection(h2Extension.getUri());
+            lastConnection.set(conn);
+            return conn;
+        }).transactionHandler(handler).build();
 
         assertThatThrownBy(() -> {
             String value;
-            h2Extension.clearLastConnection(); // reset connection
 
             try (Handle handle = jdbi.open()) {
                 value = handle.createQuery("select name from something where id = 1").mapToBean(Something.class).one().getName();
@@ -101,8 +110,8 @@ public class JdbiOpenLeakTest {
                 .hasCauseInstanceOf(SQLException.class);
 
         // see if the c'tor leaked a connection
-        assertThat(h2Extension.getLastConnection()).isNotNull(); // connection has been checked out
-        assertThat(h2Extension.getLastConnection().isClosed()).isTrue(); // connection has been closed
+        assertThat(lastConnection.get()).isNotNull(); // connection has been checked out
+        assertThat(lastConnection.get().isClosed()).isTrue(); // connection has been closed
     }
 
     static class CosmicRayException extends RuntimeException {

--- a/core/src/test/java/org/jdbi/core/TestCloseConnection.java
+++ b/core/src/test/java/org/jdbi/core/TestCloseConnection.java
@@ -34,14 +34,13 @@ public class TestCloseConnection {
 
     @Test
     void closeCustomizedConnection() throws Exception {
-        final Jdbi jdbi = Jdbi.create(() -> outerCxn);
-        jdbi.installPlugin(new JdbiPlugin() {
+        final Jdbi jdbi = Jdbi.builder(() -> outerCxn).installPlugin(new JdbiPlugin() {
             @Override
             public Connection customizeConnection(final Connection conn) throws SQLException {
                 assertThat(conn).isSameAs(outerCxn);
                 return innerCxn;
             }
-        });
+        }).build();
         jdbi.useHandle(h -> {});
         verify(outerCxn, never()).close();
         verify(innerCxn).close();
@@ -49,14 +48,13 @@ public class TestCloseConnection {
 
     @Test
     void customizeConnectionThrows() throws Exception {
-        final Jdbi jdbi = Jdbi.create(() -> outerCxn);
         final var t = new IllegalArgumentException();
-        jdbi.installPlugin(new JdbiPlugin() {
+        final Jdbi jdbi = Jdbi.builder(() -> outerCxn).installPlugin(new JdbiPlugin() {
             @Override
             public Connection customizeConnection(final Connection conn) throws SQLException {
                 throw t;
             }
-        });
+        }).build();
         assertThatThrownBy(() -> jdbi.useHandle(h -> {}))
                 .isSameAs(t);
         verify(outerCxn).close();

--- a/core/src/test/java/org/jdbi/core/TestClosingHandle.java
+++ b/core/src/test/java/org/jdbi/core/TestClosingHandle.java
@@ -154,9 +154,7 @@ public class TestClosingHandle {
 
     @Test
     public void testCloseWithOpenTransactionCheckDisabled() {
-        Handle h = h2Extension.getSharedHandle();
-
-        h.configure(Handles.class, c -> c.forceEndTransactions(false));
+        Handle h = h2Extension.getJdbi().open(cfg -> cfg.configure(Handles.class, c -> c.forceEndTransactions(false)));
 
         h.begin();
 

--- a/core/src/test/java/org/jdbi/core/TestHandle.java
+++ b/core/src/test/java/org/jdbi/core/TestHandle.java
@@ -94,9 +94,9 @@ public class TestHandle {
     @Test
     public void testAutocommitFailDoesntLeak() {
         final BoomHandler handler = new BoomHandler();
-        h2Extension.getJdbi().setTransactionHandler(handler);
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUri()).transactionHandler(handler).build();
 
-        try (Handle transactionHandle = h2Extension.openHandle()) {
+        try (Handle transactionHandle = jdbi.open()) {
             assertThat(transactionHandle.isClosed()).isFalse();
 
             handler.failTest = true;
@@ -110,8 +110,8 @@ public class TestHandle {
     @Test
     public void testRollbackFailDoesntLeak() throws Exception {
         final BoomHandler handler = new BoomHandler();
-        h2Extension.getJdbi().setTransactionHandler(handler);
-        try (Handle transactionHandle = h2Extension.openHandle()) {
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUri()).transactionHandler(handler).build();
+        try (Handle transactionHandle = jdbi.open()) {
 
             assertThat(transactionHandle.isClosed()).isFalse();
 
@@ -234,38 +234,31 @@ public class TestHandle {
             }
         };
 
-        Jdbi jdbi = h2Extension.getJdbi();
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUri()).handleCallbackDecorator(handleCallbackDecorator).build();
 
-        HandleCallbackDecorator saveHandleDecorator = jdbi.getHandleCallbackDecorator();
-        jdbi.setHandleCallbackDecorator(handleCallbackDecorator);
+        String result = jdbi.withHandle(handle -> "hey");
+        assertThat(result).isEqualTo("hey");
+        assertThat(gotCalled).isTrue();
+        gotCalled.set(false);
 
-        try {
-            String result = jdbi.withHandle(handle -> "hey");
-            assertThat(result).isEqualTo("hey");
-            assertThat(gotCalled).isTrue();
-            gotCalled.set(false);
+        jdbi.useHandle(handle -> {});
+        assertThat(gotCalled).isTrue();
+        gotCalled.set(false);
 
-            jdbi.useHandle(handle -> {});
-            assertThat(gotCalled).isTrue();
-            gotCalled.set(false);
+        result = jdbi.inTransaction(handle -> "there");
+        assertThat(result).isEqualTo("there");
+        assertThat(gotCalled).isTrue();
 
-            result = jdbi.inTransaction(handle -> "there");
-            assertThat(result).isEqualTo("there");
-            assertThat(gotCalled).isTrue();
+        jdbi.useTransaction(handle -> {});
+        assertThat(gotCalled).isTrue();
+        gotCalled.set(false);
 
-            jdbi.useTransaction(handle -> {});
-            assertThat(gotCalled).isTrue();
-            gotCalled.set(false);
-
-            overrideCallback.set(handle -> "this is different");
-            result = jdbi.inTransaction(handle -> "you");
-            assertThat(result).isEqualTo("this is different");
-            assertThat(gotCalled).isTrue();
-            gotCalled.set(false);
-            overrideCallback.set(null);
-        } finally {
-            jdbi.setHandleCallbackDecorator(saveHandleDecorator);
-        }
+        overrideCallback.set(handle -> "this is different");
+        result = jdbi.inTransaction(handle -> "you");
+        assertThat(result).isEqualTo("this is different");
+        assertThat(gotCalled).isTrue();
+        gotCalled.set(false);
+        overrideCallback.set(null);
     }
 
     static class BoomHandler extends LocalTransactionHandler {

--- a/core/src/test/java/org/jdbi/core/TestIterator.java
+++ b/core/src/test/java/org/jdbi/core/TestIterator.java
@@ -47,9 +47,9 @@ class TestIterator {
     H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
             .withPlugin(new JdbiPlugin() {
                 @Override
-                public void customizeJdbi(Jdbi jdbi) {
-                    jdbi.registerRowMapper(new SomethingMapper());
-                    jdbi.registerExtension(new SpiffyFactory());
+                public void configure(Jdbi.Builder builder) {
+                    builder.registerRowMapper(new SomethingMapper());
+                    builder.registerExtension(new SpiffyFactory());
                 }
             });
 

--- a/core/src/test/java/org/jdbi/core/TestJdbi.java
+++ b/core/src/test/java/org/jdbi/core/TestJdbi.java
@@ -31,7 +31,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestJdbi {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
+            .withConfig(b -> b.addCustomizer(StatementCustomizers.maxRows(1)));
 
     @Test
     public void testDataSourceConstructor() {
@@ -122,7 +123,7 @@ public class TestJdbi {
 
     @Test
     public void testGlobalStatementCustomizers() {
-        h2Extension.getJdbi().addCustomizer(StatementCustomizers.maxRows(1))
+        h2Extension.getJdbi()
             .useHandle(handle -> {
                 handle.execute("insert into something (id, name) values (?, ?)", 1, "hello");
                 handle.execute("insert into something (id, name) values (?, ?)", 2, "world");

--- a/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
+++ b/core/src/test/java/org/jdbi/core/TestJdbiBuilder.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-// exercises the deprecated Jdbi.installPlugin bridge and the customizeJdbi hook on purpose
-@SuppressWarnings("deprecation")
 public class TestJdbiBuilder {
 
     private static String url() {
@@ -52,32 +50,6 @@ public class TestJdbiBuilder {
                 .build();
 
         assertThat(jdbi.getTransactionHandler()).isSameAs(handler);
-    }
-
-    @Test
-    public void buildAppliesBothPluginHooksInOrder() {
-        final AtomicInteger tick = new AtomicInteger();
-        final int[] configuredAt = {-1};
-        final int[] customizedAt = {-1};
-
-        final JdbiPlugin plugin = new JdbiPlugin() {
-            @Override
-            public void configure(final Jdbi.Builder builder) {
-                configuredAt[0] = tick.getAndIncrement();
-            }
-
-            @Override
-            public void customizeJdbi(final Jdbi jdbi) {
-                customizedAt[0] = tick.getAndIncrement();
-            }
-        };
-
-        final Jdbi jdbi = Jdbi.builder(url()).installPlugin(plugin).build();
-
-        assertThat(jdbi).isNotNull();
-        // both hooks run, configure() before customizeJdbi()
-        assertThat(configuredAt[0]).isZero();
-        assertThat(customizedAt[0]).isOne();
     }
 
     @Test
@@ -128,19 +100,6 @@ public class TestJdbiBuilder {
     }
 
     @Test
-    public void installPluginBridgesConfigureHook() {
-        // A plugin that contributes only via configure(Builder) is still applied through the post-construction
-        // Jdbi.installPlugin path (the deprecation-window bridge onto the assembly funnel).
-        final RowMapper<String> mapper = (rs, ctx) -> "bridged";
-        final Jdbi jdbi = Jdbi.create(url())
-                .installPlugin(JdbiPlugin.of(b -> b.registerRowMapper(String.class, mapper)));
-
-        try (Handle h = jdbi.open()) {
-            assertThat(h.createQuery("select 1").mapTo(String.class).one()).isEqualTo("bridged");
-        }
-    }
-
-    @Test
     public void installPluginAppliesPluginOnce() {
         final AtomicInteger configureCount = new AtomicInteger();
         final JdbiPlugin plugin = new JdbiPlugin.Singleton() {
@@ -150,7 +109,7 @@ public class TestJdbiBuilder {
             }
         };
 
-        Jdbi.create(url()).installPlugin(plugin).installPlugin(plugin);
+        Jdbi.builder(url()).installPlugin(plugin).installPlugin(plugin).build();
 
         assertThat(configureCount).hasValue(1);
     }

--- a/core/src/test/java/org/jdbi/core/TestJdbiNestedCallBehavior.java
+++ b/core/src/test/java/org/jdbi/core/TestJdbiNestedCallBehavior.java
@@ -39,8 +39,8 @@ public class TestJdbiNestedCallBehavior {
     static class TestPlugin implements JdbiPlugin {
 
         @Override
-        public void customizeJdbi(Jdbi jdbi) {
-            jdbi.registerExtension(new TestExtensionFactory());
+        public void configure(Jdbi.Builder builder) {
+            builder.registerExtension(new TestExtensionFactory());
         }
     }
 

--- a/core/src/test/java/org/jdbi/core/TestOnDemandMethodBehavior.java
+++ b/core/src/test/java/org/jdbi/core/TestOnDemandMethodBehavior.java
@@ -148,7 +148,6 @@ public class TestOnDemandMethodBehavior {
 
     @Test
     public void testExceptionThrown() {
-        db.registerExtension(new UselessDaoExtension());
         UselessDao uselessDao = db.onDemand(UselessDao.class);
         assertThatThrownBy(uselessDao::blowUp).isInstanceOf(SQLException.class);
     }

--- a/core/src/test/java/org/jdbi/core/TestOnDemandMethodBehavior.java
+++ b/core/src/test/java/org/jdbi/core/TestOnDemandMethodBehavior.java
@@ -90,8 +90,7 @@ public class TestOnDemandMethodBehavior {
 
     @BeforeEach
     public void setUp() {
-        db = Jdbi.create(connectionFactory);
-        db.registerExtension(new UselessDaoExtension());
+        db = Jdbi.builder(connectionFactory).registerExtension(new UselessDaoExtension()).build();
         onDemand = db.onDemand(UselessDao.class);
         anotherOnDemand = db.onDemand(UselessDao.class);
     }

--- a/core/src/test/java/org/jdbi/core/TestOptional.java
+++ b/core/src/test/java/org/jdbi/core/TestOptional.java
@@ -63,10 +63,11 @@ public class TestOptional {
     @Test
     public void testMapRowToOptional() {
         GenericType<Optional<Something>> optionalType = new GenericType<>() {};
-        handle.registerRowMapper(Something.class, BeanMapper.of(Something.class));
 
         try (Query query = handle.createQuery("SELECT * FROM something WHERE id = :id")) {
-            Optional<Something> result = query.bind("id", 2)
+            Optional<Something> result = query
+                .registerRowMapper(Something.class, BeanMapper.of(Something.class))
+                .bind("id", 2)
                 .mapTo(optionalType)
                 .one();
 
@@ -178,8 +179,8 @@ public class TestOptional {
 
     @Test
     public void testDynamicBindOptionalOfCustomType() {
-        handle.registerArgument(new NameArgumentFactory());
         assertThat(handle.createQuery(SELECT_BY_NAME)
+            .registerArgument(new NameArgumentFactory())
             .bindByType("name", Optional.of(new Name("eric")), new GenericType<Optional<Name>>() {})
             .mapToBean(Something.class)
             .list()).hasSize(1);
@@ -218,8 +219,8 @@ public class TestOptional {
 
     @Test
     public void testBindOptionalOfCustomType() {
-        handle.registerArgument(new NameArgumentFactory());
         List<Something> result = handle.createQuery(SELECT_BY_NAME)
+            .registerArgument(new NameArgumentFactory())
             .bind("name", Optional.of(new Name("eric")))
             .mapToBean(Something.class)
             .list();

--- a/core/src/test/java/org/jdbi/core/TestOptional.java
+++ b/core/src/test/java/org/jdbi/core/TestOptional.java
@@ -23,7 +23,7 @@ import java.util.OptionalLong;
 
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.mapper.reflect.BeanMapper;
@@ -303,7 +303,7 @@ public class TestOptional {
     static class NameArgumentFactory implements ArgumentFactory {
 
         @Override
-        public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
             if (expectedType == Name.class) {
                 Name nameValue = (Name) value;
                 return Optional.of((pos, stmt, c) -> stmt.setString(pos, nameValue.value));

--- a/core/src/test/java/org/jdbi/core/TestPlugins.java
+++ b/core/src/test/java/org/jdbi/core/TestPlugins.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-// exercises the deprecated Jdbi.installPlugin path to verify the customizeHandle/customizeConnection hooks
-@SuppressWarnings("deprecation")
 public class TestPlugins {
 
     @RegisterExtension
@@ -37,14 +35,16 @@ public class TestPlugins {
         Connection connection = cf.openConnection();
         Jdbi db = Jdbi.create(connection);
         try (Handle h = db.open()) {
-            h2Extension.getJdbi().installPlugin(new JdbiPlugin() {
-                @Override
-                public Handle customizeHandle(Handle handle) {
-                    handle.close(); // otherwise the handle leaks out
-                    return h;
-                }
-            });
-            Handle testHandle = h2Extension.openHandle();
+            Jdbi jdbi = Jdbi.builder(h2Extension.getUri())
+                    .installPlugin(new JdbiPlugin() {
+                        @Override
+                        public Handle customizeHandle(Handle handle) {
+                            handle.close(); // otherwise the handle leaks out
+                            return h;
+                        }
+                    })
+                    .build();
+            Handle testHandle = jdbi.open();
             assertThat(h).isSameAs(testHandle);
         }
     }
@@ -55,14 +55,16 @@ public class TestPlugins {
         Connection connection = cf.openConnection();
         Jdbi db = Jdbi.create(connection);
         try (Handle h = db.open()) {
-            h2Extension.getJdbi().installPlugin(new JdbiPlugin() {
-                @Override
-                public Connection customizeConnection(Connection conn) throws SQLException {
-                    conn.close(); // otherwise the connection leaks out
-                    return connection;
-                }
-            });
-            try (Handle testHandle = h2Extension.openHandle()) {
+            Jdbi jdbi = Jdbi.builder(h2Extension.getUri())
+                    .installPlugin(new JdbiPlugin() {
+                        @Override
+                        public Connection customizeConnection(Connection conn) throws SQLException {
+                            conn.close(); // otherwise the connection leaks out
+                            return connection;
+                        }
+                    })
+                    .build();
+            try (Handle testHandle = jdbi.open()) {
                 assertThat(connection).isSameAs(testHandle.getConnection());
             }
         }

--- a/core/src/test/java/org/jdbi/core/TestStream.java
+++ b/core/src/test/java/org/jdbi/core/TestStream.java
@@ -46,9 +46,9 @@ class TestStream {
     H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
             .withPlugin(new JdbiPlugin() {
                 @Override
-                public void customizeJdbi(Jdbi jdbi) {
-                    jdbi.registerRowMapper(new SomethingMapper());
-                    jdbi.registerExtension(new SpiffyFactory());
+                public void configure(Jdbi.Builder builder) {
+                    builder.registerRowMapper(new SomethingMapper());
+                    builder.registerExtension(new SpiffyFactory());
                 }
             });
 

--- a/core/src/test/java/org/jdbi/core/argument/PrimitivesArgumentFactoryTest.java
+++ b/core/src/test/java/org/jdbi/core/argument/PrimitivesArgumentFactoryTest.java
@@ -44,22 +44,23 @@ public class PrimitivesArgumentFactoryTest {
             .describedAs("binding a null binds the primitive's default")
             .isZero();
 
-        handle.configure(Arguments.class, c -> c.bindingNullToPrimitivesPermitted(false));
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(Arguments.class, c -> c.bindingNullToPrimitivesPermitted(false)))) {
+            assertThatThrownBy(() -> {
+                try (Query query = handle.createQuery("select :foo")) {
+                    query.bindByType("foo", null, int.class).mapTo(int.class).one();
+                }
+            })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("binding null to a primitive int is forbidden by configuration, declare a boxed type instead");
 
-        assertThatThrownBy(() -> {
-            try (Query query = handle.createQuery("select :foo")) {
-                query.bindByType("foo", null, int.class).mapTo(int.class).one();
-            }
-        })
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("binding null to a primitive int is forbidden by configuration, declare a boxed type instead");
+            assertThat(handle.createQuery("select :foo").bindByType("foo", null, Integer.class).mapTo(Integer.class).one())
+                .describedAs("binding a null to a boxed type is fine")
+                .isNull();
 
-        assertThat(handle.createQuery("select :foo").bindByType("foo", null, Integer.class).mapTo(Integer.class).one())
-            .describedAs("binding a null to a boxed type is fine")
-            .isNull();
-
-        assertThat(handle.createQuery("select :foo").bindByType("foo", null, Long.class).mapTo(Long.class).one())
-            .describedAs("binding a null to a boxed type is fine")
-            .isNull();
+            assertThat(handle.createQuery("select :foo").bindByType("foo", null, Long.class).mapTo(Long.class).one())
+                .describedAs("binding a null to a boxed type is fine")
+                .isNull();
+        }
     }
 }

--- a/core/src/test/java/org/jdbi/core/argument/QualifiedEnumArgumentTest.java
+++ b/core/src/test/java/org/jdbi/core/argument/QualifiedEnumArgumentTest.java
@@ -30,9 +30,7 @@ public class QualifiedEnumArgumentTest {
 
     @Test
     public void methodCallCanBeAnnotatedAsByName() {
-        sqliteExtension.getJdbi().useHandle(h -> {
-            h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
-
+        sqliteExtension.getJdbi().useHandle(cfg -> cfg.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL)), h -> {
             h.createUpdate("create table enums(id int, name varchar)").execute();
 
             h.createUpdate("insert into enums (id, name) values (1, :name)")
@@ -64,9 +62,7 @@ public class QualifiedEnumArgumentTest {
 
     @Test
     public void enumCanBeAnnotatedAsByName() {
-        sqliteExtension.getJdbi().useHandle(h -> {
-            h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
-
+        sqliteExtension.getJdbi().useHandle(cfg -> cfg.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL)), h -> {
             h.createUpdate("create table enums(id int, name varchar)").execute();
 
             h.createUpdate("insert into enums(id, name) values(1, :name)")
@@ -98,9 +94,7 @@ public class QualifiedEnumArgumentTest {
 
     @Test
     public void methodCallOverridesClassForName() {
-        sqliteExtension.getJdbi().useHandle(h -> {
-            h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
-
+        sqliteExtension.getJdbi().useHandle(cfg -> cfg.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL)), h -> {
             h.createUpdate("create table enums(id int, name varchar)").execute();
 
             h.createUpdate("insert into enums(id, name) values(1, :name)")

--- a/core/src/test/java/org/jdbi/core/argument/TestAbstractArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestAbstractArgumentFactory.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.core.statement.StatementContext;
@@ -56,7 +57,7 @@ public class TestAbstractArgumentFactory {
         }
 
         @Override
-        protected Argument build(SimpleType value, ConfigRegistry config) {
+        protected Argument build(SimpleType value, ConfigView config) {
             return (pos, stmt, statementContext) -> stmt.setString(pos, value.value);
         }
     }
@@ -112,7 +113,7 @@ public class TestAbstractArgumentFactory {
         }
 
         @Override
-        protected Argument build(Box<String> value, ConfigRegistry config) {
+        protected Argument build(Box<String> value, ConfigView config) {
             return (pos, stmt, statementContext) -> stmt.setString(pos, value.value);
         }
     }
@@ -234,7 +235,7 @@ public class TestAbstractArgumentFactory {
         }
 
         @Override
-        protected Argument build(final Thing<String> value, final ConfigRegistry config) {
+        protected Argument build(final Thing<String> value, final ConfigView config) {
             return (position, stmt, ctx1) -> stmt.setString(position, value.getKey());
         }
     }

--- a/core/src/test/java/org/jdbi/core/argument/TestArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestArgumentFactory.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 import org.jdbi.core.Handle;
 import org.jdbi.core.Jdbi;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.statement.PreparedBatch;
 import org.junit.jupiter.api.Test;
@@ -92,7 +92,7 @@ public class TestArgumentFactory {
     public static class NameAF implements ArgumentFactory {
 
         @Override
-        public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
             if (expectedType == Name.class || value instanceof Name) {
                 Name nameValue = (Name) value;
                 return ArgumentResolver.forRegistry(config).findFor(String.class, nameValue.getFullName());

--- a/core/src/test/java/org/jdbi/core/argument/TestArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestArgumentFactory.java
@@ -30,12 +30,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestArgumentFactory {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
+            .withConfig(b -> b.registerArgument(new NameAF()));
 
     @Test
     public void testRegisterOnJdbi() {
         final Jdbi db = h2Extension.getJdbi();
-        db.registerArgument(new NameAF());
         try (Handle h = db.open()) {
             h.createUpdate("insert into something (id, name) values (:id, :name)")
                 .bind("id", 7)

--- a/core/src/test/java/org/jdbi/core/argument/TestArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestArgumentFactory.java
@@ -50,8 +50,7 @@ public class TestArgumentFactory {
 
     @Test
     public void testRegisterOnHandle() {
-        try (Handle h = h2Extension.openHandle()) {
-            h.registerArgument(new NameAF());
+        try (Handle h = h2Extension.getJdbi().open(cfg -> cfg.configure(Arguments.class, c -> c.register(new NameAF())))) {
             h.createUpdate("insert into something (id, name) values (:id, :name)")
                 .bind("id", 7)
                 .bind("name", new Name("Brian", "McCallister"))

--- a/core/src/test/java/org/jdbi/core/argument/TestArgumentsRegistry.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestArgumentsRegistry.java
@@ -97,7 +97,7 @@ public class TestArgumentsRegistry {
 
     @Test
     public void testPull88WeirdClassArgumentFactory() {
-        handle.registerArgument(new WeirdClassArgumentFactory());
+        handle.getConfig().configure(Arguments.class, c -> c.register(new WeirdClassArgumentFactory()));
 
         assertThat(ctx.findArgumentFor(Weird.class, new Weird()))
                 .hasValueSatisfying(a -> assertThat(a).isInstanceOf(WeirdArgument.class));
@@ -112,7 +112,7 @@ public class TestArgumentsRegistry {
 
     @Test
     public void testPull88WeirdValueArgumentFactory() {
-        handle.registerArgument(new WeirdValueArgumentFactory());
+        handle.getConfig().configure(Arguments.class, c -> c.register(new WeirdValueArgumentFactory()));
 
         assertThat(ctx.findArgumentFor(Weird.class, new Weird()))
                 .hasValueSatisfying(a -> assertThat(a).isInstanceOf(WeirdArgument.class));

--- a/core/src/test/java/org/jdbi/core/argument/TestArgumentsRegistry.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestArgumentsRegistry.java
@@ -97,7 +97,7 @@ public class TestArgumentsRegistry {
 
     @Test
     public void testPull88WeirdClassArgumentFactory() {
-        handle.getConfig().configure(Arguments.class, c -> c.register(new WeirdClassArgumentFactory()));
+        ctx.getConfig().configure(Arguments.class, c -> c.register(new WeirdClassArgumentFactory()));
 
         assertThat(ctx.findArgumentFor(Weird.class, new Weird()))
                 .hasValueSatisfying(a -> assertThat(a).isInstanceOf(WeirdArgument.class));
@@ -112,7 +112,7 @@ public class TestArgumentsRegistry {
 
     @Test
     public void testPull88WeirdValueArgumentFactory() {
-        handle.getConfig().configure(Arguments.class, c -> c.register(new WeirdValueArgumentFactory()));
+        ctx.getConfig().configure(Arguments.class, c -> c.register(new WeirdValueArgumentFactory()));
 
         assertThat(ctx.findArgumentFor(Weird.class, new Weird()))
                 .hasValueSatisfying(a -> assertThat(a).isInstanceOf(WeirdArgument.class));

--- a/core/src/test/java/org/jdbi/core/argument/TestArgumentsRegistry.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestArgumentsRegistry.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.jdbi.core.Handle;
 import org.jdbi.core.HandleAccess;
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 import org.jdbi.core.statement.StatementContextAccess;
 import org.junit.jupiter.api.BeforeEach;
@@ -159,7 +160,7 @@ public class TestArgumentsRegistry {
 
     private static class WeirdClassArgumentFactory implements ArgumentFactory {
         @Override
-        public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
             return getErasedType(expectedType) == Weird.class
                     ? Optional.of(new WeirdArgument())
                     : Optional.empty();
@@ -168,7 +169,7 @@ public class TestArgumentsRegistry {
 
     private static class WeirdValueArgumentFactory implements ArgumentFactory {
         @Override
-        public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
             return value instanceof Weird
                     ? Optional.of(new WeirdArgument())
                     : Optional.empty();
@@ -177,7 +178,7 @@ public class TestArgumentsRegistry {
 
     private static class OtherWeirdArgumentFactory implements ArgumentFactory {
         @Override
-        public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
             return getErasedType(expectedType) == Weird.class
                     ? Optional.of(new OtherWeirdArgument())
                     : Optional.empty();

--- a/core/src/test/java/org/jdbi/core/argument/TestPreparedArguments.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestPreparedArguments.java
@@ -33,7 +33,7 @@ public class TestPreparedArguments {
 
         // Changing the handle's config forks a private registry with its own resolver; a resolver is scoped
         // to the registry it was obtained from, so re-fetch it from the (now forked) config.
-        h.configure(Arguments.class, c -> c.preparedArgumentsEnabled(false));
+        h.getConfig().configure(Arguments.class, c -> c.preparedArgumentsEnabled(false));
 
         assertThat(ArgumentResolver.forRegistry(h.getConfig()).prepareFor(int.class))
                 .isEmpty();

--- a/core/src/test/java/org/jdbi/core/argument/TestPreparedArguments.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestPreparedArguments.java
@@ -27,14 +27,15 @@ public class TestPreparedArguments {
     @Test
     public void disablePreparedArguments() {
         final Handle h = h2Extension.getSharedHandle();
-        final ArgumentResolver arguments = ArgumentResolver.forRegistry(h.getConfig());
 
-        assertThat(arguments.prepareFor(int.class))
+        assertThat(ArgumentResolver.forRegistry(h.getConfig()).prepareFor(int.class))
                 .isNotEmpty();
 
+        // Changing the handle's config forks a private registry with its own resolver; a resolver is scoped
+        // to the registry it was obtained from, so re-fetch it from the (now forked) config.
         h.configure(Arguments.class, c -> c.preparedArgumentsEnabled(false));
 
-        assertThat(arguments.prepareFor(int.class))
+        assertThat(ArgumentResolver.forRegistry(h.getConfig()).prepareFor(int.class))
                 .isEmpty();
     }
 }

--- a/core/src/test/java/org/jdbi/core/argument/TestPreparedArguments.java
+++ b/core/src/test/java/org/jdbi/core/argument/TestPreparedArguments.java
@@ -31,11 +31,11 @@ public class TestPreparedArguments {
         assertThat(ArgumentResolver.forRegistry(h.getConfig()).prepareFor(int.class))
                 .isNotEmpty();
 
-        // Changing the handle's config forks a private registry with its own resolver; a resolver is scoped
-        // to the registry it was obtained from, so re-fetch it from the (now forked) config.
-        h.getConfig().configure(Arguments.class, c -> c.preparedArgumentsEnabled(false));
-
-        assertThat(ArgumentResolver.forRegistry(h.getConfig()).prepareFor(int.class))
-                .isEmpty();
+        // A config scope on a freshly opened handle disables prepared arguments; the resolver is scoped to that
+        // handle's private registry, so it resolves against the disabled configuration.
+        try (Handle disabled = h2Extension.getJdbi().open(cfg -> cfg.configure(Arguments.class, c -> c.preparedArgumentsEnabled(false)))) {
+            assertThat(ArgumentResolver.forRegistry(disabled.getConfig()).prepareFor(int.class))
+                    .isEmpty();
+        }
     }
 }

--- a/core/src/test/java/org/jdbi/core/array/TestCustomArrayType.java
+++ b/core/src/test/java/org/jdbi/core/array/TestCustomArrayType.java
@@ -18,12 +18,10 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.statement.StatementContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -32,14 +30,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestCustomArrayType {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
-
-    @BeforeEach
-    public void setUp() {
-        Jdbi db = h2Extension.getJdbi();
-        db.registerArrayType(UserId.class, "int", UserId::getId);
-        db.registerColumnMapper(new UserIdColumnMapper());
-    }
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+            .withConfig(b -> b.registerArrayType(UserId.class, "int", UserId::getId)
+                    .registerColumnMapper(new UserIdColumnMapper()));
 
     /**
      * Test binding and mapping a custom array type; binding requires registration of a {@link SqlArrayType} implementation, and mapping requires registration

--- a/core/src/test/java/org/jdbi/core/array/TestVendorArrays.java
+++ b/core/src/test/java/org/jdbi/core/array/TestVendorArrays.java
@@ -14,9 +14,7 @@
 package org.jdbi.core.array;
 
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -25,14 +23,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestVendorArrays {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
-
-    @BeforeEach
-    public void setUp() {
-        Jdbi db = h2Extension.getJdbi();
-        db.registerArrayType(Integer.class, "int");
-        db.registerArrayType(String.class, "varchar");
-    }
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+            .withConfig(b -> b.registerArrayType(Integer.class, "int")
+                    .registerArrayType(String.class, "varchar"));
 
     @Test
     public void testHsqlDb() {

--- a/core/src/test/java/org/jdbi/core/async/JdbiExecutorTest.java
+++ b/core/src/test/java/org/jdbi/core/async/JdbiExecutorTest.java
@@ -90,7 +90,8 @@ public class JdbiExecutorTest {
     }
 
     @RegisterExtension
-    private final H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+    private final H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+            .withConfig(b -> b.registerExtension(new TestExtensionFactory()));
 
     private JdbiExecutor jdbiExecutor = null;
     private Jdbi jdbi;
@@ -98,7 +99,7 @@ public class JdbiExecutorTest {
     @BeforeEach
     void setup() {
         h2Extension.getJdbi().useHandle(H2DatabaseExtension.USERS_INITIALIZER::initialize);
-        jdbi = h2Extension.getJdbi().registerExtension(new TestExtensionFactory());
+        jdbi = h2Extension.getJdbi();
         jdbiExecutor = JdbiExecutor.create(jdbi, Executors.newFixedThreadPool(2));
     }
 

--- a/core/src/test/java/org/jdbi/core/cache/DeadlockTest.java
+++ b/core/src/test/java/org/jdbi/core/cache/DeadlockTest.java
@@ -38,7 +38,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DeadlockTest {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
+            .withConfig(b -> b.configure(SqlStatements.class, c -> c.templateCache(DefaultJdbiCacheBuilder.builder().maxSize(10))));
 
     static final int THREAD_COUNT = 100;
 
@@ -62,7 +63,6 @@ class DeadlockTest {
 
     @Test
     void testIssue2274() throws Exception {
-        jdbi.configure(SqlStatements.class, c -> c.templateCache(DefaultJdbiCacheBuilder.builder().maxSize(10)));
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT,
                 new ThreadFactoryBuilder().setNameFormat("test-%d").setDaemon(true).build());
 

--- a/core/src/test/java/org/jdbi/core/codec/TestCodecFactoryH2.java
+++ b/core/src/test/java/org/jdbi/core/codec/TestCodecFactoryH2.java
@@ -29,15 +29,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestCodecFactoryH2 {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+            .withConfig(b -> b.registerCodecFactory(
+                    CodecFactory.forSingleCodec(QualifiedType.of(TestValue.class), new TestValueCodec())));
 
     @Test
     public void testCodecFactory() throws Exception {
         QualifiedType<TestValue> testType = QualifiedType.of(TestValue.class);
 
         Jdbi jdbi = h2Extension.getJdbi();
-
-        jdbi.registerCodecFactory(CodecFactory.forSingleCodec(testType, new TestValueCodec()));
 
         jdbi.useHandle(h ->
             h.execute("CREATE TABLE test (test VARCHAR PRIMARY KEY)"));

--- a/core/src/test/java/org/jdbi/core/collector/CollectorsTest.java
+++ b/core/src/test/java/org/jdbi/core/collector/CollectorsTest.java
@@ -118,15 +118,16 @@ public class CollectorsTest {
         queryString(r -> assertThat(r.list())
                 .isNotInstanceOf(LinkedList.class));
 
-        // register list type
-        handle.registerCollector(List.class, Collectors.toCollection(LinkedList::new));
-
         // look up default list type manually
         GenericType<List<String>> type = new GenericType<List<String>>() {};
-        Collector<?, ?, ?> collector = CollectorResolver.forRegistry(handle.getConfig()).findFor(type.getType())
-                .orElseGet(Assertions::fail);
 
         try (Query query = baseQuery()) {
+            // register list type
+            query.registerCollector(List.class, Collectors.toCollection(LinkedList::new));
+
+            Collector<?, ?, ?> collector = CollectorResolver.forRegistry(query.getConfig()).findFor(type.getType())
+                    .orElseGet(Assertions::fail);
+
             assertThat(query
                     .mapTo(String.class)
                     // old school, collect using a collector
@@ -140,10 +141,10 @@ public class CollectorsTest {
     void collectIntoRegisteredListTypeDirectly() {
         queryString(r -> assertThat(r.list()).isNotInstanceOf(LinkedList.class));
 
-        // register list type
-        handle.registerCollector(List.class, Collectors.toCollection(LinkedList::new));
-
         try (Query query = baseQuery()) {
+            // register list type
+            query.registerCollector(List.class, Collectors.toCollection(LinkedList::new));
+
             assertThat((List<String>) query
                     // use the registered list type
                     .collectInto(GenericTypes.parameterizeClass(List.class, String.class)))
@@ -157,11 +158,11 @@ public class CollectorsTest {
     void listIntoRegisteredListType() {
         queryString(r -> assertThat(r.collectIntoList()).isNotInstanceOf(LinkedList.class));
 
-        // register list type
-        handle.configure(JdbiCollectors.class, c ->
-                c.registerCollector(List.class, Collectors.toCollection(LinkedList::new)));
-
         try (Query query = baseQuery()) {
+            // register list type
+            query.configure(JdbiCollectors.class, c ->
+                    c.registerCollector(List.class, Collectors.toCollection(LinkedList::new)));
+
             assertThat(query
                     .mapTo(String.class)
                     // use the registered list type
@@ -189,10 +190,10 @@ public class CollectorsTest {
     void collectIntoRegisteredSetTypeDirectly() {
         queryString(r -> assertThat(r.set()).isNotInstanceOf(LinkedHashSet.class));
 
-        // register list type
-        handle.registerCollector(Set.class, Collectors.toCollection(LinkedHashSet::new));
-
         try (Query query = baseQuery()) {
+            // register list type
+            query.registerCollector(Set.class, Collectors.toCollection(LinkedHashSet::new));
+
             assertThat((Set<String>) query
                     // use the registered set type
                     .collectInto(GenericTypes.parameterizeClass(Set.class, String.class)))
@@ -205,10 +206,10 @@ public class CollectorsTest {
     void setIntoRegisteredSetType() {
         queryString(r -> assertThat(r.collectIntoSet()).isNotInstanceOf(LinkedHashSet.class));
 
-        // register set type
-        handle.registerCollector(Set.class, Collectors.toCollection(LinkedHashSet::new));
-
         try (Query query = baseQuery()) {
+            // register set type
+            query.registerCollector(Set.class, Collectors.toCollection(LinkedHashSet::new));
+
             assertThat(query
                     .mapTo(String.class)
                     // use the registered set type
@@ -235,42 +236,44 @@ public class CollectorsTest {
     @Test
     void testMultiTypes() {
 
-        // register list type
-        handle.registerCollector(new GenericType<List<String>>() {}.getType(), Collectors.toCollection(LinkedList::new));
-        handle.registerCollector(new GenericType<List<Object>>() {}.getType(), Collectors.toCollection(Vector::new));
+        // register list types
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(JdbiCollectors.class, c -> c
+            .registerCollector(new GenericType<List<String>>() {}.getType(), Collectors.toCollection(LinkedList::new))
+            .registerCollector(new GenericType<List<Object>>() {}.getType(), Collectors.toCollection(Vector::new))))) {
 
-        try (Query query = baseQuery()) {
-            final List<String> result = query
-                    // use the registered list type
-                    .mapTo(String.class)
-                    .collectInto(GenericTypes.parameterizeClass(List.class, String.class));
+            try (Query query = handle.createQuery("select * from collection")) {
+                final List<String> result = query
+                        // use the registered list type
+                        .mapTo(String.class)
+                        .collectInto(GenericTypes.parameterizeClass(List.class, String.class));
 
-            assertThat(result)
-                    .isInstanceOf(LinkedList.class)
-                    .containsExactly("a", "b", "c");
-        }
+                assertThat(result)
+                        .isInstanceOf(LinkedList.class)
+                        .containsExactly("a", "b", "c");
+            }
 
-        try (Query query = baseQuery()) {
-            final List<String> result = query
-                    // use the registered list type
-                    .mapTo(String.class)
-                    .collectInto(List.class);
+            try (Query query = handle.createQuery("select * from collection")) {
+                final List<String> result = query
+                        // use the registered list type
+                        .mapTo(String.class)
+                        .collectInto(List.class);
 
-            assertThat(result)
-                    .isInstanceOf(Vector.class)
-                    .containsExactly("a", "b", "c");
-        }
+                assertThat(result)
+                        .isInstanceOf(Vector.class)
+                        .containsExactly("a", "b", "c");
+            }
 
-        try (Query query = baseQuery()) {
-            final List<String> result = query
-                    // use the registered list type
-                    .mapTo(String.class)
-                    .collectIntoList();
+            try (Query query = handle.createQuery("select * from collection")) {
+                final List<String> result = query
+                        // use the registered list type
+                        .mapTo(String.class)
+                        .collectIntoList();
 
-            assertThat(result)
-                    // same as List<Object>
-                    .isInstanceOf(Vector.class)
-                    .containsExactly("a", "b", "c");
+                assertThat(result)
+                        // same as List<Object>
+                        .isInstanceOf(Vector.class)
+                        .containsExactly("a", "b", "c");
+            }
         }
     }
 

--- a/core/src/test/java/org/jdbi/core/config/TestConfigRegistry.java
+++ b/core/src/test/java/org/jdbi/core/config/TestConfigRegistry.java
@@ -175,7 +175,7 @@ public class TestConfigRegistry {
 
         assertThat(second).isSameAs(first);
         assertThat(builds).hasValue(1);
-        assertThat(first.registry).isSameAs(parent);
+        assertThat(first.registry).isSameAs(parent.asReadOnlyView());
     }
 
     @Test
@@ -187,7 +187,7 @@ public class TestConfigRegistry {
         View childView = child1.readAs(View.class, r -> countingView(builds, r));
 
         assertThat(childView).isNotSameAs(parentView);
-        assertThat(childView.registry).isSameAs(child1);
+        assertThat(childView.registry).isSameAs(child1.asReadOnlyView());
         assertThat(builds).hasValue(2);
         // the parent's view is unchanged and still memoized
         assertThat(parent.readAs(View.class, r -> countingView(builds, r))).isSameAs(parentView);
@@ -234,7 +234,7 @@ public class TestConfigRegistry {
 
         // delegated to the parent: same (warm) view, no rebuild, bound to the parent
         assertThat(childView).isSameAs(parentView);
-        assertThat(childView.registry).isSameAs(parent);
+        assertThat(childView.registry).isSameAs(parent.asReadOnlyView());
         assertThat(builds).hasValue(1);
     }
 
@@ -247,7 +247,7 @@ public class TestConfigRegistry {
         child1.configure(RowMappers.class, r -> r.register(FACTORY)); // forks
         View childView = child1.readAs(View.class, r -> countingView(builds, r));
 
-        assertThat(childView.registry).isSameAs(child1);
+        assertThat(childView.registry).isSameAs(child1.asReadOnlyView());
         assertThat(builds).hasValue(2);
     }
 
@@ -263,15 +263,15 @@ public class TestConfigRegistry {
         assertThat(builds).hasValue(2);
     }
 
-    private static View countingView(AtomicInteger builds, ConfigRegistry registry) {
+    private static View countingView(AtomicInteger builds, ConfigView registry) {
         builds.incrementAndGet();
         return new View(registry);
     }
 
     private static final class View {
-        private final ConfigRegistry registry;
+        private final ConfigView registry;
 
-        View(ConfigRegistry registry) {
+        View(ConfigView registry) {
             this.registry = registry;
         }
     }

--- a/core/src/test/java/org/jdbi/core/extension/TestDefaultExtensionMethods.java
+++ b/core/src/test/java/org/jdbi/core/extension/TestDefaultExtensionMethods.java
@@ -28,14 +28,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestDefaultExtensionMethods {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+            .withConfig(b -> b.configure(Extensions.class, c -> c.register(new ExtensionFrameworkTestFactory())));
 
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
         handle = h2Extension.getSharedHandle();
-        handle.configure(Extensions.class, c -> c.register(new ExtensionFrameworkTestFactory()));
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/extension/TestExtensionAnnotations.java
+++ b/core/src/test/java/org/jdbi/core/extension/TestExtensionAnnotations.java
@@ -32,14 +32,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestExtensionAnnotations {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+            .withConfig(b -> b.configure(Extensions.class, c -> c.register(new ExtensionFrameworkTestFactory())));
 
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
         handle = h2Extension.getSharedHandle();
-        handle.configure(Extensions.class, c -> c.register(new ExtensionFrameworkTestFactory()));
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/extension/TestExtensionContext.java
+++ b/core/src/test/java/org/jdbi/core/extension/TestExtensionContext.java
@@ -39,8 +39,8 @@ public class TestExtensionContext {
     static class TestPlugin implements JdbiPlugin {
 
         @Override
-        public void customizeJdbi(Jdbi jdbi) {
-            jdbi.registerExtension(new TestExtensionFactory());
+        public void configure(Jdbi.Builder builder) {
+            builder.registerExtension(new TestExtensionFactory());
         }
     }
 

--- a/core/src/test/java/org/jdbi/core/extension/TestExtensionCustomizers.java
+++ b/core/src/test/java/org/jdbi/core/extension/TestExtensionCustomizers.java
@@ -35,7 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestExtensionCustomizers {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+            .withConfig(b -> b.configure(Extensions.class, c -> c.register(new ExtensionFrameworkTestFactory())));
 
     private Handle testHandle;
 
@@ -44,7 +45,6 @@ public class TestExtensionCustomizers {
     @BeforeEach
     public void setUp() {
         testHandle = h2Extension.getSharedHandle();
-        testHandle.configure(Extensions.class, c -> c.register(new ExtensionFrameworkTestFactory()));
 
         INVOCATIONS.get().clear();
     }
@@ -107,23 +107,24 @@ public class TestExtensionCustomizers {
 
     @Test
     public void testRegisteredDecorator() {
-        testHandle.configure(Extensions.class, c -> c.registerHandlerCustomizer(
+        try (Handle testHandle = h2Extension.getJdbi().open(cfg -> cfg.configure(Extensions.class, c -> c.registerHandlerCustomizer(
                 (base, sqlObjectType, method) ->
                         (config, target) -> (handleSupplier, args) -> {
                             invoked("custom");
                             return base.attachTo(config, target).invoke(handleSupplier, args);
-                        }));
+                        })))) {
 
-        testHandle.attach(Dao.class).orderedFooBar();
+            testHandle.attach(Dao.class).orderedFooBar();
+        }
 
         assertThat(INVOCATIONS.get()).containsExactlyInAnyOrder("custom", "foo", "bar", "method");
     }
 
     @Test
     public void testRegisteredDecoratorReturnsBase() {
-        testHandle.configure(Extensions.class, c -> c.registerHandlerCustomizer((base, sqlObjectType, method) -> base));
-
-        testHandle.attach(Dao.class).orderedFooBar();
+        try (Handle testHandle = h2Extension.getJdbi().open(cfg -> cfg.configure(Extensions.class, c -> c.registerHandlerCustomizer((base, sqlObjectType, method) -> base)))) {
+            testHandle.attach(Dao.class).orderedFooBar();
+        }
 
         assertThat(INVOCATIONS.get()).containsExactly("foo", "bar", "method");
     }

--- a/core/src/test/java/org/jdbi/core/extension/TestUseCustomExtensionHandlerFactory.java
+++ b/core/src/test/java/org/jdbi/core/extension/TestUseCustomExtensionHandlerFactory.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.Something;
 import org.jdbi.core.extension.annotation.UseExtensionHandler;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
@@ -39,16 +38,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestUseCustomExtensionHandlerFactory {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
+            .withConfig(b -> {
+                b.configure(Extensions.class, e -> e.register(new ExtensionFrameworkTestFactory()));
+                b.configure(Extensions.class, c -> c.registerHandlerFactory(customExtensionHandlerFactory()));
+            });
 
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
-        Jdbi db = h2Extension.getJdbi();
-        db.configure(Extensions.class, e -> e.register(new ExtensionFrameworkTestFactory()));
+        handle = h2Extension.openHandle();
+    }
 
-        ExtensionHandlerFactory customExtensionHandlerFactory = new ExtensionHandlerFactory() {
+    private static ExtensionHandlerFactory customExtensionHandlerFactory() {
+        return new ExtensionHandlerFactory() {
 
             @Override
             public boolean accepts(Class<?> extensionType, Method method) {
@@ -69,10 +73,6 @@ public class TestUseCustomExtensionHandlerFactory {
                         .findAny();
             }
         };
-
-        db.configure(Extensions.class, c -> c.registerHandlerFactory(customExtensionHandlerFactory));
-
-        handle = db.open();
     }
 
     @AfterEach

--- a/core/src/test/java/org/jdbi/core/internal/testing/DatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/core/internal/testing/DatabaseExtension.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.core.internal.testing;
 
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import org.jdbi.core.Handle;
@@ -24,6 +25,16 @@ import org.jdbi.core.spi.JdbiPlugin;
 public interface DatabaseExtension<T extends DatabaseExtension<T>> {
 
     Jdbi getJdbi();
+
+    /**
+     * Returns a {@link Jdbi.Builder} pre-configured with this extension's connection source, installed plugins, and
+     * (unless disabled with {@link #withoutLeakChecker()}) its leak checker, so a test can add per-test configuration
+     * (a transaction handler, a spy, and the like) and build its own {@link Jdbi} that still participates in the
+     * extension's leak-check lifecycle.
+     *
+     * @return a builder assembling a {@code Jdbi} equivalent to this extension's.
+     */
+    Jdbi.Builder builder() throws Exception;
 
     String getUri();
 
@@ -41,6 +52,10 @@ public interface DatabaseExtension<T extends DatabaseExtension<T>> {
 
     default <C extends JdbiConfig<C>> T withConfig(Class<C> configClass, UnaryOperator<C> configurer) {
         return withPlugin(ConfiguringPlugin.of(configClass, configurer));
+    }
+
+    default T withConfig(Consumer<Jdbi.Builder> configurer) {
+        return withPlugin(JdbiPlugin.of(configurer));
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/org/jdbi/core/internal/testing/H2DatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/core/internal/testing/H2DatabaseExtension.java
@@ -129,10 +129,7 @@ public final class H2DatabaseExtension implements DatabaseExtension<H2DatabaseEx
     }
 
     @Override
-    public void beforeEach(ExtensionContext context) throws Exception {
-        if (jdbi != null) {
-            throw new IllegalStateException("jdbi is not null!");
-        }
+    public Jdbi.Builder builder() throws Exception {
         final Jdbi.Builder builder = Jdbi.builder(() -> {
             final Connection connection = DriverManager.getConnection(uri);
             // this will only work reliably in single-threaded tests. Any multi-threaded
@@ -143,14 +140,22 @@ public final class H2DatabaseExtension implements DatabaseExtension<H2DatabaseEx
         });
 
         installTestPlugins(builder);
+        plugins.forEach(builder::installPlugin);
 
         if (enableLeakchecker) {
             builder.configure(Handles.class, c -> c.addListener(leakChecker));
             builder.configure(SqlStatements.class, c -> c.addContextListener(leakChecker));
         }
 
-        plugins.forEach(builder::installPlugin);
-        jdbi = builder.build();
+        return builder;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        if (jdbi != null) {
+            throw new IllegalStateException("jdbi is not null!");
+        }
+        jdbi = builder().build();
         sharedHandle = jdbi.open();
 
         initializerMaybe.ifPresent(i -> i.initialize(sharedHandle));

--- a/core/src/test/java/org/jdbi/core/internal/testing/PgDatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/core/internal/testing/PgDatabaseExtension.java
@@ -106,20 +106,25 @@ public final class PgDatabaseExtension implements DatabaseExtension<PgDatabaseEx
 
         info = pg.createDatabaseInfo();
 
+        jdbi = builder().build();
+        sharedHandle = jdbi.open();
+
+        initializerMaybe.ifPresent(i -> i.initialize(sharedHandle));
+    }
+
+    @Override
+    public Jdbi.Builder builder() throws Exception {
         final Jdbi.Builder builder = Jdbi.builder(info.asDataSource());
 
         installTestPlugins(builder);
+        plugins.forEach(builder::installPlugin);
 
         if (enableLeakchecker) {
             builder.configure(Handles.class, c -> c.addListener(leakChecker));
             builder.configure(SqlStatements.class, c -> c.addContextListener(leakChecker));
         }
 
-        plugins.forEach(builder::installPlugin);
-        jdbi = builder.build();
-        sharedHandle = jdbi.open();
-
-        initializerMaybe.ifPresent(i -> i.initialize(sharedHandle));
+        return builder;
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/core/internal/testing/SqliteDatabaseExtension.java
+++ b/core/src/test/java/org/jdbi/core/internal/testing/SqliteDatabaseExtension.java
@@ -105,20 +105,25 @@ public final class SqliteDatabaseExtension implements DatabaseExtension<SqliteDa
         if (jdbi != null) {
             throw new IllegalStateException("jdbi is not null!");
         }
+        jdbi = builder().build();
+        sharedHandle = jdbi.open();
+
+        initializerMaybe.ifPresent(i -> i.initialize(sharedHandle));
+    }
+
+    @Override
+    public Jdbi.Builder builder() throws Exception {
         final Jdbi.Builder builder = Jdbi.builder(uri);
 
         installTestPlugins(builder);
+        plugins.forEach(builder::installPlugin);
 
         if (enableLeakchecker) {
             builder.configure(Handles.class, c -> c.addListener(leakChecker));
             builder.configure(SqlStatements.class, c -> c.addContextListener(leakChecker));
         }
 
-        plugins.forEach(builder::installPlugin);
-        jdbi = builder.build();
-        sharedHandle = jdbi.open();
-
-        initializerMaybe.ifPresent(i -> i.initialize(sharedHandle));
+        return builder;
     }
 
     @Override

--- a/core/src/test/java/org/jdbi/core/locator/TestClasspathSqlLocator.java
+++ b/core/src/test/java/org/jdbi/core/locator/TestClasspathSqlLocator.java
@@ -86,9 +86,9 @@ public class TestClasspathSqlLocator {
     @Test
     public void testDetailExceptionForBackTracing() {
         Handle h = h2Extension.getSharedHandle();
-        h.configure(StatementExceptions.class, c -> c.messageRendering(MessageRendering.DETAIL));
 
         assertThatThrownBy(() -> h.createUpdate(locator.locate("insert-id-name"))
+                .configure(StatementExceptions.class, c -> c.messageRendering(MessageRendering.DETAIL))
                 .bind("id", 1)
                 .execute())
             .isInstanceOf(StatementException.class)

--- a/core/src/test/java/org/jdbi/core/mapper/ImmutablesTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/ImmutablesTest.java
@@ -39,8 +39,9 @@ public class ImmutablesTest {
     public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
         .withPlugin(new JdbiPlugin() {
             @Override
-            public void customizeJdbi(Jdbi jdbi) {
-                jdbi.registerImmutable(
+            public void configure(Jdbi.Builder builder) {
+                builder.registerImmutable(
+                        Train.class,
                         SubValue.class,
                         FooBarBaz.class,
                         Getter.class,
@@ -80,7 +81,6 @@ public class ImmutablesTest {
 
     @Test
     public void simpleTest() {
-        jdbi.registerImmutable(Train.class);
         try (Handle handle = jdbi.open()) {
             handle.execute("create table train (name varchar, carriages int, observation_car boolean)");
 

--- a/core/src/test/java/org/jdbi/core/mapper/JdbiPropertyTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/JdbiPropertyTest.java
@@ -159,8 +159,8 @@ public class JdbiPropertyTest {
 
     @Test
     public void immutablesBindDefineIgnore() {
-        handle.registerImmutable(TestImmutables.class);
         assertThat(handle.select("select :id")
+                .registerImmutable(TestImmutables.class)
                 .bindPojo(ImmutableTestImmutables.builder().build())
                 .defineNamedBindings()
                 .addCustomizer(new UnboundDetector())

--- a/core/src/test/java/org/jdbi/core/mapper/JoinRowMapperTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/JoinRowMapperTest.java
@@ -30,7 +30,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JoinRowMapperTest {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withConfig(b -> b
+            // tag::mapperSetup[]
+            .registerRowMapper(ConstructorMapper.factory(User.class))
+            .registerRowMapper(ConstructorMapper.factory(Article.class))
+            // end::mapperSetup[]
+        );
 
     private Handle h;
 
@@ -61,11 +67,6 @@ public class JoinRowMapperTest {
             .bind(0, 3).bind(1, 1).add()
             .bind(0, 3).bind(1, 3).add()
             .execute();
-
-        // tag::mapperSetup[]
-        h.registerRowMapper(ConstructorMapper.factory(User.class));
-        h.registerRowMapper(ConstructorMapper.factory(Article.class));
-        // end::mapperSetup[]
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/mapper/MapEntryMapperTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/MapEntryMapperTest.java
@@ -132,21 +132,19 @@ public class MapEntryMapperTest {
 
         CharSequence sql = "select u.id u_id, u.name u_name, p.id p_id, p.phone p_phone "
             + "from \"user\" u left join phone p on u.id = p.user_id";
-        h2Extension.getJdbi()
-                .setMapKeyColumn("foo")
-                .setMapValueColumn("bar")
-                .useHandle(handle -> {
-                    Map<User, Phone> map = handle.createQuery(sql)
-                            .setMapKeyColumn(null)
-                            .setMapValueColumn(null)
-                            .registerRowMapper(ConstructorMapper.factory(User.class, "u"))
-                            .registerRowMapper(ConstructorMapper.factory(Phone.class, "p"))
-                            .collectInto(new GenericType<Map<User, Phone>>() {});
-                    assertThat(map).containsOnly(
-                            entry(new User(1, "alice"), new Phone(10, "555-0001")),
-                            entry(new User(2, "bob"), new Phone(20, "555-0002")),
-                            entry(new User(3, "cathy"), new Phone(30, "555-0003")));
-                });
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(MapEntryMappers.class, c -> c.keyColumn("foo").valueColumn("bar")))) {
+            Map<User, Phone> map = handle.createQuery(sql)
+                    .setMapKeyColumn(null)
+                    .setMapValueColumn(null)
+                    .registerRowMapper(ConstructorMapper.factory(User.class, "u"))
+                    .registerRowMapper(ConstructorMapper.factory(Phone.class, "p"))
+                    .collectInto(new GenericType<Map<User, Phone>>() {});
+            assertThat(map).containsOnly(
+                    entry(new User(1, "alice"), new Phone(10, "555-0001")),
+                    entry(new User(2, "bob"), new Phone(20, "555-0002")),
+                    entry(new User(3, "cathy"), new Phone(30, "555-0003")));
+        }
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/mapper/MapEntryMapperTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/MapEntryMapperTest.java
@@ -162,11 +162,10 @@ public class MapEntryMapperTest {
                 .add(30, 3, "555-0003")
                 .execute();
 
-        h.registerRowMapper(ConstructorMapper.factory(User.class, "u"));
-        h.registerRowMapper(ConstructorMapper.factory(Phone.class, "p"));
-
         Map<User, Phone> map =
                 h.createQuery("SELECT u.id u_id, u.name u_name, p.id p_id, p.phone p_phone FROM \"user\" u LEFT JOIN phone p ON u.id = p.user_id")
+                        .registerRowMapper(ConstructorMapper.factory(User.class, "u"))
+                        .registerRowMapper(ConstructorMapper.factory(Phone.class, "p"))
                         .mapTo(new GenericType<Map.Entry<User, Phone>>() {})
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 

--- a/core/src/test/java/org/jdbi/core/mapper/PrimitiveMapperFactoryTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/PrimitiveMapperFactoryTest.java
@@ -44,9 +44,9 @@ public class PrimitiveMapperFactoryTest {
 
     @Test
     public void forbidNullPrimitives() {
-        assertThatThrownBy(() -> h2Extension.getJdbi().withHandle(h ->
-            h.configure(ColumnMappers.class, mappers -> mappers.coalesceNullPrimitivesToDefaults(false))
-                .createQuery("select null as foo")
+        assertThatThrownBy(() -> h2Extension.getJdbi().withHandle(
+            cfg -> cfg.configure(ColumnMappers.class, mappers -> mappers.coalesceNullPrimitivesToDefaults(false)),
+            h -> h.createQuery("select null as foo")
                 .mapTo(int.class)
                 .one()
         ))
@@ -57,9 +57,9 @@ public class PrimitiveMapperFactoryTest {
 
     @Test
     public void doesntApplyToBoxed() {
-        Integer value = h2Extension.getJdbi().withHandle(h ->
-            h.configure(ColumnMappers.class, mappers -> mappers.coalesceNullPrimitivesToDefaults(false))
-                .createQuery("select null")
+        Integer value = h2Extension.getJdbi().withHandle(
+            cfg -> cfg.configure(ColumnMappers.class, mappers -> mappers.coalesceNullPrimitivesToDefaults(false)),
+            h -> h.createQuery("select null")
                 .mapTo(Integer.class)
                 .one()
         );

--- a/core/src/test/java/org/jdbi/core/mapper/QualifiedEnumMappingTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/QualifiedEnumMappingTest.java
@@ -39,9 +39,8 @@ public class QualifiedEnumMappingTest {
 
     @Test
     public void methodCallCanBeAnnotatedAsByName() {
-        h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
-
         Object byName = h.createQuery("select :name")
+            .configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL))
             .bind("name", Foobar.FOO.name())
             .mapTo(QualifiedType.of(Foobar.class).with(EnumByName.class))
             .one();
@@ -63,9 +62,8 @@ public class QualifiedEnumMappingTest {
 
     @Test
     public void enumCanBeAnnotatedAsByName() {
-        h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
-
         ByName byName = h.createQuery("select :name")
+            .configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL))
             .bind("name", ByName.ALPHABETIC.name())
             .mapTo(ByName.class)
             .one();
@@ -87,9 +85,8 @@ public class QualifiedEnumMappingTest {
 
     @Test
     public void methodCallOverridesClassForName() {
-        h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
-
         Object byName = h.createQuery("select :name")
+            .configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL))
             .bind("name", ByOrdinal.NUMERIC.name())
             .mapTo(QualifiedType.of(ByOrdinal.class).with(EnumByName.class))
             .one();

--- a/core/src/test/java/org/jdbi/core/mapper/TestIssue2016.java
+++ b/core/src/test/java/org/jdbi/core/mapper/TestIssue2016.java
@@ -32,7 +32,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestIssue2016 {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
+        .withConfig(b -> b
+            .registerRowMapper(Tag.class, new TagMapper())
+            .registerRowMapper(ModBusTag.class, BeanMapper.of(ModBusTag.class))
+            .registerRowMapper(SNMPTag.class, BeanMapper.of(SNMPTag.class))
+            .registerRowMapper(EIPTag.class, BeanMapper.of(EIPTag.class))
+            .registerRowMapper(S7Tag.class, BeanMapper.of(S7Tag.class))
+            .registerRowMapper(ICMPTag.class, BeanMapper.of(ICMPTag.class)));
 
     private Handle h;
 
@@ -43,13 +51,6 @@ public class TestIssue2016 {
 
     @Test
     public void testIssue2016() {
-        h.registerRowMapper(Tag.class, new TagMapper());
-        h.registerRowMapper(ModBusTag.class, BeanMapper.of(ModBusTag.class));
-        h.registerRowMapper(SNMPTag.class, BeanMapper.of(SNMPTag.class));
-        h.registerRowMapper(EIPTag.class, BeanMapper.of(EIPTag.class));
-        h.registerRowMapper(S7Tag.class, BeanMapper.of(S7Tag.class));
-        h.registerRowMapper(ICMPTag.class, BeanMapper.of(ICMPTag.class));
-
         h.execute("create table protocols (id integer, protocol VARCHAR(32), state VARCHAR(32))");
         h.execute("insert into protocols (id, protocol, state) values (1, 'ModBus', 'on')");
         h.execute("insert into protocols (id, protocol, state) values (2, 'ModBus', 'off')");

--- a/core/src/test/java/org/jdbi/core/mapper/TestMapMapper.java
+++ b/core/src/test/java/org/jdbi/core/mapper/TestMapMapper.java
@@ -41,27 +41,27 @@ public class TestMapMapper {
 
     @Test
     public void testCaseDefaultNop() {
-        h.configure(MapMappers.class, c -> c.caseChange(CaseStrategy.NOP));
-
-        Map<String, Object> noOne = h.createQuery("select * from Foo").mapToMap().one();
+        Map<String, Object> noOne = h.createQuery("select * from Foo")
+            .configure(MapMappers.class, c -> c.caseChange(CaseStrategy.NOP))
+            .mapToMap().one();
 
         assertThat(noOne).containsOnlyKeys("Id", "FirstName");
     }
 
     @Test
     public void testCaseLower() {
-        h.configure(MapMappers.class, c -> c.caseChange(CaseStrategy.LOCALE_LOWER));
-
-        Map<String, Object> noOne = h.createQuery("select * from Foo").mapToMap().one();
+        Map<String, Object> noOne = h.createQuery("select * from Foo")
+            .configure(MapMappers.class, c -> c.caseChange(CaseStrategy.LOCALE_LOWER))
+            .mapToMap().one();
 
         assertThat(noOne).containsOnlyKeys("id", "firstname");
     }
 
     @Test
     public void testCaseUpper() {
-        h.configure(MapMappers.class, c -> c.caseChange(CaseStrategy.LOCALE_UPPER));
-
-        Map<String, Object> noOne = h.createQuery("select * from Foo").mapToMap().one();
+        Map<String, Object> noOne = h.createQuery("select * from Foo")
+            .configure(MapMappers.class, c -> c.caseChange(CaseStrategy.LOCALE_UPPER))
+            .mapToMap().one();
 
         assertThat(noOne).containsOnlyKeys("ID", "FIRSTNAME");
     }

--- a/core/src/test/java/org/jdbi/core/mapper/TestMapperInit.java
+++ b/core/src/test/java/org/jdbi/core/mapper/TestMapperInit.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jdbi.core.Handle;
 import org.jdbi.core.Jdbi;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.statement.SqlStatements;
@@ -236,7 +236,7 @@ public class TestMapperInit {
         }
 
         @Override
-        public void init(ConfigRegistry registry) {
+        public void init(ConfigView registry) {
             initializedCount.incrementAndGet();
         }
     }
@@ -254,7 +254,7 @@ public class TestMapperInit {
         }
 
         @Override
-        public void init(ConfigRegistry registry) {
+        public void init(ConfigView registry) {
             stringValueMapper = registry.findColumnMapperFor(StringValue.class).orElseGet(() -> fail("No mapper found!"));
         }
     }

--- a/core/src/test/java/org/jdbi/core/mapper/TestMapperInit.java
+++ b/core/src/test/java/org/jdbi/core/mapper/TestMapperInit.java
@@ -27,6 +27,7 @@ import org.jdbi.core.Jdbi;
 import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
+import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.core.statement.StatementContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,11 +100,21 @@ public class TestMapperInit {
                 .mapTo(StringValue.class)
                 .list();
 
-            // a new handle has its own registry, so the mapper is initialized again
-            assertThat(mapper.getInitializedCount()).isEqualTo(2);
+            // an unmodified handle shares the Jdbi root's copy-on-write registry (and its warm resolvers),
+            // so the mapper is not re-initialized
+            assertThat(mapper.getInitializedCount()).isOne();
 
             // has been called for every row again (mapper gets reused)
             assertThat(value.size() * 3).isEqualTo(mapper.getMappedCount());
+        });
+
+        // a handle that changes its configuration forks a private registry, so the mapper re-initializes
+        jdbi.useHandle(config -> config.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true)), h -> {
+            h.createQuery("SELECT string_value FROM column_mappers")
+                .mapTo(StringValue.class)
+                .list();
+
+            assertThat(mapper.getInitializedCount()).isEqualTo(2);
         });
     }
 
@@ -157,11 +168,21 @@ public class TestMapperInit {
             List<Map.Entry<StringValue, Integer>> value = h.createQuery("SELECT * FROM column_mappers")
                 .mapTo(resultType)
                 .list();
-            // a new handle has its own registry, so the mapper is initialized again
-            assertThat(mapper.getInitializedCount()).isEqualTo(2);
+            // an unmodified handle shares the Jdbi root's copy-on-write registry (and its warm resolvers),
+            // so the mapper is not re-initialized
+            assertThat(mapper.getInitializedCount()).isOne();
 
             // has been called for every row again (mapper gets reused)
             assertThat(value).hasSize(mapper.getMappedCount() / 3);
+        });
+
+        // a handle that changes its configuration forks a private registry, so the mapper re-initializes
+        jdbi.useHandle(config -> config.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true)), h -> {
+            h.createQuery("SELECT * FROM column_mappers")
+                .mapTo(resultType)
+                .list();
+
+            assertThat(mapper.getInitializedCount()).isEqualTo(2);
         });
     }
 

--- a/core/src/test/java/org/jdbi/core/mapper/TestMapperInit.java
+++ b/core/src/test/java/org/jdbi/core/mapper/TestMapperInit.java
@@ -57,8 +57,9 @@ public class TestMapperInit {
         assertThat(mapper.getInitializedCount()).isZero();
         assertThat(mapper.getMappedCount()).isZero();
 
-        Jdbi jdbi = h2Extension.getJdbi();
-        jdbi.registerColumnMapper(StringValue.class, mapper);
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUri())
+            .registerColumnMapper(StringValue.class, mapper)
+            .build();
 
         // still not initialized, only at first retrieval
         assertThat(mapper.getInitializedCount()).isZero();
@@ -115,9 +116,10 @@ public class TestMapperInit {
         assertThat(mapper.getInitializedCount()).isZero();
         assertThat(mapper.getMappedCount()).isZero();
 
-        Jdbi jdbi = h2Extension.getJdbi();
-        jdbi.registerColumnMapper(StringValue.class, mapper);
-        jdbi.registerRowMapper(resultType, new ResultMapper());
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUri())
+            .registerColumnMapper(StringValue.class, mapper)
+            .registerRowMapper(resultType, new ResultMapper())
+            .build();
 
         // still not initialized, only at first retrieval
         assertThat(mapper.getInitializedCount()).isZero();

--- a/core/src/test/java/org/jdbi/core/mapper/TestRegisteredMappers.java
+++ b/core/src/test/java/org/jdbi/core/mapper/TestRegisteredMappers.java
@@ -28,13 +28,13 @@ import static org.mockito.Mockito.mock;
 public class TestRegisteredMappers {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
 
     @Test
     public void testRegisterInferredOnJdbi() {
         Jdbi db = h2Extension.getJdbi();
 
-        db.registerRowMapper(new SomethingMapper());
         Something sam = db.withHandle(handle1 -> {
             handle1.execute("insert into something (id, name) values (18, 'Sam')");
 
@@ -49,13 +49,13 @@ public class TestRegisteredMappers {
 
     @Test
     public void registerByGenericType() {
-        Jdbi db = h2Extension.getJdbi();
-
         @SuppressWarnings("unchecked")
         RowMapper<Iterable<Calendar>> mapper = mock(RowMapper.class);
         GenericType<Iterable<Calendar>> iterableOfCalendarType = new GenericType<Iterable<Calendar>>() {};
 
-        db.registerRowMapper(iterableOfCalendarType, mapper);
+        Jdbi db = Jdbi.builder(h2Extension.getUri())
+            .registerRowMapper(iterableOfCalendarType, mapper)
+            .build();
 
         assertThat(db.getConfig().findRowMapperFor(iterableOfCalendarType))
             .contains(mapper);

--- a/core/src/test/java/org/jdbi/core/mapper/ValueTypeMapper.java
+++ b/core/src/test/java/org/jdbi/core/mapper/ValueTypeMapper.java
@@ -20,7 +20,7 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 import org.jdbi.core.ValueType;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
@@ -35,7 +35,7 @@ public class ValueTypeMapper implements ColumnMapper<ValueType> {
 
     public static class Factory implements ColumnMapperFactory {
         @Override
-        public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+        public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
             return ValueType.class.isAssignableFrom(getErasedType(type))
                     ? Optional.of(new ValueTypeMapper())
                     : Optional.empty();

--- a/core/src/test/java/org/jdbi/core/mapper/reflect/BeanMapperMockTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/reflect/BeanMapperMockTest.java
@@ -23,6 +23,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.core.HandleAccess;
 import org.jdbi.core.SampleBean;
 import org.jdbi.core.ValueType;
+import org.jdbi.core.mapper.ColumnMappers;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.mapper.ValueTypeMapper;
 import org.jdbi.core.statement.StatementContext;
@@ -179,7 +180,7 @@ public class BeanMapperMockTest {
 
     @Test
     public void shouldUseRegisteredMapperForUnknownPropertyType() throws Exception {
-        handle.registerColumnMapper(new ValueTypeMapper());
+        ctx.getConfig().configure(ColumnMappers.class, c -> c.register(new ValueTypeMapper()));
 
         mockColumns("longField", "valueTypeField");
         Long expected = 123L;

--- a/core/src/test/java/org/jdbi/core/mapper/reflect/BeanMapperNestedTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/reflect/BeanMapperNestedTest.java
@@ -30,16 +30,18 @@ import static org.jdbi.core.internal.testing.H2DatabaseExtension.SOMETHING_INITI
 public class BeanMapperNestedTest {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(SOMETHING_INITIALIZER);
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withInitializer(SOMETHING_INITIALIZER)
+        .withConfig(b -> b
+            .registerRowMapper(BeanMapper.factory(NestedBean.class))
+            .registerRowMapper(BeanMapper.factory(NestedPrefixBean.class))
+            .registerRowMapper(BeanMapper.factory(StrangePrefixBean.class)));
 
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
         this.handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(BeanMapper.factory(NestedBean.class));
-        handle.registerRowMapper(BeanMapper.factory(NestedPrefixBean.class));
-        handle.registerRowMapper(BeanMapper.factory(StrangePrefixBean.class));
 
         handle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
     }
@@ -56,22 +58,22 @@ public class BeanMapperNestedTest {
 
     @Test
     public void testNestedStrict() {
-        handle.configure(ReflectionMappers.class, c -> c.strictMatching(true));
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(ReflectionMappers.class, c -> c.strictMatching(true)))) {
+            assertThat(handle
+                .createQuery("select id, name from something")
+                .mapTo(NestedBean.class)
+                .one())
+                .extracting("nested.id", "nested.name")
+                .containsExactly(1, "foo");
 
-        assertThat(handle
-            .createQuery("select id, name from something")
-            .mapTo(NestedBean.class)
-            .one())
-            .extracting("nested.id", "nested.name")
-            .containsExactly(1, "foo");
-
-        assertThatThrownBy(() -> {
-            try (Query query = handle.createQuery("select id, name, 1 as other from something")) {
-                query.mapTo(NestedBean.class).one();
-            }
-        })
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("could not match properties for columns: [other]");
+            assertThatThrownBy(() -> {
+                try (Query query = handle.createQuery("select id, name, 1 as other from something")) {
+                    query.mapTo(NestedBean.class).one();
+                }
+            })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("could not match properties for columns: [other]");
+        }
     }
 
     @Test
@@ -96,31 +98,31 @@ public class BeanMapperNestedTest {
 
     @Test
     public void testNestedPrefixStrict() {
-        handle.configure(ReflectionMappers.class, c -> c.strictMatching(true));
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(ReflectionMappers.class, c -> c.strictMatching(true)))) {
+            assertThat(handle
+                .createQuery("select id nested_id, name nested_name, integerValue from something")
+                .mapTo(NestedPrefixBean.class)
+                .one())
+                .extracting("nested.id", "nested.name", "integerValue")
+                .containsExactly(1, "foo", 5);
 
-        assertThat(handle
-            .createQuery("select id nested_id, name nested_name, integerValue from something")
-            .mapTo(NestedPrefixBean.class)
-            .one())
-            .extracting("nested.id", "nested.name", "integerValue")
-            .containsExactly(1, "foo", 5);
+            assertThatThrownBy(() -> {
+                try (Query query = handle.createQuery("select id nested_id, name nested_name, 1 as other from something")) {
+                    query.mapTo(NestedPrefixBean.class)
+                        .one();
+                }
+            })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("could not match properties for columns: [other]");
 
-        assertThatThrownBy(() -> {
-            try (Query query = handle.createQuery("select id nested_id, name nested_name, 1 as other from something")) {
-                query.mapTo(NestedPrefixBean.class)
-                    .one();
-            }
-        })
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("could not match properties for columns: [other]");
-
-        assertThatThrownBy(() -> {
-            try (Query query = handle.createQuery("select id nested_id, name nested_name, 1 as nested_other from something")) {
-                query.mapTo(NestedPrefixBean.class).one();
-            }
-        })
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("could not match properties for columns: [nested_other]");
+            assertThatThrownBy(() -> {
+                try (Query query = handle.createQuery("select id nested_id, name nested_name, 1 as nested_other from something")) {
+                    query.mapTo(NestedPrefixBean.class).one();
+                }
+            })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("could not match properties for columns: [nested_other]");
+        }
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/mapper/reflect/BeanMapperPropagateNullableTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/reflect/BeanMapperPropagateNullableTest.java
@@ -43,8 +43,8 @@ public class BeanMapperPropagateNullableTest {
     @Test
     public void propagateNull() {
         assertThat(handle
-            .registerRowMapper(BeanMapper.factory(PropagateNullThing.class))
             .select("SELECT null as testValue, 'foo' as s")
+            .registerRowMapper(BeanMapper.factory(PropagateNullThing.class))
             .mapTo(PropagateNullThing.class)
             .one())
             .isNull();
@@ -53,8 +53,8 @@ public class BeanMapperPropagateNullableTest {
     @Test
     public void propagateNotNull() {
         assertThat(handle
-            .registerRowMapper(BeanMapper.factory(PropagateNullThing.class))
             .select("SELECT 42 as testValue, 'foo' as s")
+            .registerRowMapper(BeanMapper.factory(PropagateNullThing.class))
             .mapTo(PropagateNullThing.class)
             .one())
             .extracting("testValue", "s")
@@ -64,8 +64,8 @@ public class BeanMapperPropagateNullableTest {
     @Test
     public void nestedPropagateNull() {
         assertThat(handle
-            .registerRowMapper(BeanMapper.factory(NestedPropagateNullThing.class))
             .select("SELECT 42 as integerValue, null as testValue, 'foo' as s")
+            .registerRowMapper(BeanMapper.factory(NestedPropagateNullThing.class))
             .mapTo(NestedPropagateNullThing.class)
             .one())
             .extracting("integerValue", "nested")
@@ -75,8 +75,8 @@ public class BeanMapperPropagateNullableTest {
     @Test
     public void nestedPropagateNotNull() {
         assertThat(handle
-            .registerRowMapper(BeanMapper.factory(NestedPropagateNullThing.class))
             .select("SELECT 42 as integerValue, 60 as testValue, 'foo' as s")
+            .registerRowMapper(BeanMapper.factory(NestedPropagateNullThing.class))
             .mapTo(NestedPropagateNullThing.class)
             .one())
             .extracting("integerValue", "nested.testValue", "nested.s")

--- a/core/src/test/java/org/jdbi/core/mapper/reflect/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/reflect/BeanMapperTest.java
@@ -38,9 +38,8 @@ public class BeanMapperTest {
 
     @Test
     public void testColumnNameAnnotation() {
-        handle.registerRowMapper(BeanMapper.factory(ColumnNameBean.class));
-
         ColumnNameBean bean = handle.createQuery("select * from something")
+            .registerRowMapper(BeanMapper.factory(ColumnNameBean.class))
             .mapTo(ColumnNameBean.class)
             .one();
 
@@ -52,9 +51,8 @@ public class BeanMapperTest {
 
     @Test
     public void testColumnNameMismatch() {
-        handle.registerRowMapper(BeanMapper.factory(MismatchColumnNameBean.class));
-
         MismatchColumnNameBean bean = handle.createQuery("select * from something")
+            .registerRowMapper(BeanMapper.factory(MismatchColumnNameBean.class))
             .mapTo(MismatchColumnNameBean.class)
             .one();
 

--- a/core/src/test/java/org/jdbi/core/mapper/reflect/ConstructorMapperPgTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/reflect/ConstructorMapperPgTest.java
@@ -28,14 +28,14 @@ public class ConstructorMapperPgTest {
     @RegisterExtension
     public static EmbeddedPgExtension pg = MultiDatabaseBuilder.instanceWithDefaults().build();
     @RegisterExtension
-    public PgDatabaseExtension pgExtension = PgDatabaseExtension.instance(pg);
+    public PgDatabaseExtension pgExtension = PgDatabaseExtension.instance(pg)
+        .withConfig(b -> b.registerRowMapper(ConstructorMapper.factory(ConstructorBean.class)));
 
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
-        handle = pgExtension.getSharedHandle()
-            .registerRowMapper(ConstructorMapper.factory(ConstructorBean.class));
+        handle = pgExtension.getSharedHandle();
 
         handle.execute("CREATE TABLE bean (s varchar primary key, i integer)");
     }

--- a/core/src/test/java/org/jdbi/core/mapper/reflect/ConstructorMapperTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/reflect/ConstructorMapperTest.java
@@ -22,6 +22,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.mapper.Nested;
 import org.jdbi.core.mapper.PropagateNull;
+import org.jdbi.core.mapper.RowMappers;
 import org.jdbi.core.statement.Query;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,19 +37,21 @@ import static org.assertj.core.api.Assertions.fail;
 public class ConstructorMapperTest {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
-
-    private Handle handle;
-
-    @BeforeEach
-    public void setUp() {
-        handle = h2Extension.getSharedHandle()
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withConfig(b -> b
             .registerRowMapper(ConstructorMapper.factory(ConstructorBean.class))
             .registerRowMapper(ConstructorMapper.factory(ConstructorPropertiesBean.class))
             .registerRowMapper(ConstructorMapper.factory(NamedParameterBean.class))
             .registerRowMapper(ConstructorMapper.factory(NullableNestedBean.class))
             .registerRowMapper(ConstructorMapper.factory(NullableParameterBean.class))
-            .registerRowMapper(ConstructorMapper.factory(StaticFactoryMethodBean.class));
+            .registerRowMapper(ConstructorMapper.factory(StaticFactoryMethodBean.class))
+            .registerRowMapper(ConstructorMapper.factory(TypeUseNullableParameterBean.class)));
+
+    private Handle handle;
+
+    @BeforeEach
+    public void setUp() {
+        handle = h2Extension.getSharedHandle();
 
         handle.execute("CREATE TABLE bean (s varchar, i integer)");
 
@@ -174,8 +177,8 @@ public class ConstructorMapperTest {
     @Test
     public void nestedParameters() {
         assertThat(handle
-                .registerRowMapper(ConstructorMapper.factory(NestedBean.class))
                 .select("select s, i from bean")
+                .registerRowMapper(ConstructorMapper.factory(NestedBean.class))
                 .mapTo(NestedBean.class)
                 .one())
                         .extracting("nested.s", "nested.i")
@@ -184,23 +187,24 @@ public class ConstructorMapperTest {
 
     @Test
     public void nestedParametersStrict() {
-        handle.configure(ReflectionMappers.class, c -> c.strictMatching(true));
-        handle.registerRowMapper(ConstructorMapper.factory(NestedBean.class));
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                .configure(ReflectionMappers.class, c -> c.strictMatching(true))
+                .configure(RowMappers.class, r -> r.register(ConstructorMapper.factory(NestedBean.class))))) {
 
-        assertThat(handle
-                .registerRowMapper(ConstructorMapper.factory(NestedBean.class))
-                .select("select s, i from bean")
-                .mapTo(NestedBean.class)
-                .one())
-                        .extracting("nested.s", "nested.i")
-                        .containsExactly("3", 2);
+            assertThat(handle
+                    .select("select s, i from bean")
+                    .mapTo(NestedBean.class)
+                    .one())
+                            .extracting("nested.s", "nested.i")
+                            .containsExactly("3", 2);
 
-        assertThatThrownBy(() -> handle
-                .createQuery("select s, i, 1 as other from bean")
-                .mapTo(NestedBean.class)
-                .one())
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessageContaining("could not match parameters for columns: [other]");
+            assertThatThrownBy(() -> handle
+                    .createQuery("select s, i, 1 as other from bean")
+                    .mapTo(NestedBean.class)
+                    .one())
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessageContaining("could not match parameters for columns: [other]");
+        }
     }
 
     static class NestedBean {
@@ -256,8 +260,8 @@ public class ConstructorMapperTest {
     @Test
     public void nestedPrefixParameters() {
         NestedPrefixBean result = handle
-                .registerRowMapper(ConstructorMapper.factory(NestedPrefixBean.class))
                 .select("select i nested_i, s nested_s from bean")
+                .registerRowMapper(ConstructorMapper.factory(NestedPrefixBean.class))
                 .mapTo(NestedPrefixBean.class)
                 .one();
         assertThat(result.nested.s).isEqualTo("3");
@@ -266,29 +270,31 @@ public class ConstructorMapperTest {
 
     @Test
     public void nestedPrefixParametersStrict() {
-        handle.configure(ReflectionMappers.class, c -> c.strictMatching(true));
-        handle.registerRowMapper(ConstructorMapper.factory(NestedPrefixBean.class));
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                .configure(ReflectionMappers.class, c -> c.strictMatching(true))
+                .configure(RowMappers.class, r -> r.register(ConstructorMapper.factory(NestedPrefixBean.class))))) {
 
-        assertThat(handle
-                .createQuery("select i nested_i, s nested_s from bean")
-                .mapTo(NestedPrefixBean.class)
-                .one())
-                        .extracting("nested.s", "nested.i")
-                        .containsExactly("3", 2);
+            assertThat(handle
+                    .createQuery("select i nested_i, s nested_s from bean")
+                    .mapTo(NestedPrefixBean.class)
+                    .one())
+                            .extracting("nested.s", "nested.i")
+                            .containsExactly("3", 2);
 
-        assertThatThrownBy(() -> handle
-                .createQuery("select i nested_i, s nested_s, 1 as other from bean")
-                .mapTo(NestedPrefixBean.class)
-                .one())
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessageContaining("could not match parameters for columns: [other]");
+            assertThatThrownBy(() -> handle
+                    .createQuery("select i nested_i, s nested_s, 1 as other from bean")
+                    .mapTo(NestedPrefixBean.class)
+                    .one())
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessageContaining("could not match parameters for columns: [other]");
 
-        assertThatThrownBy(() -> handle
-                .createQuery("select i nested_i, s nested_s, 1 as nested_other from bean")
-                .mapTo(NestedPrefixBean.class)
-                .one())
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessageContaining("could not match parameters for columns: [nested_other]");
+            assertThatThrownBy(() -> handle
+                    .createQuery("select i nested_i, s nested_s, 1 as nested_other from bean")
+                    .mapTo(NestedPrefixBean.class)
+                    .one())
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessageContaining("could not match parameters for columns: [nested_other]");
+        }
     }
 
     static class NestedPrefixBean {
@@ -302,8 +308,8 @@ public class ConstructorMapperTest {
     @Test
     public void propagateNull() {
         assertThat(handle
-                .registerRowMapper(ConstructorMapper.factory(PropagateNullThing.class))
                 .select("SELECT null as testValue, 'foo' as s")
+                .registerRowMapper(ConstructorMapper.factory(PropagateNullThing.class))
                 .mapTo(PropagateNullThing.class)
                 .one())
                         .isNull();
@@ -312,8 +318,8 @@ public class ConstructorMapperTest {
     @Test
     public void propagateNotNull() {
         assertThat(handle
-                .registerRowMapper(ConstructorMapper.factory(PropagateNullThing.class))
                 .select("SELECT 42 as testValue, 'foo' as s")
+                .registerRowMapper(ConstructorMapper.factory(PropagateNullThing.class))
                 .mapTo(PropagateNullThing.class)
                 .one())
                         .extracting("testValue", "s")
@@ -323,8 +329,8 @@ public class ConstructorMapperTest {
     @Test
     public void nestedPropagateNull() {
         assertThat(handle
-                .registerRowMapper(ConstructorMapper.factory(NestedPropagateNullThing.class))
                 .select("SELECT 42 as integerValue, null as testValue, 'foo' as s")
+                .registerRowMapper(ConstructorMapper.factory(NestedPropagateNullThing.class))
                 .mapTo(NestedPropagateNullThing.class)
                 .one())
                         .extracting("integerValue", "nested")
@@ -334,8 +340,8 @@ public class ConstructorMapperTest {
     @Test
     public void nestedPropagateNotNull() {
         assertThat(handle
-                .registerRowMapper(ConstructorMapper.factory(NestedPropagateNullThing.class))
                 .select("SELECT 42 as integerValue, 60 as testValue, 'foo' as s")
+                .registerRowMapper(ConstructorMapper.factory(NestedPropagateNullThing.class))
                 .mapTo(NestedPropagateNullThing.class)
                 .one())
                         .extracting("integerValue", "nested.testValue", "nested.s")
@@ -477,8 +483,8 @@ public class ConstructorMapperTest {
     @Test
     public void testClassWithGenerics() {
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(ClassWithGenericThing.class))
             .select("select s, i from bean")
+            .registerRowMapper(ConstructorMapper.factory(ClassWithGenericThing.class))
             .mapTo(ClassWithGenericThing.class)
             .one())
                     .extracting("s", "i")
@@ -505,8 +511,8 @@ public class ConstructorMapperTest {
     @Test
     public void testClassWithGenericsJdbiConstructor() {
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(ClassWithGenericThingJdbiConstructor.class))
             .select("select s, i from bean")
+            .registerRowMapper(ConstructorMapper.factory(ClassWithGenericThingJdbiConstructor.class))
             .mapTo(ClassWithGenericThingJdbiConstructor.class)
             .one())
                     .extracting("s", "i")
@@ -533,8 +539,8 @@ public class ConstructorMapperTest {
     @Test
     public void testClassWithGenericsCanonicalConstructor() {
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(ClassWithGenericThingAlternateJdbiConstructor.class))
             .select("select s, i from bean")
+            .registerRowMapper(ConstructorMapper.factory(ClassWithGenericThingAlternateJdbiConstructor.class))
             .mapTo(ClassWithGenericThingAlternateJdbiConstructor.class)
             .one())
                     .extracting("s", "i")
@@ -575,8 +581,8 @@ public class ConstructorMapperTest {
     @ValueSource(classes = {OneFactoryMethod.class, MultipleFactoryMethodsWhereOneIsAnnotated.class})
     public void testStaticMethodFactory(Class<?> factoryMethodClass) {
         assertThat(handle
-            .registerRowMapper(ConstructorMapper.factory(ClassWithJustOneString.class, factoryMethodClass))
             .select("select s, i from bean")
+            .registerRowMapper(ConstructorMapper.factory(ClassWithJustOneString.class, factoryMethodClass))
             .mapTo(ClassWithJustOneString.class)
             .one())
             .extracting("si")
@@ -609,7 +615,6 @@ public class ConstructorMapperTest {
     @Test
     public void testTypeUseNullableParameterPresent() {
         TypeUseNullableParameterBean bean = handle
-            .registerRowMapper(ConstructorMapper.factory(TypeUseNullableParameterBean.class))
             .select("select s, i from bean")
             .mapTo(TypeUseNullableParameterBean.class)
             .one();
@@ -620,7 +625,6 @@ public class ConstructorMapperTest {
     @Test
     public void testTypeUseNullableParameterAbsent() {
         TypeUseNullableParameterBean bean = handle
-            .registerRowMapper(ConstructorMapper.factory(TypeUseNullableParameterBean.class))
             .select("select i from bean")
             .mapTo(TypeUseNullableParameterBean.class)
             .one();
@@ -630,7 +634,6 @@ public class ConstructorMapperTest {
 
     @Test
     public void testTypeUseNonNullableAbsent() {
-        handle.registerRowMapper(ConstructorMapper.factory(TypeUseNullableParameterBean.class));
         assertThatThrownBy(() -> selectOne("select s from bean", TypeUseNullableParameterBean.class))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("parameter '[i]' has no matching columns in the result set");

--- a/core/src/test/java/org/jdbi/core/mapper/reflect/FieldMapperAccessTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/reflect/FieldMapperAccessTest.java
@@ -37,7 +37,12 @@ import static org.jdbi.core.internal.testing.H2DatabaseExtension.USERS_INITIALIZ
 public class FieldMapperAccessTest {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(USERS_INITIALIZER);
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withInitializer(USERS_INITIALIZER)
+        .withConfig(b -> b
+            .registerRowMapper(getBeanClass(), FieldMapper.of(getBeanClass()))
+            .registerRowMapper(getDerivedBeanClass(), FieldMapper.of(getDerivedBeanClass()))
+            .registerRowMapper(IdBean.class, ConstructorMapper.of(IdBean.class)));
 
     Handle handle;
 
@@ -60,9 +65,6 @@ public class FieldMapperAccessTest {
         this.derivedBeanClass = getDerivedBeanClass();
 
         this.handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(beanClass, FieldMapper.of(beanClass));
-        handle.registerRowMapper(derivedBeanClass, FieldMapper.of(derivedBeanClass));
-        handle.registerRowMapper(IdBean.class, ConstructorMapper.of(IdBean.class));
     }
 
     @Test
@@ -144,9 +146,9 @@ public class FieldMapperAccessTest {
 
     @Test
     void shouldUseRegisteredMapperForUnknownPropertyType() {
-        handle.registerColumnMapper(new ValueTypeMapper()); // valueType is the "unknown property type"
-
-        try (Query query = handle.createQuery("SELECT id as longField, name as valueTypeField FROM users order by id")) {
+        // valueType is the "unknown property type"
+        try (Query query = handle.createQuery("SELECT id as longField, name as valueTypeField FROM users order by id")
+                .registerColumnMapper(new ValueTypeMapper())) {
 
             List<?> fields = query.mapTo(beanClass).list();
             assertThat(fields).hasSize(2);
@@ -177,8 +179,8 @@ public class FieldMapperAccessTest {
 
     @Test
     void shouldThrowOnMismatchedColumnsStrictMatch() {
-        handle.configure(ReflectionMappers.class, c -> c.strictMatching(true));
-        try (Query query = handle.createQuery("SELECT id as misspelledField, id as longField FROM users order by id")) {
+        try (Query query = handle.createQuery("SELECT id as misspelledField, id as longField FROM users order by id")
+                .configure(ReflectionMappers.class, c -> c.strictMatching(true))) {
             assertThatThrownBy(() -> query.mapTo(beanClass).list()).isInstanceOf(IllegalArgumentException.class);
         }
     }

--- a/core/src/test/java/org/jdbi/core/mapper/reflect/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/reflect/FieldMapperTest.java
@@ -21,6 +21,7 @@ import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.mapper.Nested;
 import org.jdbi.core.mapper.PropagateNull;
 import org.jdbi.core.mapper.RowMapper;
+import org.jdbi.core.mapper.RowMappers;
 import org.jdbi.core.mapper.reflect.ConstructorMapperTest.ClassPropagateNullThing;
 import org.jdbi.core.statement.Query;
 import org.junit.jupiter.api.Test;
@@ -66,8 +67,8 @@ public class FieldMapperTest {
         handle.execute("insert into something (id, name) values (1, 'foo')");
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(NestedThing.class))
             .select("SELECT id, name FROM something")
+            .registerRowMapper(FieldMapper.factory(NestedThing.class))
             .mapTo(NestedThing.class)
             .one())
             .extracting("nested.i", "nested.s")
@@ -76,28 +77,27 @@ public class FieldMapperTest {
 
     @Test
     public void testNestedStrict() {
-        Handle handle = h2Extension.getSharedHandle();
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+            .configure(ReflectionMappers.class, c -> c.strictMatching(true))
+            .configure(RowMappers.class, r -> r.register(FieldMapper.factory(NestedThing.class))))) {
 
-        handle.configure(ReflectionMappers.class, c -> c.strictMatching(true));
-        handle.registerRowMapper(FieldMapper.factory(NestedThing.class));
+            handle.execute("insert into something (id, name) values (1, 'foo')");
 
-        handle.execute("insert into something (id, name) values (1, 'foo')");
+            assertThat(handle
+                .select("select id, name from something")
+                .mapTo(NestedThing.class)
+                .one())
+                .extracting("nested.i", "nested.s")
+                .containsExactly(1, "foo");
 
-        assertThat(handle
-            .registerRowMapper(FieldMapper.factory(NestedThing.class))
-            .select("select id, name from something")
-            .mapTo(NestedThing.class)
-            .one())
-            .extracting("nested.i", "nested.s")
-            .containsExactly(1, "foo");
-
-        assertThatThrownBy(() -> {
-            try (Query query = handle.createQuery("select id, name, 1 as other from something")) {
-                query.mapTo(NestedThing.class).one();
-            }
-        })
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("could not match fields for columns: [other]");
+            assertThatThrownBy(() -> {
+                try (Query query = handle.createQuery("select id, name, 1 as other from something")) {
+                    query.mapTo(NestedThing.class).one();
+                }
+            })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("could not match fields for columns: [other]");
+        }
     }
 
     static class NestedThing {
@@ -111,8 +111,8 @@ public class FieldMapperTest {
         Handle handle = h2Extension.getSharedHandle();
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(NullableNestedThing.class))
             .select("SELECT 42 as testValue, 2 as i, '3' as s")
+            .registerRowMapper(FieldMapper.factory(NullableNestedThing.class))
             .mapTo(NullableNestedThing.class)
             .one())
             .extracting("testValue", "nested.i", "nested.s")
@@ -124,8 +124,8 @@ public class FieldMapperTest {
         Handle handle = h2Extension.getSharedHandle();
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(NullableNestedThing.class))
             .select("SELECT 42 as testValue, '3' as s")
+            .registerRowMapper(FieldMapper.factory(NullableNestedThing.class))
             .mapTo(NullableNestedThing.class)
             .one())
             .extracting("testValue", "nested.i", "nested.s")
@@ -137,8 +137,8 @@ public class FieldMapperTest {
         Handle handle = h2Extension.getSharedHandle();
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(NullableNestedThing.class))
             .select("SELECT 42 as testValue")
+            .registerRowMapper(FieldMapper.factory(NullableNestedThing.class))
             .mapTo(NullableNestedThing.class)
             .one())
             .extracting("testValue", "nested")
@@ -150,8 +150,8 @@ public class FieldMapperTest {
         Handle handle = h2Extension.getSharedHandle();
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(NullableNestedThing.class))
             .select("SELECT 's' s, 1 i")
+            .registerRowMapper(FieldMapper.factory(NullableNestedThing.class))
             .mapTo(NullableNestedThing.class)
             .one())
             .extracting("testValue", "nested.s", "nested.i")
@@ -161,10 +161,9 @@ public class FieldMapperTest {
     @Test
     public void testNoRecognizedColumns() {
         Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(FieldMapper.factory(NullableNestedThing.class));
 
         assertThatThrownBy(() -> {
-            try (Query query = handle.select("SELECT 'foo' bar")) {
+            try (Query query = handle.select("SELECT 'foo' bar").registerRowMapper(FieldMapper.factory(NullableNestedThing.class))) {
                 query.mapTo(NullableNestedThing.class).one();
             }
         })
@@ -197,8 +196,8 @@ public class FieldMapperTest {
         handle.execute("insert into something (id, name) values (1, 'foo')");
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(NestedPrefixThing.class))
             .select("select id nested_id, name nested_name from something")
+            .registerRowMapper(FieldMapper.factory(NestedPrefixThing.class))
             .mapTo(NestedPrefixThing.class)
             .one())
             .extracting("nested.i", "nested.s")
@@ -207,35 +206,35 @@ public class FieldMapperTest {
 
     @Test
     public void testNestedPrefixStrict() {
-        Handle handle = h2Extension.getSharedHandle();
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+            .configure(ReflectionMappers.class, c -> c.strictMatching(true))
+            .configure(RowMappers.class, r -> r.register(FieldMapper.factory(NestedPrefixThing.class))))) {
 
-        handle.configure(ReflectionMappers.class, c -> c.strictMatching(true));
-        handle.registerRowMapper(FieldMapper.factory(NestedPrefixThing.class));
+            handle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
 
-        handle.execute("insert into something (id, name, integerValue) values (1, 'foo', 5)"); // three, sir!
+            assertThat(handle
+                .createQuery("select id nested_id, name nested_name, integerValue from something")
+                .mapTo(NestedPrefixThing.class)
+                .one())
+                .extracting("nested.i", "nested.s", "integerValue")
+                .containsExactly(1, "foo", 5);
 
-        assertThat(handle
-            .createQuery("select id nested_id, name nested_name, integerValue from something")
-            .mapTo(NestedPrefixThing.class)
-            .one())
-            .extracting("nested.i", "nested.s", "integerValue")
-            .containsExactly(1, "foo", 5);
+            assertThatThrownBy(() -> {
+                try (Query query = handle.createQuery("select id nested_id, name nested_name, 1 as other from something")) {
+                    query.mapTo(NestedPrefixThing.class).one();
+                }
+            })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("could not match fields for columns: [other]");
 
-        assertThatThrownBy(() -> {
-            try (Query query = handle.createQuery("select id nested_id, name nested_name, 1 as other from something")) {
-                query.mapTo(NestedPrefixThing.class).one();
-            }
-        })
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("could not match fields for columns: [other]");
-
-        assertThatThrownBy(() -> {
-            try (Query query = handle.createQuery("select id nested_id, name nested_name, 1 as nested_other from something")) {
-                query.mapTo(NestedPrefixThing.class).one();
-            }
-        })
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("could not match fields for columns: [nested_other]");
+            assertThatThrownBy(() -> {
+                try (Query query = handle.createQuery("select id nested_id, name nested_name, 1 as nested_other from something")) {
+                    query.mapTo(NestedPrefixThing.class).one();
+                }
+            })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("could not match fields for columns: [nested_other]");
+        }
     }
 
     static class NestedPrefixThing {
@@ -251,8 +250,8 @@ public class FieldMapperTest {
         Handle handle = h2Extension.getSharedHandle();
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(PropagateNullThing.class))
             .select("SELECT null as testValue, 'foo' as s")
+            .registerRowMapper(FieldMapper.factory(PropagateNullThing.class))
             .mapTo(PropagateNullThing.class)
             .one())
             .isNull();
@@ -263,8 +262,8 @@ public class FieldMapperTest {
         Handle handle = h2Extension.getSharedHandle();
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(PropagateNullThing.class))
             .select("SELECT 42 as testValue, 'foo' as s")
+            .registerRowMapper(FieldMapper.factory(PropagateNullThing.class))
             .mapTo(PropagateNullThing.class)
             .one())
             .extracting("testValue", "s")
@@ -276,8 +275,8 @@ public class FieldMapperTest {
         Handle handle = h2Extension.getSharedHandle();
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(NestedPropagateNullThing.class))
             .select("SELECT 42 as integerValue, null as testValue, 'foo' as s")
+            .registerRowMapper(FieldMapper.factory(NestedPropagateNullThing.class))
             .mapTo(NestedPropagateNullThing.class)
             .one())
             .extracting("integerValue", "nested")
@@ -289,8 +288,8 @@ public class FieldMapperTest {
         Handle handle = h2Extension.getSharedHandle();
 
         assertThat(handle
-            .registerRowMapper(FieldMapper.factory(NestedPropagateNullThing.class))
             .select("SELECT 42 as integerValue, 60 as testValue, 'foo' as s")
+            .registerRowMapper(FieldMapper.factory(NestedPropagateNullThing.class))
             .mapTo(NestedPropagateNullThing.class)
             .one())
             .extracting("integerValue", "nested.testValue", "nested.s")

--- a/core/src/test/java/org/jdbi/core/mapper/reflect/ReflectionMappersAccessibleStrategyTest.java
+++ b/core/src/test/java/org/jdbi/core/mapper/reflect/ReflectionMappersAccessibleStrategyTest.java
@@ -57,27 +57,24 @@ public class ReflectionMappersAccessibleStrategyTest {
 
     @Test
     void testAccessDisabledConstructorBean() {
-        handle.configure(ReflectionMappers.class, ReflectionMappers::disableAccessibleObjectStrategy);
-
-        try (Query query = handle.createQuery("SELECT id as result FROM users order by id")) {
+        try (Query query = handle.createQuery("SELECT id as result FROM users order by id")
+                .configure(ReflectionMappers.class, ReflectionMappers::disableAccessibleObjectStrategy)) {
             assertThatThrownBy(() -> query.map(FieldMapper.of(PrivateConstructorBean.class)).list()).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
     @Test
     void testAccessDisabledFieldBean() {
-        handle.configure(ReflectionMappers.class, ReflectionMappers::disableAccessibleObjectStrategy);
-
-        try (Query query = handle.createQuery("SELECT id as result FROM users order by id")) {
+        try (Query query = handle.createQuery("SELECT id as result FROM users order by id")
+                .configure(ReflectionMappers.class, ReflectionMappers::disableAccessibleObjectStrategy)) {
             assertThatThrownBy(() -> query.map(FieldMapper.of(PrivateFieldBean.class)).list()).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
     @Test
     void testAccessDisabledPublicBean() {
-        handle.configure(ReflectionMappers.class, ReflectionMappers::disableAccessibleObjectStrategy);
-
-        try (Query query = handle.createQuery("SELECT id as result FROM users order by id")) {
+        try (Query query = handle.createQuery("SELECT id as result FROM users order by id")
+                .configure(ReflectionMappers.class, ReflectionMappers::disableAccessibleObjectStrategy)) {
             List<?> fields = query.map(FieldMapper.of(PublicFieldBean.class)).list();
             assertThat(fields).hasSize(2);
             assertThat(fields).extracting("result").containsExactly(1L, 2L);

--- a/core/src/test/java/org/jdbi/core/qualifier/ReversedStringArgumentFactory.java
+++ b/core/src/test/java/org/jdbi/core/qualifier/ReversedStringArgumentFactory.java
@@ -17,7 +17,7 @@ import java.sql.Types;
 
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 // tag::argumentfactory[]
 @Reversed // <1>
@@ -27,7 +27,7 @@ public class ReversedStringArgumentFactory extends AbstractArgumentFactory<Strin
     }
 
     @Override
-    protected Argument build(String value, ConfigRegistry config) {
+    protected Argument build(String value, ConfigView config) {
         return (pos, stmt, ctx) -> stmt.setString(pos, Reverser.reverse(value));
     }
 }

--- a/core/src/test/java/org/jdbi/core/qualifier/ReversedStringMapperFactory.java
+++ b/core/src/test/java/org/jdbi/core/qualifier/ReversedStringMapperFactory.java
@@ -16,14 +16,14 @@ package org.jdbi.core.qualifier;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
 
 @Reversed
 public final class ReversedStringMapperFactory implements ColumnMapperFactory {
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         if (String.class.equals(type)) {
             return Optional.of((rs, col, ctx) -> Reverser.reverse(rs.getString(col)));
         }

--- a/core/src/test/java/org/jdbi/core/qualifier/TestCustomQualifier.java
+++ b/core/src/test/java/org/jdbi/core/qualifier/TestCustomQualifier.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Locale;
 
+import org.jdbi.core.Handle;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.Arguments;
@@ -27,6 +28,7 @@ import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMappers;
+import org.jdbi.core.mapper.RowMappers;
 import org.jdbi.core.mapper.reflect.BeanMapper;
 import org.jdbi.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.core.mapper.reflect.FieldMapper;
@@ -45,313 +47,294 @@ public class TestCustomQualifier {
     @Test
     public void qualifiedTypeUsage() {
         // tag::usage[]
-        h2Extension.getJdbi()
-            .registerArgument(new ReversedStringArgumentFactory())
-            .registerColumnMapper(new ReversedStringMapper())
-            .useHandle(handle -> {
-                QualifiedType<String> reversedString =
-                    QualifiedType.of(String.class).with(Reversed.class);
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                .configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory()))
+                .configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper())))) {
+            QualifiedType<String> reversedString =
+                QualifiedType.of(String.class).with(Reversed.class);
 
-                handle.createUpdate("INSERT INTO something (id, name) VALUES (1, :name)")
-                    .bindByType("name", "abc", reversedString) // <1>
-                    .execute();
+            handle.createUpdate("INSERT INTO something (id, name) VALUES (1, :name)")
+                .bindByType("name", "abc", reversedString) // <1>
+                .execute();
 
-                // the value is stored reversed in the database
-                String raw = handle.select("SELECT name FROM something")
-                    .mapTo(String.class)
-                    .one();
-                assertThat(raw).isEqualTo("cba");
+            // the value is stored reversed in the database
+            String raw = handle.select("SELECT name FROM something")
+                .mapTo(String.class)
+                .one();
+            assertThat(raw).isEqualTo("cba");
 
-                // mapping with the qualified type reverses it back
-                String name = handle.select("SELECT name FROM something")
-                    .mapTo(reversedString) // <2>
-                    .one();
-                assertThat(name).isEqualTo("abc");
-            });
+            // mapping with the qualified type reverses it back
+            String name = handle.select("SELECT name FROM something")
+                .mapTo(reversedString) // <2>
+                .one();
+            assertThat(name).isEqualTo("abc");
+        }
         // end::usage[]
     }
 
     @Test
     public void registerArgumentFactory() {
-        h2Extension.getJdbi()
-            .registerArgument(new ReversedStringArgumentFactory())
-            .useHandle(handle -> {
-                handle.createUpdate("INSERT INTO something (id, name) VALUES (1, :name)")
-                    .bindByType("name", "abc", QualifiedType.of(String.class).with(Reversed.class))
-                    .execute();
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory())))) {
+            handle.createUpdate("INSERT INTO something (id, name) VALUES (1, :name)")
+                .bindByType("name", "abc", QualifiedType.of(String.class).with(Reversed.class))
+                .execute();
 
-                assertThat(
-                    handle.select("SELECT name FROM something")
-                        .mapTo(String.class)
-                        .one())
-                    .isEqualTo("cba");
-            });
+            assertThat(
+                handle.select("SELECT name FROM something")
+                    .mapTo(String.class)
+                    .one())
+                .isEqualTo("cba");
+        }
     }
 
     @Test
     public void configArgumentsRegister() {
-        h2Extension.getJdbi()
-            .configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory()))
-            .useHandle(handle -> {
-                handle.createUpdate("INSERT INTO something (id, name) VALUES (1, :name)")
-                    .bindByType("name", "abc", QualifiedType.of(String.class).with(Reversed.class))
-                    .execute();
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory())))) {
+            handle.createUpdate("INSERT INTO something (id, name) VALUES (1, :name)")
+                .bindByType("name", "abc", QualifiedType.of(String.class).with(Reversed.class))
+                .execute();
 
-                assertThat(
-                    handle.select("SELECT name FROM something")
-                        .mapTo(String.class)
-                        .one())
-                    .isEqualTo("cba");
-            });
+            assertThat(
+                handle.select("SELECT name FROM something")
+                    .mapTo(String.class)
+                    .one())
+                .isEqualTo("cba");
+        }
     }
 
     @Test
     public void registerColumnMapper() {
-        h2Extension.getJdbi()
-            .registerColumnMapper(new ReversedStringMapper())
-            .useHandle(handle -> {
-                handle.execute("insert into something (id, name) values (1, 'abc')");
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper())))) {
+            handle.execute("insert into something (id, name) values (1, 'abc')");
 
-                assertThat(
-                    handle.select("SELECT name FROM something")
-                        .mapTo(QualifiedType.of(String.class).with(Reversed.class))
-                        .one())
-                    .isEqualTo("cba");
-            });
+            assertThat(
+                handle.select("SELECT name FROM something")
+                    .mapTo(QualifiedType.of(String.class).with(Reversed.class))
+                    .one())
+                .isEqualTo("cba");
+        }
     }
 
     @Test
     public void configColumnMappersRegister() {
-        h2Extension.getJdbi()
-            .configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper()))
-            .useHandle(handle -> {
-                handle.execute("insert into something (id, name) values (1, 'abc')");
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper())))) {
+            handle.execute("insert into something (id, name) values (1, 'abc')");
 
-                assertThat(
-                    handle.select("SELECT name FROM something")
-                        .mapTo(QualifiedType.of(String.class).with(Reversed.class))
-                        .one())
-                    .isEqualTo("cba");
-            });
+            assertThat(
+                handle.select("SELECT name FROM something")
+                    .mapTo(QualifiedType.of(String.class).with(Reversed.class))
+                    .one())
+                .isEqualTo("cba");
+        }
     }
 
     @Test
     public void registerColumnMapperByQualifiedType() {
-        h2Extension.getJdbi()
-            .registerColumnMapper(
-                QualifiedType.of(String.class).with(Reversed.class),
-                (r, c, ctx) -> reverse(r.getString(c)))
-            .useHandle(handle -> {
-                handle.execute("insert into something (id, name) values (1, 'abcdef')");
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(ColumnMappers.class, config -> config.register(
+                    QualifiedType.of(String.class).with(Reversed.class),
+                    (r, c, ctx) -> reverse(r.getString(c)))))) {
+            handle.execute("insert into something (id, name) values (1, 'abcdef')");
 
-                assertThat(
-                    handle.select("SELECT name FROM something")
-                        .mapTo(QualifiedType.of(String.class).with(Reversed.class))
-                        .one())
-                    .isEqualTo("fedcba");
-            });
+            assertThat(
+                handle.select("SELECT name FROM something")
+                    .mapTo(QualifiedType.of(String.class).with(Reversed.class))
+                    .one())
+                .isEqualTo("fedcba");
+        }
     }
 
     @Test
     public void configColumnMappersRegisterByQualifiedType() {
-        h2Extension.getJdbi()
-            .configure(ColumnMappers.class, config -> config.register(
-                QualifiedType.of(String.class).with(Reversed.class),
-                (r, c, ctx) -> reverse(r.getString(c))))
-            .useHandle(handle -> {
-                handle.execute("insert into something (id, name) values (1, 'abcdef')");
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(ColumnMappers.class, config -> config.register(
+                    QualifiedType.of(String.class).with(Reversed.class),
+                    (r, c, ctx) -> reverse(r.getString(c)))))) {
+            handle.execute("insert into something (id, name) values (1, 'abcdef')");
 
-                assertThat(
-                    handle.select("SELECT name FROM something")
-                        .mapTo(QualifiedType.of(String.class).with(Reversed.class))
-                        .one())
-                    .isEqualTo("fedcba");
-            });
+            assertThat(
+                handle.select("SELECT name FROM something")
+                    .mapTo(QualifiedType.of(String.class).with(Reversed.class))
+                    .one())
+                .isEqualTo("fedcba");
+        }
     }
 
     @Test
     public void registerColumnMapperFactory() {
-        h2Extension.getJdbi()
-            .registerColumnMapper(new ReversedStringMapperFactory())
-            .useHandle(handle -> {
-                handle.execute("insert into something (id, name) values (1, 'xyz')");
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(ColumnMappers.class, config -> config.register(new ReversedStringMapperFactory())))) {
+            handle.execute("insert into something (id, name) values (1, 'xyz')");
 
-                assertThat(
-                    handle.select("SELECT name FROM something")
-                        .mapTo(QualifiedType.of(String.class).with(Reversed.class))
-                        .one())
-                    .isEqualTo("zyx");
-            });
+            assertThat(
+                handle.select("SELECT name FROM something")
+                    .mapTo(QualifiedType.of(String.class).with(Reversed.class))
+                    .one())
+                .isEqualTo("zyx");
+        }
     }
 
     @Test
     public void configColumnMappersRegisterFactory() {
-        h2Extension.getJdbi()
-            .configure(ColumnMappers.class, config -> config.register(new ReversedStringMapperFactory()))
-            .useHandle(handle -> {
-                handle.execute("insert into something (id, name) values (1, 'xyz')");
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(ColumnMappers.class, config -> config.register(new ReversedStringMapperFactory())))) {
+            handle.execute("insert into something (id, name) values (1, 'xyz')");
 
-                assertThat(
-                    handle.select("SELECT name FROM something")
-                        .mapTo(QualifiedType.of(String.class).with(Reversed.class))
-                        .one())
-                    .isEqualTo("zyx");
-            });
+            assertThat(
+                handle.select("SELECT name FROM something")
+                    .mapTo(QualifiedType.of(String.class).with(Reversed.class))
+                    .one())
+                .isEqualTo("zyx");
+        }
     }
 
     @Test
     public void bindBeanQualifiedGetter() {
-        h2Extension.getJdbi()
-            .registerArgument(new ReversedStringArgumentFactory())
-            .useHandle(handle -> {
-                handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
-                    .bindBean(new QualifiedGetterThing(1, "abc"))
-                    .execute();
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory())))) {
+            handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
+                .bindBean(new QualifiedGetterThing(1, "abc"))
+                .execute();
 
-                assertThat(handle.select("SELECT name FROM something")
-                    .mapTo(String.class)
-                    .one())
-                    .isEqualTo("cba");
-            });
+            assertThat(handle.select("SELECT name FROM something")
+                .mapTo(String.class)
+                .one())
+                .isEqualTo("cba");
+        }
     }
 
     @Test
     public void mapBeanQualifiedGetter() {
-        h2Extension.getJdbi()
-            .registerColumnMapper(new ReversedStringMapper())
-            .registerRowMapper(BeanMapper.factory(QualifiedGetterThing.class))
-            .useHandle(handle -> {
-                handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                .configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper()))
+                .configure(RowMappers.class, config -> config.register(BeanMapper.factory(QualifiedGetterThing.class))))) {
+            handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
 
-                assertThat(handle.select("SELECT * FROM something")
-                    .mapTo(QualifiedGetterThing.class)
-                    .one())
-                    .isEqualTo(new QualifiedGetterThing(1, "cba"));
-            });
+            assertThat(handle.select("SELECT * FROM something")
+                .mapTo(QualifiedGetterThing.class)
+                .one())
+                .isEqualTo(new QualifiedGetterThing(1, "cba"));
+        }
     }
 
     @Test
     public void bindBeanQualifiedSetter() {
-        h2Extension.getJdbi()
-            .registerArgument(new ReversedStringArgumentFactory())
-            .useHandle(handle -> {
-                handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
-                    .bindBean(new QualifiedSetterThing(1, "abc"))
-                    .execute();
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory())))) {
+            handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
+                .bindBean(new QualifiedSetterThing(1, "abc"))
+                .execute();
 
-                assertThat(handle.select("SELECT name FROM something")
-                    .mapTo(String.class)
-                    .one())
-                    .isEqualTo("cba");
-            });
+            assertThat(handle.select("SELECT name FROM something")
+                .mapTo(String.class)
+                .one())
+                .isEqualTo("cba");
+        }
     }
 
     @Test
     public void mapBeanQualifiedSetter() {
-        h2Extension.getJdbi()
-            .registerColumnMapper(new ReversedStringMapper())
-            .registerRowMapper(BeanMapper.factory(QualifiedSetterThing.class))
-            .useHandle(handle -> {
-                handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                .configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper()))
+                .configure(RowMappers.class, config -> config.register(BeanMapper.factory(QualifiedSetterThing.class))))) {
+            handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
 
-                assertThat(handle.select("SELECT * FROM something")
-                    .mapTo(QualifiedSetterThing.class)
-                    .one())
-                    .isEqualTo(new QualifiedSetterThing(1, "cba"));
-            });
+            assertThat(handle.select("SELECT * FROM something")
+                .mapTo(QualifiedSetterThing.class)
+                .one())
+                .isEqualTo(new QualifiedSetterThing(1, "cba"));
+        }
     }
 
     @Test
     public void bindBeanQualifiedSetterParam() {
-        h2Extension.getJdbi()
-            .registerArgument(new ReversedStringArgumentFactory())
-            .useHandle(handle -> {
-                handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
-                    .bindBean(new QualifiedSetterParamThing(1, "abc"))
-                    .execute();
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory())))) {
+            handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
+                .bindBean(new QualifiedSetterParamThing(1, "abc"))
+                .execute();
 
-                assertThat(handle.select("SELECT name FROM something")
-                    .mapTo(String.class)
-                    .one())
-                    .isEqualTo("cba");
-            });
+            assertThat(handle.select("SELECT name FROM something")
+                .mapTo(String.class)
+                .one())
+                .isEqualTo("cba");
+        }
     }
 
     @Test
     public void mapBeanQualifiedSetterParam() {
-        h2Extension.getJdbi()
-            .registerColumnMapper(new ReversedStringMapper())
-            .registerRowMapper(BeanMapper.factory(QualifiedSetterParamThing.class))
-            .useHandle(handle -> {
-                handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                .configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper()))
+                .configure(RowMappers.class, config -> config.register(BeanMapper.factory(QualifiedSetterParamThing.class))))) {
+            handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
 
-                assertThat(handle.select("SELECT * FROM something")
-                    .mapTo(QualifiedSetterParamThing.class)
-                    .one())
-                    .isEqualTo(new QualifiedSetterParamThing(1, "cba"));
-            });
+            assertThat(handle.select("SELECT * FROM something")
+                .mapTo(QualifiedSetterParamThing.class)
+                .one())
+                .isEqualTo(new QualifiedSetterParamThing(1, "cba"));
+        }
     }
 
     @Test
     public void bindMethodsQualifiedMethod() {
-        h2Extension.getJdbi()
-            .registerArgument(new ReversedStringArgumentFactory())
-            .useHandle(handle -> {
-                handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
-                    .bindMethods(new QualifiedMethodThing(1, "abc"))
-                    .execute();
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory())))) {
+            handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
+                .bindMethods(new QualifiedMethodThing(1, "abc"))
+                .execute();
 
-                assertThat(handle.select("SELECT name FROM something")
-                    .mapTo(String.class)
-                    .one())
-                    .isEqualTo("cba");
-            });
+            assertThat(handle.select("SELECT name FROM something")
+                .mapTo(String.class)
+                .one())
+                .isEqualTo("cba");
+        }
     }
 
     @Test
     public void mapConstructorQualifiedParam() {
-        h2Extension.getJdbi()
-            .registerColumnMapper(new ReversedStringMapper())
-            .registerRowMapper(ConstructorMapper.factory(QualifiedConstructorParamThing.class))
-            .useHandle(handle -> {
-                handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                .configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper()))
+                .configure(RowMappers.class, config -> config.register(ConstructorMapper.factory(QualifiedConstructorParamThing.class))))) {
+            handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
 
-                assertThat(handle.select("SELECT * FROM something")
-                    .mapTo(QualifiedConstructorParamThing.class)
-                    .one())
-                    .isEqualTo(new QualifiedConstructorParamThing(1, "cba"));
-            });
+            assertThat(handle.select("SELECT * FROM something")
+                .mapTo(QualifiedConstructorParamThing.class)
+                .one())
+                .isEqualTo(new QualifiedConstructorParamThing(1, "cba"));
+        }
     }
 
     @Test
     public void bindFieldsQualified() {
-        h2Extension.getJdbi()
-            .registerArgument(new ReversedStringArgumentFactory())
-            .useHandle(handle -> {
-                handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
-                    .bindFields(new QualifiedFieldThing(1, "abc"))
-                    .execute();
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory())))) {
+            handle.createUpdate("INSERT INTO something (id, name) VALUES (:id, :name)")
+                .bindFields(new QualifiedFieldThing(1, "abc"))
+                .execute();
 
-                assertThat(handle.select("SELECT name FROM something")
-                    .mapTo(String.class)
-                    .one())
-                    .isEqualTo("cba");
-            });
+            assertThat(handle.select("SELECT name FROM something")
+                .mapTo(String.class)
+                .one())
+                .isEqualTo("cba");
+        }
     }
 
     @Test
     public void mapFieldsQualified() {
-        h2Extension.getJdbi()
-            .registerColumnMapper(new ReversedStringMapper())
-            .registerRowMapper(FieldMapper.factory(QualifiedFieldThing.class))
-            .useHandle(handle -> {
-                handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                .configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper()))
+                .configure(RowMappers.class, config -> config.register(FieldMapper.factory(QualifiedFieldThing.class))))) {
+            handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
 
-                assertThat(handle.select("SELECT * FROM something")
-                    .mapTo(QualifiedFieldThing.class)
-                    .one())
-                    .isEqualTo(new QualifiedFieldThing(1, "cba"));
-            });
+            assertThat(handle.select("SELECT * FROM something")
+                .mapTo(QualifiedFieldThing.class)
+                .one())
+                .isEqualTo(new QualifiedFieldThing(1, "cba"));
+        }
     }
 
     @Retention(RetentionPolicy.RUNTIME)
@@ -406,37 +389,35 @@ public class TestCustomQualifier {
 
     @Test
     public void bindMultipleQualifiers() {
-        h2Extension.getJdbi()
-            // should use this one - register first so it's consulted last
-            .registerArgument(new ReversedUpperCaseStringArgumentFactory())
-            .registerArgument(new ReversedStringArgumentFactory())
-            .registerArgument(new UpperCaseArgumentFactory())
-            .useHandle(handle -> {
-                handle.createUpdate("INSERT INTO something (id, name) VALUES (1, :name)")
-                    .bindByType("name", "abc", QualifiedType.of(String.class).with(Reversed.class, UpperCase.class))
-                    .execute();
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                // should use this one - register first so it's consulted last
+                .configure(Arguments.class, config -> config.register(new ReversedUpperCaseStringArgumentFactory()))
+                .configure(Arguments.class, config -> config.register(new ReversedStringArgumentFactory()))
+                .configure(Arguments.class, config -> config.register(new UpperCaseArgumentFactory())))) {
+            handle.createUpdate("INSERT INTO something (id, name) VALUES (1, :name)")
+                .bindByType("name", "abc", QualifiedType.of(String.class).with(Reversed.class, UpperCase.class))
+                .execute();
 
-                assertThat(handle.select("SELECT name FROM something")
-                    .mapTo(String.class)
-                    .one())
-                    .isEqualTo("CBA");
-            });
+            assertThat(handle.select("SELECT name FROM something")
+                .mapTo(String.class)
+                .one())
+                .isEqualTo("CBA");
+        }
     }
 
     @Test
     public void mapMultipleQualifiers() {
-        h2Extension.getJdbi()
-            // should use this one - register first so it's consulted last
-            .registerColumnMapper(new ReversedUpperCaseStringMapper())
-            .registerColumnMapper(new ReversedStringMapper())
-            .registerColumnMapper(new UpperCaseStringMapper())
-            .useHandle(handle -> {
-                handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg
+                // should use this one - register first so it's consulted last
+                .configure(ColumnMappers.class, config -> config.register(new ReversedUpperCaseStringMapper()))
+                .configure(ColumnMappers.class, config -> config.register(new ReversedStringMapper()))
+                .configure(ColumnMappers.class, config -> config.register(new UpperCaseStringMapper())))) {
+            handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
 
-                assertThat(handle.select("SELECT name FROM something")
-                    .mapTo(QualifiedType.of(String.class).with(Reversed.class, UpperCase.class))
-                    .one())
-                    .isEqualTo("CBA");
-            });
+            assertThat(handle.select("SELECT name FROM something")
+                .mapTo(QualifiedType.of(String.class).with(Reversed.class, UpperCase.class))
+                .one())
+                .isEqualTo("CBA");
+        }
     }
 }

--- a/core/src/test/java/org/jdbi/core/qualifier/TestCustomQualifier.java
+++ b/core/src/test/java/org/jdbi/core/qualifier/TestCustomQualifier.java
@@ -24,7 +24,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.Arguments;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMappers;
@@ -349,7 +349,7 @@ public class TestCustomQualifier {
         }
 
         @Override
-        protected Argument build(String value, ConfigRegistry config) {
+        protected Argument build(String value, ConfigView config) {
             return (pos, stmt, ctx) -> stmt.setString(pos, value.toUpperCase(Locale.ROOT));
         }
     }
@@ -372,7 +372,7 @@ public class TestCustomQualifier {
         }
 
         @Override
-        protected Argument build(String value, ConfigRegistry config) {
+        protected Argument build(String value, ConfigView config) {
             return (pos, stmt, ctx) -> stmt.setString(pos, reverse(value).toUpperCase(Locale.ROOT));
         }
     }

--- a/core/src/test/java/org/jdbi/core/result/TestReducing.java
+++ b/core/src/test/java/org/jdbi/core/result/TestReducing.java
@@ -35,7 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestReducing {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
 
     @BeforeEach
     public void setUp() {
@@ -46,7 +47,6 @@ public class TestReducing {
         h.execute("INSERT INTO something_location (id, location) VALUES (1, 'outside')");
         h.execute("INSERT INTO something_location (id, location) VALUES (2, 'tree')");
         h.execute("INSERT INTO something_location (id, location) VALUES (2, 'pie')");
-        h.registerRowMapper(new SomethingMapper());
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/statement/LeakTest.java
+++ b/core/src/test/java/org/jdbi/core/statement/LeakTest.java
@@ -111,8 +111,7 @@ public class LeakTest {
     @Test
     void testUnmanagedHandleExplodingStatemenCleanupBySetting() {
         assertThatExceptionOfType(UnableToExecuteStatementException.class).isThrownBy(() -> {
-            try (Handle handle = h2Extension.openHandle()) {
-                handle.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true));
+            try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true)))) {
                 handle.createQuery("SELECT name from users")
                         .setFetchSize(-1)
                         .mapTo(String.class)
@@ -123,8 +122,7 @@ public class LeakTest {
 
     @Test
     void testStatementStreamCleanupBySetting() {
-        try (Handle h = h2Extension.openHandle()) {
-            h.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true));
+        try (Handle h = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true)))) {
             Optional<String> userName = h.createQuery("SELECT name from users")
                     .mapTo(String.class)
                     .stream().findFirst();
@@ -135,8 +133,7 @@ public class LeakTest {
     @Test
     void testStatementStreamCleanupByHandleSetting() {
 
-        try (Handle h = h2Extension.openHandle()) {
-            h.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true));
+        try (Handle h = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true)))) {
             Optional<String> userName = h.createQuery("SELECT name from users")
                     .mapTo(String.class)
                     .stream().findFirst();

--- a/core/src/test/java/org/jdbi/core/statement/LeakTest.java
+++ b/core/src/test/java/org/jdbi/core/statement/LeakTest.java
@@ -110,10 +110,9 @@ public class LeakTest {
 
     @Test
     void testUnmanagedHandleExplodingStatemenCleanupBySetting() {
-        h2Extension.getJdbi().configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true));
-
         assertThatExceptionOfType(UnableToExecuteStatementException.class).isThrownBy(() -> {
             try (Handle handle = h2Extension.openHandle()) {
+                handle.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true));
                 handle.createQuery("SELECT name from users")
                         .setFetchSize(-1)
                         .mapTo(String.class)
@@ -124,9 +123,8 @@ public class LeakTest {
 
     @Test
     void testStatementStreamCleanupBySetting() {
-        h2Extension.getJdbi().configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true));
-
         try (Handle h = h2Extension.openHandle()) {
+            h.configure(SqlStatements.class, c -> c.attachAllStatementsForCleanup(true));
             Optional<String> userName = h.createQuery("SELECT name from users")
                     .mapTo(String.class)
                     .stream().findFirst();

--- a/core/src/test/java/org/jdbi/core/statement/StatementContextAccess.java
+++ b/core/src/test/java/org/jdbi/core/statement/StatementContextAccess.java
@@ -36,6 +36,6 @@ public final class StatementContextAccess {
      * with the given handle.
      */
     public static StatementContext createContext(final Handle handle) {
-        return StatementContext.create(handle.getConfig(), null, StatementContextAccess.class);
+        return StatementContext.create(handle.getConfig().createChild(), null, StatementContextAccess.class);
     }
 }

--- a/core/src/test/java/org/jdbi/core/statement/TestBatchExceptionRewrite.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestBatchExceptionRewrite.java
@@ -31,14 +31,14 @@ public class TestBatchExceptionRewrite {
     public static EmbeddedPgExtension pg = MultiDatabaseBuilder.instanceWithDefaults().build();
 
     @RegisterExtension
-    public PgDatabaseExtension pgExtension = PgDatabaseExtension.instance(pg);
+    public PgDatabaseExtension pgExtension = PgDatabaseExtension.instance(pg)
+        // silence chatty exception log
+        .withConfig(SqlStatements.class, c -> c.sqlLogger(SqlLogger.NOP_SQL_LOGGER));
 
     @BeforeEach
     public void createTable() {
         pgExtension.getJdbi()
             .useHandle(h -> h.execute("create table something (id int primary key, name varchar(50), integerValue integer, intValue integer)"));
-        // silence chatty exception log
-        pgExtension.getJdbi().configure(SqlStatements.class, c -> c.sqlLogger(SqlLogger.NOP_SQL_LOGGER));
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/statement/TestBindBeanList.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestBindBeanList.java
@@ -31,14 +31,14 @@ import static org.assertj.core.api.Assertions.tuple;
 public class TestBindBeanList {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withConfig(b -> b.registerRowMapper(FieldMapper.factory(Thing.class)));
 
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
         handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(FieldMapper.factory(Thing.class));
         handle.execute("create table thing (id identity primary key, foo varchar(50), bar varchar(50), baz varchar(50))");
         handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 1, "foo1", "bar1", "baz1");
         handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 2, "foo2", "bar2", "baz2");

--- a/core/src/test/java/org/jdbi/core/statement/TestBindList.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestBindList.java
@@ -31,14 +31,14 @@ import static org.jdbi.core.statement.EmptyHandling.NULL_KEYWORD;
 public class TestBindList {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withConfig(b -> b.registerRowMapper(FieldMapper.factory(Thing.class)));
 
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
         handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(FieldMapper.factory(Thing.class));
         handle.execute("create table thing (id identity primary key, foo varchar(50), bar varchar(50), baz varchar(50))");
         handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 1, "foo1", "bar1", "baz1");
         handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 2, "foo2", "bar2", "baz2");
@@ -84,16 +84,16 @@ public class TestBindList {
 
     @Test
     public void testBindListWithHashPrefixParser() {
-        handle
-                .registerRowMapper(FieldMapper.factory(Thing.class))
-                .setSqlParser(new HashPrefixSqlParser());
+        final HashPrefixSqlParser hashParser = new HashPrefixSqlParser();
 
         handle.createUpdate("insert into thing (<columns>) values (<values>)")
+                .configure(SqlStatements.class, c -> c.sqlParser(hashParser))
                 .defineList("columns", "id", "foo")
                 .bindList("values", 3, "abc")
                 .execute();
 
         List<Thing> list = handle.createQuery("select id, foo from thing where id in (<ids>)")
+                .configure(SqlStatements.class, c -> c.sqlParser(hashParser))
                 .bindList("ids", 1, 3)
                 .mapTo(Thing.class)
                 .list();

--- a/core/src/test/java/org/jdbi/core/statement/TestDefineList.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestDefineList.java
@@ -29,7 +29,8 @@ import static org.assertj.core.api.Assertions.tuple;
 public class TestDefineList {
 
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withConfig(b -> b.registerRowMapper(FieldMapper.factory(Thing.class)));
 
     private Handle handle;
 
@@ -41,7 +42,6 @@ public class TestDefineList {
         handle.execute("create table thing (id identity primary key, foo varchar(50), bar varchar(50), baz varchar(50))");
         handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 1, "foo1", "bar1", "baz1");
         handle.execute("insert into thing (id, foo, bar, baz) values (?, ?, ?, ?)", 2, "foo2", "bar2", "baz2");
-        handle.registerRowMapper(FieldMapper.factory(Thing.class));
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/statement/TestPreparedBatch.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestPreparedBatch.java
@@ -231,7 +231,6 @@ public class TestPreparedBatch {
     public void testMultipleExecuteBindFields() {
         Handle h = h2Extension.getSharedHandle();
 
-        h.registerRowMapper(ConstructorMapper.factory(PublicSomething.class));
         final PreparedBatch b = h.prepareBatch("insert into something (id, name) values (:id, :name)");
 
         b.bindFields(new PublicSomething(1, "Eric")).add();
@@ -243,7 +242,9 @@ public class TestPreparedBatch {
         b.bindFields(new PublicSomething(3, "Keith")).add();
         b.execute();
 
-        final List<PublicSomething> r = h.createQuery("select * from something order by id").mapTo(PublicSomething.class).list();
+        final List<PublicSomething> r = h.createQuery("select * from something order by id")
+            .registerRowMapper(ConstructorMapper.factory(PublicSomething.class))
+            .mapTo(PublicSomething.class).list();
         assertThat(r).extracting(s -> s.id, s -> s.name).containsExactly(tuple(1, "Eric"), tuple(2, "Brian"), tuple(3, "Keith"));
     }
 
@@ -251,16 +252,17 @@ public class TestPreparedBatch {
     public void testNestedNotPrepareable() {
         Handle h = h2Extension.getSharedHandle();
 
-        h.registerArgument(new WrappedIntArgumentFactory());
-        h.registerRowMapper(ConstructorMapper.factory(WrappedIntPublicSomething.class));
-        h.registerColumnMapper(new WrappedIntColumnMapperFactory());
-        final PreparedBatch b = h.prepareBatch("insert into something (id, name) values (:id, :name)");
+        final PreparedBatch b = h.prepareBatch("insert into something (id, name) values (:id, :name)")
+            .registerArgument(new WrappedIntArgumentFactory());
 
         b.bindFields(new WrappedIntPublicSomething(new WrappedInt(2), "Sally")).add();
         b.bindFields(new WrappedIntPublicSomething(new WrappedInt(3), "Erica")).add();
         b.execute();
 
-        final List<WrappedIntPublicSomething> r = h.createQuery("select * from something order by id").mapTo(WrappedIntPublicSomething.class).list();
+        final List<WrappedIntPublicSomething> r = h.createQuery("select * from something order by id")
+            .registerRowMapper(ConstructorMapper.factory(WrappedIntPublicSomething.class))
+            .registerColumnMapper(new WrappedIntColumnMapperFactory())
+            .mapTo(WrappedIntPublicSomething.class).list();
         assertThat(r).extracting(s -> s.id, s -> s.name).containsExactly(tuple(new WrappedInt(2), "Sally"), tuple(new WrappedInt(3), "Erica"));
     }
 

--- a/core/src/test/java/org/jdbi/core/statement/TestPreparedBatch.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestPreparedBatch.java
@@ -27,7 +27,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.core.Something;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.reflect.ConstructorMapper;
@@ -329,7 +329,7 @@ public class TestPreparedBatch {
 
     public static class WrappedIntArgumentFactory implements ArgumentFactory {
         @Override
-        public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type type, Object value, ConfigView config) {
             return type == WrappedInt.class
                     ? Optional.of((p, s, c) -> s.setInt(p, ((WrappedInt) value).i))
                     : Optional.empty();

--- a/core/src/test/java/org/jdbi/core/statement/TestQueriesPG.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestQueriesPG.java
@@ -37,15 +37,18 @@ public class TestQueriesPG {
     @Test
     @DisplayName("HashPrefixSqlParser works with colon-based casting in postgresql (#1389)")
     public void testCastingWithHashParser() {
-        final Handle h = pgExtension.getSharedHandle()
-            .setSqlParser(new HashPrefixSqlParser());
+        final Handle h = pgExtension.getSharedHandle();
+        final HashPrefixSqlParser hashParser = new HashPrefixSqlParser();
 
         UUID uuid1 = UUID.randomUUID();
         UUID uuid2 = UUID.randomUUID();
-        h.createUpdate("insert into something (id, uuid) values (1, #uuid)").bind("uuid", uuid1).execute();
-        h.createUpdate("insert into something (id, uuid) values (2, #uuid)").bind("uuid", uuid2).execute();
+        h.createUpdate("insert into something (id, uuid) values (1, #uuid)")
+            .configure(SqlStatements.class, c -> c.sqlParser(hashParser)).bind("uuid", uuid1).execute();
+        h.createUpdate("insert into something (id, uuid) values (2, #uuid)")
+            .configure(SqlStatements.class, c -> c.sqlParser(hashParser)).bind("uuid", uuid2).execute();
 
         final int result = h.createQuery("select id from something WHERE uuid = #value::UUID")
+            .configure(SqlStatements.class, c -> c.sqlParser(hashParser))
             .bind("value", uuid2.toString())
             .mapTo(Integer.class)
             .one();

--- a/core/src/test/java/org/jdbi/core/statement/TestScript.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestScript.java
@@ -128,11 +128,10 @@ public class TestScript {
 
     @Test
     public void testMySQLScript() {
-        Handle h = h2Extension.getSharedHandle();
-        h.configure(SqlStatements.class, c -> c.scriptStatementsNeedSemicolon(false));
         String sql = getClasspathSqlLocator().getResource("script/oracle-issue-2021.sql");
 
-        try (Script script = new Script(h, sql)) {
+        try (Handle h = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.scriptStatementsNeedSemicolon(false)));
+                Script script = new Script(h, sql)) {
             List<String> statements = script.getStatements();
 
             assertThat(statements).hasSize(3);

--- a/core/src/test/java/org/jdbi/core/statement/TestSlf4JSqlLogger.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestSlf4JSqlLogger.java
@@ -47,13 +47,12 @@ class TestSlf4JSqlLogger {
                 System.setProperty(LOGGER_PROPERTY, oldLevel);
             }
         }
-
-        h2Extension.getJdbi().configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger)));
     }
 
     @Test
     void testLogAfterExecutionForBatch() {
         try (Handle handle = h2Extension.openHandle()) {
+            handle.configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger)));
             handle.execute(CREATE);
 
             try (Batch batch = handle.createBatch()) {
@@ -65,8 +64,8 @@ class TestSlf4JSqlLogger {
 
     @Test
     void testLogWithInfoLevelAfterExecutionForBatch() {
-        h2Extension.getJdbi().configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger, Level.INFO)));
         try (Handle handle = h2Extension.openHandle()) {
+            handle.configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger, Level.INFO)));
             handle.execute(CREATE);
 
             try (Batch batch = handle.createBatch()) {
@@ -78,12 +77,14 @@ class TestSlf4JSqlLogger {
 
     @Test
     void testLogExceptionForBatch() {
-        try (Handle handle = h2Extension.openHandle();
-            Batch batch = handle.createBatch()) {
-            batch.add(INSERT);
+        try (Handle handle = h2Extension.openHandle()) {
+            handle.configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger)));
+            try (Batch batch = handle.createBatch()) {
+                batch.add(INSERT);
 
-            assertThatThrownBy(batch::execute)
-                    .isInstanceOf(UnableToExecuteStatementException.class);
+                assertThatThrownBy(batch::execute)
+                        .isInstanceOf(UnableToExecuteStatementException.class);
+            }
         }
     }
 }

--- a/core/src/test/java/org/jdbi/core/statement/TestSlf4JSqlLogger.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestSlf4JSqlLogger.java
@@ -51,8 +51,7 @@ class TestSlf4JSqlLogger {
 
     @Test
     void testLogAfterExecutionForBatch() {
-        try (Handle handle = h2Extension.openHandle()) {
-            handle.configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger)));
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger))))) {
             handle.execute(CREATE);
 
             try (Batch batch = handle.createBatch()) {
@@ -64,8 +63,7 @@ class TestSlf4JSqlLogger {
 
     @Test
     void testLogWithInfoLevelAfterExecutionForBatch() {
-        try (Handle handle = h2Extension.openHandle()) {
-            handle.configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger, Level.INFO)));
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger, Level.INFO))))) {
             handle.execute(CREATE);
 
             try (Batch batch = handle.createBatch()) {
@@ -77,8 +75,7 @@ class TestSlf4JSqlLogger {
 
     @Test
     void testLogExceptionForBatch() {
-        try (Handle handle = h2Extension.openHandle()) {
-            handle.configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger)));
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.sqlLogger(new Slf4JSqlLogger(logger))))) {
             try (Batch batch = handle.createBatch()) {
                 batch.add(INSERT);
 

--- a/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerAttributesAndBinding.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerAttributesAndBinding.java
@@ -43,8 +43,7 @@ public class TestSqlLoggerAttributesAndBinding {
     @BeforeEach
     public void before() {
         logger = new TalkativeSqlLogger();
-        h = h2Extension.openHandle();
-        h.configure(SqlStatements.class, c -> c.sqlLogger(logger));
+        h = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.sqlLogger(logger)));
     }
 
     @AfterEach
@@ -76,9 +75,8 @@ public class TestSqlLoggerAttributesAndBinding {
 
     @Test
     public void testPreparedBatch() {
-        h.configure(SqlStatements.class, c -> c.sqlLogger(SqlLogger.NOP_SQL_LOGGER));
-        h.createUpdate(CREATE).define("x", "foo").execute();
-        h.configure(SqlStatements.class, c -> c.sqlLogger(logger));
+        // silence logging for the table-creation statement only (per-statement config); the handle keeps `logger`.
+        h.createUpdate(CREATE).configure(SqlStatements.class, c -> c.sqlLogger(SqlLogger.NOP_SQL_LOGGER)).define("x", "foo").execute();
 
         int id = 0;
 

--- a/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerAttributesAndBinding.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerAttributesAndBinding.java
@@ -43,8 +43,8 @@ public class TestSqlLoggerAttributesAndBinding {
     @BeforeEach
     public void before() {
         logger = new TalkativeSqlLogger();
-        h2Extension.getJdbi().configure(SqlStatements.class, c -> c.sqlLogger(logger));
         h = h2Extension.openHandle();
+        h.configure(SqlStatements.class, c -> c.sqlLogger(logger));
     }
 
     @AfterEach

--- a/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerCallPoints.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerCallPoints.java
@@ -47,8 +47,7 @@ public class TestSqlLoggerCallPoints {
     @BeforeEach
     public void before() {
         logger = new TalkativeSqlLogger();
-        h = h2Extension.openHandle();
-        h.configure(SqlStatements.class, c -> c.sqlLogger(logger));
+        h = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.sqlLogger(logger)));
     }
 
     @AfterEach

--- a/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerCallPoints.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerCallPoints.java
@@ -47,8 +47,8 @@ public class TestSqlLoggerCallPoints {
     @BeforeEach
     public void before() {
         logger = new TalkativeSqlLogger();
-        h2Extension.getJdbi().configure(SqlStatements.class, c -> c.sqlLogger(logger));
         h = h2Extension.openHandle();
+        h.configure(SqlStatements.class, c -> c.sqlLogger(logger));
     }
 
     @AfterEach

--- a/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerToString.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerToString.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import org.jdbi.core.Handle;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.testing.SqliteDatabaseExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -167,7 +167,7 @@ public class TestSqlLoggerToString {
     private static class FooArgumentFactory implements ArgumentFactory {
 
         @Override
-        public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type type, Object value, ConfigView config) {
             if (value instanceof Foo) {
                 return Optional.of((position, statement, ctx) -> statement.setObject(1, value));
             } else {
@@ -179,7 +179,7 @@ public class TestSqlLoggerToString {
     private static class ToStringFooArgumentFactory implements ArgumentFactory {
 
         @Override
-        public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type type, Object value, ConfigView config) {
             if (value instanceof Foo) {
                 return Optional.of(new Argument() {
                     @Override

--- a/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerToString.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestSqlLoggerToString.java
@@ -46,17 +46,15 @@ public class TestSqlLoggerToString {
 
     @BeforeEach
     public void before() {
-        handle = sqliteExtension.openHandle();
-
-        handle.execute("create table foo(bar binary)");
-
-        handle.setSqlLogger(new SqlLogger() {
+        handle = sqliteExtension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.sqlLogger(new SqlLogger() {
             @Override
             public void logBeforeExecution(StatementContext context) {
                 context.getBinding().findForPosition(0).ifPresent(value -> positional = Objects.toString(value));
                 context.getBinding().findForName(NAME, context).ifPresent(value -> named = Objects.toString(value));
             }
-        });
+        })));
+
+        handle.execute("create table foo(bar binary)");
     }
 
     @AfterEach
@@ -117,36 +115,28 @@ public class TestSqlLoggerToString {
 
     @Test
     public void testNeitherHasToString() {
-        handle.registerArgument(new FooArgumentFactory());
-
-        handle.createUpdate(INSERT_POSITIONAL).bind(0, new Foo()).execute();
+        handle.createUpdate(INSERT_POSITIONAL).registerArgument(new FooArgumentFactory()).bind(0, new Foo()).execute();
 
         assertThat(positional).containsPattern("@[0-9a-f]{1,8}$");
     }
 
     @Test
     public void testObjectHasToString() {
-        handle.registerArgument(new FooArgumentFactory());
-
-        handle.createUpdate(INSERT_POSITIONAL).bind(0, new ToStringFoo()).execute();
+        handle.createUpdate(INSERT_POSITIONAL).registerArgument(new FooArgumentFactory()).bind(0, new ToStringFoo()).execute();
 
         assertThat(positional).isEqualTo("I'm a Foo");
     }
 
     @Test
     public void testArgumentHasToString() {
-        handle.registerArgument(new ToStringFooArgumentFactory());
-
-        handle.createUpdate(INSERT_POSITIONAL).bind(0, new Foo()).execute();
+        handle.createUpdate(INSERT_POSITIONAL).registerArgument(new ToStringFooArgumentFactory()).bind(0, new Foo()).execute();
 
         assertThat(positional).isEqualTo("this is a Foo");
     }
 
     @Test
     public void testBothHaveToStringAndArgumentWins() {
-        handle.registerArgument(new ToStringFooArgumentFactory());
-
-        handle.createUpdate(INSERT_POSITIONAL).bind(0, new ToStringFoo()).execute();
+        handle.createUpdate(INSERT_POSITIONAL).registerArgument(new ToStringFooArgumentFactory()).bind(0, new ToStringFoo()).execute();
 
         assertThat(positional).isEqualTo("this is a Foo");
     }

--- a/core/src/test/java/org/jdbi/core/statement/TestStatements.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestStatements.java
@@ -93,24 +93,21 @@ public class TestStatements {
     public void testStatementWithOptionalResults() {
         Handle h = h2Extension.getSharedHandle();
 
-        h.configure(ResultProducers.class, c -> c.allowNoResults(true));
-        assertThat(h.createQuery("commit").mapTo(Integer.class).findFirst()).isEmpty();
+        assertThat(h.createQuery("commit").configure(ResultProducers.class, c -> c.allowNoResults(true)).mapTo(Integer.class).findFirst()).isEmpty();
     }
 
     @Test
     public void testStatementWithOptionalBeanResults() {
         Handle h = h2Extension.getSharedHandle();
 
-        h.configure(ResultProducers.class, c -> c.allowNoResults(true));
-        assertThat(h.createQuery("commit").mapToBean(Object.class).findFirst()).isEmpty();
+        assertThat(h.createQuery("commit").configure(ResultProducers.class, c -> c.allowNoResults(true)).mapToBean(Object.class).findFirst()).isEmpty();
     }
 
     @Test
     public void testStatementWithOptionalMapResults() {
         Handle h = h2Extension.getSharedHandle();
 
-        h.configure(ResultProducers.class, c -> c.allowNoResults(true));
-        assertThat(h.createQuery("commit").mapToMap().findFirst()).isEmpty();
+        assertThat(h.createQuery("commit").configure(ResultProducers.class, c -> c.allowNoResults(true)).mapToMap().findFirst()).isEmpty();
     }
 
     @Test
@@ -127,8 +124,8 @@ public class TestStatements {
     public void testPermittedUnusedBinding() {
         Handle h = h2Extension.getSharedHandle();
 
-        assertThatCode(() -> h.configure(SqlStatements.class, s -> s.unusedBindingAllowed(true))
-            .createQuery("select * from something")
+        assertThatCode(() -> h.createQuery("select * from something")
+            .configure(SqlStatements.class, s -> s.unusedBindingAllowed(true))
             .bind("id", 1)
             .collectRows(Collectors.counting())).doesNotThrowAnyException();
     }
@@ -137,8 +134,8 @@ public class TestStatements {
     public void testPermittedUsedAndUnusedBinding() {
         Handle h = h2Extension.getSharedHandle();
 
-        assertThatCode(() -> h.configure(SqlStatements.class, s -> s.unusedBindingAllowed(true))
-            .createQuery("select * from something where id = :id")
+        assertThatCode(() -> h.createQuery("select * from something where id = :id")
+            .configure(SqlStatements.class, s -> s.unusedBindingAllowed(true))
             .bind("id", 1)
             .bind("name", "jack")
             .collectRows(Collectors.counting())).doesNotThrowAnyException();
@@ -187,8 +184,7 @@ public class TestStatements {
         Handle h = h2Extension.getSharedHandle();
 
         h.execute("CREATE ALIAS TO_DEGREES FOR \"java.lang.Math.toDegrees\"");
-        h.configure(SqlStatements.class, stmts -> stmts.unusedBindingAllowed(true));
-        try (Call call = h.createCall("? = CALL TO_DEGREES(?)")) {
+        try (Call call = h.createCall("? = CALL TO_DEGREES(?)").configure(SqlStatements.class, stmts -> stmts.unusedBindingAllowed(true))) {
             call.registerOutParameter(0, Types.DOUBLE)
                 .bind(1, 100.0d)
                 .bind(2, "foo");

--- a/core/src/test/java/org/jdbi/core/statement/TestTimingCollector.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestTimingCollector.java
@@ -34,9 +34,7 @@ public class TestTimingCollector {
     protected Handle openHandle() {
         tc = new TTC();
 
-        Handle handle = h2Extension.openHandle();
-        handle.configure(SqlStatements.class, c -> c.setTimingCollector(tc));
-        return handle;
+        return h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.setTimingCollector(tc)));
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/statement/TestTimingCollector.java
+++ b/core/src/test/java/org/jdbi/core/statement/TestTimingCollector.java
@@ -34,8 +34,9 @@ public class TestTimingCollector {
     protected Handle openHandle() {
         tc = new TTC();
 
-        h2Extension.getJdbi().configure(SqlStatements.class, c -> c.setTimingCollector(tc));
-        return h2Extension.openHandle();
+        Handle handle = h2Extension.openHandle();
+        handle.configure(SqlStatements.class, c -> c.setTimingCollector(tc));
+        return handle;
     }
 
     @Test

--- a/core/src/test/java/org/jdbi/core/transaction/RollbackOnlyTransactionHandlerTest.java
+++ b/core/src/test/java/org/jdbi/core/transaction/RollbackOnlyTransactionHandlerTest.java
@@ -14,6 +14,7 @@
 package org.jdbi.core.transaction;
 
 import org.jdbi.core.Handle;
+import org.jdbi.core.Jdbi;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -31,14 +32,16 @@ public class RollbackOnlyTransactionHandlerTest {
             h.useTransaction(txn -> txn.execute("create table pk (id integer primary key)"));
         }
 
-        h2Extension.getJdbi().setTransactionHandler(new RollbackOnlyTransactionHandler());
+        Jdbi rollbackOnly = Jdbi.builder(h2Extension.getUri())
+            .transactionHandler(new RollbackOnlyTransactionHandler())
+            .build();
 
-        try (Handle h = h2Extension.openHandle()) {
+        try (Handle h = rollbackOnly.open()) {
             h.useTransaction(txn ->
                 assertThat(txn.execute("insert into pk values(1)")).isOne());
         }
 
-        try (Handle h = h2Extension.openHandle()) {
+        try (Handle h = rollbackOnly.open()) {
             h.useTransaction(txn ->
                 assertThat(txn.execute("insert into pk values(1)")).isOne());
         }

--- a/core/src/test/java/org/jdbi/core/transaction/TestSerializableTransactionRunner.java
+++ b/core/src/test/java/org/jdbi/core/transaction/TestSerializableTransactionRunner.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import org.jdbi.core.Handle;
+import org.jdbi.core.Jdbi;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,19 +52,23 @@ public class TestSerializableTransactionRunner {
     @RegisterExtension
     public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
 
+    private Jdbi jdbi;
+
     @BeforeEach
     public void setUp() {
-        h2Extension.getJdbi().setTransactionHandler(new SerializableTransactionRunner());
-        h2Extension.getJdbi().configure(SerializableTransactionRunner.Configuration.class, config -> config
-            .maxRetries(MAX_RETRIES)
-            .onFailure(onFailure)
-            .onSuccess(onSuccess));
+        jdbi = Jdbi.builder(h2Extension.getUri())
+            .transactionHandler(new SerializableTransactionRunner())
+            .configure(SerializableTransactionRunner.Configuration.class, config -> config
+                .maxRetries(MAX_RETRIES)
+                .onFailure(onFailure)
+                .onSuccess(onSuccess))
+            .build();
     }
 
     @Test
     public void testEventuallyFails() {
         final AtomicInteger attempts = new AtomicInteger(0);
-        try (Handle handle = h2Extension.openHandle()) {
+        try (Handle handle = jdbi.open()) {
 
             assertThatExceptionOfType(SQLException.class)
                 .isThrownBy(() -> handle.inTransaction(TransactionIsolationLevel.SERIALIZABLE,
@@ -85,7 +90,7 @@ public class TestSerializableTransactionRunner {
     @Test
     public void testEventuallySucceeds() throws Exception {
         final AtomicInteger remaining = new AtomicInteger(MAX_RETRIES / 2);
-        try (Handle handle = h2Extension.openHandle()) {
+        try (Handle handle = jdbi.open()) {
             handle.inTransaction(TransactionIsolationLevel.SERIALIZABLE, conn -> {
                 if (remaining.decrementAndGet() == 0) {
                     return null;
@@ -100,7 +105,7 @@ public class TestSerializableTransactionRunner {
     @Test
     public void testEventuallySucceedsWrappexException() throws Exception {
         final AtomicInteger remaining = new AtomicInteger(MAX_RETRIES / 2);
-        try (Handle handle = h2Extension.openHandle()) {
+        try (Handle handle = jdbi.open()) {
             handle.inTransaction(TransactionIsolationLevel.SERIALIZABLE, conn -> {
                 if (remaining.decrementAndGet() == 0) {
                     return null;
@@ -115,7 +120,7 @@ public class TestSerializableTransactionRunner {
     @Test
     public void testBatchSucceeds() throws Exception {
         final AtomicInteger remaining = new AtomicInteger(MAX_RETRIES / 2);
-        try (Handle handle = h2Extension.openHandle()) {
+        try (Handle handle = jdbi.open()) {
             handle.inTransaction(TransactionIsolationLevel.SERIALIZABLE, conn -> {
                 if (remaining.decrementAndGet() == 0) {
                     return null;
@@ -131,7 +136,7 @@ public class TestSerializableTransactionRunner {
 
     @Test
     public void testNonsenseRetryCount() {
-        assertThatThrownBy(() -> h2Extension.getJdbi().configure(SerializableTransactionRunner.Configuration.class, config -> config.maxRetries(-1)))
+        assertThatThrownBy(() -> Jdbi.builder(h2Extension.getUri()).configure(SerializableTransactionRunner.Configuration.class, config -> config.maxRetries(-1)))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Set a number >= 0");
     }
@@ -157,7 +162,7 @@ public class TestSerializableTransactionRunner {
             return null;
         }).when(onSuccess).accept(anyList());
 
-        try (Handle h = h2Extension.openHandle()) {
+        try (Handle h = jdbi.open()) {
             h.inTransaction(TransactionIsolationLevel.SERIALIZABLE, conn -> {
                 if (remainingAttempts.decrementAndGet() == 0) {
                     return null;

--- a/core/src/test/java/org/jdbi/core/transaction/TestTransactions.java
+++ b/core/src/test/java/org/jdbi/core/transaction/TestTransactions.java
@@ -38,12 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestTransactions {
 
-    @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
-
     int begin, commit, rollback;
-
-    private Handle h;
 
     private final LocalTransactionHandler txSpy = new LocalTransactionHandler() {
         @Override
@@ -65,9 +60,14 @@ public class TestTransactions {
         }
     };
 
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER)
+        .withConfig(b -> b.transactionHandler(txSpy));
+
+    private Handle h;
+
     @BeforeEach
     public void setUp() {
-        h2Extension.getJdbi().setTransactionHandler(txSpy);
         h = h2Extension.openHandle();
     }
 

--- a/core/src/test/java/org/jdbi/core/transaction/TestTransactions.java
+++ b/core/src/test/java/org/jdbi/core/transaction/TestTransactions.java
@@ -24,6 +24,7 @@ import org.jdbi.core.Jdbi;
 import org.jdbi.core.Something;
 import org.jdbi.core.internal.testing.H2DatabaseExtension;
 import org.jdbi.core.statement.RenderContext;
+import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.core.statement.TemplateEngine;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -202,10 +203,12 @@ public class TestTransactions {
 
     @Test
     public void testTemplateEngineThrowsError() {
-        assertThatThrownBy(() -> h.setTemplateEngine(new BoomEngine()).inTransaction(h2 -> h2.execute("select 1")))
-            .isOfAnyClassIn(Error.class)
-            .hasMessage("boom");
-        assertThat(h.isInTransaction()).isFalse();
+        try (Handle boomHandle = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.templateEngine(new BoomEngine())))) {
+            assertThatThrownBy(() -> boomHandle.inTransaction(h2 -> h2.execute("select 1")))
+                .isOfAnyClassIn(Error.class)
+                .hasMessage("boom");
+            assertThat(boomHandle.isInTransaction()).isFalse();
+        }
     }
 
     @Test

--- a/docs/src/test/java/jdbi/doc/ArgumentsTest.java
+++ b/docs/src/test/java/jdbi/doc/ArgumentsTest.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 import org.jdbi.core.Handle;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 import org.jdbi.testing.junit.JdbiExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,7 +84,7 @@ public class ArgumentsTest {
         }
 
         @Override
-        protected Argument build(UUID value, ConfigRegistry config) {
+        protected Argument build(UUID value, ConfigView config) {
             return (position, statement, ctx) -> statement.setString(position, value.toString()); // <2>
         }
     }

--- a/docs/src/test/java/jdbi/doc/ArgumentsTest.java
+++ b/docs/src/test/java/jdbi/doc/ArgumentsTest.java
@@ -92,8 +92,8 @@ public class ArgumentsTest {
     @Test
     public void uuidArgumentFactory() {
         UUID u = UUID.randomUUID();
-        handle.registerArgument(new UUIDArgumentFactory());
         assertThat(handle.createQuery("SELECT CAST(:uuid AS VARCHAR)")
+            .registerArgument(new UUIDArgumentFactory())
             .bind("uuid", u)
             .mapTo(String.class)
             .one()).isEqualTo(u.toString());

--- a/docs/src/test/java/jdbi/doc/BindMethodsTest.java
+++ b/docs/src/test/java/jdbi/doc/BindMethodsTest.java
@@ -11,7 +11,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.jdbi.core.Handle;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.statement.StatementContext;
 import org.jdbi.sqlobject.SqlObjectPlugin;
@@ -34,17 +33,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BindMethodsTest {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin()).withInitializer(TestingInitializers.users());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin()).withInitializer(TestingInitializers.users())
+        .withConfig(b -> b.registerRowMapper(new UserMapper()));
 
     UserDao dao;
 
     @BeforeEach
     void setUp() {
-        Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new UserMapper());
-
-        this.dao = handle.attach(UserDao.class);
-
+        this.dao = h2Extension.getSharedHandle().attach(UserDao.class);
     }
 
     @Test

--- a/docs/src/test/java/jdbi/doc/CodecExampleTest.java
+++ b/docs/src/test/java/jdbi/doc/CodecExampleTest.java
@@ -42,12 +42,12 @@ public class CodecExampleTest {
 
     @Test
     public void testCounter() {
-        Jdbi jdbi = h2Extension.getJdbi();
-
         // tag::register[]
 
         // register the codec with JDBI
-        jdbi.registerCodecFactory(CodecFactory.forSingleCodec(COUNTER_TYPE, new CounterCodec()));
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUrl())
+            .registerCodecFactory(CodecFactory.forSingleCodec(COUNTER_TYPE, new CounterCodec()))
+            .build();
 
         // end::register[]
 

--- a/docs/src/test/java/jdbi/doc/CodecSqlObjectTest.java
+++ b/docs/src/test/java/jdbi/doc/CodecSqlObjectTest.java
@@ -61,12 +61,13 @@ public class CodecSqlObjectTest {
 
     @Test
     public void testCounter() {
-        Jdbi jdbi = h2Extension.getJdbi();
-
         // tag::register[]
 
         // register the codec with JDBI
-        jdbi.registerCodecFactory(CodecFactory.forSingleCodec(COUNTER_TYPE, new CounterCodec()));
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUrl())
+            .installPlugin(new SqlObjectPlugin())
+            .registerCodecFactory(CodecFactory.forSingleCodec(COUNTER_TYPE, new CounterCodec()))
+            .build();
 
         // end::register[]
 

--- a/docs/src/test/java/jdbi/doc/DefaultMethodTest.java
+++ b/docs/src/test/java/jdbi/doc/DefaultMethodTest.java
@@ -35,7 +35,8 @@ public class DefaultMethodTest {
     @RegisterExtension
     public JdbiExtension h2Extension = JdbiExtension.h2()
             .withInitializer(TestingInitializers.usersWithData())
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b.registerRowMapper(User.class, ConstructorMapper.of(User.class)));
 
     // tag::dao[]
     interface UserDao {
@@ -57,7 +58,6 @@ public class DefaultMethodTest {
     @BeforeEach
     void setUp() {
         this.jdbi = h2Extension.getJdbi();
-        jdbi.registerRowMapper(User.class, ConstructorMapper.of(User.class));
     }
 
     // tag::default-method[]

--- a/docs/src/test/java/jdbi/doc/DontUseProxyExtensionFactoryTest.java
+++ b/docs/src/test/java/jdbi/doc/DontUseProxyExtensionFactoryTest.java
@@ -43,7 +43,10 @@ class DontUseProxyExtensionFactoryTest {
     @RegisterExtension
     JdbiExtension h2Extension = JdbiExtension.h2()
             .withInitializer(TestingInitializers.something())
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b
+                    .registerRowMapper(new SomethingMapper())
+                    .configure(Extensions.class, e -> e.register(new DontUseProxyExtensionFactory())));
 
     Jdbi jdbi;
 
@@ -72,9 +75,6 @@ class DontUseProxyExtensionFactoryTest {
     @BeforeEach
     void setUp() {
         this.jdbi = h2Extension.getJdbi();
-
-        jdbi.registerRowMapper(new SomethingMapper());
-        jdbi.configure(Extensions.class, e -> e.register(new DontUseProxyExtensionFactory()));
 
         jdbi.useHandle(handle -> {
             handle.execute("INSERT INTO something (id, name) VALUES (1, 'apple')");

--- a/docs/src/test/java/jdbi/doc/ExtensionConfigCustomizerTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionConfigCustomizerTest.java
@@ -59,12 +59,13 @@ class ExtensionConfigCustomizerTest {
 
     @BeforeEach
     void setUp() {
-        this.jdbi = h2Extension.getJdbi();
-
-        // tag::register-global[]
-        jdbi.configure(Extensions.class, e ->
-                e.registerConfigCustomizerFactory(new SomethingMapperConfigCustomizerFactory())); // <1>
-        // end::register-global[]
+        this.jdbi = Jdbi.builder(h2Extension.getUrl())
+                .installPlugin(new SqlObjectPlugin())
+                // tag::register-global[]
+                .configure(Extensions.class, e ->
+                        e.registerConfigCustomizerFactory(new SomethingMapperConfigCustomizerFactory())) // <1>
+                // end::register-global[]
+                .build();
 
         jdbi.useExtension(SomethingDao.class, dao -> {
             dao.insert(new Something(1, "apple"));

--- a/docs/src/test/java/jdbi/doc/ExtensionFrameworkTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionFrameworkTest.java
@@ -39,7 +39,8 @@ class ExtensionFrameworkTest {
     @RegisterExtension
     JdbiExtension h2Extension = JdbiExtension.h2()
             .withInitializer(TestingInitializers.something())
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
     Jdbi jdbi;
 
     // tag::dao[]
@@ -66,8 +67,6 @@ class ExtensionFrameworkTest {
     @BeforeEach
     void setUp() {
         this.jdbi = h2Extension.getJdbi();
-
-        jdbi.registerRowMapper(new SomethingMapper());
 
         // tag::use[]
         jdbi.useExtension(SomethingDao.class, dao -> {

--- a/docs/src/test/java/jdbi/doc/ExtensionHandlerAnnotationTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionHandlerAnnotationTest.java
@@ -45,19 +45,20 @@ class ExtensionHandlerAnnotationTest {
 
     @BeforeEach
     void setUp() {
-        this.jdbi = h2Extension.getJdbi();
-
-        // tag::register-factory[]
-        jdbi.configure(Extensions.class, extensions ->  // <1>
-                extensions.register(extensionType ->
-                        Stream.of(extensionType.getMethods())
-                                .anyMatch(method ->
-                                        Stream.of(method.getAnnotations())
-                                                .map(annotation -> annotation.annotationType()
-                                                        .getAnnotation(UseExtensionHandler.class)) // <2>
-                                                .anyMatch(a -> a != null && "test".equals(a.id())) // <3>
-                                )));
-        // end::register-factory[]
+        this.jdbi = Jdbi.builder(h2Extension.getUrl())
+                .installPlugin(new SqlObjectPlugin())
+                // tag::register-factory[]
+                .configure(Extensions.class, extensions ->  // <1>
+                        extensions.register(extensionType ->
+                                Stream.of(extensionType.getMethods())
+                                        .anyMatch(method ->
+                                                Stream.of(method.getAnnotations())
+                                                        .map(annotation -> annotation.annotationType()
+                                                                .getAnnotation(UseExtensionHandler.class)) // <2>
+                                                        .anyMatch(a -> a != null && "test".equals(a.id())) // <3>
+                                        )))
+                // end::register-factory[]
+                .build();
     }
 
     @Test

--- a/docs/src/test/java/jdbi/doc/ExtensionHandlerCustomizerAnnotationTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionHandlerCustomizerAnnotationTest.java
@@ -57,22 +57,21 @@ class ExtensionHandlerCustomizerAnnotationTest {
     @RegisterExtension
     JdbiExtension h2Extension = JdbiExtension.h2()
             .withInitializer(TestingInitializers.something())
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b
+                    .configure(Extensions.class, extensions ->
+                            extensions.register(extensionType ->
+                                    Stream.of(extensionType.getMethods())
+                                            .anyMatch(method -> Stream.of(method.getAnnotations())
+                                                    .map(annotation -> annotation.annotationType().getAnnotation(UseExtensionHandler.class))
+                                                    .anyMatch(a -> a != null && "test".equals(a.id())))))
+                    .registerRowMapper(new SomethingMapper()));
 
     Jdbi jdbi;
 
     @BeforeEach
     void setUp() {
         this.jdbi = h2Extension.getJdbi();
-
-        jdbi.configure(Extensions.class, extensions ->
-                extensions.register(extensionType ->
-                        Stream.of(extensionType.getMethods())
-                                .anyMatch(method -> Stream.of(method.getAnnotations())
-                                        .map(annotation -> annotation.annotationType().getAnnotation(UseExtensionHandler.class))
-                                        .anyMatch(a -> a != null && "test".equals(a.id())))));
-
-        jdbi.registerRowMapper(new SomethingMapper());
 
         jdbi.useExtension(SomethingDao.class, dao -> {
             dao.insert(new Something(1, "apple"));

--- a/docs/src/test/java/jdbi/doc/ExtensionHandlerCustomizerTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionHandlerCustomizerTest.java
@@ -71,14 +71,14 @@ class ExtensionHandlerCustomizerTest {
 
     @BeforeEach
     void setUp() {
-        this.jdbi = h2Extension.getJdbi();
-
-        // tag::register-global[]
-        jdbi.configure(Extensions.class, e ->
-                e.registerHandlerCustomizer(new LoggingExtensionHandlerCustomizer())); // <1>
-        // end::register-global[]
-
-        jdbi.registerRowMapper(new SomethingMapper());
+        this.jdbi = Jdbi.builder(h2Extension.getUrl())
+                .installPlugin(new SqlObjectPlugin())
+                // tag::register-global[]
+                .configure(Extensions.class, e ->
+                        e.registerHandlerCustomizer(new LoggingExtensionHandlerCustomizer())) // <1>
+                // end::register-global[]
+                .registerRowMapper(new SomethingMapper())
+                .build();
 
         jdbi.useExtension(SomethingDao.class, SomethingDao::initialize);
     }

--- a/docs/src/test/java/jdbi/doc/ExtensionHandlerTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionHandlerTest.java
@@ -40,15 +40,14 @@ class ExtensionHandlerTest {
     @RegisterExtension
     JdbiExtension h2Extension = JdbiExtension.h2()
             .withInitializer(TestingInitializers.something())
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b.configure(Extensions.class, e -> e.register(new TestExtensionFactory())));
 
     Jdbi jdbi;
 
     @BeforeEach
     void setUp() {
         this.jdbi = h2Extension.getJdbi();
-
-        jdbi.configure(Extensions.class, e -> e.register(new TestExtensionFactory()));
     }
 
     @Test

--- a/docs/src/test/java/jdbi/doc/ExtensionHandlerTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionHandlerTest.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.Something;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.extension.ExtensionFactory;
 import org.jdbi.core.extension.ExtensionHandler;
 import org.jdbi.core.extension.ExtensionHandlerFactory;
@@ -71,7 +71,7 @@ class ExtensionHandlerTest {
         }
 
         @Override
-        public Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigRegistry config) {
+        public Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigView config) {
             return Collections.singleton(new TestExtensionHandlerFactory()); // <2>
         }
     }

--- a/docs/src/test/java/jdbi/doc/ExtensionMetadataTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionMetadataTest.java
@@ -47,15 +47,14 @@ class ExtensionMetadataTest {
     @RegisterExtension
     JdbiExtension h2Extension = JdbiExtension.h2()
             .withInitializer(TestingInitializers.something())
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b.configure(Extensions.class, e -> e.register(new TestExtensionFactory())));
 
     Jdbi jdbi;
 
     @BeforeEach
     void setUp() {
         this.jdbi = h2Extension.getJdbi();
-
-        jdbi.configure(Extensions.class, e -> e.register(new TestExtensionFactory()));
     }
 
     @Test

--- a/docs/src/test/java/jdbi/doc/ExtensionMetadataTest.java
+++ b/docs/src/test/java/jdbi/doc/ExtensionMetadataTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.Something;
 import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.extension.ExtensionFactory;
 import org.jdbi.core.extension.ExtensionHandler;
 import org.jdbi.core.extension.ExtensionHandlerFactory;
@@ -99,7 +100,7 @@ class ExtensionMetadataTest {
         }
 
         @Override
-        public Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigRegistry config) {
+        public Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigView config) {
             return Collections.singleton(new TestExtensionHandlerFactory()); // <5>
         }
     }

--- a/docs/src/test/java/jdbi/doc/FiveMinuteTourTest.java
+++ b/docs/src/test/java/jdbi/doc/FiveMinuteTourTest.java
@@ -123,9 +123,8 @@ public class FiveMinuteTourTest {
     @Test
     public void registerCustomMapper() {
         // tag::registerCustomMapper[]
-        handle.registerRowMapper(new ContactMapper());
-
         List<Contact> contacts = handle.createQuery("select * from contacts")
+                                       .registerRowMapper(new ContactMapper())
                                        .mapTo(Contact.class)
                                        .list();
         assertThat(contacts).extracting("id", "name")
@@ -136,7 +135,6 @@ public class FiveMinuteTourTest {
 
     @Test
     public void positionalParameters() {
-        handle.registerRowMapper(new ContactMapper());
         // tag::positionalParameters[]
         handle.createUpdate("insert into contacts (id, name) values (?, ?)")
               .bind(0, 3)
@@ -153,7 +151,6 @@ public class FiveMinuteTourTest {
 
     @Test
     public void namedParameters() {
-        handle.registerRowMapper(new ContactMapper());
         // tag::namedParameters[]
         handle.createUpdate("insert into contacts (id, name) values (:id, :name)")
               .bind("id", 3)

--- a/docs/src/test/java/jdbi/doc/GeneratedKeysTest.java
+++ b/docs/src/test/java/jdbi/doc/GeneratedKeysTest.java
@@ -38,7 +38,8 @@ public class GeneratedKeysTest {
     @RegisterExtension
     public JdbiExtension pgExtension = JdbiExtension.postgres(pg)
         .withPlugin(new PostgresPlugin())
-        .withPlugin(new SqlObjectPlugin());
+        .withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(ConstructorMapper.factory(User.class)));
 
     private Jdbi db;
 
@@ -59,7 +60,6 @@ public class GeneratedKeysTest {
         db = pgExtension.getJdbi();
 
         db.useHandle(h -> h.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR)"));
-        db.registerRowMapper(ConstructorMapper.factory(User.class));
     }
     // end::setup[]
 

--- a/docs/src/test/java/jdbi/doc/IntroductionTest.java
+++ b/docs/src/test/java/jdbi/doc/IntroductionTest.java
@@ -95,8 +95,9 @@ public class IntroductionTest {
     @Test
     public void sqlObject() {
         // tag::sqlobject-usage[]
-        Jdbi jdbi = Jdbi.create("jdbc:h2:mem:test");
-        jdbi.installPlugin(new SqlObjectPlugin());
+        Jdbi jdbi = Jdbi.builder("jdbc:h2:mem:test")
+                .installPlugin(new SqlObjectPlugin())
+                .build();
 
         // Jdbi implements your interface based on annotations
         List<User> userNames = jdbi.withExtension(UserDao.class, dao -> {

--- a/docs/src/test/java/jdbi/doc/NonVirtualExtensionFactoryTest.java
+++ b/docs/src/test/java/jdbi/doc/NonVirtualExtensionFactoryTest.java
@@ -43,7 +43,10 @@ class NonVirtualExtensionFactoryTest {
     @RegisterExtension
     JdbiExtension h2Extension = JdbiExtension.h2()
             .withInitializer(TestingInitializers.something())
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b
+                    .registerRowMapper(new SomethingMapper())
+                    .configure(Extensions.class, e -> e.register(new NonVirtualExtensionFactory())));
 
     Jdbi jdbi;
 
@@ -65,9 +68,6 @@ class NonVirtualExtensionFactoryTest {
     @BeforeEach
     void setUp() {
         this.jdbi = h2Extension.getJdbi();
-
-        jdbi.registerRowMapper(new SomethingMapper());
-        jdbi.configure(Extensions.class, e -> e.register(new NonVirtualExtensionFactory()));
 
         jdbi.useHandle(handle -> {
             handle.execute("INSERT INTO something (id, name) VALUES (1, 'apple')");

--- a/docs/src/test/java/jdbi/doc/OnDemandExtensionTest.java
+++ b/docs/src/test/java/jdbi/doc/OnDemandExtensionTest.java
@@ -38,7 +38,8 @@ class OnDemandExtensionTest {
     @RegisterExtension
     JdbiExtension h2Extension = JdbiExtension.h2()
             .withInitializer(TestingInitializers.something())
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
     Jdbi jdbi;
 
     interface SomethingDao {
@@ -64,8 +65,6 @@ class OnDemandExtensionTest {
     @BeforeEach
     void setUp() {
         this.jdbi = h2Extension.getJdbi();
-
-        jdbi.registerRowMapper(new SomethingMapper());
 
         // tag::use[]
         SomethingDao dao = jdbi.onDemand(SomethingDao.class);

--- a/docs/src/test/java/jdbi/doc/ResultsTest.java
+++ b/docs/src/test/java/jdbi/doc/ResultsTest.java
@@ -120,9 +120,8 @@ public class ResultsTest {
     @Test
     public void rowMapperFactory() {
         // tag::rowMapperFactory[]
-        handle.registerRowMapper(User.class, new UserMapper());
-
         handle.createQuery("SELECT id, \"name\" FROM \"user\" ORDER BY id ASC")
+              .registerRowMapper(User.class, new UserMapper())
               .mapTo(User.class)
               .useStream(stream -> {
                   Optional<String> first = stream
@@ -137,8 +136,8 @@ public class ResultsTest {
     @Test
     public void constructorMapper() {
         // tag::constructorMapper[]
-        handle.registerRowMapper(ConstructorMapper.factory(User.class));
         Set<User> userSet = handle.createQuery("SELECT * FROM \"user\" ORDER BY id ASC")
+            .registerRowMapper(ConstructorMapper.factory(User.class))
             .mapTo(User.class)
             .collect(Collectors.toSet());
 
@@ -169,10 +168,9 @@ public class ResultsTest {
 
     @Test
     public void columnMapper() {
-        handle.registerColumnMapper(userNameFactory);
-        handle.registerRowMapper(ConstructorMapper.factory(NamedUser.class));
-
         NamedUser bob = handle.createQuery("SELECT id, \"name\" FROM \"user\" WHERE \"name\" = :name")
+            .registerColumnMapper(userNameFactory)
+            .registerRowMapper(ConstructorMapper.factory(NamedUser.class))
             .bind("name", "Bob")
             .mapTo(NamedUser.class)
             .one();
@@ -184,10 +182,9 @@ public class ResultsTest {
     @Test
     public void beanMapper() {
         // tag::beanMapper[]
-        handle.registerRowMapper(BeanMapper.factory(UserBean.class));
-
         List<UserBean> users = handle
                 .createQuery("select id, \"name\" from \"user\"")
+                .registerRowMapper(BeanMapper.factory(UserBean.class))
                 .mapTo(UserBean.class)
                 .list();
         // end::beanMapper[]
@@ -231,13 +228,13 @@ public class ResultsTest {
                 101, 1, "Work", "555-9999");
 
         // tag::beanMapperPrefix[]
-        handle.registerRowMapper(BeanMapper.factory(ContactBean.class, "c"));
-        handle.registerRowMapper(BeanMapper.factory(PhoneBean.class, "p"));
-        handle.registerRowMapper(JoinRowMapper.forTypes(ContactBean.class, PhoneBean.class));
         List<JoinRow> contactPhones = handle.select("select "
                 + "c.id cid, c.\"name\" cname, "
                 + "p.id pid, p.\"name\" pname, p.\"number\" pnumber "
                 + "from contacts c left join phones p on c.id = p.contact_id")
+                .registerRowMapper(BeanMapper.factory(ContactBean.class, "c"))
+                .registerRowMapper(BeanMapper.factory(PhoneBean.class, "p"))
+                .registerRowMapper(JoinRowMapper.forTypes(ContactBean.class, PhoneBean.class))
                 .mapTo(JoinRow.class)
                 .list();
         // end::beanMapperPrefix[]

--- a/docs/src/test/java/jdbi/doc/TestCollections.java
+++ b/docs/src/test/java/jdbi/doc/TestCollections.java
@@ -90,8 +90,8 @@ public class TestCollections {
     public void test() {
         // tag::into-list[]
         List<String> names = handle
-                .registerCollector(List.class, Collectors.toCollection(ArrayList::new))
                 .createQuery("SELECT title FROM films WHERE genre = :genre ORDER BY title")
+                .registerCollector(List.class, Collectors.toCollection(ArrayList::new))
                 .bind("genre", "Action")
                 .mapTo(String.class)
                 .collectIntoList();
@@ -106,8 +106,8 @@ public class TestCollections {
     public void testIntoSet() {
         // tag::into-set[]
         Set<String> names = handle
-                .registerCollector(Set.class, Collectors.toCollection(LinkedHashSet::new))
                 .createQuery("SELECT title FROM films WHERE genre = :genre ORDER BY title")
+                .registerCollector(Set.class, Collectors.toCollection(LinkedHashSet::new))
                 .bind("genre", "Action")
                 .mapTo(String.class)
                 .collectIntoSet();
@@ -182,8 +182,8 @@ public class TestCollections {
     public void testMapTo() {
         // tag::to-map[]
         Map<Integer, String> names = handle
-                .registerRowMapper(Movie.class, ConstructorMapper.of(Movie.class))
                 .createQuery("SELECT * FROM films WHERE genre = :genre ORDER BY title")
+                .registerRowMapper(Movie.class, ConstructorMapper.of(Movie.class))
                 .bind("genre", "Action")
                 .mapTo(Movie.class)
                 .collectToMap(Movie::id, Movie::title);
@@ -247,8 +247,8 @@ public class TestCollections {
     public void testMovieResult() {
         // tag::movie-result[]
         Movie movie = handle
-                .registerRowMapper(Movie.class, ConstructorMapper.of(Movie.class))
                 .createQuery("SELECT * FROM films WHERE id = :id")
+                .registerRowMapper(Movie.class, ConstructorMapper.of(Movie.class))
                 .bind("id", 1)
                 .mapTo(Movie.class)
                 .one();

--- a/docs/src/test/java/jdbi/doc/TestInheritedValueH2.java
+++ b/docs/src/test/java/jdbi/doc/TestInheritedValueH2.java
@@ -96,10 +96,11 @@ public class TestInheritedValueH2 {
 
     @Test
     public void testType() {
-        Jdbi jdbi = h2Extension.getJdbi();
-
         // register the codec with JDBI
-        jdbi.registerCodecFactory(TypeResolvingCodecFactory.forSingleCodec(DATA_TYPE, new DataCodec()));
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUrl())
+            .installPlugin(new SqlObjectPlugin())
+            .registerCodecFactory(TypeResolvingCodecFactory.forSingleCodec(DATA_TYPE, new DataCodec()))
+            .build();
 
         StringValue data = new StringValue("one");
 
@@ -121,10 +122,11 @@ public class TestInheritedValueH2 {
 
     @Test
     public void testBean() {
-        Jdbi jdbi = h2Extension.getJdbi();
-
         // register the codec with JDBI
-        jdbi.registerCodecFactory(TypeResolvingCodecFactory.forSingleCodec(DATA_TYPE, new DataCodec()));
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUrl())
+            .installPlugin(new SqlObjectPlugin())
+            .registerCodecFactory(TypeResolvingCodecFactory.forSingleCodec(DATA_TYPE, new DataCodec()))
+            .build();
 
         StringBean stringBean = new StringBean(UUID.randomUUID().toString(), new StringValue("two"));
 
@@ -143,13 +145,14 @@ public class TestInheritedValueH2 {
 
     @Test
     public void testCollection() {
-        Jdbi jdbi = h2Extension.getJdbi();
-
         // register codec
-        jdbi.registerCodecFactory(TypeResolvingCodecFactory.builder()
-            .addCodec(AUTOVALUE_SET_TYPE, new AutoValueSetCodec())
-            .addCodec(DATA_TYPE, new DataCodec())
-            .build());
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUrl())
+            .installPlugin(new SqlObjectPlugin())
+            .registerCodecFactory(TypeResolvingCodecFactory.builder()
+                .addCodec(AUTOVALUE_SET_TYPE, new AutoValueSetCodec())
+                .addCodec(DATA_TYPE, new DataCodec())
+                .build())
+            .build();
 
         String id = UUID.randomUUID().toString();
         ImmutableSet<AutoValue> data = ImmutableSet.of(AutoValue.create("one"), AutoValue.create("two"), AutoValue.create("three"));
@@ -169,13 +172,14 @@ public class TestInheritedValueH2 {
 
     @Test
     public void testCollectionBean() {
-        Jdbi jdbi = h2Extension.getJdbi();
-
         // register codec
-        jdbi.registerCodecFactory(TypeResolvingCodecFactory.builder()
-            .addCodec(AUTOVALUE_SET_TYPE, new AutoValueSetCodec())
-            .addCodec(DATA_TYPE, new DataCodec())
-            .build());
+        Jdbi jdbi = Jdbi.builder(h2Extension.getUrl())
+            .installPlugin(new SqlObjectPlugin())
+            .registerCodecFactory(TypeResolvingCodecFactory.builder()
+                .addCodec(AUTOVALUE_SET_TYPE, new AutoValueSetCodec())
+                .addCodec(DATA_TYPE, new DataCodec())
+                .build())
+            .build();
 
         AutoValueBean bean = new AutoValueBean(
             UUID.randomUUID().toString(),

--- a/docs/src/test/java/jdbi/doc/TransactionTest.java
+++ b/docs/src/test/java/jdbi/doc/TransactionTest.java
@@ -54,7 +54,8 @@ public class TransactionTest {
     @RegisterExtension
     public JdbiExtension pgExtension = JdbiExtension.postgres(pg)
             .withPlugin(new PostgresPlugin())
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b.registerRowMapper(ConstructorMapper.factory(User.class)));
 
     private Handle handle;
     private Jdbi jdbi;
@@ -62,7 +63,6 @@ public class TransactionTest {
     @BeforeEach
     public void setUp() {
         jdbi = pgExtension.getJdbi();
-        jdbi.registerRowMapper(ConstructorMapper.factory(User.class));
         handle = pgExtension.openHandle();
 
         handle.useTransaction(h -> {
@@ -187,51 +187,58 @@ public class TransactionTest {
 
     @Test
     public void serializableTransaction() throws Exception {
+        var dataSource = pg.createDatabaseInfo().asDataSource();
+
         // tag::serializable[]
         // Automatically rerun transactions
-        jdbi.setTransactionHandler(new SerializableTransactionRunner());
-        handle.execute("CREATE TABLE ints (value INTEGER)");
+        Jdbi jdbi = Jdbi.builder(dataSource)
+                .transactionHandler(new SerializableTransactionRunner())
+                .build();
 
-        // Set up some values
-        handle.execute("INSERT INTO ints (value) VALUES(?)", 10);
-        handle.execute("INSERT INTO ints (value) VALUES(?)", 20);
+        try (Handle handle = jdbi.open()) {
+            handle.execute("CREATE TABLE ints (value INTEGER)");
 
-        // Run the following twice in parallel, and synchronize
-        ExecutorService executor = Executors.newCachedThreadPool();
-        CountDownLatch latch = new CountDownLatch(2);
+            // Set up some values
+            handle.execute("INSERT INTO ints (value) VALUES(?)", 10);
+            handle.execute("INSERT INTO ints (value) VALUES(?)", 20);
 
-        Callable<Integer> sumAndInsert = () ->
-                jdbi.inTransaction(TransactionIsolationLevel.SERIALIZABLE, transactionHandle -> {
-                    // Both threads read initial state of table
-                    int sum = transactionHandle.select("SELECT sum(value) FROM ints").mapTo(int.class).one();
+            // Run the following twice in parallel, and synchronize
+            ExecutorService executor = Executors.newCachedThreadPool();
+            CountDownLatch latch = new CountDownLatch(2);
 
-                    // synchronize threads, make sure that they each has successfully read the data
-                    latch.countDown();
-                    latch.await();
+            Callable<Integer> sumAndInsert = () ->
+                    jdbi.inTransaction(TransactionIsolationLevel.SERIALIZABLE, transactionHandle -> {
+                        // Both threads read initial state of table
+                        int sum = transactionHandle.select("SELECT sum(value) FROM ints").mapTo(int.class).one();
 
-                    // Now do the write.
-                    synchronized (this) {
-                        // handle can be used by multiple threads, but not at the same time
-                        transactionHandle.execute("INSERT INTO ints (value) VALUES(?)", sum);
-                    }
-                    return sum;
-                });
+                        // synchronize threads, make sure that they each has successfully read the data
+                        latch.countDown();
+                        latch.await();
 
-        // Both of these would calculate 10 + 20 = 30, but that violates serialization!
-        Future<Integer> result1 = executor.submit(sumAndInsert);
-        Future<Integer> result2 = executor.submit(sumAndInsert);
+                        // Now do the write.
+                        synchronized (this) {
+                            // handle can be used by multiple threads, but not at the same time
+                            transactionHandle.execute("INSERT INTO ints (value) VALUES(?)", sum);
+                        }
+                        return sum;
+                    });
 
-        // One of the transactions gets 30, the other will abort and automatically rerun.
-        // On the second attempt it will compute 10 + 20 + 30 = 60, seeing the update from its sibling.
-        // This assertion fails under any isolation level below SERIALIZABLE!
-        assertThat(result1.get() + result2.get()).isEqualTo(30 + 60);
+            // Both of these would calculate 10 + 20 = 30, but that violates serialization!
+            Future<Integer> result1 = executor.submit(sumAndInsert);
+            Future<Integer> result2 = executor.submit(sumAndInsert);
 
-        executor.shutdown();
-        // end::serializable[]
+            // One of the transactions gets 30, the other will abort and automatically rerun.
+            // On the second attempt it will compute 10 + 20 + 30 = 60, seeing the update from its sibling.
+            // This assertion fails under any isolation level below SERIALIZABLE!
+            assertThat(result1.get() + result2.get()).isEqualTo(30 + 60);
 
-        List<Integer> results = handle.createQuery("SELECT * from ints").mapTo(Integer.class).list();
-        // both threads have committed their result
-        assertThat(results.size()).isEqualTo(4);
+            executor.shutdown();
+            // end::serializable[]
+
+            List<Integer> results = handle.createQuery("SELECT * from ints").mapTo(Integer.class).list();
+            // both threads have committed their result
+            assertThat(results.size()).isEqualTo(4);
+        }
 
     }
 }

--- a/e2e/src/test/java/org/jdbi/e2e/lombok/LombokMappingTest.java
+++ b/e2e/src/test/java/org/jdbi/e2e/lombok/LombokMappingTest.java
@@ -30,13 +30,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class LombokMappingTest {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiH2Extension.h2().withInitializer((ds, h) -> {
-        h.execute("create table test_table (table_name varchar, is_view boolean)");
-        h.execute("insert into test_table (table_name, is_view) values ('abc', 1)");
-        h.execute("insert into test_table (table_name, is_view) values ('def', 0)");
-        h.registerRowMapper(BooleanObjectTable.class, BeanMapper.of(BooleanObjectTable.class));
-        h.registerRowMapper(BooleanPrimitiveTable.class, BeanMapper.of(BooleanPrimitiveTable.class));
-    });
+    public JdbiExtension h2Extension = JdbiH2Extension.h2()
+        .withConfig(b -> b
+            .registerRowMapper(BooleanObjectTable.class, BeanMapper.of(BooleanObjectTable.class))
+            .registerRowMapper(BooleanPrimitiveTable.class, BeanMapper.of(BooleanPrimitiveTable.class)))
+        .withInitializer((ds, h) -> {
+            h.execute("create table test_table (table_name varchar, is_view boolean)");
+            h.execute("insert into test_table (table_name, is_view) values ('abc', 1)");
+            h.execute("insert into test_table (table_name, is_view) values ('def', 0)");
+        });
 
     private Handle handle;
 

--- a/e2e/src/test/java/org/jdbi/e2e/virtualthread/TestVirtualThreads.java
+++ b/e2e/src/test/java/org/jdbi/e2e/virtualthread/TestVirtualThreads.java
@@ -73,7 +73,7 @@ class TestVirtualThreads {
         hikariCfg.setMaximumPoolSize(10);
         hikariCfg.setJdbcUrl(h2Extension.getUrl());
         try (var pool = new HikariDataSource(hikariCfg)) {
-            final var dao = Jdbi.create(pool).installPlugin(new SqlObjectPlugin()).onDemand(UserDao.class);
+            final var dao = Jdbi.builder(pool).installPlugin(new SqlObjectPlugin()).build().onDemand(UserDao.class);
             final var inserts = IntStream.range(100, 200)
                     .mapToObj(id -> new User(id, "User " + id))
                     .toList();

--- a/examples/src/main/java/org/jdbi/examples/CustomSqlArrayType.java
+++ b/examples/src/main/java/org/jdbi/examples/CustomSqlArrayType.java
@@ -52,28 +52,28 @@ public final class CustomSqlArrayType {
             Instant.parse("9999-12-31T23:59:59Z"),
         };
 
-        withDatabase(jdbi -> {
-            // create database table
-            jdbi.inTransaction(th -> {
-                th.execute("DROP TABLE IF EXISTS custom_sql");
-                th.execute("CREATE TABLE custom_sql (t TIMESTAMP[])");
-                return null;
-            });
-
+        withDatabase(
             // register the custom array type to map instant to timestamp
-            jdbi.registerArrayType(Instant.class, "timestamp");
+            builder -> builder.registerArrayType(Instant.class, "timestamp"),
+            jdbi -> {
+                // create database table
+                jdbi.inTransaction(th -> {
+                    th.execute("DROP TABLE IF EXISTS custom_sql");
+                    th.execute("CREATE TABLE custom_sql (t TIMESTAMP[])");
+                    return null;
+                });
 
-            CustomSqlObject dao = jdbi.onDemand(CustomSqlObject.class);
+                CustomSqlObject dao = jdbi.onDemand(CustomSqlObject.class);
 
-            // write data (with a sql object)
-            dao.insertInstantArray(testInstants);
+                // write data (with a sql object)
+                dao.insertInstantArray(testInstants);
 
-            // fetch results back
-            List<Instant> result = dao.fetchInstantList();
+                // fetch results back
+                List<Instant> result = dao.fetchInstantList();
 
-            // display results
-            result.forEach(r -> System.out.printf("%s%n", r));
-        });
+                // display results
+                result.forEach(r -> System.out.printf("%s%n", r));
+            });
     }
 
     public interface CustomSqlObject {

--- a/examples/src/main/java/org/jdbi/examples/QualifiedTypes.java
+++ b/examples/src/main/java/org/jdbi/examples/QualifiedTypes.java
@@ -42,9 +42,9 @@ public final class QualifiedTypes {
         throw new AssertionError("do not instantiate");
     }
 
-    public static void registerMappers(Jdbi jdbi) {
-        jdbi.registerColumnMapper(QualifiedType.of(new GenericType<List<String>>() {}).with(Colon.class), new ColonMapper());
-        jdbi.registerColumnMapper(QualifiedType.of(new GenericType<List<String>>() {}).with(Comma.class), new CommaMapper());
+    public static void registerMappers(Jdbi.Builder builder) {
+        builder.registerColumnMapper(QualifiedType.of(new GenericType<List<String>>() {}).with(Colon.class), new ColonMapper());
+        builder.registerColumnMapper(QualifiedType.of(new GenericType<List<String>>() {}).with(Comma.class), new CommaMapper());
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/examples/src/main/java/org/jdbi/examples/order/OrderSupport.java
+++ b/examples/src/main/java/org/jdbi/examples/order/OrderSupport.java
@@ -28,14 +28,14 @@ public final class OrderSupport {
     }
 
     public static void withOrders(Consumer<Jdbi> jdbiConsumer) throws Exception {
-        DatabaseSupport.withDatabase(jdbi -> {
-            createTables(jdbi);
-            populateOrders(jdbi, 3, 20);
+        DatabaseSupport.withDatabase(
+            builder -> builder.registerRowMapper(new OrderMapper()),
+            jdbi -> {
+                createTables(jdbi);
+                populateOrders(jdbi, 3, 20);
 
-            jdbi.registerRowMapper(new OrderMapper());
-
-            jdbiConsumer.accept(jdbi);
-        });
+                jdbiConsumer.accept(jdbi);
+            });
     }
 
     public static void createTables(Jdbi jdbi) {

--- a/examples/src/main/java/org/jdbi/examples/support/DatabaseSupport.java
+++ b/examples/src/main/java/org/jdbi/examples/support/DatabaseSupport.java
@@ -35,9 +35,10 @@ public final class DatabaseSupport {
             .build()
             .start()) {
             DatabaseInfo databaseInfo = manager.getDatabaseInfo();
-            Jdbi jdbi = Jdbi.create(databaseInfo.asDataSource());
-            jdbi.installPlugin(new SqlObjectPlugin())
-                .installPlugin(new PostgresPlugin());
+            Jdbi jdbi = Jdbi.builder(databaseInfo.asDataSource())
+                .installPlugin(new SqlObjectPlugin())
+                .installPlugin(new PostgresPlugin())
+                .build();
 
             jdbiConsumer.accept(jdbi);
         }

--- a/examples/src/main/java/org/jdbi/examples/support/DatabaseSupport.java
+++ b/examples/src/main/java/org/jdbi/examples/support/DatabaseSupport.java
@@ -29,18 +29,22 @@ public final class DatabaseSupport {
     }
 
     public static void withDatabase(Consumer<Jdbi> jdbiConsumer) throws Exception {
+        withDatabase(builder -> {}, jdbiConsumer);
+    }
+
+    public static void withDatabase(Consumer<Jdbi.Builder> builderConfig, Consumer<Jdbi> jdbiConsumer) throws Exception {
         try (DatabaseManager manager = DatabaseManager.singleDatabase()
             // same as EmbeddedPostgres.defaultInstance()
             .withInstancePreparer(EmbeddedPostgres.Builder::withDefaults)
             .build()
             .start()) {
             DatabaseInfo databaseInfo = manager.getDatabaseInfo();
-            Jdbi jdbi = Jdbi.builder(databaseInfo.asDataSource())
+            Jdbi.Builder builder = Jdbi.builder(databaseInfo.asDataSource())
                 .installPlugin(new SqlObjectPlugin())
-                .installPlugin(new PostgresPlugin())
-                .build();
+                .installPlugin(new PostgresPlugin());
+            builderConfig.accept(builder);
 
-            jdbiConsumer.accept(jdbi);
+            jdbiConsumer.accept(builder.build());
         }
     }
 }

--- a/examples/src/test/java/org/jdbi/examples/TestQualifiedTypes.java
+++ b/examples/src/test/java/org/jdbi/examples/TestQualifiedTypes.java
@@ -41,16 +41,17 @@ public class TestQualifiedTypes {
                 h.execute("CREATE TABLE data (id serial primary key, comma varchar(50), colon varchar(50))");
                 h.execute("INSERT INTO data (comma,colon) VALUES ('one,two,three,four', 'eins:zwei:drei:vier')");
             })
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> {
+                b.registerRowMapper(Data.class, ConstructorMapper.of(Data.class));
+                QualifiedTypes.registerMappers(b);
+            });
 
     private DataDao dao;
 
     @BeforeEach
     public void setUp() {
-        var jdbi = pgExtension.getJdbi();
-        jdbi.registerRowMapper(Data.class, ConstructorMapper.of(Data.class));
-        QualifiedTypes.registerMappers(jdbi);
-        this.dao = jdbi.onDemand(DataDao.class);
+        this.dao = pgExtension.getJdbi().onDemand(DataDao.class);
     }
 
     @Test

--- a/examples/src/test/java/org/jdbi/examples/auth/TestAuthenticationExample.java
+++ b/examples/src/test/java/org/jdbi/examples/auth/TestAuthenticationExample.java
@@ -42,16 +42,14 @@ public class TestAuthenticationExample {
                 h.execute("INSERT INTO users (name, password) VALUES ('user','correct')");
                 h.execute("INSERT INTO data (value) VALUES ('secret')");
             })
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b.registerRowMapper(Data.class, ConstructorMapper.of(Data.class)));
 
     private DataDao dao;
 
     @BeforeEach
     public void setUp() {
-        var jdbi = pgExtension.getJdbi();
-        jdbi.registerRowMapper(Data.class, ConstructorMapper.of(Data.class));
-
-        this.dao = jdbi.onDemand(DataDao.class);
+        this.dao = pgExtension.getJdbi().onDemand(DataDao.class);
     }
 
     @Test

--- a/freemarker/src/main/java/org/jdbi/freemarker/FreemarkerConfig.java
+++ b/freemarker/src/main/java/org/jdbi/freemarker/FreemarkerConfig.java
@@ -15,6 +15,7 @@ package org.jdbi.freemarker;
 
 import java.util.Optional;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.template.Configuration;
 import org.jdbi.core.config.JdbiConfig;
@@ -38,6 +39,7 @@ public final class FreemarkerConfig implements JdbiConfig<FreemarkerConfig> {
         return configuration;
     }
 
+    @CheckReturnValue
     public FreemarkerConfig freemarkerConfiguration(Configuration freemarkerConfiguration) {
         return new FreemarkerConfig(freemarkerConfiguration);
     }

--- a/freemarker/src/test/java/org/jdbi/freemarker/BindBeanListTest.java
+++ b/freemarker/src/test/java/org/jdbi/freemarker/BindBeanListTest.java
@@ -42,13 +42,14 @@ public class BindBeanListTest {
     private List<Something> expectedSomethings;
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something());
+    public JdbiExtension h2Extension = JdbiExtension.h2()
+        .withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()))
+        .withInitializer(TestingInitializers.something());
 
     @BeforeEach
     public void before() {
         final Jdbi db = h2Extension.getJdbi();
-        db.installPlugin(new SqlObjectPlugin());
-        db.registerRowMapper(new SomethingMapper());
         handle = db.open();
 
         handle.execute("insert into something(id, name) values(1, '1')");

--- a/freemarker/src/test/java/org/jdbi/freemarker/BindListTest.java
+++ b/freemarker/src/test/java/org/jdbi/freemarker/BindListTest.java
@@ -43,13 +43,14 @@ public class BindListTest {
     private List<Something> expectedSomethings;
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something());
+    public JdbiExtension h2Extension = JdbiExtension.h2()
+        .withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()))
+        .withInitializer(TestingInitializers.something());
 
     @BeforeEach
     public void before() {
         final Jdbi db = h2Extension.getJdbi();
-        db.installPlugin(new SqlObjectPlugin());
-        db.registerRowMapper(new SomethingMapper());
         handle = db.open();
 
         handle.execute("insert into something(id, name) values(1, '1')");

--- a/freemarker/src/test/java/org/jdbi/freemarker/TestIssue2562.java
+++ b/freemarker/src/test/java/org/jdbi/freemarker/TestIssue2562.java
@@ -36,7 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestIssue2562 {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(User.class, ConstructorMapper.of(User.class)));
 
     private Handle handle;
     private UserSearchDao dao;
@@ -45,7 +46,6 @@ public class TestIssue2562 {
     @BeforeEach
     public void setUp() {
         handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(User.class, ConstructorMapper.of(User.class));
         handle.execute("CREATE TABLE users (user_id identity primary key, name varchar(64))");
         dao = handle.attach(UserSearchDao.class);
 

--- a/generator/src/test/java/org/jdbi/generator/NonpublicSubclassTest.java
+++ b/generator/src/test/java/org/jdbi/generator/NonpublicSubclassTest.java
@@ -51,7 +51,8 @@ public class NonpublicSubclassTest {
     public JdbiExtension h2Extension = JdbiExtension.h2()
         .withPlugins(new H2DatabasePlugin(), new SqlObjectPlugin())
         .withInitializer(TestingInitializers.something())
-        .withConfig(Extensions.class, c -> c.allowProxy(false));
+        .withConfig(Extensions.class, c -> c.allowProxy(false))
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
 
     private Handle handle;
     private AbstractClassDao dao;
@@ -59,7 +60,6 @@ public class NonpublicSubclassTest {
     @BeforeEach
     public void setUp() {
         handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new SomethingMapper());
         dao = handle.attach(AbstractClassDao.class);
     }
 

--- a/gson2/src/main/java/org/jdbi/gson2/Gson2Config.java
+++ b/gson2/src/main/java/org/jdbi/gson2/Gson2Config.java
@@ -14,6 +14,7 @@
 package org.jdbi.gson2;
 
 import com.google.gson.Gson;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 
 /**
@@ -35,6 +36,7 @@ public final class Gson2Config implements JdbiConfig<Gson2Config> {
      * @param gson the mapper to use
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Gson2Config gson(Gson gson) {
         return new Gson2Config(gson);
     }

--- a/gson2/src/main/java/org/jdbi/gson2/GsonJsonMapper.java
+++ b/gson2/src/main/java/org/jdbi/gson2/GsonJsonMapper.java
@@ -18,13 +18,13 @@ import java.lang.reflect.Type;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.result.UnableToProduceResultException;
 import org.jdbi.json.JsonMapper;
 
 class GsonJsonMapper implements JsonMapper {
     @Override
-    public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+    public TypedJsonMapper forType(Type type, ConfigView config) {
         return new TypedJsonMapper() {
             @SuppressWarnings("rawtypes")
             private final TypeAdapter adapter = config.get(Gson2Config.class)
@@ -32,12 +32,12 @@ class GsonJsonMapper implements JsonMapper {
 
             @SuppressWarnings("unchecked")
             @Override
-            public String toJson(Object value, ConfigRegistry config) {
+            public String toJson(Object value, ConfigView config) {
                 return adapter.toJson(value);
             }
 
             @Override
-            public Object fromJson(String json, ConfigRegistry config) {
+            public Object fromJson(String json, ConfigView config) {
                 try {
                     return adapter.fromJson(json);
                 } catch (IOException e) {

--- a/gson2/src/test/java/org/jdbi/gson2/TestGson2Plugin.java
+++ b/gson2/src/test/java/org/jdbi/gson2/TestGson2Plugin.java
@@ -55,14 +55,12 @@ public class TestGson2Plugin extends AbstractJsonMapperTest {
 
     @Test
     public void typeCanBeOverridden() {
-        pgExtension.getJdbi().useHandle(h -> {
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapter(SuperUser.class, new SuperUserAdapter())
+            .registerTypeAdapter(SubUser.class, new SubUserAdapter())
+            .create();
+        pgExtension.getJdbi().useHandle(cfg -> cfg.configure(Gson2Config.class, c -> c.gson(gson)), h -> {
             h.createUpdate("create table users(usr json)").execute();
-
-            Gson gson = new GsonBuilder()
-                .registerTypeAdapter(SuperUser.class, new SuperUserAdapter())
-                .registerTypeAdapter(SubUser.class, new SubUserAdapter())
-                .create();
-            h.configure(Gson2Config.class, c -> c.gson(gson));
 
             h.createUpdate("insert into users(usr) values(:user)")
                 // declare that the subuser should be mapped as a superuser

--- a/guava/src/main/java/org/jdbi/guava/GuavaArguments.java
+++ b/guava/src/main/java/org/jdbi/guava/GuavaArguments.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
 import org.jdbi.core.argument.ArgumentResolver;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.UtilityClassException;
 
 import static org.jdbi.core.generic.GenericTypes.findGenericParameter;
@@ -50,7 +50,7 @@ public class GuavaArguments {
     private static class Factory implements ArgumentFactory {
 
         @Override
-        public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
             if (value instanceof com.google.common.base.Optional<?> maybeValue) {
                 Object nestedValue = maybeValue.orNull();
                 Type nestedType = findOptionalType(expectedType, nestedValue);

--- a/guava/src/test/java/org/jdbi/guava/TestGuavaMappers.java
+++ b/guava/src/test/java/org/jdbi/guava/TestGuavaMappers.java
@@ -34,15 +34,15 @@ public class TestGuavaMappers {
     public static EmbeddedPgExtension pg = MultiDatabaseBuilder.instanceWithDefaults().build();
 
     @RegisterExtension
-    public JdbiExtension pgExtension = JdbiExtension.postgres(pg).withPlugin(new GuavaPlugin());
+    public JdbiExtension pgExtension = JdbiExtension.postgres(pg).withPlugin(new GuavaPlugin())
+            .withConfig(b -> b
+                .registerArrayType(Integer.class, "integer")
+                .registerArrayType(UUID.class, "uuid"));
 
     private Handle h;
 
     @BeforeEach
     public void setUp() {
-        pgExtension.getJdbi()
-                .registerArrayType(Integer.class, "integer")
-                .registerArrayType(UUID.class, "uuid");
         h = pgExtension.openHandle();
         h.useTransaction(th -> {
             th.execute("DROP TABLE IF EXISTS arrays");

--- a/guava/src/test/java/org/jdbi/guava/TestGuavaOptional.java
+++ b/guava/src/test/java/org/jdbi/guava/TestGuavaOptional.java
@@ -22,7 +22,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.core.Something;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.result.ResultIterable;
 import org.jdbi.core.statement.Query;
@@ -165,7 +165,7 @@ public class TestGuavaOptional {
 
     static class NameArgumentFactory implements ArgumentFactory {
         @Override
-        public java.util.Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+        public java.util.Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
             if (expectedType == Name.class) {
                 Name nameValue = (Name) value;
                 return java.util.Optional.of((pos, stmt, c) -> stmt.setString(pos, nameValue.value));

--- a/guava/src/test/java/org/jdbi/guava/TestGuavaOptional.java
+++ b/guava/src/test/java/org/jdbi/guava/TestGuavaOptional.java
@@ -82,8 +82,8 @@ public class TestGuavaOptional {
 
     @Test
     public void testDynamicBindOptionalOfCustomType() {
-        handle.registerArgument(new NameArgumentFactory());
         List<Something> result = handle.createQuery(SELECT_BY_NAME)
+            .registerArgument(new NameArgumentFactory())
             .bindByType("name", Optional.of(new Name("eric")), new GenericType<Optional<Name>>() {})
             .mapToBean(Something.class)
             .list();
@@ -123,8 +123,8 @@ public class TestGuavaOptional {
 
     @Test
     public void testBindOptionalOfCustomType() {
-        handle.registerArgument(new NameArgumentFactory());
         List<Something> result = handle.createQuery(SELECT_BY_NAME)
+            .registerArgument(new NameArgumentFactory())
             .bind("name", Optional.of(new Name("eric")))
             .mapToBean(Something.class)
             .list();

--- a/guice/src/main/java/org/jdbi/guice/GuiceJdbiCustomizer.java
+++ b/guice/src/main/java/org/jdbi/guice/GuiceJdbiCustomizer.java
@@ -16,18 +16,19 @@ package org.jdbi.guice;
 import org.jdbi.core.Jdbi;
 
 /**
- * Allows specific customizations of the {@link Jdbi} instance during creation.
+ * Allows specific customizations of the {@link Jdbi} instance during creation, contributed through its
+ * {@link Jdbi.Builder} while the instance is being assembled.
  */
 @FunctionalInterface
 public interface GuiceJdbiCustomizer {
 
     /** Does not modify the Jdbi instance. */
-    GuiceJdbiCustomizer NOP = jdbi -> {};
+    GuiceJdbiCustomizer NOP = builder -> {};
 
     /**
-     * Customize the {@link Jdbi} instance passed in.
+     * Customize the {@link Jdbi} instance being assembled by contributing to its builder.
      *
-     * @param jdbi A {@link Jdbi} instance.
+     * @param builder the {@link Jdbi.Builder} for the instance being assembled.
      */
-    void customize(Jdbi jdbi);
+    void customize(Jdbi.Builder builder);
 }

--- a/guice/src/main/java/org/jdbi/guice/internal/InternalGuiceJdbiCustomizer.java
+++ b/guice/src/main/java/org/jdbi/guice/internal/InternalGuiceJdbiCustomizer.java
@@ -68,19 +68,19 @@ public class InternalGuiceJdbiCustomizer implements GuiceJdbiCustomizer {
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public void customize(Jdbi jdbi) {
-        rowMappers.forEach(jdbi::registerRowMapper);
-        qualifiedRowMappers.forEach(jdbi::registerRowMapper);
+    public void customize(Jdbi.Builder builder) {
+        rowMappers.forEach(builder::registerRowMapper);
+        qualifiedRowMappers.forEach(builder::registerRowMapper);
 
-        columnMappers.forEach(jdbi::registerColumnMapper);
-        qualifiedColumnMappers.forEach((k, v) -> jdbi.registerColumnMapper((QualifiedType) k, (ColumnMapper) v));
+        columnMappers.forEach(builder::registerColumnMapper);
+        qualifiedColumnMappers.forEach((k, v) -> builder.registerColumnMapper((QualifiedType) k, (ColumnMapper) v));
 
-        jdbi.registerColumnMapper(codecFactory);
-        jdbi.registerArgument(codecFactory);
+        builder.registerColumnMapper(codecFactory);
+        builder.registerArgument(codecFactory);
 
-        plugins.forEach(jdbi::installPlugin);
+        plugins.forEach(builder::installPlugin);
 
-        arrayTypes.forEach(jdbi::registerArrayType);
-        customizers.forEach(c -> c.customize(jdbi));
+        arrayTypes.forEach(builder::registerArrayType);
+        customizers.forEach(c -> c.customize(builder));
     }
 }

--- a/guice/src/main/java/org/jdbi/guice/internal/InternalGuiceJdbiFactory.java
+++ b/guice/src/main/java/org/jdbi/guice/internal/InternalGuiceJdbiFactory.java
@@ -44,9 +44,9 @@ public final class InternalGuiceJdbiFactory implements Provider<Jdbi> {
 
     @Override
     public Jdbi get() {
-        Jdbi jdbi = Jdbi.create(dataSource);
-        moduleCustomizers.forEach(c -> c.customize(jdbi));
+        Jdbi.Builder builder = Jdbi.builder(dataSource);
+        moduleCustomizers.forEach(c -> c.customize(builder));
 
-        return jdbi;
+        return builder.build();
     }
 }

--- a/guice/src/test/java/org/jdbi/guice/TestJdbiBinder.java
+++ b/guice/src/test/java/org/jdbi/guice/TestJdbiBinder.java
@@ -30,7 +30,7 @@ import com.google.inject.Scopes;
 import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
 import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
 import org.jdbi.core.Jdbi;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.statement.StatementContext;
@@ -195,7 +195,7 @@ public class TestJdbiBinder {
             }
 
             @Override
-            public void init(ConfigRegistry registry) {
+            public void init(ConfigView registry) {
                 myStringMapper = registry.findColumnMapperFor(MyString.class).orElseThrow(IllegalStateException::new);
             }
         }

--- a/guice/src/test/java/org/jdbi/guice/util/table/Table.java
+++ b/guice/src/test/java/org/jdbi/guice/util/table/Table.java
@@ -23,7 +23,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.statement.StatementContext;
@@ -96,7 +96,7 @@ public final class Table {
         public TableMapper() {}
 
         @Override
-        public void init(ConfigRegistry registry) {
+        public void init(ConfigView registry) {
             this.jsonMapper = registry.findColumnMapperFor(JsonCodec.TYPE).orElseThrow(IllegalStateException::new);
         }
 

--- a/jackson2/src/main/java/org/jdbi/jackson2/Jackson2Config.java
+++ b/jackson2/src/main/java/org/jdbi/jackson2/Jackson2Config.java
@@ -14,6 +14,7 @@
 package org.jdbi.jackson2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 
 /**
@@ -41,6 +42,7 @@ public final class Jackson2Config implements JdbiConfig<Jackson2Config> {
      * @param mapper the mapper to use
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson2Config mapper(ObjectMapper mapper) {
         return new Jackson2Config(mapper, serializationView, deserializationView, useStaticType);
     }
@@ -60,6 +62,7 @@ public final class Jackson2Config implements JdbiConfig<Jackson2Config> {
      * @param view the view class
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson2Config view(Class<?> view) {
         return serializationView(view).deserializationView(view);
     }
@@ -69,6 +72,7 @@ public final class Jackson2Config implements JdbiConfig<Jackson2Config> {
      * @param serializationView the serialization view
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson2Config serializationView(Class<?> serializationView) {
         return new Jackson2Config(mapper, serializationView, deserializationView, useStaticType);
     }
@@ -87,6 +91,7 @@ public final class Jackson2Config implements JdbiConfig<Jackson2Config> {
      * @param deserializationView the serialization view
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson2Config deserializationView(Class<?> deserializationView) {
         return new Jackson2Config(mapper, serializationView, deserializationView, useStaticType);
     }
@@ -107,6 +112,7 @@ public final class Jackson2Config implements JdbiConfig<Jackson2Config> {
      * @param useStaticType whether to prefer using static type information
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson2Config useStaticType(boolean useStaticType) {
         return new Jackson2Config(mapper, serializationView, deserializationView, useStaticType);
     }

--- a/jackson2/src/main/java/org/jdbi/jackson2/JacksonJsonMapper.java
+++ b/jackson2/src/main/java/org/jdbi/jackson2/JacksonJsonMapper.java
@@ -21,13 +21,13 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.result.UnableToProduceResultException;
 import org.jdbi.json.JsonMapper;
 
 class JacksonJsonMapper implements JsonMapper {
     @Override
-    public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+    public TypedJsonMapper forType(Type type, ConfigView config) {
         return new TypedJsonMapper() {
             private final Jackson2Config jacksonConfig = config.get(Jackson2Config.class);
             private final ObjectMapper mapper = jacksonConfig.getMapper();
@@ -39,7 +39,7 @@ class JacksonJsonMapper implements JsonMapper {
                             : mapper.writer();
 
             @Override
-            public String toJson(Object value, ConfigRegistry config) {
+            public String toJson(Object value, ConfigView config) {
                 final Class<?> view = config.get(Jackson2Config.class).getSerializationView();
                 final ObjectWriter viewWriter =
                           view == null
@@ -53,7 +53,7 @@ class JacksonJsonMapper implements JsonMapper {
             }
 
             @Override
-            public Object fromJson(String json, ConfigRegistry config) {
+            public Object fromJson(String json, ConfigView config) {
                 final Class<?> view = config.get(Jackson2Config.class).getDeserializationView();
                 final ObjectReader viewReader =
                           view == null

--- a/jackson2/src/test/java/org/jdbi/jackson2/TestJackson2Plugin.java
+++ b/jackson2/src/test/java/org/jdbi/jackson2/TestJackson2Plugin.java
@@ -28,10 +28,8 @@ import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
 import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
 import org.immutables.value.Value;
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.qualifier.QualifiedType;
-import org.jdbi.core.spi.JdbiPlugin;
 import org.jdbi.json.AbstractJsonMapperTest;
 import org.jdbi.json.Json;
 import org.jdbi.postgres.PostgresPlugin;
@@ -60,12 +58,7 @@ public class TestJackson2Plugin extends AbstractJsonMapperTest {
         .withConfig(Jackson2Config.class, c -> c.mapper(new ObjectMapper()
             .registerModule(new ParameterNamesModule())
             .registerModule(new Jdk8Module())))
-        .withPlugin(new JdbiPlugin() {
-            @Override
-            public void customizeJdbi(Jdbi jdbi) {
-                jdbi.registerImmutable(JsonContainer.class);
-            }
-        });
+        .withConfig(b -> b.registerImmutable(JsonContainer.class));
 
     private Handle h;
 

--- a/jackson2/src/test/java/org/jdbi/jackson2/TestJackson2Plugin.java
+++ b/jackson2/src/test/java/org/jdbi/jackson2/TestJackson2Plugin.java
@@ -133,8 +133,8 @@ public class TestJackson2Plugin extends AbstractJsonMapperTest {
 
     @Test
     public void testSerializationView() {
-        h.configure(Jackson2Config.class, c -> c.serializationView(ViewTest.ViewB.class));
         assertThat(h.createQuery("select :vt::json ->> 'a'")
+                .configure(Jackson2Config.class, c -> c.serializationView(ViewTest.ViewB.class))
                 .bindByType("vt", viewValue, viewJsonType)
                 .mapTo(Integer.class)
                 .one())
@@ -143,8 +143,8 @@ public class TestJackson2Plugin extends AbstractJsonMapperTest {
 
     @Test
     public void testDeserializationView() {
-        h.configure(Jackson2Config.class, c -> c.deserializationView(ViewTest.ViewA.class));
         assertThat(h.createQuery("select '{\"a\":42,\"b\":43}'::json")
+                .configure(Jackson2Config.class, c -> c.deserializationView(ViewTest.ViewA.class))
                 .mapTo(viewJsonType)
                 .one())
             .extracting(ViewTest::getA, ViewTest::getB)

--- a/jackson3/src/main/java/org/jdbi/jackson3/Jackson3Config.java
+++ b/jackson3/src/main/java/org/jdbi/jackson3/Jackson3Config.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.jackson3;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import tools.jackson.databind.ObjectMapper;
 
@@ -41,6 +42,7 @@ public final class Jackson3Config implements JdbiConfig<Jackson3Config> {
      * @param mapper the mapper to use
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson3Config mapper(final ObjectMapper mapper) {
         return new Jackson3Config(mapper, serializationView, deserializationView, useStaticType);
     }
@@ -60,6 +62,7 @@ public final class Jackson3Config implements JdbiConfig<Jackson3Config> {
      * @param view the view class
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson3Config view(final Class<?> view) {
         return serializationView(view).deserializationView(view);
     }
@@ -69,6 +72,7 @@ public final class Jackson3Config implements JdbiConfig<Jackson3Config> {
      * @param serializationView the serialization view
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson3Config serializationView(final Class<?> serializationView) {
         return new Jackson3Config(mapper, serializationView, deserializationView, useStaticType);
     }
@@ -87,6 +91,7 @@ public final class Jackson3Config implements JdbiConfig<Jackson3Config> {
      * @param deserializationView the serialization view
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson3Config deserializationView(final Class<?> deserializationView) {
         return new Jackson3Config(mapper, serializationView, deserializationView, useStaticType);
     }
@@ -107,6 +112,7 @@ public final class Jackson3Config implements JdbiConfig<Jackson3Config> {
      * @param useStaticType whether to prefer using static type information
      * @return the derived configuration
      */
+    @CheckReturnValue
     public Jackson3Config useStaticType(final boolean useStaticType) {
         return new Jackson3Config(mapper, serializationView, deserializationView, useStaticType);
     }

--- a/jackson3/src/main/java/org/jdbi/jackson3/JacksonJsonMapper.java
+++ b/jackson3/src/main/java/org/jdbi/jackson3/JacksonJsonMapper.java
@@ -15,7 +15,7 @@ package org.jdbi.jackson3;
 
 import java.lang.reflect.Type;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.result.UnableToProduceResultException;
 import org.jdbi.json.JsonMapper;
 import tools.jackson.core.JacksonException;
@@ -26,7 +26,7 @@ import tools.jackson.databind.ObjectWriter;
 
 class JacksonJsonMapper implements JsonMapper {
     @Override
-    public TypedJsonMapper forType(final Type type, final ConfigRegistry config) {
+    public TypedJsonMapper forType(final Type type, final ConfigView config) {
         return new TypedJsonMapper() {
             private final Jackson3Config jacksonConfig = config.get(Jackson3Config.class);
             private final ObjectMapper mapper = jacksonConfig.getMapper();
@@ -38,7 +38,7 @@ class JacksonJsonMapper implements JsonMapper {
                             : mapper.writer();
 
             @Override
-            public String toJson(final Object value, final ConfigRegistry config) {
+            public String toJson(final Object value, final ConfigView config) {
                 final Class<?> view = config.get(Jackson3Config.class).getSerializationView();
                 final ObjectWriter viewWriter =
                           view == null
@@ -52,7 +52,7 @@ class JacksonJsonMapper implements JsonMapper {
             }
 
             @Override
-            public Object fromJson(final String json, final ConfigRegistry config) {
+            public Object fromJson(final String json, final ConfigView config) {
                 final Class<?> view = config.get(Jackson3Config.class).getDeserializationView();
                 final ObjectReader viewReader =
                           view == null

--- a/jackson3/src/test/java/org/jdbi/jackson3/TestJackson3Plugin.java
+++ b/jackson3/src/test/java/org/jdbi/jackson3/TestJackson3Plugin.java
@@ -23,10 +23,8 @@ import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
 import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
 import org.immutables.value.Value;
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.qualifier.QualifiedType;
-import org.jdbi.core.spi.JdbiPlugin;
 import org.jdbi.json.AbstractJsonMapperTest;
 import org.jdbi.json.Json;
 import org.jdbi.postgres.PostgresPlugin;
@@ -54,12 +52,7 @@ public class TestJackson3Plugin extends AbstractJsonMapperTest {
     @RegisterExtension
     JdbiExtension pgExtension = JdbiExtension.postgres(pg)
         .withPlugins(new SqlObjectPlugin(), new PostgresPlugin(), new Jackson3Plugin())
-        .withPlugin(new JdbiPlugin() {
-            @Override
-            public void customizeJdbi(Jdbi jdbi) {
-                jdbi.registerImmutable(JsonContainer.class);
-            }
-        });
+        .withConfig(b -> b.registerImmutable(JsonContainer.class));
 
     private Handle h;
 

--- a/jackson3/src/test/java/org/jdbi/jackson3/TestJackson3Plugin.java
+++ b/jackson3/src/test/java/org/jdbi/jackson3/TestJackson3Plugin.java
@@ -127,8 +127,8 @@ public class TestJackson3Plugin extends AbstractJsonMapperTest {
 
     @Test
     public void testSerializationView() {
-        h.configure(Jackson3Config.class, c -> c.serializationView(ViewTest.ViewB.class));
         assertThat(h.createQuery("select :vt::json ->> 'a'")
+                .configure(Jackson3Config.class, c -> c.serializationView(ViewTest.ViewB.class))
                 .bindByType("vt", viewValue, viewJsonType)
                 .mapTo(Integer.class)
                 .one())
@@ -137,8 +137,8 @@ public class TestJackson3Plugin extends AbstractJsonMapperTest {
 
     @Test
     public void testDeserializationView() {
-        h.configure(Jackson3Config.class, c -> c.deserializationView(ViewTest.ViewA.class));
         assertThat(h.createQuery("select '{\"a\":42,\"b\":43}'::json")
+                .configure(Jackson3Config.class, c -> c.deserializationView(ViewTest.ViewA.class))
                 .mapTo(viewJsonType)
                 .one())
             .extracting(ViewTest::getA, ViewTest::getB)

--- a/jodatime2/src/main/java/org/jdbi/jodatime2/DateTimeArgumentFactory.java
+++ b/jodatime2/src/main/java/org/jdbi/jodatime2/DateTimeArgumentFactory.java
@@ -20,7 +20,7 @@ import java.sql.Types;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.internal.strategies.LoggableBinderArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.joda.time.DateTime;
 
 /**
@@ -32,7 +32,7 @@ public class DateTimeArgumentFactory extends AbstractArgumentFactory<DateTime> {
     }
 
     @Override
-    protected Argument build(DateTime value, ConfigRegistry config) {
+    protected Argument build(DateTime value, ConfigView config) {
         return new LoggableBinderArgument<>(new Timestamp(value.getMillis()), PreparedStatement::setTimestamp);
     }
 }

--- a/jpa/src/main/java/org/jdbi/jpa/JpaMapperFactory.java
+++ b/jpa/src/main/java/org/jdbi/jpa/JpaMapperFactory.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import javax.persistence.Entity;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.mapper.RowMapperFactory;
 
@@ -29,7 +29,7 @@ import static org.jdbi.core.generic.GenericTypes.getErasedType;
  */
 public class JpaMapperFactory implements RowMapperFactory {
     @Override
-    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<RowMapper<?>> build(Type type, ConfigView config) {
         Class<?> clazz = getErasedType(type);
         return clazz.isAnnotationPresent(Entity.class)
                 ? Optional.of(new JpaMapper<>(clazz))

--- a/json/src/main/java/org/jdbi/json/JsonConfig.java
+++ b/json/src/main/java/org/jdbi/json/JsonConfig.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.json;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.json.internal.UnimplementedJsonMapper;
 
@@ -27,6 +28,7 @@ public final class JsonConfig implements JdbiConfig<JsonConfig> {
         this.mapper = mapper;
     }
 
+    @CheckReturnValue
     public JsonConfig jsonMapper(JsonMapper jsonMapper) {
         return new JsonConfig(jsonMapper);
     }

--- a/json/src/main/java/org/jdbi/json/JsonMapper.java
+++ b/json/src/main/java/org/jdbi/json/JsonMapper.java
@@ -15,7 +15,7 @@ package org.jdbi.json;
 
 import java.lang.reflect.Type;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * Deserializes JSON to Java objects, and serializes Java objects to JSON.
@@ -28,19 +28,19 @@ import org.jdbi.core.config.ConfigRegistry;
 @SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface JsonMapper {
     @Deprecated(since = "3.40.0", forRemoval = true)
-    default String toJson(Type type, Object value, ConfigRegistry config) {
+    default String toJson(Type type, Object value, ConfigView config) {
         return forType(type, config).toJson(value, config);
     }
 
     @Deprecated(since = "3.40.0", forRemoval = true)
-    default Object fromJson(Type type, String json, ConfigRegistry config) {
+    default Object fromJson(Type type, String json, ConfigView config) {
         return forType(type, config).fromJson(json, config);
     }
 
-    TypedJsonMapper forType(Type type, ConfigRegistry config);
+    TypedJsonMapper forType(Type type, ConfigView config);
 
     interface TypedJsonMapper {
-        String toJson(Object value, ConfigRegistry config);
-        Object fromJson(String json, ConfigRegistry config);
+        String toJson(Object value, ConfigView config);
+        Object fromJson(String json, ConfigView config);
     }
 }

--- a/json/src/main/java/org/jdbi/json/internal/JsonArgumentFactory.java
+++ b/json/src/main/java/org/jdbi/json/internal/JsonArgumentFactory.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
 import org.jdbi.core.argument.ArgumentResolver;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.JdbiOptionals;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.core.statement.UnableToCreateStatementException;
@@ -42,7 +42,7 @@ public class JsonArgumentFactory implements ArgumentFactory.Preparable {
     );
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         TypedJsonMapper mapper = config.get(JsonConfig.class).getJsonMapper().forType(type, config);
         ArgumentResolver a = ArgumentResolver.forRegistry(config);
         // look for specialized json support first, revert to simple String binding if absent

--- a/json/src/main/java/org/jdbi/json/internal/JsonColumnMapperFactory.java
+++ b/json/src/main/java/org/jdbi/json/internal/JsonColumnMapperFactory.java
@@ -16,7 +16,7 @@ package org.jdbi.json.internal;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.JdbiOptionals;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
@@ -38,7 +38,7 @@ public class JsonColumnMapperFactory implements ColumnMapperFactory {
     );
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         // look for specialized json support first, revert to simple String mapping if absent
         ColumnMapper<String> jsonStringMapper = JdbiOptionals.findFirstPresent(
                 () -> config.findColumnMapperFor(QualifiedType.of(String.class).with(EncodedJson.class)),

--- a/json/src/main/java/org/jdbi/json/internal/UnimplementedJsonMapper.java
+++ b/json/src/main/java/org/jdbi/json/internal/UnimplementedJsonMapper.java
@@ -15,7 +15,7 @@ package org.jdbi.json.internal;
 
 import java.lang.reflect.Type;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.UnableToCreateStatementException;
 import org.jdbi.json.JsonConfig;
 import org.jdbi.json.JsonMapper;
@@ -28,7 +28,7 @@ public class UnimplementedJsonMapper implements JsonMapper {
     );
 
     @Override
-    public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+    public TypedJsonMapper forType(Type type, ConfigView config) {
         throw new UnableToCreateStatementException(NO_IMPL_INSTALLED);
     }
 }

--- a/json/src/test/java/org/jdbi/json/AbstractIssue2395Test.java
+++ b/json/src/test/java/org/jdbi/json/AbstractIssue2395Test.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.jdbi.core.Handle;
+import org.jdbi.core.mapper.RowMappers;
 import org.jdbi.core.mapper.reflect.BeanMapper;
 import org.jdbi.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.core.mapper.reflect.FieldMapper;
@@ -41,11 +42,6 @@ public abstract class AbstractIssue2395Test {
     @BeforeEach
     void setUp() {
         this.handle = getHandle();
-        // register a mapper for the wrapper class that contains a json field.
-        this.handle.registerRowMapper(ConstructorWrapper.class, ConstructorMapper.of(ConstructorWrapper.class));
-        this.handle.registerRowMapper(FieldWrapper.class, FieldMapper.of(FieldWrapper.class));
-        this.handle.registerRowMapper(BeanWrapper.class, BeanMapper.of(BeanWrapper.class));
-
         this.handle.execute("create table test2395 (id integer not null primary key, name varchar(255), data json)");
     }
 
@@ -57,16 +53,19 @@ public abstract class AbstractIssue2395Test {
                 new JsonData("fourth", "four", 16), new JsonData("fifth", "five", 23), new JsonData("sixth", "six", 42)));
         final ConstructorWrapper data2 = new ConstructorWrapper(2, "bob", Collections.singletonList(new JsonData("toast", "words", 8)));
 
-        CtorDao dao = handle.attach(CtorDao.class);
+        try (Handle handle = this.handle.getJdbi().open(cfg -> cfg.configure(RowMappers.class,
+            r -> r.register(ConstructorWrapper.class, ConstructorMapper.of(ConstructorWrapper.class))))) {
+            CtorDao dao = handle.attach(CtorDao.class);
 
-        dao.write(data1);
-        dao.write(data2);
+            dao.write(data1);
+            dao.write(data2);
 
-        List<ConstructorWrapper> data = dao.readAll();
-        assertThat(data).containsExactly(data1, data2);
+            List<ConstructorWrapper> data = dao.readAll();
+            assertThat(data).containsExactly(data1, data2);
 
-        assertThat(dao.retrieve(1)).isEqualTo(data1);
-        assertThat(dao.retrieve(2)).isEqualTo(data2);
+            assertThat(dao.retrieve(1)).isEqualTo(data1);
+            assertThat(dao.retrieve(2)).isEqualTo(data2);
+        }
     }
 
     @Test
@@ -83,16 +82,19 @@ public abstract class AbstractIssue2395Test {
         data2.name = "bob";
         data2.data = Collections.singletonList(new JsonData("toast", "words", 8));
 
-        FieldDao dao = handle.attach(FieldDao.class);
+        try (Handle handle = this.handle.getJdbi().open(cfg -> cfg.configure(RowMappers.class,
+            r -> r.register(FieldWrapper.class, FieldMapper.of(FieldWrapper.class))))) {
+            FieldDao dao = handle.attach(FieldDao.class);
 
-        dao.write(data1);
-        dao.write(data2);
+            dao.write(data1);
+            dao.write(data2);
 
-        List<FieldWrapper> data = dao.readAll();
-        assertThat(data).containsExactly(data1, data2);
+            List<FieldWrapper> data = dao.readAll();
+            assertThat(data).containsExactly(data1, data2);
 
-        assertThat(dao.retrieve(1)).isEqualTo(data1);
-        assertThat(dao.retrieve(2)).isEqualTo(data2);
+            assertThat(dao.retrieve(1)).isEqualTo(data1);
+            assertThat(dao.retrieve(2)).isEqualTo(data2);
+        }
     }
 
     @Test
@@ -109,16 +111,19 @@ public abstract class AbstractIssue2395Test {
         data2.setName("bob");
         data2.setData(Collections.singletonList(new JsonData("toast", "words", 8)));
 
-        BeanDao dao = handle.attach(BeanDao.class);
+        try (Handle handle = this.handle.getJdbi().open(cfg -> cfg.configure(RowMappers.class,
+            r -> r.register(BeanWrapper.class, BeanMapper.of(BeanWrapper.class))))) {
+            BeanDao dao = handle.attach(BeanDao.class);
 
-        dao.write(data1);
-        dao.write(data2);
+            dao.write(data1);
+            dao.write(data2);
 
-        List<BeanWrapper> data = dao.readAll();
-        assertThat(data).containsExactly(data1, data2);
+            List<BeanWrapper> data = dao.readAll();
+            assertThat(data).containsExactly(data1, data2);
 
-        assertThat(dao.retrieve(1)).isEqualTo(data1);
-        assertThat(dao.retrieve(2)).isEqualTo(data2);
+            assertThat(dao.retrieve(1)).isEqualTo(data1);
+            assertThat(dao.retrieve(2)).isEqualTo(data2);
+        }
     }
 
     public interface CtorDao {

--- a/json/src/test/java/org/jdbi/json/JsonPluginTest.java
+++ b/json/src/test/java/org/jdbi/json/JsonPluginTest.java
@@ -16,7 +16,7 @@ package org.jdbi.json;
 import java.lang.reflect.Type;
 
 import org.jdbi.core.Jdbi;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.qualifier.QualifiedType;
 import org.jdbi.testing.junit.JdbiExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,17 +43,17 @@ public class JsonPluginTest {
         Object result = jdbi.withHandle(
             cfg -> cfg.configure(JsonConfig.class, c -> c.jsonMapper(new JsonMapper() {
                 @Override
-                public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+                public TypedJsonMapper forType(Type type, ConfigView config) {
                     assertThat(type).isEqualTo(Foo.class);
                     return new TypedJsonMapper() {
                         @Override
-                        public String toJson(Object value, ConfigRegistry config) {
+                        public String toJson(Object value, ConfigView config) {
                             assertThat(value).isEqualTo(instance);
                             return json;
                         }
 
                         @Override
-                        public Object fromJson(String readJson, ConfigRegistry config) {
+                        public Object fromJson(String readJson, ConfigView config) {
                             assertThat(readJson).isEqualTo(json);
                             return instance;
                         }

--- a/json/src/test/java/org/jdbi/json/JsonPluginTest.java
+++ b/json/src/test/java/org/jdbi/json/JsonPluginTest.java
@@ -40,38 +40,38 @@ public class JsonPluginTest {
         Object instance = new Foo();
         String json = "foo";
 
-        jdbi.configure(JsonConfig.class, cfg -> cfg.jsonMapper(new JsonMapper() {
-            @Override
-            public TypedJsonMapper forType(Type type, ConfigRegistry config) {
-                assertThat(type).isEqualTo(Foo.class);
-                return new TypedJsonMapper() {
-                    @Override
-                    public String toJson(Object value, ConfigRegistry config) {
-                        assertThat(value).isEqualTo(instance);
-                        return json;
-                    }
+        Object result = jdbi.withHandle(
+            cfg -> cfg.configure(JsonConfig.class, c -> c.jsonMapper(new JsonMapper() {
+                @Override
+                public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+                    assertThat(type).isEqualTo(Foo.class);
+                    return new TypedJsonMapper() {
+                        @Override
+                        public String toJson(Object value, ConfigRegistry config) {
+                            assertThat(value).isEqualTo(instance);
+                            return json;
+                        }
 
-                    @Override
-                    public Object fromJson(String readJson, ConfigRegistry config) {
-                        assertThat(readJson).isEqualTo(json);
-                        return instance;
-                    }
-                };
-            }
-        }));
+                        @Override
+                        public Object fromJson(String readJson, ConfigRegistry config) {
+                            assertThat(readJson).isEqualTo(json);
+                            return instance;
+                        }
+                    };
+                }
+            })),
+            h -> {
+                h.createUpdate("insert into foo(bar) values(:foo)")
+                    .bindByType("foo", instance, QualifiedType.of(Foo.class).with(Json.class))
+                    .execute();
 
-        Object result = h2Extension.getJdbi().withHandle(h -> {
-            h.createUpdate("insert into foo(bar) values(:foo)")
-                .bindByType("foo", instance, QualifiedType.of(Foo.class).with(Json.class))
-                .execute();
+                assertThat(h.createQuery("select bar from foo").mapTo(String.class).one())
+                    .isEqualTo(json);
 
-            assertThat(h.createQuery("select bar from foo").mapTo(String.class).one())
-                .isEqualTo(json);
-
-            return h.createQuery("select bar from foo")
-                .mapTo(QualifiedType.of(Foo.class).with(Json.class))
-                .one();
-        });
+                return h.createQuery("select bar from foo")
+                    .mapTo(QualifiedType.of(Foo.class).with(Json.class))
+                    .one();
+            });
 
         assertThat(result).isSameAs(instance);
     }

--- a/kotlin-sqlobject/src/main/kotlin/org/jdbi/sqlobject/kotlin/KotlinSqlObjectPlugin.kt
+++ b/kotlin-sqlobject/src/main/kotlin/org/jdbi/sqlobject/kotlin/KotlinSqlObjectPlugin.kt
@@ -29,10 +29,10 @@ import org.jdbi.sqlobject.SqlObjects
  */
 class KotlinSqlObjectPlugin(private val installKotlinMapperFactory: Boolean = true, private val enableCoroutineSupport: Boolean = false) :
     JdbiPlugin.Singleton() {
-    override fun customizeJdbi(jdbi: Jdbi) {
-        jdbi.installPlugin(KotlinPlugin(installKotlinMapperFactory = installKotlinMapperFactory, enableCoroutineSupport = enableCoroutineSupport))
-        jdbi.installPlugin(SqlObjectPlugin())
-        jdbi.configure(SqlObjects::class) { c -> c.defaultParameterCustomizerFactory(KotlinSqlStatementCustomizerFactory()) }
-        jdbi.configure(Extensions::class) { c -> c.registerHandlerFactory(KotlinDefaultMethodHandlerFactory()) }
+    override fun configure(builder: Jdbi.Builder) {
+        builder.installPlugin(KotlinPlugin(installKotlinMapperFactory = installKotlinMapperFactory, enableCoroutineSupport = enableCoroutineSupport))
+        builder.installPlugin(SqlObjectPlugin())
+        builder.configure(SqlObjects::class) { c -> c.defaultParameterCustomizerFactory(KotlinSqlStatementCustomizerFactory()) }
+        builder.configure(Extensions::class) { c -> c.registerHandlerFactory(KotlinDefaultMethodHandlerFactory()) }
     }
 }

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestIssue1577.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestIssue1577.kt
@@ -41,13 +41,13 @@ class TestIssue1577 {
             handle.execute("INSERT INTO data (comma) VALUES ('one,two,three,four')")
         }
         .withPlugin(KotlinSqlObjectPlugin())
+        // Register with an explicit type: the inferring single-argument overload needs KotlinPlugin's row-mapper
+        // interceptor, which is not yet installed when this withConfig hook runs during Jdbi assembly.
+        .withConfig { b -> b.registerRowMapper(Data::class.java, KotlinMapper(Data::class)) }
 
     @BeforeEach
     fun setup() {
-        val jdbi = pgExtension.jdbi
-        jdbi.registerRowMapper(KotlinMapper(Data::class))
-
-        this.onDemandDao = jdbi.onDemand(DataDao::class.java)
+        this.onDemandDao = pgExtension.jdbi.onDemand(DataDao::class.java)
     }
 
     @Test

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestIssue2751.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestIssue2751.kt
@@ -32,6 +32,12 @@ class TestIssue2751 {
     var h2Extension: JdbiExtension = JdbiExtension.h2()
         .withInitializer(TestingInitializers.something())
         .withPlugins(KotlinSqlObjectPlugin())
+        .withConfig { b ->
+            b.registerColumnMapper(
+                QualifiedType.of(object : GenericType<List<@JvmSuppressWildcards String>>() {}).with(Stringy::class.java),
+                ListStringMapper()
+            )
+        }
 
     data class TestClass(val param: List<String>)
 
@@ -52,10 +58,6 @@ class TestIssue2751 {
     @Test
     fun testGenericMapperRegistrationSuppressOnType() {
         val jdbi = h2Extension.jdbi
-        val type: QualifiedType<List<String>> = QualifiedType.of(object : GenericType<List<@JvmSuppressWildcards String>>() {})
-            .with(Stringy::class.java)
-
-        jdbi.registerColumnMapper(type, ListStringMapper())
 
         jdbi.useHandle<Exception> { handle -> handle.execute("INSERT INTO something(id, name) VALUES(1, 'a,b,c,d,e,f')") }
 

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestIssue2790.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestIssue2790.kt
@@ -50,8 +50,6 @@ class TestIssue2790 {
 
     @Test
     fun testListsWork() {
-        handle.registerRowMapper(KotlinMapperFactory())
-
         val list = listOf("a", "b", "c")
         val ktBean = EvenMoreThings(1, list)
 
@@ -60,6 +58,7 @@ class TestIssue2790 {
             .execute()
 
         val result = handle.createQuery("SELECT id, name from something")
+            .registerRowMapper(KotlinMapperFactory())
             .mapTo<Something>()
             .single()
 

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestListArgument.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestListArgument.kt
@@ -15,6 +15,7 @@ package org.jdbi.sqlobject.kotlin
 
 import org.jdbi.core.argument.AbstractArgumentFactory
 import org.jdbi.core.argument.Argument
+import org.jdbi.core.argument.Arguments
 import org.jdbi.core.config.ConfigRegistry
 import org.jdbi.sqlobject.SqlObject
 import org.jdbi.sqlobject.statement.SqlQuery
@@ -58,8 +59,7 @@ class TestListArgument {
 
     @Test
     fun testSingleInsert() {
-        h2Extension.openHandle().use { handle ->
-            handle.registerArgument(StringListArgumentFactory())
+        h2Extension.jdbi.open { cfg -> cfg.configure(Arguments::class.java) { it.register(StringListArgumentFactory()) } }.use { handle ->
             val dao = handle.attach(SomethingDao::class)
 
             dao.insertList(1, listOf("one", "two"))
@@ -85,8 +85,7 @@ class TestListArgument {
 
     @Test
     fun testSingleInsertWithMagicValue() {
-        h2Extension.openHandle().use { handle ->
-            handle.registerArgument(MagicListArgumentFactory())
+        h2Extension.jdbi.open { cfg -> cfg.configure(Arguments::class.java) { it.register(MagicListArgumentFactory()) } }.use { handle ->
             val dao = handle.attach(SomethingDao::class)
 
             dao.inserValueList(1, listOf(MagicValue("one"), MagicValue("two")))

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestListArgument.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestListArgument.kt
@@ -16,7 +16,7 @@ package org.jdbi.sqlobject.kotlin
 import org.jdbi.core.argument.AbstractArgumentFactory
 import org.jdbi.core.argument.Argument
 import org.jdbi.core.argument.Arguments
-import org.jdbi.core.config.ConfigRegistry
+import org.jdbi.core.config.ConfigView
 import org.jdbi.sqlobject.SqlObject
 import org.jdbi.sqlobject.statement.SqlQuery
 import org.jdbi.sqlobject.statement.SqlUpdate
@@ -48,7 +48,7 @@ class TestListArgument {
     }
 
     class StringListArgumentFactory : AbstractArgumentFactory<List<String>>(Types.VARCHAR) {
-        override fun build(value: List<String>?, config: ConfigRegistry): Argument? = Argument { position, statement, _ ->
+        override fun build(value: List<String>?, config: ConfigView): Argument? = Argument { position, statement, _ ->
             if (value != null) {
                 statement.setString(position, value.joinToString(","))
             } else {
@@ -74,7 +74,7 @@ class TestListArgument {
     value class MagicValue(val value: String)
 
     class MagicListArgumentFactory : AbstractArgumentFactory<List<MagicValue>>(Types.VARCHAR) {
-        override fun build(value: List<MagicValue>?, config: ConfigRegistry): Argument? = Argument { position, statement, _ ->
+        override fun build(value: List<MagicValue>?, config: ConfigView): Argument? = Argument { position, statement, _ ->
             if (value != null) {
                 statement.setString(position, value.joinToString(",") { x -> x.value })
             } else {

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestValueClasses.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestValueClasses.kt
@@ -24,7 +24,9 @@ import org.jdbi.core.kotlin.internal.KotlinValueClassArgumentFactory
 import org.jdbi.core.kotlin.internal.KotlinValueClassColumnMapperFactory
 import org.jdbi.core.mapper.ColumnMapper
 import org.jdbi.core.mapper.ColumnMapperFactory
+import org.jdbi.core.mapper.ColumnMappers
 import org.jdbi.core.mapper.RowMapper
+import org.jdbi.core.mapper.RowMappers
 import org.jdbi.core.statement.StatementContext
 import org.jdbi.sqlobject.customizer.Bind
 import org.jdbi.sqlobject.statement.SqlQuery
@@ -67,6 +69,15 @@ class TestValueClasses {
     fun tearDown() {
         handle.close()
     }
+
+    // Config formerly registered on the (now read-only) Handle is applied when opening an isolated, scoped handle
+    // that shares the extension's in-memory database.
+    private fun openWithMappers(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory, rowMapper: RowMapper<*>): Handle =
+        h2Extension.jdbi.open { cfg ->
+            cfg.configure(RowMappers::class.java) { it.register(Something::class.java, rowMapper) }
+            cfg.configure(ColumnMappers::class.java) { it.register(columnMapperFactory) }
+            cfg.configure(org.jdbi.core.argument.Arguments::class.java) { it.register(argumentFactory) }
+        }
 
     @JvmInline
     value class ValueId(val value: Int)
@@ -112,115 +123,105 @@ class TestValueClasses {
     @ParameterizedTest
     @MethodSource("arguments")
     fun testMapper(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory, rowMapper: RowMapper<*>) {
-        handle.registerRowMapper(Something::class.java, rowMapper)
-        handle.registerColumnMapper(columnMapperFactory)
-        handle.registerArgument(argumentFactory)
+        openWithMappers(columnMapperFactory, argumentFactory, rowMapper).use { handle ->
+            handle.execute("insert into something (id, name) values (6, 'Martin')")
 
-        handle.execute("insert into something (id, name) values (6, 'Martin')")
-
-        val dao = handle.attach(Dao::class)
-        val s = dao.retrieveById(ValueId(6))
-        assertThat(s.name).isEqualTo("Martin")
+            val dao = handle.attach(Dao::class)
+            val s = dao.retrieveById(ValueId(6))
+            assertThat(s.name).isEqualTo("Martin")
+        }
     }
 
     @ParameterizedTest
     @MethodSource("arguments")
     fun testListMapper(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory, rowMapper: RowMapper<*>) {
-        handle.registerRowMapper(Something::class.java, rowMapper)
-        handle.registerColumnMapper(columnMapperFactory)
-        handle.registerArgument(argumentFactory)
+        openWithMappers(columnMapperFactory, argumentFactory, rowMapper).use { handle ->
+            val dao = handle.attach(Dao::class)
 
-        val dao = handle.attach(Dao::class)
+            dao.insert(ValueId(2), "Bean")
+            dao.insert(ValueId(6), "Martin")
 
-        dao.insert(ValueId(2), "Bean")
-        dao.insert(ValueId(6), "Martin")
-
-        val s = dao.loadAll()
-        assertThat(s).hasSize(2)
-        assertThat(s).containsExactly(Something(ValueId(2), "Bean"), Something(ValueId(6), "Martin"))
+            val s = dao.loadAll()
+            assertThat(s).hasSize(2)
+            assertThat(s).containsExactly(Something(ValueId(2), "Bean"), Something(ValueId(6), "Martin"))
+        }
     }
 
     @ParameterizedTest
     @MethodSource("arguments")
     fun testListMapperForJava(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory, rowMapper: RowMapper<*>) {
-        handle.registerRowMapper(Something::class.java, rowMapper)
-        handle.registerColumnMapper(columnMapperFactory)
-        handle.registerArgument(argumentFactory)
+        openWithMappers(columnMapperFactory, argumentFactory, rowMapper).use { handle ->
+            val dao = handle.attach(Dao::class)
 
-        val dao = handle.attach(Dao::class)
+            dao.insert(ValueId(2), "Bean")
+            dao.insert(ValueId(6), "Martin")
 
-        dao.insert(ValueId(2), "Bean")
-        dao.insert(ValueId(6), "Martin")
-
-        val s: java.util.List<Something> = dao.loadAllJava()
-        assertThat(s).hasSize(2)
-        assertThat(s).containsExactly(Something(ValueId(2), "Bean"), Something(ValueId(6), "Martin"))
+            val s: java.util.List<Something> = dao.loadAllJava()
+            assertThat(s).hasSize(2)
+            assertThat(s).containsExactly(Something(ValueId(2), "Bean"), Something(ValueId(6), "Martin"))
+        }
     }
 
     @ParameterizedTest
     @MethodSource("arguments")
     fun testValueClassListMapper(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory, rowMapper: RowMapper<*>) {
-        handle.registerRowMapper(Something::class.java, rowMapper)
-        handle.registerColumnMapper(columnMapperFactory)
-        handle.registerArgument(argumentFactory)
+        openWithMappers(columnMapperFactory, argumentFactory, rowMapper).use { handle ->
+            val dao = handle.attach(Dao::class)
 
-        val dao = handle.attach(Dao::class)
+            dao.insert(ValueId(2), "Bean")
+            dao.insert(ValueId(6), "Martin")
 
-        dao.insert(ValueId(2), "Bean")
-        dao.insert(ValueId(6), "Martin")
-
-        val s = dao.loadAllIds()
-        assertThat(s).hasSize(2)
-        assertThat(s).containsExactly(ValueId(2), ValueId(6))
+            val s = dao.loadAllIds()
+            assertThat(s).hasSize(2)
+            assertThat(s).containsExactly(ValueId(2), ValueId(6))
+        }
     }
 
     @ParameterizedTest
     @MethodSource("arguments")
     fun testValueClassListMapperForJava(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory, rowMapper: RowMapper<*>) {
-        handle.registerRowMapper(Something::class.java, rowMapper)
-        handle.registerColumnMapper(columnMapperFactory)
-        handle.registerArgument(argumentFactory)
+        openWithMappers(columnMapperFactory, argumentFactory, rowMapper).use { handle ->
+            val dao = handle.attach(Dao::class)
 
-        val dao = handle.attach(Dao::class)
+            dao.insert(ValueId(2), "Bean")
+            dao.insert(ValueId(6), "Martin")
 
-        dao.insert(ValueId(2), "Bean")
-        dao.insert(ValueId(6), "Martin")
-
-        val s: java.util.List<ValueId> = dao.loadAllIdsJava()
-        assertThat(s).hasSize(2)
-        assertThat(s).containsExactly(ValueId(2), ValueId(6))
+            val s: java.util.List<ValueId> = dao.loadAllIdsJava()
+            assertThat(s).hasSize(2)
+            assertThat(s).containsExactly(ValueId(2), ValueId(6))
+        }
     }
 
     @ParameterizedTest
     @MethodSource("arguments")
     fun testRegularListMapper(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory, rowMapper: RowMapper<*>) {
-        handle.registerRowMapper(Something::class.java, rowMapper)
-        handle.registerColumnMapper(columnMapperFactory)
-        handle.registerArgument(argumentFactory)
+        openWithMappers(columnMapperFactory, argumentFactory, rowMapper).use { handle ->
+            val dao = handle.attach(Dao::class)
 
-        val dao = handle.attach(Dao::class)
+            dao.insert(ValueId(2), "Bean")
+            dao.insert(ValueId(6), "Martin")
 
-        dao.insert(ValueId(2), "Bean")
-        dao.insert(ValueId(6), "Martin")
-
-        val s = dao.loadAllNames()
-        assertThat(s).hasSize(2)
-        assertThat(s).containsExactly("Bean", "Martin")
+            val s = dao.loadAllNames()
+            assertThat(s).hasSize(2)
+            assertThat(s).containsExactly("Bean", "Martin")
+        }
     }
 
     @Test
     fun testValueClassColumn() {
-        handle.registerColumnMapper(ValueId::class.java, ValueIdColumnMapper())
+        h2Extension.jdbi.open { cfg ->
+            cfg.configure(ColumnMappers::class.java) { it.register(ValueId::class.java, ValueIdColumnMapper()) }
+        }.use { handle ->
+            val dao = handle.attach(Dao::class)
 
-        val dao = handle.attach(Dao::class)
+            dao.insert(ValueId(6), "Martin")
 
-        dao.insert(ValueId(6), "Martin")
+            val s = dao.findIdByName("Martin")
+            assertThat(s).isEqualTo(ValueId(6))
 
-        val s = dao.findIdByName("Martin")
-        assertThat(s).isEqualTo(ValueId(6))
-
-        val t = dao.findIdByName("Brian")
-        assertThat(t).isNull()
+            val t = dao.findIdByName("Brian")
+            assertThat(t).isNull()
+        }
     }
 
     @UseStringTemplateSqlLocator

--- a/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestValueClasses.kt
+++ b/kotlin-sqlobject/src/test/kotlin/org/jdbi/sqlobject/kotlin/TestValueClasses.kt
@@ -18,7 +18,7 @@ import org.jdbi.core.Handle
 import org.jdbi.core.argument.AbstractArgumentFactory
 import org.jdbi.core.argument.Argument
 import org.jdbi.core.argument.ArgumentFactory
-import org.jdbi.core.config.ConfigRegistry
+import org.jdbi.core.config.ConfigView
 import org.jdbi.core.kotlin.KotlinMapper
 import org.jdbi.core.kotlin.internal.KotlinValueClassArgumentFactory
 import org.jdbi.core.kotlin.internal.KotlinValueClassColumnMapperFactory
@@ -265,14 +265,13 @@ class TestValueClasses {
     data class Something(val id: ValueId, val name: String)
 
     class ValueIdArgumentFactory : AbstractArgumentFactory<ValueId>(Types.INTEGER) {
-        override fun build(value: ValueId?, config: ConfigRegistry): Argument? =
-            Argument { position: Int, statement: PreparedStatement, ctx: StatementContext ->
-                if (value != null) {
-                    statement.setInt(position, value.value)
-                } else {
-                    statement.setNull(position, Types.INTEGER)
-                }
+        override fun build(value: ValueId?, config: ConfigView): Argument? = Argument { position: Int, statement: PreparedStatement, ctx: StatementContext ->
+            if (value != null) {
+                statement.setInt(position, value.value)
+            } else {
+                statement.setNull(position, Types.INTEGER)
             }
+        }
 
         override fun toString(): String = "ValueIdArgumentFactory"
     }
@@ -280,7 +279,7 @@ class TestValueClasses {
     // value type as a column
 
     class ValueIdColumnMapperFactory : ColumnMapperFactory {
-        override fun build(type: Type?, config: ConfigRegistry?): Optional<ColumnMapper<*>> {
+        override fun build(type: Type?, config: ConfigView?): Optional<ColumnMapper<*>> {
             if (type == ValueId::class.java) {
                 return Optional.of(ValueIdColumnMapper())
             }

--- a/kotlin/src/main/kotlin/org/jdbi/core/kotlin/KotlinMapperFactory.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/core/kotlin/KotlinMapperFactory.kt
@@ -13,7 +13,7 @@
  */
 package org.jdbi.core.kotlin
 
-import org.jdbi.core.config.ConfigRegistry
+import org.jdbi.core.config.ConfigView
 import org.jdbi.core.generic.GenericTypes.getErasedType
 import org.jdbi.core.mapper.RowMapper
 import org.jdbi.core.mapper.RowMapperFactory
@@ -31,7 +31,7 @@ import java.util.Optional
  */
 class KotlinMapperFactory : RowMapperFactory {
 
-    override fun build(type: Type, config: ConfigRegistry): Optional<RowMapper<*>> {
+    override fun build(type: Type, config: ConfigView): Optional<RowMapper<*>> {
         val erasedType = getErasedType(type)
 
         // TODO: Validate if we should only handle 'data' classes with the Kotlin mapper

--- a/kotlin/src/main/kotlin/org/jdbi/core/kotlin/KotlinPlugin.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/core/kotlin/KotlinPlugin.kt
@@ -33,15 +33,15 @@ import org.jdbi.core.spi.JdbiPlugin
  */
 class KotlinPlugin(private val installKotlinMapperFactory: Boolean = true, private val enableCoroutineSupport: Boolean = false) : JdbiPlugin.Singleton() {
 
-    override fun customizeJdbi(jdbi: Jdbi) {
-        jdbi.configure(RowMappers::class.java) {
+    override fun configure(builder: Jdbi.Builder) {
+        builder.configure(RowMappers::class.java) {
             it.withInferenceInterceptor(KotlinRowMapperInterceptor())
         }
 
         if (installKotlinMapperFactory) {
-            jdbi.registerRowMapper(KotlinMapperFactory())
-            jdbi.registerColumnMapper(KotlinValueClassColumnMapperFactory())
-            jdbi.registerArgument(KotlinValueClassArgumentFactory())
+            builder.registerRowMapper(KotlinMapperFactory())
+            builder.registerColumnMapper(KotlinValueClassColumnMapperFactory())
+            builder.registerArgument(KotlinValueClassArgumentFactory())
         }
 
         // install a special handle scope that can deal with coroutines.
@@ -49,7 +49,7 @@ class KotlinPlugin(private val installKotlinMapperFactory: Boolean = true, priva
         // Note that this needs to be revisited in the future if we move from the ThreadLocal in Jdbi
         // to e.g., structured concurrency. Right now, this delegates to a ThreadLocalHandleScope.
         if (enableCoroutineSupport) {
-            jdbi.handleScope = CoroutineHandleScope()
+            builder.handleScope(CoroutineHandleScope())
         }
     }
 }

--- a/kotlin/src/main/kotlin/org/jdbi/core/kotlin/internal/KotlinValueClassArgumentFactory.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/core/kotlin/internal/KotlinValueClassArgumentFactory.kt
@@ -16,7 +16,7 @@ package org.jdbi.core.kotlin.internal
 import org.jdbi.core.argument.Argument
 import org.jdbi.core.argument.ArgumentFactory
 import org.jdbi.core.argument.ArgumentResolver
-import org.jdbi.core.config.ConfigRegistry
+import org.jdbi.core.config.ConfigView
 import org.jdbi.meta.Alpha
 import java.lang.reflect.Type
 import java.util.Optional
@@ -27,7 +27,7 @@ import kotlin.reflect.full.memberProperties
  */
 @Alpha
 class KotlinValueClassArgumentFactory : ArgumentFactory {
-    override fun build(type: Type, value: Any?, config: ConfigRegistry): Optional<Argument> {
+    override fun build(type: Type, value: Any?, config: ConfigView): Optional<Argument> {
         val clazz = (type as? Class<*>)?.kotlin?.also {
             if (!it.isValue) return Optional.empty()
         } ?: return Optional.empty()

--- a/kotlin/src/main/kotlin/org/jdbi/core/kotlin/internal/KotlinValueClassColumnMapperFactory.kt
+++ b/kotlin/src/main/kotlin/org/jdbi/core/kotlin/internal/KotlinValueClassColumnMapperFactory.kt
@@ -13,7 +13,7 @@
  */
 package org.jdbi.core.kotlin.internal
 
-import org.jdbi.core.config.ConfigRegistry
+import org.jdbi.core.config.ConfigView
 import org.jdbi.core.mapper.ColumnMapper
 import org.jdbi.core.mapper.ColumnMapperFactory
 import org.jdbi.core.mapper.NoSuchMapperException
@@ -29,7 +29,7 @@ import kotlin.reflect.full.primaryConstructor
  */
 @Alpha
 class KotlinValueClassColumnMapperFactory : ColumnMapperFactory {
-    override fun build(type: Type, config: ConfigRegistry): Optional<ColumnMapper<*>> {
+    override fun build(type: Type, config: ConfigView): Optional<ColumnMapper<*>> {
         val clazz = (type as? Class<*>)?.kotlin?.also {
             if (!it.isValue) return Optional.empty()
         } ?: return Optional.empty()

--- a/kotlin/src/test/kotlin/org/jdbi/core/kotlin/Issue1944Test.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/core/kotlin/Issue1944Test.kt
@@ -13,6 +13,7 @@
  */
 package org.jdbi.core.kotlin
 
+import org.jdbi.core.Handle
 import org.jdbi.core.HandleCallback
 import org.jdbi.core.Jdbi
 import org.jdbi.core.mapper.JoinRow
@@ -44,37 +45,37 @@ class Issue1944Test {
 
     data class Product(val id: Int?, val primaryName: String?, val tagId: Int?)
 
+    // The mappers are registered on the handle rather than the read-only Jdbi. Registering a KotlinMapper needs the
+    // KotlinRowMapperInterceptor that KotlinPlugin installs; on a Jdbi.Builder the plugin's configure() hook only runs
+    // at build() time, so the interceptor is not yet present when register* is called on the builder.
     @Test
     fun testWithKotlinMapperFactory(jdbi: Jdbi) {
-        jdbi.installPlugin(KotlinPlugin())
+        doTest(jdbi) { handle ->
             // the required mapper for Tag is implicit and will be created on the fly without a prefix by the KotlinMapperFactory
-            .registerRowMapper(KotlinMapper(Product::class.java, "p"))
-            .registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
-
-        doTest(jdbi)
+            handle.registerRowMapper(KotlinMapper(Product::class.java, "p"))
+            handle.registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
+        }
     }
 
     @Test
     fun testWithoutKotlinMapperFactory(jdbi: Jdbi) {
-        jdbi.installPlugin(KotlinPlugin(false))
-            .registerRowMapper(KotlinMapper(Product::class.java, "p"))
-            .registerRowMapper(KotlinMapper(Tag::class.java))
-            .registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
-
-        doTest(jdbi)
+        doTest(jdbi) { handle ->
+            handle.registerRowMapper(KotlinMapper(Product::class.java, "p"))
+            handle.registerRowMapper(KotlinMapper(Tag::class.java))
+            handle.registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
+        }
     }
 
     @Test
     fun testNativeKotlin(jdbi: Jdbi) {
-        jdbi.installPlugin(KotlinPlugin(false))
-            .registerRowMapper(KotlinMapper(Product::class, "p"))
-            .registerRowMapper(KotlinMapper(Tag::class))
-            .registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
-
-        doTest(jdbi)
+        doTest(jdbi) { handle ->
+            handle.registerRowMapper(KotlinMapper(Product::class, "p"))
+            handle.registerRowMapper(KotlinMapper(Tag::class))
+            handle.registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
+        }
     }
 
-    fun doTest(jdbi: Jdbi) {
+    fun doTest(jdbi: Jdbi, registerMappers: (Handle) -> Unit) {
         val sql = """
             SELECT
               t.id, t.name,
@@ -83,7 +84,10 @@ class Issue1944Test {
         """.trimIndent()
 
         val rows = jdbi.withHandle(
-            HandleCallback<List<JoinRow>, RuntimeException> { handle -> handle.createQuery(sql).mapTo<JoinRow>().list() }
+            HandleCallback<List<JoinRow>, RuntimeException> { handle ->
+                registerMappers(handle)
+                handle.createQuery(sql).mapTo<JoinRow>().list()
+            }
         )
 
         assertNotNull(rows)

--- a/kotlin/src/test/kotlin/org/jdbi/core/kotlin/Issue1944Test.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/core/kotlin/Issue1944Test.kt
@@ -13,11 +13,11 @@
  */
 package org.jdbi.core.kotlin
 
-import org.jdbi.core.Handle
 import org.jdbi.core.HandleCallback
 import org.jdbi.core.Jdbi
 import org.jdbi.core.mapper.JoinRow
 import org.jdbi.core.mapper.JoinRowMapper
+import org.jdbi.core.statement.Query
 import org.jdbi.testing.junit.JdbiExtension
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -45,37 +45,37 @@ class Issue1944Test {
 
     data class Product(val id: Int?, val primaryName: String?, val tagId: Int?)
 
-    // The mappers are registered on the handle rather than the read-only Jdbi. Registering a KotlinMapper needs the
+    // The mappers are registered on the statement rather than the read-only Jdbi. Registering a KotlinMapper needs the
     // KotlinRowMapperInterceptor that KotlinPlugin installs; on a Jdbi.Builder the plugin's configure() hook only runs
     // at build() time, so the interceptor is not yet present when register* is called on the builder.
     @Test
     fun testWithKotlinMapperFactory(jdbi: Jdbi) {
-        doTest(jdbi) { handle ->
+        doTest(jdbi) { query ->
             // the required mapper for Tag is implicit and will be created on the fly without a prefix by the KotlinMapperFactory
-            handle.registerRowMapper(KotlinMapper(Product::class.java, "p"))
-            handle.registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
+            query.registerRowMapper(KotlinMapper(Product::class.java, "p"))
+            query.registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
         }
     }
 
     @Test
     fun testWithoutKotlinMapperFactory(jdbi: Jdbi) {
-        doTest(jdbi) { handle ->
-            handle.registerRowMapper(KotlinMapper(Product::class.java, "p"))
-            handle.registerRowMapper(KotlinMapper(Tag::class.java))
-            handle.registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
+        doTest(jdbi) { query ->
+            query.registerRowMapper(KotlinMapper(Product::class.java, "p"))
+            query.registerRowMapper(KotlinMapper(Tag::class.java))
+            query.registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
         }
     }
 
     @Test
     fun testNativeKotlin(jdbi: Jdbi) {
-        doTest(jdbi) { handle ->
-            handle.registerRowMapper(KotlinMapper(Product::class, "p"))
-            handle.registerRowMapper(KotlinMapper(Tag::class))
-            handle.registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
+        doTest(jdbi) { query ->
+            query.registerRowMapper(KotlinMapper(Product::class, "p"))
+            query.registerRowMapper(KotlinMapper(Tag::class))
+            query.registerRowMapper(JoinRowMapper.forTypes(Tag::class.java, Product::class.java))
         }
     }
 
-    fun doTest(jdbi: Jdbi, registerMappers: (Handle) -> Unit) {
+    fun doTest(jdbi: Jdbi, registerMappers: (Query) -> Unit) {
         val sql = """
             SELECT
               t.id, t.name,
@@ -85,8 +85,9 @@ class Issue1944Test {
 
         val rows = jdbi.withHandle(
             HandleCallback<List<JoinRow>, RuntimeException> { handle ->
-                registerMappers(handle)
-                handle.createQuery(sql).mapTo<JoinRow>().list()
+                val query = handle.createQuery(sql)
+                registerMappers(query)
+                query.mapTo<JoinRow>().list()
             }
         )
 

--- a/kotlin/src/test/kotlin/org/jdbi/core/kotlin/KotlinPropagateNullTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/core/kotlin/KotlinPropagateNullTest.kt
@@ -44,8 +44,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         propagateNullOnNested { q -> q.mapTo<Test1Bean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test21Bean::class))
-        propagateNullOnNested { q -> q.mapTo<Test21Bean>() }
+        propagateNullOnNested { q -> q.registerRowMapper(KotlinMapper(Test21Bean::class)).mapTo<Test21Bean>() }
     }
 
     data class Test1Bean(@Nested private val nestedBean: NestedBean?) : TestBean {
@@ -66,8 +65,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         propagateNullOnNestedWithFK { q -> q.mapTo<Test1FKBean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test21FKBean::class))
-        propagateNullOnNestedWithFK { q -> q.mapTo<Test21FKBean>() }
+        propagateNullOnNestedWithFK { q -> q.registerRowMapper(KotlinMapper(Test21FKBean::class)).mapTo<Test21FKBean>() }
     }
 
     data class Test1FKBean(@Nested private val nestedBean: NestedBean?) : TestBean {
@@ -88,8 +86,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         propagateNullOnNestedColumn { q -> q.mapTo<Test2Bean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test22Bean::class))
-        propagateNullOnNestedColumn { q -> q.mapTo<Test22Bean>() }
+        propagateNullOnNestedColumn { q -> q.registerRowMapper(KotlinMapper(Test22Bean::class)).mapTo<Test22Bean>() }
     }
 
     /**
@@ -101,8 +98,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         testPropagateNullOnNestedWithPrefixCaseInsensitive { q -> q.mapTo<Test2Bean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test22Bean::class))
-        testPropagateNullOnNestedWithPrefixCaseInsensitive { q -> q.mapTo<Test22Bean>() }
+        testPropagateNullOnNestedWithPrefixCaseInsensitive { q -> q.registerRowMapper(KotlinMapper(Test22Bean::class)).mapTo<Test22Bean>() }
     }
 
     data class Test2Bean(@Nested("bean") private val nestedBean: NestedBean?) : TestBean {
@@ -123,8 +119,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         propagateNullOnNestedColumnWithFK { q -> q.mapTo<Test2FKBean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test22FKBean::class))
-        propagateNullOnNestedColumnWithFK { q -> q.mapTo<Test22FKBean>() }
+        propagateNullOnNestedColumnWithFK { q -> q.registerRowMapper(KotlinMapper(Test22FKBean::class)).mapTo<Test22FKBean>() }
     }
 
     /**
@@ -136,8 +131,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         testPropagateNullOnNestedWithPrefixCaseInsensitiveWithFK { q -> q.mapTo<Test2FKBean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test22FKBean::class))
-        testPropagateNullOnNestedWithPrefixCaseInsensitiveWithFK { q -> q.mapTo<Test22FKBean>() }
+        testPropagateNullOnNestedWithPrefixCaseInsensitiveWithFK { q -> q.registerRowMapper(KotlinMapper(Test22FKBean::class)).mapTo<Test22FKBean>() }
     }
 
     data class Test2FKBean(@Nested("bean") private val nestedBean: NestedBean?) : TestBean {
@@ -157,8 +151,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         propagateNullOnNestedColumn { q -> q.mapTo<Test3Bean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test23Bean::class))
-        propagateNullOnNestedColumn { q -> q.mapTo<Test23Bean>() }
+        propagateNullOnNestedColumn { q -> q.registerRowMapper(KotlinMapper(Test23Bean::class)).mapTo<Test23Bean>() }
     }
 
     data class Test3Bean(@Nested("bean") private val nestedBean: NestedBean?) : TestBean {
@@ -178,8 +171,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         doubleNestedPropagateNull { q -> q.mapTo<Test4Bean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test24Bean::class))
-        doubleNestedPropagateNull { q -> q.mapTo<Test24Bean>() }
+        doubleNestedPropagateNull { q -> q.registerRowMapper(KotlinMapper(Test24Bean::class)).mapTo<Test24Bean>() }
     }
 
     data class Test4Bean(
@@ -203,8 +195,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         doubleNestedPropagateNullWithFK { q -> q.mapTo<Test4FKBean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test24FKBean::class))
-        doubleNestedPropagateNullWithFK { q -> q.mapTo<Test24FKBean>() }
+        doubleNestedPropagateNullWithFK { q -> q.registerRowMapper(KotlinMapper(Test24FKBean::class)).mapTo<Test24FKBean>() }
     }
 
     data class Test4FKBean(
@@ -229,8 +220,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         doubleNestedPropagateNull { q -> q.mapTo<Test5Bean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test25Bean::class))
-        doubleNestedPropagateNull { q -> q.mapTo<Test25Bean>() }
+        doubleNestedPropagateNull { q -> q.registerRowMapper(KotlinMapper(Test25Bean::class)).mapTo<Test25Bean>() }
     }
 
     data class Test5Bean(
@@ -258,8 +248,7 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         doubleNestedPropagateNullWithFK { q -> q.mapTo<Test5FKBean>() }
 
         // also test the field bean from the Java test
-        handle.registerRowMapper(KotlinMapper(Test25FKBean::class))
-        doubleNestedPropagateNullWithFK { q -> q.mapTo<Test25FKBean>() }
+        doubleNestedPropagateNullWithFK { q -> q.registerRowMapper(KotlinMapper(Test25FKBean::class)).mapTo<Test25FKBean>() }
     }
 
     data class Test5FKBean(
@@ -283,9 +272,8 @@ class KotlinPropagateNullTest : AbstractPropagateNullTest() {
         assertThat(e.message).containsIgnoringCase("@PropagateNull does not support a value (id)")
         assertThat(e.message).containsIgnoringCase("nestedBean")
 
-        handle.registerRowMapper(KotlinMapper(Test26Bean::class))
         val e2 = assertThrows<IllegalArgumentException> {
-            testPropagateNullOnNestedWithPrefixCaseInsensitive { q -> q.mapTo<Test26Bean>() }
+            testPropagateNullOnNestedWithPrefixCaseInsensitive { q -> q.registerRowMapper(KotlinMapper(Test26Bean::class)).mapTo<Test26Bean>() }
         }
         assertThat(e2.message).containsIgnoringCase("@PropagateNull does not support a value (id)")
         assertThat(e2.message).containsIgnoringCase("nestedBean")

--- a/kotlin/src/test/kotlin/org/jdbi/core/kotlin/KotlinQualifierTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/core/kotlin/KotlinQualifierTest.kt
@@ -33,14 +33,16 @@ class KotlinQualifierTest {
     @RegisterExtension
     @JvmField
     val h2Extension: JdbiExtension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(KotlinPlugin())
+        .withConfig { b ->
+            b.registerArgument(ReversedStringArgumentFactory())
+                .registerColumnMapper(ReversedStringMapper())
+        }
 
     private lateinit var handle: Handle
 
     @BeforeEach
     fun setup() {
         handle = h2Extension.sharedHandle
-            .registerArgument(ReversedStringArgumentFactory())
-            .registerColumnMapper(ReversedStringMapper())
     }
 
     @Test

--- a/kotlin/src/test/kotlin/org/jdbi/core/kotlin/KotlinValueTypeTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/core/kotlin/KotlinValueTypeTest.kt
@@ -109,16 +109,16 @@ class KotlinValueTypeTest {
     @ParameterizedTest
     @MethodSource("arguments")
     fun testValueClass(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory) {
-        handle.registerArgument(argumentFactory)
-        handle.registerColumnMapper(columnMapperFactory)
         val expected = MagicType("does this work?")
 
         handle.createUpdate("INSERT INTO something(id, first) VALUES(:id, :first)")
+            .registerArgument(argumentFactory)
             .bind("id", 1)
             .bind("first", expected)
             .execute()
 
         val result = handle.createQuery("SELECT first FROM something")
+            .registerColumnMapper(columnMapperFactory)
             .mapTo<MagicType>()
             .single()
 
@@ -128,18 +128,18 @@ class KotlinValueTypeTest {
     @ParameterizedTest
     @MethodSource("arguments")
     fun testValueClassList(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory) {
-        handle.registerArgument(argumentFactory)
-        handle.registerColumnMapper(columnMapperFactory)
         val expected = MagicType("does this work?")
 
         for (i in 1..10) {
             handle.createUpdate("INSERT INTO something(id, first) VALUES(:id, :first)")
+                .registerArgument(argumentFactory)
                 .bind("id", i)
                 .bind("first", expected)
                 .execute()
         }
 
         val result = handle.createQuery("SELECT first FROM something ORDER BY id")
+            .registerColumnMapper(columnMapperFactory)
             .mapTo<MagicType>()
             .list()
 
@@ -152,15 +152,14 @@ class KotlinValueTypeTest {
     @ParameterizedTest
     @MethodSource("arguments")
     fun testValueClassNull(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory) {
-        handle.registerArgument(argumentFactory)
-        handle.registerColumnMapper(columnMapperFactory)
-
         handle.createUpdate("INSERT INTO something(id, first) VALUES(:id, :first)")
+            .registerArgument(argumentFactory)
             .bind("id", 1)
             .bindNull("first", Types.VARCHAR)
             .execute()
 
         val result = handle.createQuery("SELECT first FROM something")
+            .registerColumnMapper(columnMapperFactory)
             .mapTo<MagicType>()
             .single()
 
@@ -172,20 +171,18 @@ class KotlinValueTypeTest {
     @ParameterizedTest
     @MethodSource("arguments")
     fun testValueBean(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory) {
-        handle.registerArgument(argumentFactory)
-        handle.registerColumnMapper(columnMapperFactory)
-
-        // Not automatically registered b/c using installKotlinMapperFactory = false
-        handle.registerRowMapper(KotlinMapperFactory())
-
         val expected = MagicType("does this work?")
 
         handle.createUpdate("INSERT INTO something(id, first) VALUES(:id, :first)")
+            .registerArgument(argumentFactory)
             .bind("id", 1)
             .bind("first", expected)
             .execute()
 
         val result = handle.createQuery("SELECT id, first from something")
+            .registerColumnMapper(columnMapperFactory)
+            // Not automatically registered b/c using installKotlinMapperFactory = false
+            .registerRowMapper(KotlinMapperFactory())
             .mapTo<TheThings>()
             .single()
 
@@ -195,22 +192,20 @@ class KotlinValueTypeTest {
     @ParameterizedTest
     @MethodSource("arguments")
     fun testValueBeanList(columnMapperFactory: ColumnMapperFactory, argumentFactory: ArgumentFactory) {
-        handle.registerArgument(argumentFactory)
-        handle.registerColumnMapper(columnMapperFactory)
-
-        // Not automatically registered b/c using installKotlinMapperFactory = false
-        handle.registerRowMapper(KotlinMapperFactory())
-
         val expected = MagicType("does this work?")
 
         for (i in 1..10) {
             handle.createUpdate("INSERT INTO something(id, first) VALUES(:id, :first)")
+                .registerArgument(argumentFactory)
                 .bind("id", i)
                 .bind("first", expected)
                 .execute()
         }
 
         val result = handle.createQuery("SELECT id, first from something")
+            .registerColumnMapper(columnMapperFactory)
+            // Not automatically registered b/c using installKotlinMapperFactory = false
+            .registerRowMapper(KotlinMapperFactory())
             .mapTo<TheThings>()
             .list()
 
@@ -229,19 +224,18 @@ class KotlinValueTypeTest {
 
     @Test
     fun testMultiValueClasses() {
-        handle.registerArgument(KotlinValueClassArgumentFactory())
-        handle.registerColumnMapper(KotlinValueClassColumnMapperFactory())
-        handle.registerRowMapper(KotlinMapperFactory())
-
         val expected = MagicType("does this work?")
         val other = SpaceType("no it does not.")
         val ktBean = MoreThings(1, expected, other)
 
         handle.createUpdate("INSERT INTO something(id, first, other) VALUES(:id, :first, :other)")
+            .registerArgument(KotlinValueClassArgumentFactory())
             .bindKotlin(ktBean)
             .execute()
 
         val result = handle.createQuery("SELECT id, first, other from something")
+            .registerColumnMapper(KotlinValueClassColumnMapperFactory())
+            .registerRowMapper(KotlinMapperFactory())
             .mapTo<MoreThings>()
             .single()
 

--- a/kotlin/src/test/kotlin/org/jdbi/core/kotlin/KotlinValueTypeTest.kt
+++ b/kotlin/src/test/kotlin/org/jdbi/core/kotlin/KotlinValueTypeTest.kt
@@ -18,7 +18,7 @@ import org.jdbi.core.Handle
 import org.jdbi.core.argument.AbstractArgumentFactory
 import org.jdbi.core.argument.Argument
 import org.jdbi.core.argument.ArgumentFactory
-import org.jdbi.core.config.ConfigRegistry
+import org.jdbi.core.config.ConfigView
 import org.jdbi.core.kotlin.internal.KotlinValueClassArgumentFactory
 import org.jdbi.core.kotlin.internal.KotlinValueClassColumnMapperFactory
 import org.jdbi.core.mapper.ColumnMapper
@@ -56,14 +56,13 @@ class KotlinValueTypeTest {
     value class MagicType(val first: String)
 
     class MagicTypeArgumentFactory : AbstractArgumentFactory<MagicType>(Types.VARCHAR) {
-        override fun build(value: MagicType?, config: ConfigRegistry): Argument =
-            Argument { position: Int, statement: PreparedStatement, ctx: StatementContext ->
-                if (value != null) {
-                    statement.setString(position, value.first)
-                } else {
-                    statement.setNull(position, Types.VARCHAR)
-                }
+        override fun build(value: MagicType?, config: ConfigView): Argument = Argument { position: Int, statement: PreparedStatement, ctx: StatementContext ->
+            if (value != null) {
+                statement.setString(position, value.first)
+            } else {
+                statement.setNull(position, Types.VARCHAR)
             }
+        }
     }
 
     class MagicTypeColumnMapper : ColumnMapper<MagicType?> {
@@ -74,7 +73,7 @@ class KotlinValueTypeTest {
     }
 
     class MagicTypeColumnMapperFactory : ColumnMapperFactory {
-        override fun build(type: Type?, config: ConfigRegistry?): Optional<ColumnMapper<*>> {
+        override fun build(type: Type?, config: ConfigView?): Optional<ColumnMapper<*>> {
             if (type == MagicType::class.java) {
                 return Optional.of(MagicTypeColumnMapper())
             }

--- a/moshi/src/main/java/org/jdbi/moshi/MoshiConfig.java
+++ b/moshi/src/main/java/org/jdbi/moshi/MoshiConfig.java
@@ -14,6 +14,7 @@
 package org.jdbi.moshi;
 
 import com.squareup.moshi.Moshi;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 
 /**
@@ -37,6 +38,7 @@ public final class MoshiConfig implements JdbiConfig<MoshiConfig> {
      * @param moshi the mapper to use
      * @return the derived configuration
      */
+    @CheckReturnValue
     public MoshiConfig moshi(Moshi moshi) {
         return new MoshiConfig(moshi);
     }

--- a/moshi/src/main/java/org/jdbi/moshi/MoshiJsonMapper.java
+++ b/moshi/src/main/java/org/jdbi/moshi/MoshiJsonMapper.java
@@ -17,23 +17,23 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 
 import com.squareup.moshi.JsonAdapter;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.result.UnableToProduceResultException;
 import org.jdbi.json.JsonMapper;
 
 class MoshiJsonMapper implements JsonMapper {
     @Override
-    public TypedJsonMapper forType(Type type, ConfigRegistry config) {
+    public TypedJsonMapper forType(Type type, ConfigView config) {
         return new TypedJsonMapper() {
             private final JsonAdapter<Object> adapter = config.get(MoshiConfig.class).getMoshi().adapter(type);
 
             @Override
-            public String toJson(Object value, ConfigRegistry config) {
+            public String toJson(Object value, ConfigView config) {
                 return adapter.toJson(value);
             }
 
             @Override
-            public Object fromJson(String json, ConfigRegistry config) {
+            public Object fromJson(String json, ConfigView config) {
                 try {
                     return adapter.fromJson(json);
                 } catch (IOException e) {

--- a/moshi/src/test/java/org/jdbi/moshi/TestMoshiPlugin.java
+++ b/moshi/src/test/java/org/jdbi/moshi/TestMoshiPlugin.java
@@ -57,15 +57,13 @@ public class TestMoshiPlugin extends AbstractJsonMapperTest {
 
     @Test
     public void typeCanBeOverridden() {
-        pgExtension.getJdbi().useHandle(h -> {
+        Moshi moshi = new Moshi.Builder()
+            .add(new OptionalAdapter())
+            .add(SuperUser.class, new SuperUserAdapter())
+            .add(SubUser.class, new SubUserAdapter())
+            .build();
+        pgExtension.getJdbi().useHandle(cfg -> cfg.configure(MoshiConfig.class, c -> c.moshi(moshi)), h -> {
             h.createUpdate("create table users(usr json)").execute();
-
-            Moshi moshi = new Moshi.Builder()
-                .add(new OptionalAdapter())
-                .add(SuperUser.class, new SuperUserAdapter())
-                .add(SubUser.class, new SubUserAdapter())
-                .build();
-            h.configure(MoshiConfig.class, c -> c.moshi(moshi));
 
             h.createUpdate("insert into users(usr) values(:user)")
                 // declare that the subuser should be mapped as a superuser

--- a/moshi/src/test/java/org/jdbi/moshi/TestMoshiPlugin.java
+++ b/moshi/src/test/java/org/jdbi/moshi/TestMoshiPlugin.java
@@ -45,13 +45,14 @@ public class TestMoshiPlugin extends AbstractJsonMapperTest {
     public static EmbeddedPgExtension pg = MultiDatabaseBuilder.instanceWithDefaults().build();
 
     @RegisterExtension
-    JdbiExtension pgExtension = JdbiExtension.postgres(pg).withPlugins(new SqlObjectPlugin(), new PostgresPlugin(), new MoshiPlugin());
+    JdbiExtension pgExtension = JdbiExtension.postgres(pg)
+        .withPlugins(new SqlObjectPlugin(), new PostgresPlugin(), new MoshiPlugin())
+        .withConfig(b -> b.configure(MoshiConfig.class, c -> c.moshi(
+            new Moshi.Builder().add(new OptionalAdapter()).build())));
 
     @BeforeEach
     public void before() {
-        jdbi = pgExtension.getJdbi().installPlugin(new MoshiPlugin())
-            .configure(MoshiConfig.class, c -> c.moshi(
-                new Moshi.Builder().add(new OptionalAdapter()).build()));
+        jdbi = pgExtension.getJdbi();
     }
 
     @Test

--- a/noparameters/src/test/java/org/jdbi/noparameters/TestSqlObjectNoParameterNames.java
+++ b/noparameters/src/test/java/org/jdbi/noparameters/TestSqlObjectNoParameterNames.java
@@ -38,7 +38,8 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 public class TestSqlObjectNoParameterNames {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(BeanMapper.factory(Something.class)));
 
     Handle h;
 
@@ -47,7 +48,6 @@ public class TestSqlObjectNoParameterNames {
         assumeFalse(BindDao.class.getMethod("getByIdImplicitBindPositional", int.class).getParameters()[0].isNamePresent());
 
         h = h2Extension.getSharedHandle();
-        h.registerRowMapper(BeanMapper.factory(Something.class));
 
         h.execute("insert into something (id, name) values (1, 'Elsie Hughes')");
     }

--- a/opentelemetry/src/test/java/org/jdbi/opentelemetry/TestTelemetry.java
+++ b/opentelemetry/src/test/java/org/jdbi/opentelemetry/TestTelemetry.java
@@ -34,7 +34,6 @@ import org.jdbi.core.statement.JdbiStatementEvent;
 import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.testing.junit.JdbiExtension;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -50,15 +49,21 @@ import static org.assertj.core.api.Assertions.tuple;
 @EnabledIf("org.jdbi.core.statement.internal.JfrSupport#isFlightRecorderAvailable")
 // While JFR is available all the way back to Java 9, the utilities to test it are not.
 public class TestTelemetry {
+    InMemorySpanExporter traces = new InMemorySpanExporter();
+
+    OpenTelemetrySdk otelSdk = OpenTelemetrySdk.builder()
+        .setTracerProvider(SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(traces))
+            .setSampler(Sampler.alwaysOn())
+            .build())
+        .build();
+
     @RegisterExtension
-    JdbiExtension ext = JdbiExtension.h2();
+    JdbiExtension ext = JdbiExtension.h2().withPlugin(new JdbiOpenTelemetryPlugin(otelSdk));
 
     public JfrEvents jfrEvents = new JfrEvents();
 
-    InMemorySpanExporter traces = new InMemorySpanExporter();
-
     Class<?> testCode;
-    Method setupOpenTelemetryMethod;
     Method eventsMethod;
     Method truncateMethod;
     Method doNotIncludeBindingsMethod;
@@ -66,17 +71,11 @@ public class TestTelemetry {
 
     public TestTelemetry() throws ReflectiveOperationException {
         this.testCode = Class.forName(this.getClass().getName() + "$TestCode");
-        this.setupOpenTelemetryMethod = testCode.getMethod("setupOpenTelemetry");
         this.eventsMethod = testCode.getMethod("events");
         this.truncateMethod = testCode.getMethod("truncate");
         this.doNotIncludeBindingsMethod = testCode.getMethod("doNotIncludeBindings");
 
         this.instance = testCode.getDeclaredConstructors()[0].newInstance(this);
-    }
-
-    @BeforeEach
-    void setupOpenTelemetry() throws InvocationTargetException, IllegalAccessException {
-        setupOpenTelemetryMethod.invoke(instance);
     }
 
     @Test
@@ -95,21 +94,6 @@ public class TestTelemetry {
     }
 
     public final class TestCode {
-        OpenTelemetrySdk otelSdk;
-
-
-        @BeforeEach
-        public void setupOpenTelemetry() {
-            final var tracerProvider = SdkTracerProvider.builder()
-                .addSpanProcessor(SimpleSpanProcessor.create(traces))
-                .setSampler(Sampler.alwaysOn())
-                .build();
-            otelSdk = OpenTelemetrySdk.builder()
-                .setTracerProvider(tracerProvider)
-                .build();
-
-            ext.getJdbi().installPlugin(new JdbiOpenTelemetryPlugin(otelSdk));
-        }
 
         @AfterEach
         public void resetOpenTelemetry() {
@@ -186,12 +170,12 @@ public class TestTelemetry {
         }
 
         public void truncate() {
-            ext.getJdbi().configure(SqlStatements.class, c -> c
-                .jfrSqlMaxLength(10)
-                .jfrParamMaxLength(32));
             final var create = "create table something(id identity primary key, name varchar(50))";
             final var insert = "insert into something (id, name) values (:id, :name)";
             try (var h = ext.openHandle()) {
+                h.configure(SqlStatements.class, c -> c
+                    .jfrSqlMaxLength(10)
+                    .jfrParamMaxLength(32));
                 h.execute(create);
                 insertSomething(h, insert, 1, "abcdefghijklmnopqrstuvwxyz");
             }
@@ -212,12 +196,11 @@ public class TestTelemetry {
         public void doNotIncludeBindings() {
             final var sensitiveData = "sensitive_data";
 
-            ext.getJdbi().configure(SqlStatements.class, c -> c
-                .includeBindingsInTelemetry(false));
-
             final var create = "create table something(id identity primary key, name varchar(50))";
             final var insert = "insert into something (id, name) values (:id, :name)";
             try (var h = ext.openHandle()) {
+                h.configure(SqlStatements.class, c -> c
+                    .includeBindingsInTelemetry(false));
                 h.execute(create);
                 insertSomething(h, insert, 1, sensitiveData);
             }

--- a/opentelemetry/src/test/java/org/jdbi/opentelemetry/TestTelemetry.java
+++ b/opentelemetry/src/test/java/org/jdbi/opentelemetry/TestTelemetry.java
@@ -172,10 +172,9 @@ public class TestTelemetry {
         public void truncate() {
             final var create = "create table something(id identity primary key, name varchar(50))";
             final var insert = "insert into something (id, name) values (:id, :name)";
-            try (var h = ext.openHandle()) {
-                h.configure(SqlStatements.class, c -> c
-                    .jfrSqlMaxLength(10)
-                    .jfrParamMaxLength(32));
+            try (var h = ext.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c
+                .jfrSqlMaxLength(10)
+                .jfrParamMaxLength(32)))) {
                 h.execute(create);
                 insertSomething(h, insert, 1, "abcdefghijklmnopqrstuvwxyz");
             }
@@ -198,9 +197,8 @@ public class TestTelemetry {
 
             final var create = "create table something(id identity primary key, name varchar(50))";
             final var insert = "insert into something (id, name) values (:id, :name)";
-            try (var h = ext.openHandle()) {
-                h.configure(SqlStatements.class, c -> c
-                    .includeBindingsInTelemetry(false));
+            try (var h = ext.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c
+                .includeBindingsInTelemetry(false)))) {
                 h.execute(create);
                 insertSomething(h, insert, 1, sensitiveData);
             }

--- a/oracle12/src/test/java/org/jdbi/oracle12/TestOraclePlugin.java
+++ b/oracle12/src/test/java/org/jdbi/oracle12/TestOraclePlugin.java
@@ -15,6 +15,7 @@ package org.jdbi.oracle12;
 
 import java.sql.Types;
 
+import org.jdbi.core.ConnectionFactory;
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.argument.Arguments;
 import org.jdbi.core.argument.NullArgument;
@@ -26,18 +27,18 @@ public class TestOraclePlugin {
 
     @Test
     public void testPluginSetsUntypedNullArgument() {
-        Jdbi jdbi = Jdbi.create(() -> {
+        ConnectionFactory connectionFactory = () -> {
             throw new UnsupportedOperationException();
-        });
+        };
 
-        // before installing the plugin, the default is Types.OTHER
-        NullArgument defaultNull = (NullArgument) jdbi.getConfig(Arguments.class).getUntypedNullArgument();
+        // without the plugin, the default is Types.OTHER
+        Jdbi defaultJdbi = Jdbi.builder(connectionFactory).build();
+        NullArgument defaultNull = (NullArgument) defaultJdbi.getConfig(Arguments.class).getUntypedNullArgument();
         assertThat(defaultNull.getSqlType()).isEqualTo(Types.OTHER);
 
-        jdbi.installPlugin(new OraclePlugin());
-
-        // after installing the plugin, the untyped null uses Types.NULL
-        NullArgument oracleNull = (NullArgument) jdbi.getConfig(Arguments.class).getUntypedNullArgument();
+        // with the plugin installed, the untyped null uses Types.NULL
+        Jdbi oracleJdbi = Jdbi.builder(connectionFactory).installPlugin(new OraclePlugin()).build();
+        NullArgument oracleNull = (NullArgument) oracleJdbi.getConfig(Arguments.class).getUntypedNullArgument();
         assertThat(oracleNull.getSqlType()).isEqualTo(Types.NULL);
     }
 

--- a/postgres/src/main/java/org/jdbi/postgres/BlobInputStreamArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/BlobInputStreamArgumentFactory.java
@@ -20,7 +20,7 @@ import java.sql.Types;
 
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 
 class BlobInputStreamArgumentFactory extends AbstractArgumentFactory<InputStream> {
@@ -29,7 +29,7 @@ class BlobInputStreamArgumentFactory extends AbstractArgumentFactory<InputStream
     }
 
     @Override
-    protected Argument build(InputStream value, ConfigRegistry config) {
+    protected Argument build(InputStream value, ConfigView config) {
         return new LobInputStreamArgument(value);
     }
 

--- a/postgres/src/main/java/org/jdbi/postgres/BlobInputStreamColumnMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/BlobInputStreamColumnMapperFactory.java
@@ -19,14 +19,14 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
 import org.jdbi.core.statement.StatementContext;
 
 class BlobInputStreamColumnMapperFactory implements ColumnMapperFactory {
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         if (InputStream.class != type) {
             return Optional.empty();
         }

--- a/postgres/src/main/java/org/jdbi/postgres/ClobReaderArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/ClobReaderArgumentFactory.java
@@ -18,7 +18,7 @@ import java.sql.Types;
 
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.postgres.BlobInputStreamArgumentFactory.LobInputStreamArgument;
 import org.postgresql.util.ReaderInputStream;
 
@@ -28,7 +28,7 @@ class ClobReaderArgumentFactory extends AbstractArgumentFactory<Reader> {
     }
 
     @Override
-    protected Argument build(Reader value, ConfigRegistry config) {
+    protected Argument build(Reader value, ConfigView config) {
         return new LobInputStreamArgument(new ReaderInputStream(value));
     }
 }

--- a/postgres/src/main/java/org/jdbi/postgres/ClobReaderColumnMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/ClobReaderColumnMapperFactory.java
@@ -19,14 +19,14 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
 import org.jdbi.postgres.BlobInputStreamColumnMapperFactory.LobColumnMapper;
 
 class ClobReaderColumnMapperFactory implements ColumnMapperFactory {
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         if (Reader.class != type) {
             return Optional.empty();
         }

--- a/postgres/src/main/java/org/jdbi/postgres/DurationArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/DurationArgumentFactory.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ObjectArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.postgresql.util.PGInterval;
 
 /**
@@ -48,7 +48,7 @@ public class DurationArgumentFactory extends AbstractArgumentFactory<Duration> {
     }
 
     @Override
-    public Argument build(Duration duration, ConfigRegistry config) {
+    public Argument build(Duration duration, ConfigView config) {
         Duration d = duration;
         final boolean isNegative = d.isNegative();
         if (isNegative) {

--- a/postgres/src/main/java/org/jdbi/postgres/DurationColumnMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/DurationColumnMapperFactory.java
@@ -18,7 +18,7 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
 import org.postgresql.util.PGInterval;
@@ -33,7 +33,7 @@ import org.postgresql.util.PGInterval;
  */
 public class DurationColumnMapperFactory implements ColumnMapperFactory {
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         if (type != Duration.class) {
             return Optional.empty();
         }

--- a/postgres/src/main/java/org/jdbi/postgres/HStoreArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/HStoreArgumentFactory.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ObjectArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * An argument factory which binds Java's {@link Map} to Postgres' hstore type.
@@ -33,7 +33,7 @@ public class HStoreArgumentFactory extends AbstractArgumentFactory<Map> {
     }
 
     @Override
-    protected Argument build(Map value, ConfigRegistry config) {
+    protected Argument build(Map value, ConfigView config) {
         return ObjectArgument.of(value);
     }
 }

--- a/postgres/src/main/java/org/jdbi/postgres/InetArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/InetArgumentFactory.java
@@ -19,7 +19,7 @@ import java.sql.Types;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ObjectArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * Postgres version of argument factory for {@code InetAddress}.
@@ -30,7 +30,7 @@ public class InetArgumentFactory extends AbstractArgumentFactory<InetAddress> {
     }
 
     @Override
-    protected Argument build(InetAddress value, ConfigRegistry config) {
+    protected Argument build(InetAddress value, ConfigView config) {
         return ObjectArgument.of(value.getHostAddress(), Types.OTHER);
     }
 

--- a/postgres/src/main/java/org/jdbi/postgres/JsonArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/JsonArgumentFactory.java
@@ -17,7 +17,7 @@ import java.sql.Types;
 
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.json.EncodedJson;
 
 @EncodedJson
@@ -27,7 +27,7 @@ class JsonArgumentFactory extends AbstractArgumentFactory<String> {
     }
 
     @Override
-    protected Argument build(String value, ConfigRegistry config) {
+    protected Argument build(String value, ConfigView config) {
         return (p, s, c) -> s.setObject(p, value, Types.OTHER);
     }
 }

--- a/postgres/src/main/java/org/jdbi/postgres/MacAddrArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/MacAddrArgumentFactory.java
@@ -17,7 +17,7 @@ import java.sql.Types;
 
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.postgresql.util.PGobject;
 
 /**
@@ -30,7 +30,7 @@ class MacAddrArgumentFactory extends AbstractArgumentFactory<String> {
     }
 
     @Override
-    protected Argument build(String value, ConfigRegistry config) {
+    protected Argument build(String value, ConfigView config) {
         return (pos, stmt, ctx) -> {
             PGobject obj = new PGobject();
             obj.setType("macaddr");

--- a/postgres/src/main/java/org/jdbi/postgres/PGobjectArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/PGobjectArgumentFactory.java
@@ -18,7 +18,7 @@ import java.sql.Types;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ObjectArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.postgresql.util.PGobject;
 
 /**
@@ -31,7 +31,7 @@ class PGobjectArgumentFactory extends AbstractArgumentFactory<PGobject> {
     }
 
     @Override
-    protected Argument build(PGobject value, ConfigRegistry config) {
+    protected Argument build(PGobject value, ConfigView config) {
         return ObjectArgument.of(value, Types.OTHER);
     }
 

--- a/postgres/src/main/java/org/jdbi/postgres/PGobjectColumnMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/PGobjectColumnMapperFactory.java
@@ -16,7 +16,7 @@ package org.jdbi.postgres;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
@@ -28,7 +28,7 @@ import org.postgresql.util.PGobject;
 class PGobjectColumnMapperFactory implements ColumnMapperFactory {
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         Class<?> erasedType = GenericTypes.getErasedType(type);
         if (PGobject.class.isAssignableFrom(erasedType)) {
             return Optional.of((rs, col, ctx) -> rs.getObject(col, erasedType));

--- a/postgres/src/main/java/org/jdbi/postgres/PeriodArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/PeriodArgumentFactory.java
@@ -19,7 +19,7 @@ import java.time.Period;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ObjectArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.postgresql.util.PGInterval;
 
 /**
@@ -32,7 +32,7 @@ public class PeriodArgumentFactory extends AbstractArgumentFactory<Period> {
     }
 
     @Override
-    public Argument build(Period period, ConfigRegistry config) {
+    public Argument build(Period period, ConfigView config) {
         PGInterval interval = new PGInterval(period.getYears(), period.getMonths(), period.getDays(), 0, 0, 0);
         return ObjectArgument.of(interval, Types.OTHER);
     }

--- a/postgres/src/main/java/org/jdbi/postgres/PeriodColumnMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/PeriodColumnMapperFactory.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 import java.time.Period;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
 import org.postgresql.util.PGInterval;
@@ -31,7 +31,7 @@ import org.postgresql.util.PGInterval;
  */
 public class PeriodColumnMapperFactory implements ColumnMapperFactory {
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         if (type != Period.class) {
             return Optional.empty();
         }

--- a/postgres/src/main/java/org/jdbi/postgres/PostgresCustomTypeArrayFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/PostgresCustomTypeArrayFactory.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 
 import org.jdbi.core.array.SqlArrayType;
 import org.jdbi.core.array.SqlArrayTypeFactory;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 
 /**
@@ -30,7 +30,7 @@ import org.jdbi.core.generic.GenericTypes;
  */
 final class PostgresCustomTypeArrayFactory implements SqlArrayTypeFactory {
     @Override
-    public Optional<SqlArrayType<?>> build(Type elementType, ConfigRegistry config) {
+    public Optional<SqlArrayType<?>> build(Type elementType, ConfigView config) {
         final String typeName = config.get(PostgresTypes.class).sqlArrayTypeName(GenericTypes.getErasedType(elementType));
         return Optional.ofNullable(typeName).map(name -> SqlArrayType.of(name, Function.identity()));
     }

--- a/postgres/src/main/java/org/jdbi/postgres/PostgresPlugin.java
+++ b/postgres/src/main/java/org/jdbi/postgres/PostgresPlugin.java
@@ -19,9 +19,9 @@ import java.util.Map;
 
 import com.pgvector.PGbit;
 import com.pgvector.PGvector;
-import org.jdbi.core.Handle;
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.argument.ArgumentFactory;
+import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.internal.JdbiClassUtils;
 import org.jdbi.core.internal.UtilityClassException;
@@ -168,14 +168,18 @@ public class PostgresPlugin extends JdbiPlugin.Singleton {
     }
 
     @Override
-    public Handle customizeHandle(Handle handle) throws SQLException {
-        Connection conn = handle.getConnection();
+    public Connection customizeConnection(Connection conn) throws SQLException {
         if (PGVECTOR_AVAILABLE) {
             VectorEnabler.enable(conn);
         }
-        PGConnection pgConnection = conn.unwrap(PGConnection.class);
-        return handle.configure(PostgresTypes.class, pt ->
-            pt.addTypesToConnection(pgConnection).lobApi(new PgLobApiImpl(conn)));
+        return conn;
+    }
+
+    @Override
+    public void customizeHandleConfig(Connection connection, ConfigRegistry config) throws SQLException {
+        PGConnection pgConnection = connection.unwrap(PGConnection.class);
+        config.configure(PostgresTypes.class, pt ->
+            pt.addTypesToConnection(pgConnection).lobApi(new PgLobApiImpl(connection)));
     }
 
     static final class VectorEnabler {

--- a/postgres/src/main/java/org/jdbi/postgres/PostgresTypes.java
+++ b/postgres/src/main/java/org/jdbi/postgres/PostgresTypes.java
@@ -16,6 +16,7 @@ package org.jdbi.postgres;
 import java.util.HashMap;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.internal.exceptions.Unchecked;
 import org.postgresql.PGConnection;
@@ -50,6 +51,7 @@ public final class PostgresTypes implements JdbiConfig<PostgresTypes> {
      * @param typeName the Postgres custom type name
      * @return a copy of this configuration with the custom type registered
      */
+    @CheckReturnValue
     public PostgresTypes registerCustomType(Class<? extends PGobject> clazz, String typeName) {
         final Map<Class<? extends PGobject>, String> updated = new HashMap<>(types);
         updated.put(clazz, typeName);

--- a/postgres/src/main/java/org/jdbi/postgres/TypedEnumArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/TypedEnumArgumentFactory.java
@@ -18,7 +18,7 @@ import java.sql.Types;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ObjectArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * Default {@code jdbi} behavior is to bind {@code Enum} subclasses as
@@ -32,7 +32,7 @@ public class TypedEnumArgumentFactory extends AbstractArgumentFactory<Enum> {
     }
 
     @Override
-    protected Argument build(Enum value, ConfigRegistry config) {
+    protected Argument build(Enum value, ConfigView config) {
         return ObjectArgument.of(value, Types.OTHER);
     }
 }

--- a/postgres/src/main/java/org/jdbi/postgres/internal/BitStringEnumSetArgumentFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/internal/BitStringEnumSetArgumentFactory.java
@@ -20,12 +20,12 @@ import java.util.function.Function;
 
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 
 public class BitStringEnumSetArgumentFactory implements ArgumentFactory.Preparable {
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         if (!EnumSet.class.isAssignableFrom(GenericTypes.getErasedType(type))) {
             return Optional.empty();
         }

--- a/postgres/src/main/java/org/jdbi/postgres/internal/BitStringEnumSetMapperFactory.java
+++ b/postgres/src/main/java/org/jdbi/postgres/internal/BitStringEnumSetMapperFactory.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 import java.util.EnumSet;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
@@ -25,7 +25,7 @@ import org.jdbi.core.mapper.ColumnMapperFactory;
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class BitStringEnumSetMapperFactory implements ColumnMapperFactory {
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         if (!EnumSet.class.isAssignableFrom(GenericTypes.getErasedType(type))) {
             return Optional.empty();
         }

--- a/postgres/src/test/java/org/jdbi/TestStatementsTimeout.java
+++ b/postgres/src/test/java/org/jdbi/TestStatementsTimeout.java
@@ -55,12 +55,13 @@ public class TestStatementsTimeout {
 
     @Test
     public void testTimeout() {
-        h.configure(SqlStatements.class, c -> c.queryTimeout(2));
-
-        assertThatCode(h.createQuery("select pg_sleep(1)").mapTo(String.class)::one)
+        assertThatCode(h.createQuery("select pg_sleep(1)")
+                .configure(SqlStatements.class, c -> c.queryTimeout(2))
+                .mapTo(String.class)::one)
             .doesNotThrowAnyException();
 
-        try (Query query = h.createQuery("select pg_sleep(3)")) {
+        try (Query query = h.createQuery("select pg_sleep(3)")
+                .configure(SqlStatements.class, c -> c.queryTimeout(2))) {
             ResultIterable<String> iterable = query.mapTo(String.class);
 
             assertThatThrownBy(iterable::one)

--- a/postgres/src/test/java/org/jdbi/postgres/TestImmutablesHStore.java
+++ b/postgres/src/test/java/org/jdbi/postgres/TestImmutablesHStore.java
@@ -20,7 +20,6 @@ import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
 import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
 import org.immutables.value.Value;
 import org.jdbi.core.Jdbi;
-import org.jdbi.core.spi.JdbiPlugin;
 import org.jdbi.sqlobject.SqlObjectPlugin;
 import org.jdbi.sqlobject.customizer.BindPojo;
 import org.jdbi.sqlobject.statement.SqlQuery;
@@ -41,12 +40,7 @@ public class TestImmutablesHStore {
 
     @RegisterExtension
     public JdbiExtension pgExtension = JdbiExtension.postgres(pg).withPlugins(new SqlObjectPlugin(), new PostgresPlugin())
-        .withPlugin(new JdbiPlugin() {
-            @Override
-            public void customizeJdbi(Jdbi jdbi) {
-                jdbi.registerImmutable(Mappy.class);
-            }
-        })
+        .withConfig(b -> b.registerImmutable(Mappy.class))
         .withInitializer((ds, h) -> h.execute("create table mappy (numbers hstore not null)"));
 
     MappyDao dao;

--- a/postgres/src/test/java/org/jdbi/postgres/TestJsonOperator.java
+++ b/postgres/src/test/java/org/jdbi/postgres/TestJsonOperator.java
@@ -139,8 +139,8 @@ public class TestJsonOperator {
         }
 
         @Override
-        public void customizeJdbi(Jdbi jdbi) {
-            jdbi.configure(SqlStatements.class, c -> c.templateEngine(templateEngine));
+        public void configure(Jdbi.Builder builder) {
+            builder.configure(SqlStatements.class, c -> c.templateEngine(templateEngine));
         }
     }
 }

--- a/postgres/src/test/java/org/jdbi/postgres/TestSqlArrays.java
+++ b/postgres/src/test/java/org/jdbi/postgres/TestSqlArrays.java
@@ -62,16 +62,16 @@ public class TestSqlArrays {
         .withInitializer((ds, h) -> h.useTransaction(th -> {
             th.execute("DROP TABLE IF EXISTS uuids");
             th.execute("CREATE TABLE uuids (u UUID[], i INT[], t TIMESTAMPTZ[])");
-        }));
+        }))
+        // register array type to every handle
+        .withConfig(b -> b.registerArrayType(Instant.class, "timestamptz"));
 
     private Handle handle;
     private ArrayObject ao;
 
     @BeforeEach
     public void setUp() {
-        handle = pgExtension.openHandle()
-            // register array type to the handle
-            .registerArrayType(Instant.class, "timestamptz");
+        handle = pgExtension.openHandle();
 
         // attach the array object to the handle as well.
         ao = handle.attach(ArrayObject.class);
@@ -201,8 +201,8 @@ public class TestSqlArrays {
 
     @Test
     public void testReusedArrayWithString() throws Exception {
-        handle.registerArrayType(String.class, "text");
         assertThat(handle.createQuery("select :array = :array")
+                .registerArrayType(String.class, "text")
                 .bindArray("array", String.class, Collections.singletonList("element"))
                 .mapTo(boolean.class)
                 .one()).isTrue();

--- a/spring/src/main/java/org/jdbi/spring/JdbiFactoryBean.java
+++ b/spring/src/main/java/org/jdbi/spring/JdbiFactoryBean.java
@@ -44,13 +44,13 @@ public class JdbiFactoryBean extends AbstractFactoryBean<Jdbi> {
 
     @Override
     protected Jdbi createInstance() throws Exception {
-        final Jdbi jdbi = Jdbi.create(new SpringConnectionFactory(dataSource));
+        final Jdbi.Builder builder = Jdbi.builder(new SpringConnectionFactory(dataSource));
 
-        plugins.forEach(jdbi::installPlugin);
+        plugins.forEach(builder::installPlugin);
 
-        globalDefines.forEach(jdbi::define);
+        globalDefines.forEach(builder::define);
 
-        return jdbi;
+        return builder.build();
     }
 
     /**

--- a/spring/src/test/java/org/jdbi/spring/ManualPlugin.java
+++ b/spring/src/test/java/org/jdbi/spring/ManualPlugin.java
@@ -21,7 +21,7 @@ public class ManualPlugin implements JdbiPlugin {
     static final String VALUE = "installed";
 
     @Override
-    public void customizeJdbi(Jdbi jdbi) {
-        jdbi.define(KEY, VALUE);
+    public void configure(Jdbi.Builder builder) {
+        builder.define(KEY, VALUE);
     }
 }

--- a/spring/src/test/java/org/jdbi/spring/TestPluginInstall.java
+++ b/spring/src/test/java/org/jdbi/spring/TestPluginInstall.java
@@ -56,7 +56,7 @@ public class TestPluginInstall {
         public JdbiPlugin pluginA() {
             return new JdbiPlugin() {
                 @Override
-                public void customizeJdbi(final Jdbi db) {
+                public void configure(final Jdbi.Builder db) {
                     pluginACalled = true;
                 }
             };
@@ -66,7 +66,7 @@ public class TestPluginInstall {
         public JdbiPlugin pluginB() {
             return new JdbiPlugin() {
                 @Override
-                public void customizeJdbi(final Jdbi db) {
+                public void configure(final Jdbi.Builder db) {
                     pluginBCalled = true;
                 }
             };

--- a/spring/src/test/java/org/jdbi/spring/jta/JdbiJtaTest.java
+++ b/spring/src/test/java/org/jdbi/spring/jta/JdbiJtaTest.java
@@ -18,11 +18,7 @@ import java.util.List;
 import java.util.Spliterators;
 import java.util.stream.StreamSupport;
 
-import org.jdbi.core.Handles;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.result.ResultIterator;
-import org.jdbi.core.spi.JdbiPlugin;
-import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.core.statement.UnableToCreateStatementException;
 import org.jdbi.testing.internal.JdbiLeakChecker;
 import org.junit.jupiter.api.Assertions;
@@ -39,28 +35,24 @@ public class JdbiJtaTest {
     @Autowired
     private SomethingService somethingService;
 
+    // attached to the (immutable) Jdbi at assembly time via JdbiLeakCheckerPlugin in test-context.xml
     @Autowired
-    private Jdbi jdbi;
+    private JdbiLeakChecker jdbiLeakChecker;
 
     @Test
     void testQueryWithoutTxDoesNotLeak() {
-        JdbiLeakChecker jdbiLeakChecker = installJdbiLeakChecker(jdbi);
         somethingService.withoutTransaction(SomethingDao::queryReturningList);
         jdbiLeakChecker.checkForLeaks();
-
     }
 
     @Test
     void testQueryInTxDoesNotLeak() {
-        JdbiLeakChecker jdbiLeakChecker = installJdbiLeakChecker(jdbi);
         somethingService.inTransaction(SomethingDao::queryReturningList);
         jdbiLeakChecker.checkForLeaks();
-
     }
 
     @Test
     void testIteratorInTxDoesNotLeak() {
-        JdbiLeakChecker jdbiLeakChecker = installJdbiLeakChecker(jdbi);
         somethingService.inTransaction(somethingDao -> {
             List<String> result = new ArrayList<>();
             ResultIterator<String> iterator = somethingDao.queryReturningResultIterator();
@@ -72,31 +64,9 @@ public class JdbiJtaTest {
 
     @Test
     void testExceptionInTxDoesNotLeak() {
-        JdbiLeakChecker jdbiLeakChecker = installJdbiLeakChecker(jdbi);
         Assertions.assertThrows(UnableToCreateStatementException.class,
                 () -> somethingService.inTransaction(SomethingDao::exceptionThrowingQuery)
         );
         jdbiLeakChecker.checkForLeaks();
-    }
-
-    public static JdbiLeakChecker installJdbiLeakChecker(Jdbi jdbi) {
-        JdbiLeakChecker jdbiLeakChecker = new JdbiLeakChecker();
-        JdbiLeakCheckerPlugin plugin = new JdbiLeakCheckerPlugin(jdbiLeakChecker);
-        jdbi.installPlugin(plugin);
-        return jdbiLeakChecker;
-    }
-
-    public static class JdbiLeakCheckerPlugin implements JdbiPlugin {
-        private final JdbiLeakChecker leakChecker;
-
-        public JdbiLeakCheckerPlugin(JdbiLeakChecker leakChecker) {
-            this.leakChecker = leakChecker;
-        }
-
-        @Override
-        public void customizeJdbi(Jdbi jdbi) {
-            jdbi.configure(Handles.class, h -> h.addListener(leakChecker));
-            jdbi.configure(SqlStatements.class, h -> h.addContextListener(leakChecker));
-        }
     }
 }

--- a/spring/src/test/java/org/jdbi/spring/jta/JdbiLeakCheckerPlugin.java
+++ b/spring/src/test/java/org/jdbi/spring/jta/JdbiLeakCheckerPlugin.java
@@ -11,25 +11,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jdbi.cache.caffeine;
+package org.jdbi.spring.jta;
 
+import org.jdbi.core.Handles;
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.spi.JdbiPlugin;
-import org.jdbi.core.statement.ColonPrefixSqlParser;
 import org.jdbi.core.statement.SqlStatements;
-
-import static org.jdbi.core.statement.CachingSqlParser.PARSED_SQL_CACHE_SIZE;
-import static org.jdbi.core.statement.SqlStatements.SQL_TEMPLATE_CACHE_SIZE;
+import org.jdbi.testing.internal.JdbiLeakChecker;
 
 /**
- * Installing this plugin restores the up-to 3.36.0 behavior of using the Caffeine cache library for SQL statements and the colon prefix parser.
+ * Attaches a {@link JdbiLeakChecker} to a {@link Jdbi} at assembly time, so a Spring-managed (immutable) {@code Jdbi}
+ * can participate in leak checking.
  */
-public final class CaffeineCachePlugin implements JdbiPlugin {
+public class JdbiLeakCheckerPlugin implements JdbiPlugin {
+
+    private final JdbiLeakChecker leakChecker;
+
+    public JdbiLeakCheckerPlugin(JdbiLeakChecker leakChecker) {
+        this.leakChecker = leakChecker;
+    }
 
     @Override
     public void configure(Jdbi.Builder builder) {
-        builder.configure(SqlStatements.class, config -> config
-                .templateCache(CaffeineCacheBuilder.instance().maxSize(SQL_TEMPLATE_CACHE_SIZE))
-                .sqlParser(new ColonPrefixSqlParser(CaffeineCacheBuilder.instance().maxSize(PARSED_SQL_CACHE_SIZE))));
+        builder.configure(Handles.class, h -> h.addListener(leakChecker));
+        builder.configure(SqlStatements.class, s -> s.addContextListener(leakChecker));
     }
 }

--- a/spring/src/test/resources/org/jdbi/spring/jta/test-context.xml
+++ b/spring/src/test/resources/org/jdbi/spring/jta/test-context.xml
@@ -28,11 +28,16 @@
         <property name="url" value="jdbc:h2:mem:testing;INIT=create table if not exists something ( id integer, name varchar(50), integerValue integer, intValue integer )" />
     </bean>
 
+    <bean id="jdbiLeakChecker" class="org.jdbi.testing.internal.JdbiLeakChecker"/>
+
     <bean id="myJdbi" class="org.jdbi.spring.JdbiFactoryBean">
         <property name="dataSource" ref="db"/>
         <property name="plugins">
             <list>
                 <bean class="org.jdbi.sqlobject.SqlObjectPlugin"/>
+                <bean class="org.jdbi.spring.jta.JdbiLeakCheckerPlugin">
+                    <constructor-arg ref="jdbiLeakChecker"/>
+                </bean>
             </list>
         </property>
     </bean>

--- a/sqlite/src/main/java/org/jdbi/sqlite3/URLArgumentFactory.java
+++ b/sqlite/src/main/java/org/jdbi/sqlite3/URLArgumentFactory.java
@@ -21,7 +21,7 @@ import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
 import org.jdbi.core.argument.internal.strategies.LoggableBinderArgument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 /**
  * Build URL objects as strings.
@@ -35,7 +35,7 @@ class URLArgumentFactory extends AbstractArgumentFactory<URL> {
     }
 
     @Override
-    protected Argument build(URL url, ConfigRegistry config) {
+    protected Argument build(URL url, ConfigView config) {
         return LoggableBinderArgument.bindAsString(url);
     }
 }

--- a/sqlite/src/test/java/org/jdbi/sqlite3/TestUrls.java
+++ b/sqlite/src/test/java/org/jdbi/sqlite3/TestUrls.java
@@ -33,8 +33,7 @@ public class TestUrls {
 
     @BeforeEach
     public void setUp() {
-        Jdbi jdbi = Jdbi.create("jdbc:sqlite::memory:");
-        jdbi.installPlugin(new SQLitePlugin());
+        Jdbi jdbi = Jdbi.builder("jdbc:sqlite::memory:").installPlugin(new SQLitePlugin()).build();
         handle = jdbi.open();
         handle.useTransaction(h -> h.execute("CREATE TABLE foo(url URL);"));
     }

--- a/sqlobject/src/main/java/org/jdbi/sqlobject/AbstractSqlObjectFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/sqlobject/AbstractSqlObjectFactory.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jdbi.core.HandleCallback;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.extension.ConfigCustomizerFactory;
 import org.jdbi.core.extension.ExtensionFactory;
 import org.jdbi.core.extension.ExtensionHandler;
@@ -53,13 +53,13 @@ abstract class AbstractSqlObjectFactory implements ExtensionFactory {
     }
 
     @Override
-    public Collection<ExtensionHandlerCustomizer> getExtensionHandlerCustomizers(ConfigRegistry config) {
+    public Collection<ExtensionHandlerCustomizer> getExtensionHandlerCustomizers(ConfigView config) {
         final HandlerDecorators handlerDecorators = config.get(HandlerDecorators.class);
         return Collections.singleton(handlerDecorators::customize);
     }
 
     @Override
-    public Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigRegistry config) {
+    public Collection<ExtensionHandlerFactory> getExtensionHandlerFactories(ConfigView config) {
         final Handlers handlers = config.get(Handlers.class);
         List<ExtensionHandlerFactory> factories = new ArrayList<>();
 
@@ -69,7 +69,7 @@ abstract class AbstractSqlObjectFactory implements ExtensionFactory {
     }
 
     @Override
-    public Collection<ConfigCustomizerFactory> getConfigCustomizerFactories(ConfigRegistry config) {
+    public Collection<ConfigCustomizerFactory> getConfigCustomizerFactories(ConfigView config) {
         return Collections.singleton(SqlObjectCustomizerFactory.FACTORY);
     }
 

--- a/sqlobject/src/main/java/org/jdbi/sqlobject/HandlerDecorators.java
+++ b/sqlobject/src/main/java/org/jdbi/sqlobject/HandlerDecorators.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.extension.ExtensionHandler;
 import org.jdbi.core.internal.RegistrationLists;
@@ -31,7 +31,7 @@ import org.jdbi.core.internal.RegistrationLists;
  * decorator will be the outermost decorator around the method handler.
  *
  * @deprecated Use {@link org.jdbi.core.extension.ExtensionHandlerCustomizer} instances which are returned directly
- * from the {@link org.jdbi.core.extension.ExtensionFactory#getExtensionHandlerCustomizers(ConfigRegistry)}.
+ * from the {@link org.jdbi.core.extension.ExtensionFactory#getExtensionHandlerCustomizers(ConfigView)}.
  */
 @Deprecated(since = "3.38.0", forRemoval = true)
 public final class HandlerDecorators implements JdbiConfig<HandlerDecorators> {

--- a/sqlobject/src/main/java/org/jdbi/sqlobject/HandlerDecorators.java
+++ b/sqlobject/src/main/java/org/jdbi/sqlobject/HandlerDecorators.java
@@ -16,6 +16,7 @@ package org.jdbi.sqlobject;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.extension.ExtensionHandler;
@@ -50,6 +51,7 @@ public final class HandlerDecorators implements JdbiConfig<HandlerDecorators> {
      * @param decorator the decorator to register
      * @return a copy of this configuration with the decorator registered
      */
+    @CheckReturnValue
     public HandlerDecorators register(HandlerDecorator decorator) {
         return new HandlerDecorators(RegistrationLists.append(decorators, decorator));
     }

--- a/sqlobject/src/main/java/org/jdbi/sqlobject/Handlers.java
+++ b/sqlobject/src/main/java/org/jdbi/sqlobject/Handlers.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.extension.ExtensionHandlerFactory;
 import org.jdbi.core.internal.RegistrationLists;
@@ -31,7 +31,7 @@ import org.jdbi.core.internal.RegistrationLists;
  * method, the last-registered factory takes precedence.
  *
  * @deprecated Use {@link ExtensionHandlerFactory} instances that are returned
- * from the {@link org.jdbi.core.extension.ExtensionFactory#getExtensionHandlerFactories(ConfigRegistry)} method.
+ * from the {@link org.jdbi.core.extension.ExtensionFactory#getExtensionHandlerFactories(ConfigView)} method.
  */
 @Deprecated(since = "3.38.0", forRemoval = true)
 public final class Handlers implements JdbiConfig<Handlers> {

--- a/sqlobject/src/main/java/org/jdbi/sqlobject/Handlers.java
+++ b/sqlobject/src/main/java/org/jdbi/sqlobject/Handlers.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.extension.ExtensionHandlerFactory;
@@ -53,6 +54,7 @@ public final class Handlers implements JdbiConfig<Handlers> {
      * @param factory the factory to register
      * @return a copy of this configuration with the factory registered
      */
+    @CheckReturnValue
     public Handlers register(HandlerFactory factory) {
         return new Handlers(RegistrationLists.prepend(factories, factory));
     }

--- a/sqlobject/src/main/java/org/jdbi/sqlobject/SqlObjects.java
+++ b/sqlobject/src/main/java/org/jdbi/sqlobject/SqlObjects.java
@@ -15,6 +15,7 @@ package org.jdbi.sqlobject;
 
 import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.sqlobject.customizer.SqlStatementCustomizerFactory;
 import org.jdbi.sqlobject.locator.AnnotationSqlLocator;
@@ -53,6 +54,7 @@ public final class SqlObjects implements JdbiConfig<SqlObjects> {
      * @param sqlLocator the new SQL locator.
      * @return the derived configuration
      */
+    @CheckReturnValue
     public SqlObjects sqlLocator(SqlLocator sqlLocator) {
         return new SqlObjects(Objects.requireNonNull(sqlLocator), defaultParameterCustomizerFactory);
     }
@@ -73,6 +75,7 @@ public final class SqlObjects implements JdbiConfig<SqlObjects> {
      * @param defaultParameterCustomizerFactory the new default parameter customizer factory.
      * @return the derived configuration
      */
+    @CheckReturnValue
     public SqlObjects defaultParameterCustomizerFactory(ParameterCustomizerFactory defaultParameterCustomizerFactory) {
         return new SqlObjects(sqlLocator, defaultParameterCustomizerFactory);
     }

--- a/sqlobject/src/main/java/org/jdbi/sqlobject/customizer/TimestampedConfig.java
+++ b/sqlobject/src/main/java/org/jdbi/sqlobject/customizer/TimestampedConfig.java
@@ -15,6 +15,7 @@ package org.jdbi.sqlobject.customizer;
 
 import java.time.ZoneId;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 
 /**
@@ -47,6 +48,7 @@ public final class TimestampedConfig implements JdbiConfig<TimestampedConfig> {
      * @param timezone used in the resulting {@link java.time.OffsetDateTime}
      * @return the derived configuration
      */
+    @CheckReturnValue
     public TimestampedConfig timezone(ZoneId timezone) {
         return new TimestampedConfig(timezone);
     }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/GenericMapMapperFactoryTest.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/GenericMapMapperFactoryTest.java
@@ -38,13 +38,14 @@ public class GenericMapMapperFactoryTest {
     private static final String QUERY = "select 1.0 as one, 2.0 as two, 3.0 as three";
 
     @RegisterExtension
-    public JdbiExtension sqliteExtension = JdbiExtension.sqlite().withPlugin(new SqlObjectPlugin());
+    public JdbiExtension sqliteExtension = JdbiExtension.sqlite().withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(new GenericMapMapperFactory()));
 
     private Jdbi jdbi;
 
     @BeforeEach
     public void before() {
-        jdbi = sqliteExtension.getJdbi().registerRowMapper(new GenericMapMapperFactory());
+        jdbi = sqliteExtension.getJdbi();
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/GenericMapMapperFactoryTest.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/GenericMapMapperFactoryTest.java
@@ -134,8 +134,8 @@ public class GenericMapMapperFactoryTest {
     @Test
     public void duplicateColumnsWithoutCaseChangeCauseException() {
         jdbi.useHandle(h -> {
-            h.configure(MapMappers.class, c -> c.caseChange(CaseStrategy.NOP));
-            try (Query query = h.createQuery(QUERY.replace("two", "one"))) {
+            try (Query query = h.createQuery(QUERY.replace("two", "one"))
+                    .configure(MapMappers.class, c -> c.caseChange(CaseStrategy.NOP))) {
                 ResultIterable<Map<String, BigDecimal>> iterable = query.mapToMap(BigDecimal.class);
 
                 assertThatThrownBy(iterable::one)
@@ -147,9 +147,8 @@ public class GenericMapMapperFactoryTest {
     @Test
     public void duplicateKeysAfterCaseChangeCauseException() {
         jdbi.useHandle(h -> {
-            h.configure(MapMappers.class, c -> c.caseChange(CaseStrategy.LOWER));
-
-            try (Query query = h.createQuery(QUERY.replace("two", "ONE"))) {
+            try (Query query = h.createQuery(QUERY.replace("two", "ONE"))
+                    .configure(MapMappers.class, c -> c.caseChange(CaseStrategy.LOWER))) {
                 // one and ONE
                 ResultIterable<Map<String, BigDecimal>> iterable = query.mapToMap(BigDecimal.class);
 

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/MapOptionalTest.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/MapOptionalTest.java
@@ -23,7 +23,6 @@ import org.jdbi.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.sqlobject.statement.SqlQuery;
 import org.jdbi.testing.junit.JdbiExtension;
 import org.jdbi.testing.junit.internal.TestingInitializers;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -33,17 +32,12 @@ import static org.assertj.core.groups.Tuple.tuple;
 public class MapOptionalTest {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(ConstructorMapper.factory(OptionalBean.class)));
 
     public interface OptionalBeanDao {
         @SqlQuery("select intValue, name from something order by id")
         List<OptionalBean> getBeans();
-    }
-
-    @BeforeEach
-    public void setUp() {
-        final Jdbi jdbi = h2Extension.getJdbi();
-        jdbi.registerRowMapper(ConstructorMapper.factory(OptionalBean.class));
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/NestedBeanTest.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/NestedBeanTest.java
@@ -34,7 +34,12 @@ import static org.assertj.core.groups.Tuple.tuple;
 public class NestedBeanTest {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b
+            .registerRowMapper(ConstructorMapper.factory(MainBeanOne.class))
+            .registerRowMapper(ConstructorMapper.factory(NestedBeanOne.class))
+            .registerRowMapper(ConstructorMapper.factory(MainBeanTwo.class))
+            .registerRowMapper(ConstructorMapper.factory(NestedBeanTwo.class)));
 
     public interface BeanDao {
         @SqlQuery("select intValue as nested_val, name as nested_name, id from something order by id")
@@ -141,12 +146,6 @@ public class NestedBeanTest {
 
     @BeforeEach
     public void setUp() {
-        final Jdbi jdbi = h2Extension.getJdbi();
-        jdbi.registerRowMapper(ConstructorMapper.factory(MainBeanOne.class));
-        jdbi.registerRowMapper(ConstructorMapper.factory(NestedBeanOne.class));
-        jdbi.registerRowMapper(ConstructorMapper.factory(MainBeanTwo.class));
-        jdbi.registerRowMapper(ConstructorMapper.factory(NestedBeanTwo.class));
-
         final Handle h = h2Extension.getSharedHandle();
         h.execute("insert into something(intValue, name) values(1, 'Duke')");
         h.execute("insert into something(intValue, name) values(null, null)");

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/SqlObjectEnumQualifierTest.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/SqlObjectEnumQualifierTest.java
@@ -48,53 +48,53 @@ public class SqlObjectEnumQualifierTest {
 
     @Test
     public void byNameOverridesDefaultInBindingAndMapping() {
-        sqliteExtension.getJdbi().useHandle(h -> {
-            h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL));
+        sqliteExtension.getJdbi().useHandle(
+            cfg -> cfg.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL)),
+            h -> {
+                h.execute("create table enums(name varchar)");
 
-            h.execute("create table enums(name varchar)");
+                FooByNameDao dao = h.attach(FooByNameDao.class);
 
-            FooByNameDao dao = h.attach(FooByNameDao.class);
+                dao.insert(Foo.BAR);
+                assertThat(h.createQuery("select name from enums").mapTo(String.class).one()).isEqualTo("BAR");
 
-            dao.insert(Foo.BAR);
-            assertThat(h.createQuery("select name from enums").mapTo(String.class).one()).isEqualTo("BAR");
-
-            Foo value = dao.select();
-            assertThat(value).isEqualTo(Foo.BAR);
-        });
+                Foo value = dao.select();
+                assertThat(value).isEqualTo(Foo.BAR);
+            });
     }
 
     @Test
     public void useEnumStrategyOrdinalAnnotation() {
-        sqliteExtension.getJdbi().useHandle(h -> {
-            h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_NAME)); // dao annotations will override
+        sqliteExtension.getJdbi().useHandle(
+            cfg -> cfg.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_NAME)), // dao annotations will override
+            h -> {
+                h.execute("create table enums(ordinal int)");
 
-            h.execute("create table enums(ordinal int)");
+                UseEnumStrategyOrdinalDao dao = h.attach(UseEnumStrategyOrdinalDao.class);
 
-            UseEnumStrategyOrdinalDao dao = h.attach(UseEnumStrategyOrdinalDao.class);
+                dao.insert(Foo.BAR);
+                assertThat(h.createQuery("select ordinal from enums").mapTo(Integer.class).one()).isZero();
 
-            dao.insert(Foo.BAR);
-            assertThat(h.createQuery("select ordinal from enums").mapTo(Integer.class).one()).isZero();
-
-            Foo value = dao.select();
-            assertThat(value).isEqualTo(Foo.BAR);
-        });
+                Foo value = dao.select();
+                assertThat(value).isEqualTo(Foo.BAR);
+            });
     }
 
     @Test
     public void useEnumStrategyNameAnnotation() {
-        sqliteExtension.getJdbi().useHandle(h -> {
-            h.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL)); // dao annotations will override
+        sqliteExtension.getJdbi().useHandle(
+            cfg -> cfg.configure(Enums.class, c -> c.defaultStrategy(EnumStrategy.BY_ORDINAL)), // dao annotations will override
+            h -> {
+                h.execute("create table enums(name varchar)");
 
-            h.execute("create table enums(name varchar)");
+                UseEnumStrategyNameDao dao = h.attach(UseEnumStrategyNameDao.class);
 
-            UseEnumStrategyNameDao dao = h.attach(UseEnumStrategyNameDao.class);
+                dao.insert(Foo.BAR);
+                assertThat(h.createQuery("select name from enums").mapTo(String.class).one()).isEqualTo("BAR");
 
-            dao.insert(Foo.BAR);
-            assertThat(h.createQuery("select name from enums").mapTo(String.class).one()).isEqualTo("BAR");
-
-            Foo value = dao.select();
-            assertThat(value).isEqualTo(Foo.BAR);
-        });
+                Foo value = dao.select();
+                assertThat(value).isEqualTo(Foo.BAR);
+            });
     }
 
     public enum Foo {

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/SqlObjectLeakTest.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/SqlObjectLeakTest.java
@@ -23,6 +23,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.mapper.RowMappers;
 import org.jdbi.core.mapper.reflect.ConstructorMapper;
+import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.core.statement.StatementCustomizers;
 import org.jdbi.core.statement.UnableToExecuteStatementException;
 import org.jdbi.sqlobject.statement.SqlQuery;
@@ -65,8 +66,8 @@ public class SqlObjectLeakTest {
     @Test
     void testManagedHandleExplodingAttachedDao() {
         assertThatExceptionOfType(UnableToExecuteStatementException.class).isThrownBy(() -> {
-            try (Handle handle = h2Extension.openHandle()) {
-                handle.addCustomizer(StatementCustomizers.fetchSize(-1));
+            try (Handle handle = h2Extension.getJdbi().open(
+                    cfg -> cfg.configure(SqlStatements.class, c -> c.addCustomizer(StatementCustomizers.fetchSize(-1))))) {
                 UserDao handleDao = handle.attach(UserDao.class);
                 handleDao.getUserNames();
             }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/SqlObjectLeakTest.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/SqlObjectLeakTest.java
@@ -13,6 +13,9 @@
  */
 package org.jdbi.sqlobject;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 import java.util.Objects;
 
@@ -38,6 +41,27 @@ public class SqlObjectLeakTest {
             .withInitializer(TestingInitializers.usersWithData())
             .withConfig(RowMappers.class, r -> r.register(User.class, ConstructorMapper.of(User.class)));
 
+    /**
+     * A second Jdbi carrying a {@code fetchSize(-1)} customizer that makes every statement explode at execution time.
+     * The read-only {@link Jdbi} cannot be mutated per-test, so on-demand and extension DAOs use this dedicated
+     * extension instead. The users table is seeded through the raw {@link javax.sql.DataSource} so the customizer does
+     * not break setup (it would otherwise make the initializer's own statements explode). The leak checker is enabled
+     * by default, so it still verifies handle cleanup on the failing paths.
+     */
+    @RegisterExtension
+    public JdbiExtension explodingExtension = JdbiExtension.h2()
+            .withPlugin(new SqlObjectPlugin())
+            .withInitializer((ds, handle) -> {
+                try (Connection conn = ds.getConnection(); Statement stmt = conn.createStatement()) {
+                    stmt.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))");
+                    stmt.execute("INSERT INTO users VALUES (1, 'Alice')");
+                    stmt.execute("INSERT INTO users VALUES (2, 'Bob')");
+                } catch (SQLException e) {
+                    throw new IllegalStateException("could not seed users table", e);
+                }
+            })
+            .withConfig(b -> b.addCustomizer(StatementCustomizers.fetchSize(-1)));
+
     @Test
     void testManagedHandleExplodingAttachedDao() {
         assertThatExceptionOfType(UnableToExecuteStatementException.class).isThrownBy(() -> {
@@ -52,20 +76,15 @@ public class SqlObjectLeakTest {
     @Test
     void testExplodingOnDemandDao() {
         assertThatExceptionOfType(UnableToExecuteStatementException.class).isThrownBy(() -> {
-            Jdbi jdbi = h2Extension.getJdbi();
-            jdbi.addCustomizer(StatementCustomizers.fetchSize(-1));
-            UserDao jdbiDao = h2Extension.getJdbi().onDemand(UserDao.class);
+            UserDao jdbiDao = explodingExtension.getJdbi().onDemand(UserDao.class);
             jdbiDao.getUserNames();
         });
     }
 
     @Test
     void testExplodingExtensionDao() {
-        assertThatExceptionOfType(UnableToExecuteStatementException.class).isThrownBy(() -> {
-            Jdbi jdbi = h2Extension.getJdbi();
-            jdbi.addCustomizer(StatementCustomizers.fetchSize(-1));
-            jdbi.withExtension(UserDao.class, UserDao::getUserNames);
-        });
+        assertThatExceptionOfType(UnableToExecuteStatementException.class).isThrownBy(() ->
+            explodingExtension.getJdbi().withExtension(UserDao.class, UserDao::getUserNames));
     }
 
     public static class User {

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestBatching.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestBatching.java
@@ -197,8 +197,10 @@ public class TestBatching {
                 h2Extension.getSharedHandle().getConnection());
         var c = Mockito.mock(Connection.class, Mockito.withSettings()
                 .defaultAnswer(delegateAnswer));
-        Jdbi jdbi = Jdbi.create(c).installPlugin(new SqlObjectPlugin());
-        jdbi.setTransactionHandler(new SerializableTransactionRunner());
+        Jdbi jdbi = Jdbi.builder(c)
+                .installPlugin(new SqlObjectPlugin())
+                .transactionHandler(new SerializableTransactionRunner())
+                .build();
 
         var failed = new AtomicBoolean();
         jdbi.useHandle(jdbiHandle -> {

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindBean.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindBean.java
@@ -20,6 +20,7 @@ import org.jdbi.core.Something;
 import org.jdbi.core.ValueType;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
+import org.jdbi.core.argument.Arguments;
 import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.mapper.ValueTypeMapper;
 import org.jdbi.sqlobject.config.RegisterColumnMapper;
@@ -92,13 +93,15 @@ public class TestBindBean {
     @Test
     public void testArgumentFactoryRegisteredForProperty() {
         handle.execute("create table beans (id integer, value_type varchar, fromField varchar, fromGetter varchar)");
-        handle.registerArgument(new ValueTypeArgumentFactory());
 
-        BeanDao beanDao = handle.attach(BeanDao.class);
+        try (Handle scoped = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(Arguments.class, a -> a.register(new ValueTypeArgumentFactory())))) {
+            BeanDao beanDao = scoped.attach(BeanDao.class);
 
-        beanDao.insert(new Bean(1, ValueType.valueOf("foo")));
-        assertThat(beanDao.getById(1)).extracting(Bean::getId, Bean::getValueType)
-                .containsExactly(1, ValueType.valueOf("foo"));
+            beanDao.insert(new Bean(1, ValueType.valueOf("foo")));
+            assertThat(beanDao.getById(1)).extracting(Bean::getId, Bean::getValueType)
+                    .containsExactly(1, ValueType.valueOf("foo"));
+        }
     }
 
     public static class Bean {

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindBean.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindBean.java
@@ -21,7 +21,7 @@ import org.jdbi.core.ValueType;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.Arguments;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ValueTypeMapper;
 import org.jdbi.sqlobject.config.RegisterColumnMapper;
 import org.jdbi.sqlobject.config.RegisterConstructorMapper;
@@ -132,7 +132,7 @@ public class TestBindBean {
         }
 
         @Override
-        protected Argument build(ValueType value, ConfigRegistry config) {
+        protected Argument build(ValueType value, ConfigView config) {
             return (pos, stmt, ctx) -> stmt.setString(pos, value.getValue());
         }
     }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindListParameter.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindListParameter.java
@@ -37,8 +37,7 @@ public class TestBindListParameter {
 
     @BeforeEach
     public void setUp() {
-        db = Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID());
-        db.installPlugin(new SqlObjectPlugin());
+        db = Jdbi.builder("jdbc:h2:mem:" + UUID.randomUUID()).installPlugin(new SqlObjectPlugin()).build();
         handle = db.open();
         handle.createUpdate(
                 "create table foo (id int, bar varchar(100) default null);")

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindMethods.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindMethods.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import org.jdbi.core.Handle;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.statement.StatementContext;
 import org.jdbi.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.sqlobject.customizer.Bind;
@@ -228,7 +228,7 @@ public class TestBindMethods {
         }
 
         @Override
-        protected Argument build(final Number value, final ConfigRegistry config) {
+        protected Argument build(final Number value, final ConfigView config) {
             return new BigIntNumberArgument(value);
         }
     }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindMethodsList.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindMethodsList.java
@@ -36,12 +36,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestBindMethodsList {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(FieldMapper.factory(TestBindBeanList.Thing.class)));
 
     @BeforeEach
     public void setUp() {
         Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(FieldMapper.factory(TestBindBeanList.Thing.class));
         handle.execute("create table thing (id identity primary key, foo varchar(50), bar varchar(50), baz varchar(50))");
     }
 

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindProperties.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestBindProperties.java
@@ -36,8 +36,8 @@ public class TestBindProperties {
     public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin())
         .withPlugin(new JdbiPlugin() {
             @Override
-            public void customizeJdbi(Jdbi jdbi) {
-                jdbi.registerImmutable(Train.class);
+            public void configure(Jdbi.Builder builder) {
+                builder.registerImmutable(Train.class);
             }
         });
 

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestColumnMappers.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestColumnMappers.java
@@ -22,6 +22,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.core.ValueType;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.mapper.ColumnMapper;
+import org.jdbi.core.mapper.ColumnMappers;
 import org.jdbi.core.mapper.ValueTypeMapper;
 import org.jdbi.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.sqlobject.config.RegisterColumnMapper;
@@ -308,9 +309,10 @@ public class TestColumnMappers {
         ColumnMapper<Iterable<Calendar>> mapper = mock(ColumnMapper.class);
         GenericType<Iterable<Calendar>> iterableOfCalendarType = new GenericType<Iterable<Calendar>>() {};
 
-        h.registerColumnMapper(iterableOfCalendarType, mapper);
-
-        assertThat(h.getConfig().findColumnMapperFor(iterableOfCalendarType))
-            .contains(mapper);
+        try (Handle scoped = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(ColumnMappers.class, c -> c.register(iterableOfCalendarType, mapper)))) {
+            assertThat(scoped.getConfig().findColumnMapperFor(iterableOfCalendarType))
+                .contains(mapper);
+        }
     }
 }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestCreateSqlObjectAnnotation.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestCreateSqlObjectAnnotation.java
@@ -44,7 +44,6 @@ public class TestCreateSqlObjectAnnotation {
     @BeforeEach
     public void setUp() {
         handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new SomethingMapper());
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestCreateSqlObjectAnnotation.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestCreateSqlObjectAnnotation.java
@@ -36,13 +36,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestCreateSqlObjectAnnotation {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
 
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
-        h2Extension.getJdbi().registerRowMapper(new SomethingMapper());
         handle = h2Extension.getSharedHandle();
         handle.registerRowMapper(new SomethingMapper());
     }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestGetGeneratedKeysHsqlDb.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestGetGeneratedKeysHsqlDb.java
@@ -33,8 +33,9 @@ public class TestGetGeneratedKeysHsqlDb {
 
     @BeforeEach
     public void setUp() {
-        db = Jdbi.create("jdbc:hsqldb:mem:" + UUID.randomUUID(), "username", "password")
-                .installPlugin(new SqlObjectPlugin());
+        db = Jdbi.builder("jdbc:hsqldb:mem:" + UUID.randomUUID(), "username", "password")
+                .installPlugin(new SqlObjectPlugin())
+                .build();
         db.useHandle(handle -> handle.execute("create table something (id identity primary key, name varchar(32))"));
     }
 

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2497.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2497.java
@@ -123,9 +123,9 @@ public class TestIssue2497 {
     @Test
     public void testMapToObjectArgument() {
         final Jdbi db = h2Extension.getJdbi();
-        db.registerArgument(new ListObjectFactory());
 
         try (Handle h = db.open()) {
+            h.registerArgument(new ListObjectFactory());
             h.execute("insert into something (id, name) values (1, ?)",
                 List.of(Parameters.thing("Hello"), Parameters.thing("World")));
             h.execute("insert into something (id, name) values (2, ?)",

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2497.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2497.java
@@ -26,6 +26,7 @@ import org.jdbi.core.Jdbi;
 import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
+import org.jdbi.core.argument.Arguments;
 import org.jdbi.core.config.ConfigRegistry;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.sqlobject.TestIssue2497.Parameters.Thing;
@@ -50,9 +51,8 @@ public class TestIssue2497 {
     @Test
     public void testMapToArrayArgument() {
         final Jdbi db = h2Extension.getJdbi();
-        try (Handle h = db.open()) {
+        try (Handle h = db.open(cfg -> cfg.configure(Arguments.class, a -> a.register(new ListArrayArgumentFactory())))) {
             h.execute("create table foo (id identity primary key, v integer array)");
-            h.registerArgument(new ListArrayArgumentFactory());
             h.execute("insert into foo (id, v) values (1, ?)", List.of(1, 2));
             h.execute("insert into foo (id, v) values (2, ?)", List.of(4, 3, 2));
             h.execute("insert into foo (id, v) values (3, ?)", List.of(5, 6));
@@ -81,8 +81,7 @@ public class TestIssue2497 {
     @Test
     public void testMapToStringArgument() {
         final Jdbi db = h2Extension.getJdbi();
-        try (Handle h = db.open()) {
-            h.registerArgument(new ListStringFactory());
+        try (Handle h = db.open(cfg -> cfg.configure(Arguments.class, a -> a.register(new ListStringFactory())))) {
             h.execute("insert into something (id, name) values (1, ?)", List.of("Hello", "World"));
             h.execute("insert into something (id, name) values (2, ?)", List.of("The", "quick", "brown", "fox"));
             h.execute("insert into something (id, name) values (3, ?)", List.of("Now", "is", "the", "time"));
@@ -124,8 +123,7 @@ public class TestIssue2497 {
     public void testMapToObjectArgument() {
         final Jdbi db = h2Extension.getJdbi();
 
-        try (Handle h = db.open()) {
-            h.registerArgument(new ListObjectFactory());
+        try (Handle h = db.open(cfg -> cfg.configure(Arguments.class, a -> a.register(new ListObjectFactory())))) {
             h.execute("insert into something (id, name) values (1, ?)",
                 List.of(Parameters.thing("Hello"), Parameters.thing("World")));
             h.execute("insert into something (id, name) values (2, ?)",
@@ -155,12 +153,12 @@ public class TestIssue2497 {
 
         List<Sulu> sulus = Arrays.asList(new Sulu(1, "George", "Takei"),
             new Sulu(2, "John", "Cho"));
-        db.useExtension(SuluDao.class, s -> {
-            Handle h = s.getHandle();
-            h.registerArgument(new SuluArgumentFactory());
-            SuluDao dao = h.attach(SuluDao.class);
-            dao.insertSulus(sulus);
-        });
+        db.useHandle(
+            cfg -> cfg.configure(Arguments.class, a -> a.register(new SuluArgumentFactory())),
+            h -> {
+                SuluDao dao = h.attach(SuluDao.class);
+                dao.insertSulus(sulus);
+            });
 
         db.useExtension(SuluDao.class, s -> {
             assertThat(s.findName(1)).isEqualTo("George Takei");
@@ -176,12 +174,13 @@ public class TestIssue2497 {
             new Sulu(1, "George", "Takei"),
             new Sulu(2, "John", "Cho"));
 
-        db.withHandle(h -> {
-            h.registerArgument(new SuluArgumentFactory());
-            SuluDao dao = h.attach(SuluDao.class);
-            dao.insertSulus(sulus);
-            return null;
-        });
+        db.withHandle(
+            cfg -> cfg.configure(Arguments.class, a -> a.register(new SuluArgumentFactory())),
+            h -> {
+                SuluDao dao = h.attach(SuluDao.class);
+                dao.insertSulus(sulus);
+                return null;
+            });
 
         db.useExtension(SuluDao.class, s -> {
             assertThat(s.findName(1)).isEqualTo("George Takei");

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2497.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2497.java
@@ -27,7 +27,7 @@ import org.jdbi.core.argument.AbstractArgumentFactory;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
 import org.jdbi.core.argument.Arguments;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.sqlobject.TestIssue2497.Parameters.Thing;
 import org.jdbi.sqlobject.customizer.Bind;
@@ -73,7 +73,7 @@ public class TestIssue2497 {
         }
 
         @Override
-        protected Argument build(List<Integer> value, ConfigRegistry config) {
+        protected Argument build(List<Integer> value, ConfigView config) {
             return (position, statement, ctx) -> statement.setObject(position, value.toArray(new Integer[0]));
         }
     }
@@ -108,7 +108,7 @@ public class TestIssue2497 {
         }
 
         @Override
-        protected Argument build(List<String> value, ConfigRegistry config) {
+        protected Argument build(List<String> value, ConfigView config) {
             return (position, statement, ctx) -> {
                 if (value == null) {
                     statement.setNull(position, Types.NULL);
@@ -212,7 +212,7 @@ public class TestIssue2497 {
         }
 
         @Override
-        protected Argument build(List<Thing> value, ConfigRegistry config) {
+        protected Argument build(List<Thing> value, ConfigView config) {
             return (position, statement, ctx) -> {
                 if (value == null) {
                     statement.setNull(position, Types.NULL);
@@ -268,7 +268,7 @@ public class TestIssue2497 {
     public static final class SuluArgumentFactory implements ArgumentFactory {
 
         @Override
-        public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type type, Object value, ConfigView config) {
             return Optional.of(type)
                 .filter(t -> t == Sulu.class)
                 .map(t -> (position, statement, ctx) -> {

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2623.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2623.java
@@ -28,7 +28,6 @@ import org.jdbi.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.sqlobject.statement.SqlQuery;
 import org.jdbi.testing.junit.JdbiExtension;
 import org.jdbi.testing.junit.internal.TestingInitializers;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,12 +38,8 @@ public class TestIssue2623 {
     @RegisterExtension
     public JdbiExtension h2Extension = JdbiExtension.h2()
         .withInitializer(TestingInitializers.usersWithData())
-        .withPlugins(new SqlObjectPlugin(), new GuavaPlugin());
-
-    @BeforeEach
-    public void setUp() {
-        h2Extension.getJdbi().registerRowMapper(new GenericType<>() {}, new UserIntegerMapper());
-    }
+        .withPlugins(new SqlObjectPlugin(), new GuavaPlugin())
+        .withConfig(b -> b.registerRowMapper(new GenericType<>() {}, new UserIntegerMapper()));
 
     @Test
     public void testParameterizeTypedMapper() {

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2669.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2669.java
@@ -51,16 +51,16 @@ public class TestIssue2669 {
     @RegisterExtension
     public JdbiExtension pgExtension = JdbiExtension.postgres(pg)
             .withInitializer((ds, handle) -> handle.execute("CREATE TABLE foo (key VARCHAR NOT NULL PRIMARY KEY, value VARCHAR)"))
-            .withPlugins(new SqlObjectPlugin());
+            .withPlugins(new SqlObjectPlugin())
+            .withConfig(b -> b
+                .registerColumnMapper(Value.class, ColumnMapper.getDefaultColumnMapper())
+                .registerRowMapper((RowMapperFactory) new ValueMapper()));
 
     private Jdbi jdbi;
 
     @BeforeEach
     public void setUp() {
         this.jdbi = pgExtension.getJdbi();
-
-        jdbi.registerColumnMapper(Value.class, ColumnMapper.getDefaultColumnMapper())
-                .registerRowMapper((RowMapperFactory) new ValueMapper());
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2669.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestIssue2669.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
 import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
 import org.jdbi.core.Jdbi;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.mapper.RowMapperFactory;
@@ -90,7 +90,7 @@ public class TestIssue2669 {
     public static class ValueMapper
             implements RowMapperFactory, RowMapper<Value> {
         @Override
-        public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+        public Optional<RowMapper<?>> build(Type type, ConfigView config) {
             if (type.equals(Value.class)) {
                 return Optional.of(this);
             }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestModifiers.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestModifiers.java
@@ -39,13 +39,13 @@ import static org.jdbi.core.transaction.TransactionIsolationLevel.READ_UNCOMMITT
 public class TestModifiers {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
         handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new SomethingMapper());
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestNestedExtensionSubtype.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestNestedExtensionSubtype.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.jdbi.core.Jdbi;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.extension.ExtensionFactory;
 import org.jdbi.core.extension.HandleSupplier;
 import org.jdbi.core.mapper.ColumnMapper;
@@ -110,7 +110,7 @@ class TestNestedExtensionSubtype {
 
     public static class SuperIntFactory implements ColumnMapperFactory {
         @Override
-        public Optional<ColumnMapper<?>> build(final Type type, final ConfigRegistry config) {
+        public Optional<ColumnMapper<?>> build(final Type type, final ConfigView config) {
             if (SuperInt.class.equals(type)) {
                 return Optional.of((r, c, ctx) -> new SuperInt(r.getInt(c)));
             } else if (SubInt.class.equals(type)) {

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestNestedExtensionSubtype.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestNestedExtensionSubtype.java
@@ -35,14 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TestNestedExtensionSubtype {
     @RegisterExtension
-    JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin());
-
-    Jdbi jdbi;
-
-    @BeforeEach
-    void setUp() {
-        jdbi = h2Extension.getJdbi();
-        jdbi.registerExtension(new ExtensionFactory() {
+    JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerExtension(new ExtensionFactory() {
             @Override
             public boolean accepts(final Class<?> extensionType) {
                 return Supertype.class.equals(extensionType);
@@ -57,7 +51,13 @@ class TestNestedExtensionSubtype {
             public <E> E attach(final Class<E> extensionType, final HandleSupplier handleSupplier) {
                 return extensionType.cast(handleSupplier.getHandle().attach(Subtype.class));
             }
-        });
+        }));
+
+    Jdbi jdbi;
+
+    @BeforeEach
+    void setUp() {
+        jdbi = h2Extension.getJdbi();
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestNewApiOnDbiAndHandle.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestNewApiOnDbiAndHandle.java
@@ -88,8 +88,9 @@ public class TestNewApiOnDbiAndHandle {
 
     @Test
     public void testCorrectExceptionIfUnableToConnectOnDemand() {
-        assertThatThrownBy(() -> Jdbi.create("jdbc:mysql://invalid.invalid/test", "john", "scott")
+        assertThatThrownBy(() -> Jdbi.builder("jdbc:mysql://invalid.invalid/test", "john", "scott")
             .installPlugin(new SqlObjectPlugin())
+            .build()
             .onDemand(Spiffy.class)
             .findNameById(1)).isInstanceOf(ConnectionException.class);
     }
@@ -98,8 +99,9 @@ public class TestNewApiOnDbiAndHandle {
     public void testCorrectExceptionIfUnableToConnectOnOpen() {
         assertThatThrownBy(() -> {
             try (Handle handle =
-                Jdbi.create("jdbc:mysql://invalid.invalid/test", "john", "scott")
+                Jdbi.builder("jdbc:mysql://invalid.invalid/test", "john", "scott")
                     .installPlugin(new SqlObjectPlugin())
+                    .build()
                     .open()) {
                 handle.attach(Spiffy.class);
             }
@@ -110,8 +112,9 @@ public class TestNewApiOnDbiAndHandle {
     public void testCorrectExceptionIfUnableToConnectOnAttach() {
         assertThatThrownBy(() -> {
             try (Handle handle =
-                Jdbi.create("jdbc:mysql://invalid.invalid/test", "john", "scott")
+                Jdbi.builder("jdbc:mysql://invalid.invalid/test", "john", "scott")
                     .installPlugin(new SqlObjectPlugin())
+                    .build()
                     .open()) {
                 handle.attach(Spiffy.class);
             }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestOnDemandObjectMethodBehavior.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestOnDemandObjectMethodBehavior.java
@@ -40,8 +40,9 @@ public class TestOnDemandObjectMethodBehavior {
                 throw new AssertionError();
             }
         };
-        Jdbi.create(cf)
+        Jdbi.builder(cf)
                 .installPlugin(new SqlObjectPlugin())
+                .build()
                 .onDemand(UselessDao.class)
                 .finalize();
     }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestOnDemandSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestOnDemandSqlObject.java
@@ -61,9 +61,13 @@ public class TestOnDemandSqlObject {
 
     @BeforeEach
     public void setUp() throws Exception {
-        jdbi = h2Extension.getJdbi();
-        // do not pull into the extension clause, otherwise the shared handle counts!
-        jdbi.installPlugin(tracker);
+        // Build a dedicated Jdbi against the same (shared-handle-kept-alive) database so the tracker only observes
+        // handles opened by this test. Installing the tracker on the extension's Jdbi is no longer possible (it is
+        // read-only) and would have counted the extension's shared handle anyway.
+        jdbi = Jdbi.builder(h2Extension.getUrl())
+                .installPlugin(new SqlObjectPlugin())
+                .installPlugin(tracker)
+                .build();
         assertThat(tracker.hasOpenedHandle()).isFalse();
     }
 

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestOnDemandSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestOnDemandSqlObject.java
@@ -92,7 +92,7 @@ public class TestOnDemandSqlObject {
                         ArgumentMatchers.eq(ResultSet.CONCUR_READ_ONLY));
         Mockito.doThrow(CloseException.class).when(c).close();
 
-        Spiffy s = Jdbi.create(c).installPlugin(new SqlObjectPlugin()).onDemand(Spiffy.class);
+        Spiffy s = Jdbi.builder(c).installPlugin(new SqlObjectPlugin()).build().onDemand(Spiffy.class);
         assertThatThrownBy(() -> s.insert(1, "Tom")).isInstanceOf(TransactionException.class);
     }
 

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestRegisterArgumentFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestRegisterArgumentFactory.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.sqlobject.customizer.Bind;
 import org.jdbi.sqlobject.statement.SqlQuery;
@@ -82,14 +82,14 @@ public class TestRegisterArgumentFactory {
 
     public static class LazyAF implements ArgumentFactory {
         @Override
-        public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type type, Object value, ConfigView config) {
             return Optional.empty();
         }
     }
 
     public static class NameAF implements ArgumentFactory {
         @Override
-        public Optional<Argument> build(Type expectedType, Object value, ConfigRegistry config) {
+        public Optional<Argument> build(Type expectedType, Object value, ConfigView config) {
             if (expectedType == Name.class || value instanceof Name) {
                 Name nameValue = (Name) value;
                 return Optional.of((position, statement, ctx1) -> statement.setString(position, nameValue.getFullName()));

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestRegisterJoinRowMapper.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestRegisterJoinRowMapper.java
@@ -23,6 +23,7 @@ import org.jdbi.core.mapper.JoinRow;
 import org.jdbi.core.mapper.JoinRowMapperTest;
 import org.jdbi.core.mapper.JoinRowMapperTest.Article;
 import org.jdbi.core.mapper.JoinRowMapperTest.User;
+import org.jdbi.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.sqlobject.config.RegisterJoinRowMapper;
 import org.jdbi.sqlobject.statement.SqlQuery;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,9 +34,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRegisterJoinRowMapper {
 
-    // Do not replace with JdbiExtension, this uses a core tests (JoinRowMapperTest) which uses the H2DatabaseExtension
+    // Do not replace with JdbiExtension, this uses a core tests (JoinRowMapperTest) which uses the H2DatabaseExtension.
+    // The User/Article mappers are registered here (build time) because JoinRowMapperTest#setUp is reused below with
+    // this extension injected, and it registers them on its own extension field rather than on the shared handle.
     @RegisterExtension
-    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withPlugin(new SqlObjectPlugin());
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance()
+        .withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b
+            .registerRowMapper(ConstructorMapper.factory(User.class))
+            .registerRowMapper(ConstructorMapper.factory(Article.class)));
 
     @BeforeEach
     public void setUp() {

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestRegisterRowMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestRegisterRowMapperFactory.java
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.internal.exceptions.Unchecked;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.mapper.RowMapperFactory;
@@ -67,7 +67,7 @@ public class TestRegisterRowMapperFactory {
 
     public static class MyFactory implements RowMapperFactory {
         @Override
-        public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+        public Optional<RowMapper<?>> build(Type type, ConfigView config) {
             Class<?> erasedType = getErasedType(type);
             MapWith mapWith = erasedType.getAnnotation(MapWith.class);
             return mapWith == null

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestRegisteredMappersWork.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestRegisteredMappersWork.java
@@ -23,6 +23,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.core.Something;
 import org.jdbi.core.mapper.NoSuchMapperException;
 import org.jdbi.core.mapper.RowMapper;
+import org.jdbi.core.mapper.RowMappers;
 import org.jdbi.core.mapper.SomethingMapper;
 import org.jdbi.core.result.ResultSetException;
 import org.jdbi.core.statement.StatementContext;
@@ -133,14 +134,15 @@ public class TestRegisteredMappersWork {
 
     @Test
     public void testRegistered() {
-        h2Extension.getSharedHandle().registerRowMapper(new SomethingMapper());
+        try (Handle h = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(RowMappers.class, r -> r.register(new SomethingMapper())))) {
+            Spiffy s = h.attach(Spiffy.class);
 
-        Spiffy s = h2Extension.getSharedHandle().attach(Spiffy.class);
+            s.insert(1, "Tatu");
 
-        s.insert(1, "Tatu");
-
-        Something t = s.byId(1);
-        assertThat(t).isEqualTo(new Something(1, "Tatu"));
+            Something t = s.byId(1);
+            assertThat(t).isEqualTo(new Something(1, "Tatu"));
+        }
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlMethodDecorators.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlMethodDecorators.java
@@ -103,23 +103,24 @@ public class TestSqlMethodDecorators {
 
     @Test
     public void testRegisteredDecorator() {
-        testHandle.configure(HandlerDecorators.class, c -> c.register(
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(HandlerDecorators.class, c -> c.register(
                 (base, sqlObjectType, method) ->
                         (target, args, handleSupplier) -> {
                             invoked("custom");
                             return base.invoke(target, args, handleSupplier);
-                        }));
-
-        testHandle.attach(Dao.class).orderedFooBar();
+                        })))) {
+            handle.attach(Dao.class).orderedFooBar();
+        }
 
         assertThat(INVOCATIONS.get()).containsExactly("custom", "foo", "bar", "method");
     }
 
     @Test
     public void testRegisteredDecoratorReturnsBase() {
-        testHandle.configure(HandlerDecorators.class, c -> c.register((base, sqlObjectType, method) -> base));
-
-        testHandle.attach(Dao.class).orderedFooBar();
+        try (Handle handle = h2Extension.getJdbi().open(
+                cfg -> cfg.configure(HandlerDecorators.class, c -> c.register((base, sqlObjectType, method) -> base)))) {
+            handle.attach(Dao.class).orderedFooBar();
+        }
 
         assertThat(INVOCATIONS.get()).containsExactly("foo", "bar", "method");
     }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlObject.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlObject.java
@@ -70,7 +70,7 @@ public class TestSqlObject {
         c = Mockito.mock(Connection.class, Mockito.withSettings()
                 .defaultAnswer(AdditionalAnswers.delegatesTo(
                         h2Extension.getSharedHandle().getConnection())));
-        jdbi = Jdbi.create(c).installPlugin(new SqlObjectPlugin());
+        jdbi = Jdbi.builder(c).installPlugin(new SqlObjectPlugin()).build();
         handle = jdbi.open();
         TestingInitializers.something().initialize(null, handle);
     }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlObjectFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlObjectFactory.java
@@ -29,11 +29,9 @@ public class TestSqlObjectFactory {
 
     @BeforeEach
     public void setUp() {
-        jdbi = Jdbi.create(() -> {
+        jdbi = Jdbi.builder(() -> {
             throw new UnsupportedOperationException();
-        });
-
-        jdbi.registerExtension(new SqlObjectFactory());
+        }).registerExtension(new SqlObjectFactory()).build();
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlObjectMethodBehavior.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlObjectMethodBehavior.java
@@ -38,11 +38,9 @@ public class TestSqlObjectMethodBehavior {
 
     @BeforeEach
     public void setUp() {
-        jdbi = Jdbi.create(() -> {
+        jdbi = Jdbi.builder(() -> {
             throw new UnsupportedOperationException();
-        });
-
-        jdbi.registerExtension(new SqlObjectFactory());
+        }).registerExtension(new SqlObjectFactory()).build();
 
         // TODO - rewrite this test, it is strongly discouraged to create a handle supplier
         // manually. Once we go to Java 17, HandleSupplier will be a sealed class.

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlObjectTransactions.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestSqlObjectTransactions.java
@@ -20,6 +20,7 @@ import org.jdbi.core.Handle;
 import org.jdbi.core.Jdbi;
 import org.jdbi.core.mapper.reflect.ConstructorMapper;
 import org.jdbi.core.transaction.DelegatingTransactionHandler;
+import org.jdbi.core.transaction.LocalTransactionHandler;
 import org.jdbi.core.transaction.TransactionHandler;
 import org.jdbi.sqlobject.statement.SqlUpdate;
 import org.jdbi.sqlobject.transaction.Transaction;
@@ -45,10 +46,14 @@ public class TestSqlObjectTransactions {
 
     @BeforeEach
     public void setUp() {
-        this.jdbi = h2Extension.getJdbi();
-        this.jdbi.registerRowMapper(User.class, ConstructorMapper.of(User.class));
-        this.transactionHandler = new CountingTransactionHandler(jdbi.getTransactionHandler());
-        jdbi.setTransactionHandler(transactionHandler);
+        // The transaction handler must wrap the assembled Jdbi's handler, so build a dedicated Jdbi against the same
+        // (shared-handle-kept-alive) database rather than mutating the extension's read-only Jdbi.
+        this.transactionHandler = new CountingTransactionHandler(LocalTransactionHandler.binding());
+        this.jdbi = Jdbi.builder(h2Extension.getUrl())
+                .installPlugin(new SqlObjectPlugin())
+                .registerRowMapper(User.class, ConstructorMapper.of(User.class))
+                .transactionHandler(transactionHandler)
+                .build();
     }
 
     /**

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestTimingCollector.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestTimingCollector.java
@@ -52,10 +52,14 @@ public class TestTimingCollector {
 
     @BeforeEach
     public void setUp() {
-        db = h2Extension.getJdbi();
-        db.useHandle(h -> h.execute("CREATE ALIAS custom_insert FOR "
-            + "\"org.jdbi.sqlobject.TestTimingCollector.customInsert\";"));
-        db.setTimingCollector(timingCollector);
+        // Create the alias without the timing collector attached (it must not record this statement), then build a
+        // dedicated Jdbi carrying the collector against the same (shared-handle-kept-alive) database.
+        h2Extension.getSharedHandle().execute("CREATE ALIAS custom_insert FOR "
+            + "\"org.jdbi.sqlobject.TestTimingCollector.customInsert\";");
+        db = Jdbi.builder(h2Extension.getUrl())
+            .installPlugin(new SqlObjectPlugin())
+            .setTimingCollector(timingCollector)
+            .build();
         dao = db.onDemand(DAO.class);
     }
 

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/TestUseTemplateEngine.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/TestUseTemplateEngine.java
@@ -30,13 +30,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestUseTemplateEngine {
 
     @RegisterExtension
-    public JdbiExtension sqliteExtension = JdbiExtension.sqlite().withPlugin(new SqlObjectPlugin());
+    public JdbiExtension sqliteExtension = JdbiExtension.sqlite().withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.setTemplateEngine(TemplateEngine.NOP));
 
     private Jdbi jdbi;
 
     @BeforeEach
     public void before() {
-        jdbi = sqliteExtension.getJdbi().setTemplateEngine(TemplateEngine.NOP);
+        jdbi = sqliteExtension.getJdbi();
     }
 
     @Test

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/config/LongValueColumnMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/config/LongValueColumnMapperFactory.java
@@ -16,13 +16,13 @@ package org.jdbi.sqlobject.config;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
 
 public class LongValueColumnMapperFactory implements ColumnMapperFactory {
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         return LongValue.class.equals(type)
                 ? Optional.of(new LongValueColumnMapper())
                 : Optional.empty();

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/config/LongValueRowMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/config/LongValueRowMapperFactory.java
@@ -16,13 +16,13 @@ package org.jdbi.sqlobject.config;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.mapper.RowMapperFactory;
 
 public class LongValueRowMapperFactory implements RowMapperFactory {
     @Override
-    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<RowMapper<?>> build(Type type, ConfigView config) {
         return LongValue.class.equals(type)
                 ? Optional.of(new LongValueRowMapper())
                 : Optional.empty();

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/config/StringValueColumnMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/config/StringValueColumnMapperFactory.java
@@ -16,13 +16,13 @@ package org.jdbi.sqlobject.config;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
 
 public class StringValueColumnMapperFactory implements ColumnMapperFactory {
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         return StringValue.class.equals(type)
                 ? Optional.of(new StringValueColumnMapper())
                 : Optional.empty();

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/config/StringValueRowMapperFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/config/StringValueRowMapperFactory.java
@@ -16,13 +16,13 @@ package org.jdbi.sqlobject.config;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.mapper.RowMapperFactory;
 
 public class StringValueRowMapperFactory implements RowMapperFactory {
     @Override
-    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<RowMapper<?>> build(Type type, ConfigView config) {
         return StringValue.class.equals(type)
                 ? Optional.of(new StringValueRowMapper())
                 : Optional.empty();

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/config/TestUseConfiguredDefaultParameterCustomizerFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/config/TestUseConfiguredDefaultParameterCustomizerFactory.java
@@ -16,13 +16,11 @@ package org.jdbi.sqlobject.config;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.Something;
 import org.jdbi.core.mapper.SomethingMapper;
 import org.jdbi.sqlobject.SqlObjectPlugin;
 import org.jdbi.sqlobject.SqlObjects;
 import org.jdbi.sqlobject.customizer.Bind;
-import org.jdbi.sqlobject.statement.ParameterCustomizerFactory;
 import org.jdbi.sqlobject.statement.SqlQuery;
 import org.jdbi.testing.junit.JdbiExtension;
 import org.jdbi.testing.junit.internal.TestingInitializers;
@@ -35,24 +33,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUseConfiguredDefaultParameterCustomizerFactory {
 
+    private final AtomicInteger invocationCounter = new AtomicInteger(0);
+
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.configure(SqlObjects.class, c -> c.defaultParameterCustomizerFactory(
+            (sqlObjectType, method, param, index, type) -> {
+                invocationCounter.incrementAndGet();
+                return (stmt, arg) -> stmt.bind("mybind" + index, arg);
+            })));
 
     private Handle handle;
 
-    private AtomicInteger invocationCounter = new AtomicInteger(0);
-
     @BeforeEach
     public void setUp() {
-        Jdbi db = h2Extension.getJdbi();
-
-        ParameterCustomizerFactory defaultParameterCustomizerFactory = (sqlObjectType, method, param, index, type) -> {
-            invocationCounter.incrementAndGet();
-            return (stmt, arg) -> stmt.bind("mybind" + index, arg);
-        };
-
-        db.configure(SqlObjects.class, c -> c.defaultParameterCustomizerFactory(defaultParameterCustomizerFactory));
-        handle = db.open();
+        handle = h2Extension.getJdbi().open();
     }
 
     @AfterEach

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/config/TestUseCustomHandlerFactory.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/config/TestUseCustomHandlerFactory.java
@@ -67,8 +67,7 @@ public class TestUseCustomHandlerFactory {
             }
         };
 
-        db.configure(Handlers.class, c -> c.register(defaultHandlerFactory));
-        handle = db.open();
+        handle = db.open(cfg -> cfg.configure(Handlers.class, c -> c.register(defaultHandlerFactory)));
     }
 
     @AfterEach

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/config/TestUseSqlParser.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/config/TestUseSqlParser.java
@@ -14,7 +14,6 @@
 package org.jdbi.sqlobject.config;
 
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.Something;
 import org.jdbi.core.mapper.SomethingMapper;
 import org.jdbi.core.statement.ColonPrefixSqlParser;
@@ -36,17 +35,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestUseSqlParser {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin())
+        // this is the default, but be explicit for sake of clarity in test
+        .withConfig(b -> b.setSqlParser(new ColonPrefixSqlParser()));
 
     private Handle handle;
 
     @BeforeEach
     public void setUp() {
-        Jdbi db = h2Extension.getJdbi();
-
-        // this is the default, but be explicit for sake of clarity in test
-        db.setSqlParser(new ColonPrefixSqlParser());
-        handle = db.open();
+        handle = h2Extension.getJdbi().open();
     }
 
     @AfterEach

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/customizer/MapResultTest.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/customizer/MapResultTest.java
@@ -44,7 +44,8 @@ public class MapResultTest {
 
     @RegisterExtension
     JdbiExtension pgExtension = JdbiExtension.postgres(pg)
-            .withPlugins(new SqlObjectPlugin());
+            .withPlugins(new SqlObjectPlugin())
+            .withConfig(b -> b.registerRowMapper(JsonBean.class, ConstructorMapper.of(JsonBean.class)));
 
     Jdbi jdbi;
     UUID content;
@@ -52,8 +53,6 @@ public class MapResultTest {
     @BeforeEach
     void setUp() {
         this.jdbi = pgExtension.getJdbi();
-
-        jdbi.registerRowMapper(JsonBean.class, ConstructorMapper.of(JsonBean.class));
 
         jdbi.useHandle(handle -> handle.execute("CREATE TABLE json_data (id INTEGER PRIMARY KEY, key VARCHAR, value UUID)"));
 
@@ -84,8 +83,9 @@ public class MapResultTest {
 
     @Test
     public void testGoodMethodFailsWhenRequested() {
-        jdbi.configure(Extensions.class, Extensions::failFast);
-        assertThatThrownBy(() -> jdbi.withExtension(MapDao.class, dao -> dao.getValues(1)))
+        assertThatThrownBy(() -> jdbi.withHandle(
+                cfg -> cfg.configure(Extensions.class, Extensions::failFast),
+                handle -> handle.attach(MapDao.class).getValues(1)))
                 .isInstanceOf(UnableToCreateExtensionException.class)
                 .hasMessageContaining("getValuesMissingAnnotation")
                 .hasMessageContaining(

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/customizer/TestAllowUnusedBindings.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/customizer/TestAllowUnusedBindings.java
@@ -53,8 +53,10 @@ public class TestAllowUnusedBindings {
 
     @Test
     public void testUnannotated() {
-        h2Extension.getJdbi().configure(SqlStatements.class, c -> c.unusedBindingAllowed(true));
-        assertThat(dao.unannotated("42")).isTrue();
+        boolean result = h2Extension.getJdbi().withHandle(
+            cfg -> cfg.configure(SqlStatements.class, c -> c.unusedBindingAllowed(true)),
+            handle -> handle.attach(UnusedBindingDao.class).unannotated("42"));
+        assertThat(result).isTrue();
     }
 
     interface UnusedBindingDao extends SqlObject {

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/customizer/TestAllowUnusedBindings.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/customizer/TestAllowUnusedBindings.java
@@ -45,8 +45,9 @@ public class TestAllowUnusedBindings {
 
     @Test
     public void testDisallowed() {
-        dao.getHandle().configure(SqlStatements.class, c -> c.unusedBindingAllowed(true));
-        assertThatThrownBy(() -> dao.disallowed("43"))
+        assertThatThrownBy(() -> h2Extension.getJdbi().withHandle(
+                cfg -> cfg.configure(SqlStatements.class, c -> c.unusedBindingAllowed(true)),
+                handle -> handle.attach(UnusedBindingDao.class).disallowed("43")))
             .isInstanceOf(UnableToCreateStatementException.class)
             .hasMessageContaining("named parameter");
     }

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/customizer/internal/TestTimestamped.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/customizer/internal/TestTimestamped.java
@@ -24,7 +24,6 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.mapper.RowMapper;
 import org.jdbi.core.statement.SqlLogger;
 import org.jdbi.core.statement.StatementContext;
@@ -54,7 +53,23 @@ public class TestTimestamped {
     private static final OffsetDateTime UTC_MOMENT = OffsetDateTime.of(LocalDate.of(2018, Month.JANUARY, 1), LocalTime.NOON, ZoneOffset.UTC);
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b
+            .configure(TimestampedConfig.class, c -> c.timezone(GMT_PLUS_2))
+            .setSqlLogger(new SqlLogger() {
+                @Override
+                public void logBeforeExecution(StatementContext ctx) {
+                    String name = logNext.get();
+                    if (name != null) {
+                        String toString = ctx.getBinding()
+                            .findForName(name, ctx)
+                            .orElseThrow(AssertionError::new)
+                            .toString();
+                        insertedTimestamp.set(OffsetDateTime.parse(toString));
+                        logNext.set(null);
+                    }
+                }
+            }));
 
     private PersonDAO personDAO;
 
@@ -66,25 +81,7 @@ public class TestTimestamped {
     @BeforeEach
     public void before() {
         TimestampedFactory.setTimeSource(clock::withZone);
-        final Jdbi db = h2Extension.getJdbi();
-        db.configure(TimestampedConfig.class, c -> c.timezone(GMT_PLUS_2));
-
-        db.setSqlLogger(new SqlLogger() {
-            @Override
-            public void logBeforeExecution(StatementContext ctx) {
-                String name = logNext.get();
-                if (name != null) {
-                    String toString = ctx.getBinding()
-                        .findForName(name, ctx)
-                        .orElseThrow(AssertionError::new)
-                        .toString();
-                    insertedTimestamp.set(OffsetDateTime.parse(toString));
-                    logNext.set(null);
-                }
-            }
-        });
-
-        personDAO = db.onDemand(PersonDAO.class);
+        personDAO = h2Extension.getJdbi().onDemand(PersonDAO.class);
         personDAO.createTable();
     }
 

--- a/sqlobject/src/test/java/org/jdbi/sqlobject/locator/TestSqlLocator.java
+++ b/sqlobject/src/test/java/org/jdbi/sqlobject/locator/TestSqlLocator.java
@@ -43,14 +43,13 @@ public class TestSqlLocator {
 
             h.execute("insert into something (id, name) values (?, ?)", 2, "Alice");
             h.execute("insert into something (id, name) values (?, ?)", 1, "Bob");
-        });
+        })
+        .withConfig(b -> b.configure(SqlObjects.class, c -> c.sqlLocator(
+            (type, method, config) -> config.get(TestConfig.class).sql)));
 
     @Test
     public void testLocateConfigDriven() throws Exception {
         Jdbi jdbi = pgExtension.getJdbi();
-
-        jdbi.configure(SqlObjects.class, c -> c.sqlLocator(
-            (type, method, config) -> config.get(TestConfig.class).sql));
 
         jdbi.useHandle(h -> {
             h.getConfig(TestConfig.class).sql = "select * from something order by id";

--- a/stringtemplate4/src/main/java/org/jdbi/stringtemplate4/StringTemplates.java
+++ b/stringtemplate4/src/main/java/org/jdbi/stringtemplate4/StringTemplates.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.stringtemplate4;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import org.jdbi.core.config.JdbiConfig;
 
 /**
@@ -44,6 +45,7 @@ public final class StringTemplates implements JdbiConfig<StringTemplates> {
      * @param failOnMissingAttribute whether a missing attribute throws an exception
      * @return the derived configuration
      */
+    @CheckReturnValue
     public StringTemplates failOnMissingAttribute(boolean failOnMissingAttribute) {
         return new StringTemplates(failOnMissingAttribute);
     }

--- a/stringtemplate4/src/test/java/org/jdbi/core/statement/TestDefineNamedBindingsST.java
+++ b/stringtemplate4/src/test/java/org/jdbi/core/statement/TestDefineNamedBindingsST.java
@@ -27,9 +27,9 @@ public class TestDefineNamedBindingsST {
 
     @Test
     public void testDefineBoolean() {
-        h2Extension.getSharedHandle().setTemplateEngine(new StringTemplateEngine());
         assertThat(
             h2Extension.getSharedHandle().createQuery("select <a> from values(:a) <if(b)>where false=:b<endif>")
+                .setTemplateEngine(new StringTemplateEngine())
                 .defineNamedBindings()
                 .bindBean(new DefinedBean())
                 .mapTo(boolean.class)

--- a/stringtemplate4/src/test/java/org/jdbi/sqlobject/BindBeanListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/sqlobject/BindBeanListTest.java
@@ -19,7 +19,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.Something;
 import org.jdbi.core.mapper.SomethingMapper;
 import org.jdbi.sqlobject.customizer.BindBeanList;
@@ -42,14 +41,13 @@ public class BindBeanListTest {
     private List<Something> expectedSomethings;
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something());
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something())
+        .withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
 
     @BeforeEach
     public void before() {
-        final Jdbi db = h2Extension.getJdbi();
-        db.installPlugin(new SqlObjectPlugin());
-        db.registerRowMapper(new SomethingMapper());
-        handle = db.open();
+        handle = h2Extension.getJdbi().open();
 
         handle.execute("insert into something(id, name) values(1, '1')");
         handle.execute("insert into something(id, name) values(2, '2')");

--- a/stringtemplate4/src/test/java/org/jdbi/sqlobject/BindListNullTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/sqlobject/BindListNullTest.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.Something;
 import org.jdbi.core.mapper.SomethingMapper;
 import org.jdbi.core.statement.ColonPrefixSqlParser;
@@ -41,14 +40,13 @@ public class BindListNullTest {
     private Handle handle;
 
     @RegisterExtension
-    public final JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something());
+    public final JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something())
+        .withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
 
     @BeforeEach
     public void before() {
-        final Jdbi db = h2Extension.getJdbi();
-        db.registerRowMapper(new SomethingMapper());
-        db.installPlugin(new SqlObjectPlugin());
-        handle = db.open();
+        handle = h2Extension.getJdbi().open();
 
         handle.execute("insert into something(id, name) values(1, null)");
         handle.execute("insert into something(id, name) values(2, null)");

--- a/stringtemplate4/src/test/java/org/jdbi/sqlobject/BindListNullTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/sqlobject/BindListNullTest.java
@@ -22,6 +22,7 @@ import org.jdbi.core.mapper.SomethingMapper;
 import org.jdbi.core.statement.ColonPrefixSqlParser;
 import org.jdbi.core.statement.ParsedSql;
 import org.jdbi.core.statement.SqlParser;
+import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.core.statement.StatementContext;
 import org.jdbi.sqlobject.customizer.BindList;
 import org.jdbi.sqlobject.statement.SqlQuery;
@@ -91,25 +92,27 @@ public class BindListNullTest {
     @Test
     public void testSomethingByIterableHandleVoidWithNull() {
         final List<String> log = new ArrayList<>();
-        handle.setSqlParser(new LoggingParser(log));
-        final SomethingByIterableHandleVoid s = handle.attach(SomethingByIterableHandleVoid.class);
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.sqlParser(new LoggingParser(log))))) {
+            final SomethingByIterableHandleVoid s = handle.attach(SomethingByIterableHandleVoid.class);
 
-        final List<Something> out = s.get(null);
+            final List<Something> out = s.get(null);
 
-        assertThat(out).isEmpty();
-        assertThat(log).hasSize(1).allMatch(e -> e.contains(" where id in ();"));
+            assertThat(out).isEmpty();
+            assertThat(log).hasSize(1).allMatch(e -> e.contains(" where id in ();"));
+        }
     }
 
     @Test
     public void testSomethingByIterableHandleVoidWithEmptyList() {
         final List<String> log = new ArrayList<>();
-        handle.setSqlParser(new LoggingParser(log));
-        final SomethingByIterableHandleVoid s = handle.attach(SomethingByIterableHandleVoid.class);
+        try (Handle handle = h2Extension.getJdbi().open(cfg -> cfg.configure(SqlStatements.class, c -> c.sqlParser(new LoggingParser(log))))) {
+            final SomethingByIterableHandleVoid s = handle.attach(SomethingByIterableHandleVoid.class);
 
-        final List<Something> out = s.get(new ArrayList<>());
+            final List<Something> out = s.get(new ArrayList<>());
 
-        assertThat(out).isEmpty();
-        assertThat(log).hasSize(1).allMatch(e -> e.contains(" where id in ();"));
+            assertThat(out).isEmpty();
+            assertThat(log).hasSize(1).allMatch(e -> e.contains(" where id in ();"));
+        }
     }
 
     public interface SomethingByIterableHandleVoid {

--- a/stringtemplate4/src/test/java/org/jdbi/sqlobject/BindListTest.java
+++ b/stringtemplate4/src/test/java/org/jdbi/sqlobject/BindListTest.java
@@ -41,16 +41,15 @@ import static org.jdbi.sqlobject.customizer.BindList.EmptyHandling.VOID;
 public class BindListTest {
 
     @RegisterExtension
-    public final JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+    public final JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin())
+        .withConfig(b -> b.registerRowMapper(new SomethingMapper()));
 
     private Handle handle;
     private List<Something> expectedSomethings;
 
     @BeforeEach
     public void before() {
-        handle = h2Extension.getJdbi()
-            .registerRowMapper(new SomethingMapper())
-            .open();
+        handle = h2Extension.getJdbi().open();
 
         handle.execute("insert into something(id, name) values(1, '1')");
         handle.execute("insert into something(id, name) values(2, '2')");

--- a/stringtemplate4/src/test/java/org/jdbi/stringtemplate4/TestDefineNull.java
+++ b/stringtemplate4/src/test/java/org/jdbi/stringtemplate4/TestDefineNull.java
@@ -29,7 +29,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestDefineNull {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2();
+    public JdbiExtension h2Extension = JdbiExtension.h2()
+        .withConfig(b -> b.setTemplateEngine(new StringTemplateEngine()));
 
     private Handle h;
 
@@ -41,7 +42,6 @@ public class TestDefineNull {
         savedErr = System.err;
         System.setErr(new PrintStream(err));
         h = h2Extension.getSharedHandle();
-        h.setTemplateEngine(new StringTemplateEngine());
     }
 
     @AfterEach

--- a/stringtemplate4/src/test/java/org/jdbi/stringtemplate4/TestErrorHandling.java
+++ b/stringtemplate4/src/test/java/org/jdbi/stringtemplate4/TestErrorHandling.java
@@ -27,14 +27,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestErrorHandling {
 
     @RegisterExtension
-    public JdbiExtension h2Extension = JdbiExtension.h2();
+    public JdbiExtension h2Extension = JdbiExtension.h2()
+        .withConfig(b -> b.setTemplateEngine(new StringTemplateEngine()));
 
     Handle handle;
 
     @BeforeEach
     void setup() {
         handle = h2Extension.getSharedHandle();
-        handle.setTemplateEngine(new StringTemplateEngine());
     }
 
     @Test

--- a/testcontainers/src/test/java/org/jdbi/testcontainers/mysql/TestMySQL.java
+++ b/testcontainers/src/test/java/org/jdbi/testcontainers/mysql/TestMySQL.java
@@ -46,12 +46,12 @@ public class TestMySQL {
 
     @RegisterExtension
     JdbiExtension extension = JdbiTestcontainersExtension.instance(dbContainer)
-            .withPlugin(new SqlObjectPlugin());
+            .withPlugin(new SqlObjectPlugin())
+            .withConfig(b -> b.registerRowMapper(Contact.class, ConstructorMapper.of(Contact.class)));
 
     @Test
     void testIssue2402() {
         final Handle handle = extension.getSharedHandle();
-        handle.registerRowMapper(Contact.class, ConstructorMapper.of(Contact.class));
 
         handle.execute("CREATE TABLE contacts (contact_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT, etag VARCHAR(255))");
 

--- a/testcontainers/src/test/java/org/jdbi/testcontainers/mysql/TestScript.java
+++ b/testcontainers/src/test/java/org/jdbi/testcontainers/mysql/TestScript.java
@@ -21,7 +21,6 @@ import org.jdbi.core.statement.Script;
 import org.jdbi.core.statement.SqlStatements;
 import org.jdbi.testing.junit.JdbiExtension;
 import org.jdbi.testing.junit.tc.JdbiTestcontainersExtension;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -40,12 +39,8 @@ public class TestScript {
     static JdbcDatabaseContainer<?> dbContainer = new MySQLContainer<>(MYSQL_VERSION).withUrlParam("rewriteBatchedStatements", "true");
 
     @RegisterExtension
-    JdbiExtension extension = JdbiTestcontainersExtension.instance(dbContainer);
-
-    @BeforeEach
-    public void setUp() {
-        extension.getSharedHandle().configure(SqlStatements.class, c -> c.scriptStatementsNeedSemicolon(false));
-    }
+    JdbiExtension extension = JdbiTestcontainersExtension.instance(dbContainer)
+            .withConfig(b -> b.configure(SqlStatements.class, c -> c.scriptStatementsNeedSemicolon(false)));
 
     @Test
     void testIssue2554Script() {

--- a/testing/src/main/java/org/jdbi/testing/junit/JdbiExtension.java
+++ b/testing/src/main/java/org/jdbi/testing/junit/JdbiExtension.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import javax.sql.DataSource;
@@ -282,6 +283,23 @@ public abstract class JdbiExtension implements BeforeAllCallback, AfterAllCallba
     }
 
     /**
+     * Apply build-time configuration to the {@link Jdbi} instance via its {@link Jdbi.Builder}. Use this to register
+     * mappers, arguments, and the like as test fixtures.
+     *
+     * <pre>{@code
+     *     @RegisterExtension
+     *     public JdbiExtension h2Extension = JdbiExtension.h2()
+     *             .withConfig(b -> b.registerRowMapper(Foo.class, new FooMapper()));
+     * }</pre>
+     *
+     * @param configurer applied to the {@link Jdbi.Builder} while the {@link Jdbi} is assembled.
+     * @return The extension itself for chaining method calls.
+     */
+    public final JdbiExtension withConfig(Consumer<Jdbi.Builder> configurer) {
+        return withPlugin(JdbiPlugin.of(configurer));
+    }
+
+    /**
      * Convenience method to attach an extension (such as a SqlObject) to the shared handle.
      */
     public final <T> T attach(final Class<T> extension) {
@@ -315,22 +333,31 @@ public abstract class JdbiExtension implements BeforeAllCallback, AfterAllCallba
         }
 
         final DataSource ds = getDataSource();
-
-        if (enableLeakchecker) {
-            withConfig(Handles.class, h -> h.addListener(leakChecker));
-            withConfig(SqlStatements.class, s -> s.addContextListener(leakChecker));
-        }
-
-        final Jdbi.Builder builder = Jdbi.builder(ds);
-        plugins.forEach(builder::installPlugin);
-        final Jdbi jdbiInstance = builder.build();
-
+        final Jdbi jdbiInstance = builder().build();
         final Handle sharedHandleInstance = jdbiInstance.open();
 
         this.jdbi = jdbiInstance;
         this.sharedHandle = sharedHandleInstance;
 
         initializerMaybe.ifPresent(i -> i.initialize(ds, sharedHandleInstance));
+    }
+
+    /**
+     * Returns a {@link Jdbi.Builder} pre-configured with this extension's data source, installed plugins, and (unless
+     * disabled with {@link #withoutLeakChecker()}) its leak checker, so a test can add per-test configuration (a
+     * transaction handler, a spy, and the like) and build its own {@link Jdbi} that still participates in the
+     * extension's leak-check lifecycle.
+     *
+     * @return a builder assembling a {@code Jdbi} equivalent to this extension's.
+     */
+    public final Jdbi.Builder builder() throws Exception {
+        final Jdbi.Builder builder = Jdbi.builder(getDataSource());
+        plugins.forEach(builder::installPlugin);
+        if (enableLeakchecker) {
+            builder.configure(Handles.class, h -> h.addListener(leakChecker));
+            builder.configure(SqlStatements.class, s -> s.addContextListener(leakChecker));
+        }
+        return builder;
     }
 
     protected void stopExtension() throws Exception {

--- a/vavr/src/main/java/org/jdbi/vavr/TupleMappers.java
+++ b/vavr/src/main/java/org/jdbi/vavr/TupleMappers.java
@@ -13,6 +13,7 @@
  */
 package org.jdbi.vavr;
 
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import io.vavr.Tuple;
 import org.jdbi.core.config.JdbiConfig;
 import org.jdbi.core.mapper.MapEntryConfig;
@@ -47,6 +48,7 @@ public final class TupleMappers implements JdbiConfig<TupleMappers>, MapEntryCon
     }
 
     @Override
+    @CheckReturnValue
     public TupleMappers keyColumn(String keyColumn) {
         return column(KEY_COLUMN_TUPLE_INDEX, keyColumn);
     }
@@ -57,6 +59,7 @@ public final class TupleMappers implements JdbiConfig<TupleMappers>, MapEntryCon
     }
 
     @Override
+    @CheckReturnValue
     public TupleMappers valueColumn(String valueColumn) {
         return column(VALUE_COLUMN_TUPLE_INDEX, valueColumn);
     }
@@ -68,6 +71,7 @@ public final class TupleMappers implements JdbiConfig<TupleMappers>, MapEntryCon
      * @param name       the column name to be mapped explicitly
      * @return the derived configuration
      */
+    @CheckReturnValue
     public TupleMappers column(int tupleIndex, String name) {
         final String[] newColumns = columns.clone();
         newColumns[tupleIndex - 1] = name;

--- a/vavr/src/main/java/org/jdbi/vavr/VavrOptionColumnMapperFactory.java
+++ b/vavr/src/main/java/org/jdbi/vavr/VavrOptionColumnMapperFactory.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 
 import io.vavr.control.Option;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 import org.jdbi.core.mapper.ColumnMapper;
 import org.jdbi.core.mapper.ColumnMapperFactory;
@@ -28,13 +28,13 @@ import static org.jdbi.core.generic.GenericTypes.getErasedType;
 class VavrOptionColumnMapperFactory implements ColumnMapperFactory {
 
     @Override
-    public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<ColumnMapper<?>> build(Type type, ConfigView config) {
         return Optional.of(type)
             .filter(t -> getErasedType(t) == Option.class)
             .map(t -> create(t, config));
     }
 
-    private static ColumnMapper<?> create(Type type, ConfigRegistry config) {
+    private static ColumnMapper<?> create(Type type, ConfigView config) {
         final ColumnMapper<?> mapper = config.findColumnMapperFor(
                 GenericTypes.findGenericParameter(type, Option.class)
                     .orElseThrow(() -> new NoSuchMapperException("No mapper for raw vavr Option type")))

--- a/vavr/src/main/java/org/jdbi/vavr/VavrOptionRowMapperFactory.java
+++ b/vavr/src/main/java/org/jdbi/vavr/VavrOptionRowMapperFactory.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 
 import io.vavr.control.Option;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericTypes;
 import org.jdbi.core.mapper.NoSuchMapperException;
 import org.jdbi.core.mapper.RowMapper;
@@ -28,13 +28,13 @@ import static org.jdbi.core.generic.GenericTypes.getErasedType;
 class VavrOptionRowMapperFactory implements RowMapperFactory {
 
     @Override
-    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<RowMapper<?>> build(Type type, ConfigView config) {
         return Optional.of(type)
             .filter(t -> getErasedType(t) == Option.class)
             .flatMap(t -> create(t, config));
     }
 
-    private static Optional<RowMapper<?>> create(Type type, ConfigRegistry config) {
+    private static Optional<RowMapper<?>> create(Type type, ConfigView config) {
         return config.findRowMapperFor(
                 GenericTypes.findGenericParameter(type, Option.class)
                     .orElseThrow(() -> new NoSuchMapperException("No mapper for raw vavr Option type")))

--- a/vavr/src/main/java/org/jdbi/vavr/VavrTupleRowMapperFactory.java
+++ b/vavr/src/main/java/org/jdbi/vavr/VavrTupleRowMapperFactory.java
@@ -31,7 +31,7 @@ import io.vavr.Tuple7;
 import io.vavr.Tuple8;
 import io.vavr.collection.Array;
 import io.vavr.control.Option;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.mapper.MapEntryMappers;
 import org.jdbi.core.mapper.NoSuchMapperException;
 import org.jdbi.core.mapper.RowMapper;
@@ -45,7 +45,7 @@ class VavrTupleRowMapperFactory implements RowMapperFactory {
 
     @Override
     @SuppressWarnings({"unchecked", "PMD.AvoidDeeplyNestedIfStmts"})
-    public Optional<RowMapper<?>> build(Type type, ConfigRegistry config) {
+    public Optional<RowMapper<?>> build(Type type, ConfigView config) {
         Class<?> erasedType = getErasedType(type);
 
         boolean emptyTupleType = Tuple0.class.equals(erasedType) || Tuple.class.equals(erasedType);
@@ -110,7 +110,7 @@ class VavrTupleRowMapperFactory implements RowMapperFactory {
         return Optional.empty();
     }
 
-    Array<Tuple3<Type, Integer, Option<String>>> resolveKeyValueColumns(ConfigRegistry config, Array<Tuple2<Type, Integer>> tupleTypes) {
+    Array<Tuple3<Type, Integer, Option<String>>> resolveKeyValueColumns(ConfigView config, Array<Tuple2<Type, Integer>> tupleTypes) {
         Array<Tuple3<Type, Integer, Option<String>>> withConfiguredColumnName;
         Tuple2<Type, Integer> keyType = tupleTypes.get(0);
         Tuple2<Type, Integer> valueType = tupleTypes.get(1);
@@ -157,22 +157,22 @@ class VavrTupleRowMapperFactory implements RowMapperFactory {
         throw new IllegalArgumentException("unknown tuple type " + tupleClass);
     }
 
-    Optional<RowMapper<?>> getColumnMapper(Type type, int tupleIndex, ConfigRegistry config) {
+    Optional<RowMapper<?>> getColumnMapper(Type type, int tupleIndex, ConfigView config) {
         int colIndex = tupleIndex;
         return config.findColumnMapperFor(type)
                 .map(cm -> new SingleColumnMapper<>(cm, colIndex));
     }
 
-    private Optional<RowMapper<?>> getRowMapper(Type type, ConfigRegistry config) {
+    private Optional<RowMapper<?>> getRowMapper(Type type, ConfigView config) {
         return config.findRowMapperFor(type);
     }
 
-    private Optional<RowMapper<?>> getColumnMapperForDefinedColumn(Type type, String col, ConfigRegistry config) {
+    private Optional<RowMapper<?>> getColumnMapperForDefinedColumn(Type type, String col, ConfigView config) {
         return config.findColumnMapperFor(type)
                 .map(cm -> new SingleColumnMapper<>(cm, col));
     }
 
-    Option<String> getConfiguredColumnName(int tupleIndex, ConfigRegistry config) {
+    Option<String> getConfiguredColumnName(int tupleIndex, ConfigView config) {
         return Option.of(config.get(TupleMappers.class)
                 .getColumn(tupleIndex));
     }

--- a/vavr/src/main/java/org/jdbi/vavr/VavrValueArgumentFactory.java
+++ b/vavr/src/main/java/org/jdbi/vavr/VavrValueArgumentFactory.java
@@ -27,7 +27,7 @@ import io.vavr.control.Validation;
 import org.jdbi.core.argument.Argument;
 import org.jdbi.core.argument.ArgumentFactory;
 import org.jdbi.core.argument.ArgumentResolver;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 
 import static org.jdbi.core.generic.GenericTypes.findGenericParameter;
 import static org.jdbi.core.generic.GenericTypes.getErasedType;
@@ -44,7 +44,7 @@ class VavrValueArgumentFactory implements ArgumentFactory.Preparable {
     private static final Supplier<Type> OBJECT_SUPPLIER = () -> Object.class;
 
     @Override
-    public Optional<Argument> build(Type type, Object value, ConfigRegistry config) {
+    public Optional<Argument> build(Type type, Object value, ConfigView config) {
         if (acceptType(type)) {
             Object nestedValue = unwrapValue((Value<?>) value);
             Type nestedType = findGenericType(type, nestedValue);
@@ -55,7 +55,7 @@ class VavrValueArgumentFactory implements ArgumentFactory.Preparable {
     }
 
     @Override
-    public Optional<Function<Object, Argument>> prepare(Type type, ConfigRegistry config) {
+    public Optional<Function<Object, Argument>> prepare(Type type, ConfigView config) {
         if (acceptType(type)) {
             return ArgumentResolver.forRegistry(config)
                 .prepareFor(findGenericType(type, null))

--- a/vavr/src/test/java/org/jdbi/vavr/TestVavrMapCollectorWithDB.java
+++ b/vavr/src/test/java/org/jdbi/vavr/TestVavrMapCollectorWithDB.java
@@ -23,7 +23,6 @@ import io.vavr.collection.Map;
 import io.vavr.collection.Multimap;
 import io.vavr.collection.Seq;
 import org.jdbi.core.Handle;
-import org.jdbi.core.Jdbi;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.mapper.MapEntryMappers;
 import org.jdbi.core.mapper.reflect.ConstructorMapper;
@@ -63,16 +62,14 @@ public class TestVavrMapCollectorWithDB {
 
     @Test
     public void testMapCollectorWithGlobalKeyValueShouldSucceed() {
-        Jdbi jdbiWithKeyColAndValCol = h2Extension.getJdbi()
-            .setMapKeyColumn("key_c")
-            .setMapValueColumn("val_c");
-
-        Boolean executed = jdbiWithKeyColAndValCol.withHandle(h -> {
-            Map<String, String> valueMap = h.createQuery("select val_c, key_c from keyval")
-                .collectInto(new GenericType<Map<String, String>>() {});
-            assertThat(valueMap).hasSameElementsAs(expectedMap);
-            return true;
-        });
+        Boolean executed = h2Extension.getJdbi().withHandle(
+            cfg -> cfg.configure(MapEntryMappers.class, c -> c.keyColumn("key_c").valueColumn("val_c")),
+            h -> {
+                Map<String, String> valueMap = h.createQuery("select val_c, key_c from keyval")
+                    .collectInto(new GenericType<Map<String, String>>() {});
+                assertThat(valueMap).hasSameElementsAs(expectedMap);
+                return true;
+            });
 
         assertThat(executed).isTrue();
     }

--- a/vavr/src/test/java/org/jdbi/vavr/TestVavrMapCollectorWithDB.java
+++ b/vavr/src/test/java/org/jdbi/vavr/TestVavrMapCollectorWithDB.java
@@ -77,8 +77,8 @@ public class TestVavrMapCollectorWithDB {
     @Test
     public void testMapCollectorWithTupleConfigShouldSucceed() {
         Map<String, String> valueMap = h2Extension.getSharedHandle()
-            .configure(TupleMappers.class, c -> c.keyColumn("key_c").valueColumn("val_c"))
             .createQuery("select val_c, key_c from keyval")
+            .configure(TupleMappers.class, c -> c.keyColumn("key_c").valueColumn("val_c"))
             .collectInto(new GenericType<Map<String, String>>() {});
 
         assertThat(valueMap).hasSameElementsAs(expectedMap);
@@ -87,8 +87,8 @@ public class TestVavrMapCollectorWithDB {
     @Test
     public void testMapCollectorWithCorrespondingTupleColsShouldSucceed() {
         var valueMap = h2Extension.getSharedHandle()
-            .configure(TupleMappers.class, c -> c.column(1, "key_c").column(2, "val_c"))
             .createQuery("select val_c, key_c from keyval")
+            .configure(TupleMappers.class, c -> c.column(1, "key_c").column(2, "val_c"))
             .collectInto(new GenericType<Map<String, String>>() {});
 
         assertThat(valueMap).hasSameElementsAs(expectedMap);
@@ -96,8 +96,9 @@ public class TestVavrMapCollectorWithDB {
 
     @Test
     public void testSingleInstanceAssignmentWithSelectedKeyValueShouldSucceed() {
-        Handle handle = h2Extension.getSharedHandle().configure(MapEntryMappers.class, c -> c.keyColumn("key_c").valueColumn("val_c"));
-        Optional<Tuple2<String, String>> valueMap = handle.createQuery("select val_c, key_c from keyval")
+        Optional<Tuple2<String, String>> valueMap = h2Extension.getSharedHandle()
+            .createQuery("select val_c, key_c from keyval")
+            .configure(MapEntryMappers.class, c -> c.keyColumn("key_c").valueColumn("val_c"))
             .mapTo(new GenericType<Tuple2<String, String>>() {})
             .findFirst();
 

--- a/vavr/src/test/java/org/jdbi/vavr/TestVavrOptionMapperWithDB.java
+++ b/vavr/src/test/java/org/jdbi/vavr/TestVavrOptionMapperWithDB.java
@@ -60,8 +60,8 @@ public class TestVavrOptionMapperWithDB {
     @Test
     public void testOptionMappedWithoutGenericParameterShouldFail() {
         assertThatThrownBy(() -> h2Extension.getSharedHandle()
-            .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
             .createQuery("select name from something")
+            .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
             .collectInto(new GenericType<Set<Option>>() {}))
                 .isInstanceOf(NoSuchMapperException.class)
                 .hasMessageContaining("raw");
@@ -79,8 +79,8 @@ public class TestVavrOptionMapperWithDB {
     @Test
     public void testOptionMappedWithinObjectIfPresentShouldContainValue() {
         final SomethingWithOption result = h2Extension.getSharedHandle()
-            .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
             .createQuery("select id, name from something where id = 1")
+            .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
             .mapTo(SomethingWithOption.class)
             .one();
 
@@ -91,8 +91,8 @@ public class TestVavrOptionMapperWithDB {
     @Test
     public void testOptionWithinObjectIfMissingShouldBeNone() {
         final SomethingWithOption result = h2Extension.getSharedHandle()
-            .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
             .createQuery("select id, name from something where id = 2")
+            .registerRowMapper(ConstructorMapper.factory(SomethingWithOption.class))
             .mapTo(SomethingWithOption.class)
             .one();
 
@@ -104,9 +104,9 @@ public class TestVavrOptionMapperWithDB {
     public void testOptionWithRowMapper() {
         GenericType<Option<Something>> vavrType = new GenericType<>() {};
         final Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(Something.class, BeanMapper.of(Something.class));
 
-        try (Query query = handle.createQuery("SELECT * FROM something WHERE id = :id")) {
+        try (Query query = handle.createQuery("SELECT * FROM something WHERE id = :id")
+                .registerRowMapper(Something.class, BeanMapper.of(Something.class))) {
             Option<Something> result = query.bind("id", 1)
                 .mapTo(vavrType)
                 .one();

--- a/vavr/src/test/java/org/jdbi/vavr/TestVavrTupleRowMapperFactory.java
+++ b/vavr/src/test/java/org/jdbi/vavr/TestVavrTupleRowMapperFactory.java
@@ -29,7 +29,7 @@ import io.vavr.Tuple7;
 import io.vavr.Tuple8;
 import io.vavr.collection.Array;
 import io.vavr.control.Option;
-import org.jdbi.core.config.ConfigRegistry;
+import org.jdbi.core.config.ConfigView;
 import org.jdbi.core.generic.GenericType;
 import org.jdbi.core.mapper.RowMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,17 +46,17 @@ public class TestVavrTupleRowMapperFactory {
         unit = new VavrTupleRowMapperFactory() {
             // mock the resolution of column mappers in jdbi
             @Override
-            Optional<RowMapper<?>> getColumnMapper(Type type, int tupleIndex, ConfigRegistry config) {
+            Optional<RowMapper<?>> getColumnMapper(Type type, int tupleIndex, ConfigView config) {
                 return Optional.of((rs, ctx) -> tupleIndex);
             }
 
             @Override
-            Option<String> getConfiguredColumnName(int tupleIndex, ConfigRegistry config) {
+            Option<String> getConfiguredColumnName(int tupleIndex, ConfigView config) {
                 return Option.none();
             }
 
             @Override
-            Array<Tuple3<Type, Integer, Option<String>>> resolveKeyValueColumns(ConfigRegistry config, Array<Tuple2<Type, Integer>> tupleTypes) {
+            Array<Tuple3<Type, Integer, Option<String>>> resolveKeyValueColumns(ConfigView config, Array<Tuple2<Type, Integer>> tupleTypes) {
                 return tupleTypes.map(t -> Tuple.of(t._1, t._2, Option.<String>none()));
             }
         };

--- a/vavr/src/test/java/org/jdbi/vavr/TestVavrTupleRowMapperFactoryWithDB.java
+++ b/vavr/src/test/java/org/jdbi/vavr/TestVavrTupleRowMapperFactoryWithDB.java
@@ -58,10 +58,10 @@ public class TestVavrTupleRowMapperFactoryWithDB {
     @Test
     public void testMapTuple1UsingRegisteredRowMapperShouldSucceed() {
         Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new SomethingMapper());
 
         Tuple1<Something> result = handle
                 .createQuery("select id, name from something where id = 1")
+                .registerRowMapper(new SomethingMapper())
                 .mapTo(new GenericType<Tuple1<Something>>() {})
                 .one();
 
@@ -71,13 +71,13 @@ public class TestVavrTupleRowMapperFactoryWithDB {
     @Test
     public void testMapTuple2UsingRegisteredRowMappersShouldSucceed() {
         Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new SomethingMapper());
-        handle.registerRowMapper(SomethingValues.class,
-                (rs, ctx) -> new SomethingValues(rs.getInt("integerValue"),
-                        rs.getInt("intValue")));
 
         Tuple2<Something, SomethingValues> result = handle
                 .createQuery("select * from something where id = 2")
+                .registerRowMapper(new SomethingMapper())
+                .registerRowMapper(SomethingValues.class,
+                        (rs, ctx) -> new SomethingValues(rs.getInt("integerValue"),
+                                rs.getInt("intValue")))
                 .mapTo(new GenericType<Tuple2<Something, SomethingValues>>() {})
                 .one();
 
@@ -88,10 +88,10 @@ public class TestVavrTupleRowMapperFactoryWithDB {
     @Test
     public void testMapTuple2HavingOnlyOneRowMapperShouldFail() {
         final Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new SomethingMapper());
 
         assertThatThrownBy(() -> handle
                 .createQuery("select * from something where id = 1")
+                .registerRowMapper(new SomethingMapper())
                 .mapTo(new GenericType<Tuple2<Something, SomethingValues>>() {})
                 .one()
        ).isInstanceOf(NoSuchMapperException.class)
@@ -101,12 +101,12 @@ public class TestVavrTupleRowMapperFactoryWithDB {
     @Test
     public void testMapTuple3WithExtraSpecifiedColumnShouldSucceed() {
         Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new SomethingMapper());
-        handle.configure(TupleMappers.class, c ->
-                c.column(2, "integerValue").column(3, "intValue"));
 
         Tuple3<Something, Integer, Integer> result = handle
                 .createQuery("select * from something where id = 1")
+                .registerRowMapper(new SomethingMapper())
+                .configure(TupleMappers.class, c ->
+                        c.column(2, "integerValue").column(3, "intValue"))
                 .mapTo(new GenericType<Tuple3<Something, Integer, Integer>>() {})
                 .one();
 
@@ -118,13 +118,13 @@ public class TestVavrTupleRowMapperFactoryWithDB {
     @Test
     public void testMapTuple3WithAllSpecifiedColumnsShouldRespectConfiguration() {
         Handle handle = h2Extension.getSharedHandle();
-        handle.configure(TupleMappers.class, c ->
-                c.column(1, "integerValue")
-                        .column(2, "intValue")
-                        .column(3, "id"));
 
         Tuple3<Integer, Integer, Integer> result = handle
                 .createQuery("select * from something where id = 1")
+                .configure(TupleMappers.class, c ->
+                        c.column(1, "integerValue")
+                                .column(2, "intValue")
+                                .column(3, "id"))
                 .mapTo(new GenericType<Tuple3<Integer, Integer, Integer>>() {})
                 .one();
 
@@ -136,10 +136,10 @@ public class TestVavrTupleRowMapperFactoryWithDB {
     @Test
     public void testMapTuple3WithoutSpecifiedColumnShouldFail() {
         Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new SomethingMapper());
 
         assertThatThrownBy(() -> handle
                 .createQuery("select * from something where id = 1")
+                .registerRowMapper(new SomethingMapper())
                 .mapTo(new GenericType<Tuple3<Integer, Something, Integer>>() {})
                 .one())
                 .isInstanceOf(NoSuchMapperException.class)
@@ -149,12 +149,12 @@ public class TestVavrTupleRowMapperFactoryWithDB {
     @Test
     public void testMapTuple3WithOnlyOneSpecifiedColumnShouldFail() {
         Handle handle = h2Extension.getSharedHandle();
-        handle.registerRowMapper(new SomethingMapper());
-        handle.configure(TupleMappers.class, c ->
-                c.column(1, "integerValue"));
 
         assertThatThrownBy(() -> handle
                 .createQuery("select * from something where id = 1")
+                .registerRowMapper(new SomethingMapper())
+                .configure(TupleMappers.class, c ->
+                        c.column(1, "integerValue"))
                 .mapTo(new GenericType<Tuple3<Integer, Something, Integer>>() {})
                 .one()).isInstanceOf(NoSuchMapperException.class)
                 .isInstanceOf(NoSuchMapperException.class)


### PR DESCRIPTION
Fourth feature PR of the stack, on top of pr4. It completes the immutable-configuration model: a built Jdbi and every Handle become read-only, the post-construction mutation API (deprecated in pr4) is removed, and a handle now derives its configuration copy-on-write instead of copying it — the #2992 warm-metadata payoff.

What's here:
  
 - Jdbi is read-only. It goes from Configurable to ConfigReader; the post-construction mutation API is removed, so a Jdbi is configured only through Jdbi.builder() (pr4). Internal sites that assembled a Jdbi by mutating it after construction migrate to the builder.
 - Handle carries no configuration. It goes from Configurable to ConfigReader — a connection plus transaction state, nothing more. getConfig() returns a read-only view of the owning Jdbi's configuration.
 - Handle configuration is copy-on-write (#2992). A handle derives a copy-on-write child of the Jdbi's frozen config (createChild()), so an unmodified handle shares the root's warm resolver views instead of paying a full copy on open. A handle-per-operation benchmark for the payoff is included.
 - A read-only ConfigView split. getConfig() on Jdbi and Handle returns a new ConfigView (read and derive only) that can't be cast back to the mutable ConfigRegistry, and the resolving SPIs are narrowed to ConfigView — closing the last in-place-mutation backdoors.
 - Wither misuse fails the build. @CheckReturnValue on the immutable-config withers turns a discarded wither result into a static-analysis error.
