### PR TITLE
fix: bind mixed bean subclasses in PreparedBatch

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -245,21 +245,18 @@ class ArgumentBinder {
                                     .<Entry<PrepareKey, Function<Object, Argument>>>map(pf -> new AbstractMap.SimpleImmutableEntry<>(e.getKey(), pf)).stream())
                             .findFirst();
                     if (preparation.isPresent()) {
-                        Entry<PrepareKey, Function<Object, Argument>> p = preparation.get();
+                        // The first binding proves this parameter is preparable. Each batch
+                        // element may still use a different runtime type (and thus PrepareKey),
+                        // e.g. mixed subclasses bound via @BindBean Collection<Base>. Resolve
+                        // the prepared property accessor from the current binding rather than
+                        // hard-coding the template's PrepareKey (see #2974).
                         innerBinders.add(wrapCheckedConsumer(name,
-                            binding -> p.getValue()
-                                .apply(binding.prepareKeys.get(p.getKey()))
+                            binding -> preparedArgument(binding, name)
+                                .orElseGet(() -> dynamicNamedArgument(binding, name))
                                 .apply(index + 1, stmt, ctx)));
                     } else {
                         innerBinders.add(wrapCheckedConsumer(name,
-                            binding -> binding.namedArgumentFinder.stream()
-                                .flatMap(naf -> naf.find(name, ctx).stream())
-                                .findFirst()
-                                .orElseGet(() ->
-                                    binding.realizedBackupArgumentFinders.get().stream()
-                                        .flatMap(naf -> naf.find(name, ctx).stream())
-                                        .findFirst()
-                                        .orElseThrow(() -> missingNamedParameter(name, binding)))
+                            binding -> dynamicNamedArgument(binding, name)
                                 .apply(index + 1, stmt, ctx)));
                     }
                 } else {
@@ -270,6 +267,37 @@ class ArgumentBinder {
                 }
             }
             return binding -> innerBinders.forEach(b -> b.accept(binding));
+        }
+
+        /**
+         * Look up a prepared {@link Argument} for {@code name} using this binding's
+         * {@link PrepareKey}s. Keys include the runtime class, so each batch row may
+         * need a different prepared property accessor.
+         */
+        private Optional<Argument> preparedArgument(PreparedBinding binding, String name) {
+            for (Entry<PrepareKey, Object> entry : binding.prepareKeys.entrySet()) {
+                Function<String, Optional<Function<Object, Argument>>> finder =
+                        batch.preparedFinders.get(entry.getKey());
+                if (finder == null) {
+                    continue;
+                }
+                Optional<Function<Object, Argument>> prepared = finder.apply(name);
+                if (prepared.isPresent()) {
+                    return Optional.of(prepared.get().apply(entry.getValue()));
+                }
+            }
+            return Optional.empty();
+        }
+
+        private Argument dynamicNamedArgument(PreparedBinding binding, String name) {
+            return binding.namedArgumentFinder.stream()
+                    .flatMap(naf -> naf.find(name, ctx).stream())
+                    .findFirst()
+                    .orElseGet(() ->
+                            binding.realizedBackupArgumentFinders.get().stream()
+                                    .flatMap(naf -> naf.find(name, ctx).stream())
+                                    .findFirst()
+                                    .orElseThrow(() -> missingNamedParameter(name, binding)));
         }
 
         @Override

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestPreparedBatch.java
@@ -275,6 +275,77 @@ public class TestPreparedBatch {
             .execute()).containsExactly(1, 1, 1);
     }
 
+    /**
+     * Regression for #2974: PreparedBatch bindBean with mixed subclasses must not NPE
+     * when the prepared binder was built from the first row's runtime type.
+     */
+    @Test
+    public void testBindBeanMixedSubclasses() {
+        Handle h = h2Extension.getSharedHandle();
+
+        BaseBean subclass = new SubBean();
+        subclass.setId(1);
+        subclass.setName("sub");
+
+        BaseBean base = new BaseBean();
+        base.setId(2);
+        base.setName("base");
+
+        // Subclass first so the prepared binder is keyed on SubBean; base second triggers the bug
+        PreparedBatch b = h.prepareBatch("insert into something (id, name) values (:id, :name)");
+        b.bindBean(subclass).add();
+        b.bindBean(base).add();
+        b.execute();
+
+        // Opposite order as well
+        BaseBean base2 = new BaseBean();
+        base2.setId(3);
+        base2.setName("base2");
+        BaseBean subclass2 = new SubBean();
+        subclass2.setId(4);
+        subclass2.setName("sub2");
+
+        PreparedBatch b2 = h.prepareBatch("insert into something (id, name) values (:id, :name)");
+        b2.bindBean(base2).add();
+        b2.bindBean(subclass2).add();
+        b2.execute();
+
+        List<Something> rows = h.createQuery("select * from something order by id")
+            .mapToBean(Something.class)
+            .list();
+        assertThat(rows).extracting(Something::getId, Something::getName)
+            .containsExactly(
+                tuple(1, "sub"),
+                tuple(2, "base"),
+                tuple(3, "base2"),
+                tuple(4, "sub2"));
+    }
+
+    public static class BaseBean {
+        private int id;
+        private String name;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class SubBean extends BaseBean {
+        // empty subclass — same bean properties, different runtime class
+    }
+
     public static class PublicSomething {
         public int id;
         public String name;


### PR DESCRIPTION
## Summary

Fixes #2974.

`ArgumentBinder.Prepared` builds a binder from the **first** batch row. For `@BindBean` / `bindBean`, each row's `PrepareKey` includes the **runtime class**. When a later row is a different subclass, `binding.prepareKeys.get(templateKey)` returned `null` and `BeanPojoProperty.get` NPEd.

### Change

When a parameter is preparable via named-argument finders, resolve the prepared property accessor from **each binding's own** `PrepareKey` set (and the corresponding entry in `preparedFinders`), instead of hard-coding the template row's key. Fall back to dynamic named/backup finders if needed.

### AI disclosure

This change was developed with **human-reviewed AI assistance** (Grok / Cursor harness). Please apply the **AI** label to this PR per [AI-GUIDELINES.md](https://github.com/jdbi/jdbi/blob/master/AI-GUIDELINES.md).

## Testing

```bash
export JAVA_HOME=$(/usr/libexec/java_home -v 21 2>/dev/null || echo /opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home)
./mvnw -pl core -am test -Dtest=TestPreparedBatch,TestArgumentBinder,TestBatch \
  -Dsurefire.failIfNoSpecifiedTests=false -Djdbi.check.skip=true
```

Results: **37 tests, 0 failures** (includes new `testBindBeanMixedSubclasses`).

Also: `checkstyle:check` on core — 0 violations for the change.