### PR TITLE
Move GraalVM CI to matrix (25.0, 25.2) and native-build-tools to 1.1.5

### DIFF
--- a/.github/workflows/graal-ci.yml
+++ b/.github/workflows/graal-ci.yml
@@ -24,10 +24,22 @@ permissions:
 jobs:
   native-build:
     runs-on: ubuntu-latest
-    name: GraalVM native build
+    name: GraalVM ${{ matrix.graalvm-version }} ${{ matrix.distribution }} native build
     strategy:
+      fail-fast: false
+      # Spelled out rather than a cross product, because the cells are not
+      # interchangeable: only the interim releases can run exact reachability
+      # metadata, so that will be enabled per cell rather than globally.
       matrix:
-        java-version: [ 25 ]
+        include:
+          - graalvm-version: '25.0'
+            distribution: 'graalvm'
+          - graalvm-version: '25.0'
+            distribution: 'graalvm-community'
+          - graalvm-version: '25.2'
+            distribution: 'graalvm'
+          - graalvm-version: '25.2'
+            distribution: 'graalvm-community'
 
     steps:
       - uses: actions/checkout@v6
@@ -39,8 +51,10 @@ jobs:
         name: setup build jdk
         id: build_jdk
         with:
-          java-version: ${{ matrix.java-version }}
+          version: ${{ matrix.graalvm-version }}
+          distribution: ${{ matrix.distribution }}
           cache: maven
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build code
         id: install
@@ -61,7 +75,7 @@ jobs:
         continue-on-error: true
         if: ${{ always() }}
         with:
-          name: build logs (${{ github.job }}, ${{ matrix.java-version }})
+          name: build logs (${{ github.job }}, ${{ matrix.graalvm-version }}, ${{ matrix.distribution }})
           retention-days: 90
           path: |
             **/target
@@ -73,7 +87,7 @@ jobs:
         id: upload_build_artifacts
         continue-on-error: true
         with:
-          name: build artifacts (${{ github.job }}, ${{ matrix.java-version }})
+          name: build artifacts (${{ github.job }}, ${{ matrix.graalvm-version }}, ${{ matrix.distribution }})
           retention-days: 1
           path: |
             **/target/native-tests
@@ -81,10 +95,19 @@ jobs:
 
   native-demo:
     runs-on: ubuntu-latest
-    name: GraalVM native demo
+    name: GraalVM ${{ matrix.graalvm-version }} ${{ matrix.distribution }} native demo
     strategy:
+      fail-fast: false
       matrix:
-        java-version: [ 25 ]
+        include:
+          - graalvm-version: '25.0'
+            distribution: 'graalvm'
+          - graalvm-version: '25.0'
+            distribution: 'graalvm-community'
+          - graalvm-version: '25.2'
+            distribution: 'graalvm'
+          - graalvm-version: '25.2'
+            distribution: 'graalvm-community'
 
     # examples/native-demo is deliberately not a reactor module: it builds standalone
     # against released Jdbi artifacts, the way a user's own project does. Nothing in the
@@ -96,8 +119,10 @@ jobs:
         name: setup build jdk
         id: build_jdk
         with:
-          java-version: ${{ matrix.java-version }}
+          version: ${{ matrix.graalvm-version }}
+          distribution: ${{ matrix.distribution }}
           cache: maven
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build native demo
         id: demo
@@ -137,7 +162,7 @@ jobs:
         continue-on-error: true
         if: ${{ failure() && (steps.demo.conclusion == 'failure' || steps.demo_run.conclusion == 'failure') }}
         with:
-          name: build logs (${{ github.job }}, ${{ matrix.java-version }})
+          name: build logs (${{ github.job }}, ${{ matrix.graalvm-version }}, ${{ matrix.distribution }})
           retention-days: 90
           path: |
             demo.log

--- a/core/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-core/reachability-metadata.json
+++ b/core/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-core/reachability-metadata.json
@@ -23,6 +23,7 @@
     {"type":"java.lang.Math","methods":[{"name":"toDegrees"}]},
     {"type":"java.lang.Integer","methods":[{"name":"parseInt","parameterTypes":["java.lang.String"]}]},
     {"type":"java.util.HashMap","methods":[{"name":"clone"}]},
