### PR TITLE
Add OSGi bundle manifests to all published modules

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- add OSGi bundle manifests to all published modules (#2247)
+
 # 3.54.0
 
 - fix deadlock in configuration caching (#2980)

--- a/cache/caffeine-cache/pom.xml
+++ b/cache/caffeine-cache/pom.xml
@@ -68,6 +68,39 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/cache/noop-cache/pom.xml
+++ b/cache/noop-cache/pom.xml
@@ -64,6 +64,39 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/commons-text/pom.xml
+++ b/commons-text/pom.xml
@@ -75,4 +75,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -139,6 +139,48 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                                DynamicImport-Package: *
+                                Import-Package:\
+                                    !org.antlr.v4.runtime*,\
+                                    com.google.errorprone.annotations*;resolution:=optional,\
+                                    jakarta.annotation;resolution:=optional,\
+                                    jdk.jfr;resolution:=optional,\
+                                    *
+                                Require-Capability:\
+                                    osgi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional,\
+                                    osgi.serviceloader;filter:="(osgi.serviceloader=org.jdbi.v3.core.spi.JdbiPlugin)";cardinality:=multiple;resolution:=optional
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.basepom.maven</groupId>
                 <artifactId>inline-maven-plugin</artifactId>
                 <executions>

--- a/freemarker/pom.xml
+++ b/freemarker/pom.xml
@@ -79,4 +79,44 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    org.jdbi.v3.sqlobject*;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -87,6 +87,38 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/gson2/pom.xml
+++ b/gson2/pom.xml
@@ -97,4 +97,42 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -73,4 +73,45 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    com.google.errorprone.annotations*;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -126,4 +126,45 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    jakarta.inject;resolution:=optional,\
+                                    javax.inject;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -91,6 +91,7 @@
         <dep.pg-embedded.version>5.4.1</dep.pg-embedded.version>
         <dep.pgvector.version>0.1.6</dep.pgvector.version>
         <dep.plugin.asciidoctor.version>3.2.0</dep.plugin.asciidoctor.version>
+        <dep.plugin.bnd.version>7.3.0</dep.plugin.bnd.version>
         <dep.plugin.cyclonedx.version>2.9.1</dep.plugin.cyclonedx.version>
         <dep.plugin.detekt.version>1.23.8</dep.plugin.detekt.version>
         <dep.plugin.dokka.version>2.2.0-Beta</dep.plugin.dokka.version>
@@ -919,6 +920,11 @@
                             <dependencies>remove</dependencies>
                         </pomElements>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-maven-plugin</artifactId>
+                    <version>${dep.plugin.bnd.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.basepom.maven</groupId>

--- a/jackson2/pom.xml
+++ b/jackson2/pom.xml
@@ -122,4 +122,42 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.jackson2.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jackson3/pom.xml
+++ b/jackson3/pom.xml
@@ -110,4 +110,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jodatime2/pom.xml
+++ b/jodatime2/pom.xml
@@ -55,4 +55,42 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -72,4 +72,45 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    org.jdbi.v3.sqlobject*;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -70,4 +70,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.json.*
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/kotlin-sqlobject/pom.xml
+++ b/kotlin-sqlobject/pom.xml
@@ -114,4 +114,42 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -123,4 +123,45 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    kotlinx.coroutines;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/moshi/pom.xml
+++ b/moshi/pom.xml
@@ -85,4 +85,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -100,4 +100,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/opentelemetry/pom.xml
+++ b/opentelemetry/pom.xml
@@ -79,4 +79,42 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/oracle12/pom.xml
+++ b/oracle12/pom.xml
@@ -111,4 +111,46 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    org.jdbi.v3.testing;resolution:=optional,\
+                                    org.testcontainers.containers;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/postgis/pom.xml
+++ b/postgis/pom.xml
@@ -97,6 +97,44 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>no-docker</id>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -137,6 +137,43 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.postgres.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    com.pgvector.*;resolution:=optional,\
+                                    org.jdbi.v3.json.*;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
                 <configuration>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -98,6 +98,43 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>native</id>

--- a/spring5/pom.xml
+++ b/spring5/pom.xml
@@ -101,6 +101,38 @@
                     <skipNativeTests>true</skipNativeTests>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/sqlite/pom.xml
+++ b/sqlite/pom.xml
@@ -43,4 +43,42 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/sqlobject/pom.xml
+++ b/sqlobject/pom.xml
@@ -128,4 +128,45 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.sqlobject.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    jakarta.annotation;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/stringtemplate4/pom.xml
+++ b/stringtemplate4/pom.xml
@@ -103,4 +103,44 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    org.jdbi.v3.sqlobject*;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -308,6 +308,41 @@
                     </exceptions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    org.testcontainers.junit.jupiter;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -122,6 +122,50 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                Bundle-SymbolicName: ${moduleName}
+                                Import-Package:\
+                                    com.opentable.db.postgres.*;resolution:=optional,\
+                                    de.softwareforge.testing.postgres.*;resolution:=optional,\
+                                    org.flywaydb.core*;resolution:=optional,\
+                                    org.h2*;resolution:=optional,\
+                                    org.junit;resolution:=optional,\
+                                    org.junit.jupiter.api*;resolution:=optional,\
+                                    org.junit.rules;resolution:=optional,\
+                                    org.junit.runner*;resolution:=optional,\
+                                    org.postgresql*;resolution:=optional,\
+                                    org.sqlite;resolution:=optional,\
+                                    *
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -76,4 +76,42 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                -exportcontents: org.jdbi.v3.*
+                                -metainf-services: auto
+                                Bundle-SymbolicName: ${moduleName}
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This implements #2247: all published jdbi3 modules now ship OSGi bundle manifests, generated at build time by `bnd-maven-plugin` (`bnd-process` goal). The plugin version is managed in the build parent; each module carries its own inline `<bnd>` instructions, and `maven-jar-plugin` picks up the generated manifest on the `default-jar` execution only (`-tests` jars are unchanged).

### Design

- `Bundle-SymbolicName` = the JPMS `Automatic-Module-Name` (`${moduleName}`).
- `-exportcontents: org.jdbi.v3.*` — every package in each jar is exported, including `.internal` packages. Jdbi's internals are a de-facto inter-module API (e.g. sqlobject imports `org.jdbi.v3.core.internal`), so hiding them would make the downstream bundles unresolvable. Exports carry the bundle version, so inter-module imports get proper computed ranges (`[3.54,4)`).
- Imports mirror the poms: Maven `<optional>` dependencies that are referenced in bytecode are declared `resolution:=optional` (`com.pgvector` and `org.jdbi.v3.json` in postgres, `org.jdbi.v3.sqlobject` in freemarker/stringtemplate4/jpa, `jakarta.annotation`, `jdk.jfr`, errorprone annotations, the junit/flyway/driver packages in testing, …). Everything else keeps bnd's computed mandatory import with a version range.
- core additionally has:
  - `Import-Package: !org.antlr.v4.runtime*` — the antlr runtime is inlined/relocated by `inline-maven-plugin` *after* the manifest is generated, so it must not be imported (the relocated packages stay private, verified);
  - `DynamicImport-Package: *` — so `Jdbi.create(url)`/`DriverManager` can see driver classes registered by driver bundles (same approach as EclipseLink and Hibernate);
  - Aries SPI-Fly consumer headers (`osgi.serviceloader.processor`, both `resolution:=optional`) so the deprecated `installPlugins()` ServiceLoader path works under an SPI-Fly-equipped framework.
- Modules that ship `META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin` use `-metainf-services: auto`, which advertises the plugins via `osgi.serviceloader` capabilities; SPI-Fly registers them as OSGi services.
- bnd is deliberately **not** gated behind `basepom.check.*`, so release builds keep the headers, and reproducible builds are preserved (no `Bnd-LastModified`; the existing `compare-reproducible` job passes).

### Verification

- `make install` passes on the full reactor.
- Runtime-tested on WSO2 Micro Integrator 4.6.0 (Equinox + Aries SPI-Fly). All module bundles resolve and start:

```
g! ss jdbi
"Framework is launched."

id	State       Bundle
175	ACTIVE      org.jdbi.v3.cache.noop_3.54.1.SNAPSHOT
176	ACTIVE      org.jdbi.v3.caffeine_3.54.1.SNAPSHOT
177	ACTIVE      org.jdbi.v3.commonstext_3.54.1.SNAPSHOT
178	ACTIVE      org.jdbi.v3.core_3.54.1.SNAPSHOT
179	ACTIVE      org.jdbi.v3.freemarker_3.54.1.SNAPSHOT
180	ACTIVE      org.jdbi.v3.generator_3.54.1.SNAPSHOT
181	ACTIVE      org.jdbi.v3.gson2_3.54.1.SNAPSHOT
182	ACTIVE      org.jdbi.v3.guava_3.54.1.SNAPSHOT
183	ACTIVE      org.jdbi.v3.guice_3.54.1.SNAPSHOT
184	ACTIVE      org.jdbi.v3.jackson2_3.54.1.SNAPSHOT
185	ACTIVE      org.jdbi.v3.jackson3_3.54.1.SNAPSHOT
186	ACTIVE      org.jdbi.v3.jodatime2_3.54.1.SNAPSHOT
187	ACTIVE      org.jdbi.v3.jpa_3.54.1.SNAPSHOT
188	ACTIVE      org.jdbi.v3.json_3.54.1.SNAPSHOT
189	ACTIVE      org.jdbi.v3.kotlin_3.54.1.SNAPSHOT
190	ACTIVE      org.jdbi.v3.moshi_3.54.1.SNAPSHOT
191	ACTIVE      org.jdbi.v3.mysql_3.54.1.SNAPSHOT
192	ACTIVE      org.jdbi.v3.opentelemetry_3.54.1.SNAPSHOT
193	ACTIVE      org.jdbi.v3.oracle12_3.54.1.SNAPSHOT
194	ACTIVE      org.jdbi.v3.postgis_3.54.1.SNAPSHOT
195	ACTIVE      org.jdbi.v3.postgres_3.54.1.SNAPSHOT
196	ACTIVE      org.jdbi.v3.spring_3.54.1.SNAPSHOT
197	ACTIVE      org.jdbi.v3.spring5_3.54.1.SNAPSHOT
198	ACTIVE      org.jdbi.v3.sqlite_3.54.1.SNAPSHOT
199	ACTIVE      org.jdbi.v3.sqlobject_3.54.1.SNAPSHOT
200	ACTIVE      org.jdbi.v3.sqlobject.kotlin_3.54.1.SNAPSHOT
201	ACTIVE      org.jdbi.v3.stringtemplate4_3.54.1.SNAPSHOT
202	ACTIVE      org.jdbi.v3.testcontainers_3.54.1.SNAPSHOT
203	ACTIVE      org.jdbi.v3.testing_3.54.1.SNAPSHOT
204	ACTIVE      org.jdbi.v3.vavr_3.54.1.SNAPSHOT
```

- End-to-end test of core/sqlobject/json/jackson2/postgres inside the running container: `@SqlUpdate` methods executed against a PostgreSQL database, including a `Map<String, String>` ↔ `hstore` mapping.
- ServiceLoader path tested deliberately: with all explicit `installPlugin(...)` calls removed, `installPlugins()` discovers and installs the plugins via SPI-Fly bytecode weaving — providers register correctly. The usual OSGi caveat applies: `installPlugins()` takes a one-shot snapshot, so bundle start ordering matters; explicit plugin registration (as the deprecation note already recommends) or consuming the `JdbiPlugin` OSGi services that SPI-Fly registers are the robust alternatives.

### Notes

- core needs slf4j 2.x at runtime (`org.slf4j;[2.0,3)`) — `Slf4JSqlLogger` uses slf4j 2 API (`Logger.atLevel`). This is the honest range for what the code requires.
- moshi and pgvector publish no OSGi metadata upstream, so those (optional/mandatory) imports are unversioned.
- guice 5.1.0's own manifest pins guava at `[30.1,31)`, which conflicts with the guava range jdbi builds against; running jdbi3-guice under OSGi works with Guice 7.x, whose range matches current guava. Not something jdbi's manifests can fix.
- bnd 7 emits `java.*` package imports (OSGi R7+ style); frameworks older than ~2018 would need `-noimportjava: true`, which I did not add.

Per AI-GUIDELINES.md: this PR was developed with AI assistance (Claude Code). I reviewed all changes, and built and runtime-verified the result myself. Please apply the `AI` label — I cannot set labels on this repository.