+    {"type":"java.util.concurrent.ConcurrentHashMap","methods":[{"name":"<init>","parameterTypes":[]}]},
     {"type":"org.h2.jdbc.JdbcSQLNonTransientException","allPublicConstructors": true,"allPublicMethods": true,"allDeclaredFields": true},
     {"type":"org.jdbi.v3.core.Something","allPublicConstructors": true,"allPublicMethods": true},
     {"type":"org.jdbi.v3.core.argument.TestNamedParams$1","allPublicConstructors": true,"allPublicMethods": true,"allDeclaredFields": true},
@@ -71,6 +72,7 @@
   ],
   "resources": [
     {"glob":"*.sql"},
+    {"glob":"mockito-extensions/org.mockito.plugins.MockMaker"},
     {"glob":"org/**/*.sql"},
     {"glob":"script/**/*.sql"}
   ]

--- a/examples/native-demo/pom.xml
+++ b/examples/native-demo/pom.xml
@@ -54,7 +54,7 @@
         <dep.h2.version>2.3.232</dep.h2.version>
         <dep.jdbi3.version>3.54.0</dep.jdbi3.version>
         <dep.slf4j.version>2.0.17</dep.slf4j.version>
-        <dep.plugin.native.version>0.10.6</dep.plugin.native.version>
+        <dep.plugin.native.version>1.1.5</dep.plugin.native.version>
         <project.build.targetJdk>21</project.build.targetJdk>
         <basepom.main-class>org.jdbi.nativedemo.NativeMain</basepom.main-class>
         <basepom.executable.name>jdbi3-graalvm-jit-executable</basepom.executable.name>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -99,7 +99,9 @@
         <dep.plugin.japicmp.version>0.25.4</dep.plugin.japicmp.version>
         <dep.plugin.kotlin.version>${dep.kotlin.version}</dep.plugin.kotlin.version>
         <dep.plugin.ktlint.version>3.5.0</dep.plugin.ktlint.version>
-        <dep.plugin.native.version>0.11.5</dep.plugin.native.version>
+        <!-- 1.1.6 fails before building an image, with NoClassDefFoundError on
+             org/apache/maven/shared/utils/logging/MessageUtils -->
+        <dep.plugin.native.version>1.1.5</dep.plugin.native.version>
         <dep.plugin.sortpom.version>4.0.0</dep.plugin.sortpom.version>
         <dep.postgresql.version>42.7.12</dep.postgresql.version>
         <dep.slf4j.version>2.0.17</dep.slf4j.version>

--- a/native-tests/pom.xml
+++ b/native-tests/pom.xml
@@ -445,6 +445,12 @@
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <buildArgs combine.children="append">
+                        <!-- hsqldb formats dates through Locale.UK, so en-GB bundles must be in the image -->
+                        <buildArg>-H:IncludeLocales=en-GB</buildArg>
+                    </buildArgs>
+                </configuration>
                 <executions>
                     <execution>
                         <id>test-native</id>

--- a/postgres/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-postgres/reachability-metadata.json
+++ b/postgres/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-postgres/reachability-metadata.json
@@ -13,6 +13,7 @@
     {"type":{"proxy":["org.jdbi.v3.postgres.TestUuid$UuidObject"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestBatchGeneratedKeys$UsesBatching"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestJsonOperator$KeyValueStore"]}},
+    {"type":"java.sql.Timestamp[]"},
     {"type":"org.jdbi.v3.postgres.FooBarPGType","methods":[{"name":"<init>"}]},
     {"type":"org.jdbi.v3.postgres.ImmutableMappy"},
     {"type":"org.postgresql.util.PGmoney","methods":[{"name":"<init>"}]}


### PR DESCRIPTION
Change Graal native-image to a matrix build and track both LTS and "Innovation" streams

Update native plugin to 1.1.5. 1.1.6 is skipped: it cannot run under Maven 3.9 at all (native-build-tools#1000).

Three registrations are needed on top of the version bumps, each verified load-bearing by removing it and watching the suite fail:

- Jdbi ships core/src/test/resources/mockito-extensions/org.mockito. plugins.MockMaker to select the proxy mock maker, so Jdbi declares the resource that makes it readable in the image. The metadata repository covers Mockito's own jar, not files we add to its extension directory. Without it all 150 Mockito tests fail.
- java.sql.Timestamp[] for TestSqlArrays and ConcurrentHashMap's constructor for MapCollectorFactoryTest, both reached reflectively.
- hsqldb formats dates through Locale.UK, so en-GB has to be in the image explicitly or HsqlDateTime's initialiser dies on a CLDR bundle.