### PR TITLE
Materialize ConfigRegistry copies lazily instead of caching derived attach configurations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+- `ConfigRegistry.createCopy()` now materializes each config object lazily on its first access instead
+  of copying every config object eagerly. This removes most of the allocation cost of extension attach
+  (`Jdbi#onDemand` re-attaches on every call), of `Handle` creation, and of statement creation
+  (#2982, thanks @ulmetrs!). If code depends on the exact moment a copy is taken, restore the old
+  timing with `ConfigRegistry#setEagerCopies(true)` (Alpha).
 - Fix jdbi3-spring excluding spring-jcl from consumers since 3.51.0, which broke Spring Boot 3
   applications at startup with `NoClassDefFoundError: org.apache.commons.logging.LogFactory` (#2990)
 - Fix PreparedBatch NPE when rows bind different runtime types, e.g. mixed bean subclasses (#2974, thanks @arimu1!)

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/OnDemandAttachBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/OnDemandAttachBenchmark.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Exercises the per-{@code attach} configuration derivation cost.
+ *
+ * <p>{@link Jdbi#onDemand(Class)} (and {@link Jdbi#withExtension}) re-attaches the extension on every
+ * method call against the same, stable {@code Jdbi}-level configuration. Each attach derives an
+ * instance configuration plus one configuration per extension method, each a full
+ * {@code ConfigRegistry.createCopy()}. The {@code ManyMethodDao} below has many methods so that the
+ * {@code 1 + methodCount} copies dominate, making the effect of caching the derived configurations
+ * visible. {@link #handleAttach()} attaches against a per-{@link Handle} configuration (a one-shot
+ * attach source that does not benefit from the cache) and is included to confirm there is no
+ * regression on that path.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@Measurement(time = 5, iterations = 5)
+@Warmup(time = 5, iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+public class OnDemandAttachBenchmark {
+
+    private Jdbi jdbi;
+    private Handle handle;
+
+    @Setup(Level.Iteration)
+    public void setUp() {
+        jdbi = Jdbi.create("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=10");
+        jdbi.installPlugin(new SqlObjectPlugin());
+        jdbi.registerRowMapper(Data.class, new DataMapper());
+
+        handle = jdbi.open();
+        handle.execute("drop table if exists tbl");
+        handle.execute("create table tbl (id identity, name varchar, description varchar)");
+        handle.execute("insert into tbl (id, name, description) values (0, 'name', 'description')");
+    }
+
+    @TearDown(Level.Iteration)
+    public void close() {
+        if (handle != null) {
+            handle.close();
+            handle = null;
+        }
+        jdbi = null;
+    }
+
+    /**
+     * On-demand style attach: re-attaches against the stable {@code Jdbi} configuration on every call,
+     * so the derived configurations can be cached and reused.
+     */
+    @Benchmark
+    public Data onDemandAttach() {
+        return jdbi.withExtension(ManyMethodDao.class, dao -> dao.getById(0));
+    }
+
+    /**
+     * Opens a fresh {@link Handle} per call and attaches against its per-handle configuration — a
+     * one-shot attach source (a new configuration each call) that does <em>not</em> reuse cached
+     * configurations. This mirrors the typical open-handle-per-unit-of-work pattern and confirms there
+     * is no regression on the path the cache cannot help.
+     */
+    @Benchmark
+    public Data handleAttach() {
+        try (Handle h = jdbi.open()) {
+            return h.attach(ManyMethodDao.class).getById(0);
+        }
+    }
+
+    @RegisterRowMapper(DataMapper.class)
+    public interface ManyMethodDao {
+
+        @SqlQuery("select * from tbl where id = :id")
+        Data getById(@Bind("id") long id);
+
+        @SqlQuery("select * from tbl order by id")
+        List<Data> listAll();
+
+        @SqlQuery("select * from tbl where name = :name")
+        Data getByName(@Bind("name") String name);
+
+        @SqlQuery("select * from tbl where description = :description")
+        Data getByDescription(@Bind("description") String description);
+
+        @SqlQuery("select count(*) from tbl")
+        long count();
+
+        @SqlQuery("select name from tbl where id = :id")
+        String nameById(@Bind("id") long id);
+
+        @SqlQuery("select description from tbl where id = :id")
+        String descriptionById(@Bind("id") long id);
+
+        @SqlQuery("select id from tbl order by id")
+        List<Long> listIds();
+
+        @SqlQuery("select * from tbl where id > :id")
+        List<Data> listAfter(@Bind("id") long id);
+
+        @SqlQuery("select * from tbl where id < :id")
+        List<Data> listBefore(@Bind("id") long id);
+    }
+
+    public static class Data {
+
+        private final int id;
+        private final String name;
+        private final String description;
+
+        public Data(int id, String name, String description) {
+            this.id = id;
+            this.name = name;
+            this.description = description;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public String description() {
+            return description;
+        }
+    }
+
+    public static class DataMapper implements RowMapper<Data> {
+
+        @Override
+        public Data map(final ResultSet r, final StatementContext ctx) throws SQLException {
+            return new Data(r.getInt("id"), r.getString("name"), r.getString("description"));
+        }
+    }
+}

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/OnDemandAttachBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/OnDemandAttachBenchmark.java
@@ -45,12 +45,11 @@ import org.openjdk.jmh.annotations.Warmup;
  *
  * <p>{@link Jdbi#onDemand(Class)} (and {@link Jdbi#withExtension}) re-attaches the extension on every
  * method call against the same, stable {@code Jdbi}-level configuration. Each attach derives an
- * instance configuration plus one configuration per extension method, each a full
+ * instance configuration plus one configuration per extension method, each a
  * {@code ConfigRegistry.createCopy()}. The {@code ManyMethodDao} below has many methods so that the
- * {@code 1 + methodCount} copies dominate, making the effect of caching the derived configurations
- * visible. {@link #handleAttach()} attaches against a per-{@link Handle} configuration (a one-shot
- * attach source that does not benefit from the cache) and is included to confirm there is no
- * regression on that path.
+ * {@code 1 + methodCount} copies dominate the cost of a call. {@link #handleAttach()} opens a fresh
+ * {@link Handle} per call and attaches against the per-{@link Handle} configuration, so it also
+ * measures the copy that each {@link Handle} takes from the {@code Jdbi} configuration.
  */
 @State(Scope.Thread)
 @BenchmarkMode(Mode.Throughput)
@@ -85,8 +84,7 @@ public class OnDemandAttachBenchmark {
     }
 
     /**
-     * On-demand style attach: re-attaches against the stable {@code Jdbi} configuration on every call,
-     * so the derived configurations can be cached and reused.
+     * On-demand style attach: re-attaches against the stable {@code Jdbi} configuration on every call.
      */
     @Benchmark
     public Data onDemandAttach() {
@@ -94,10 +92,8 @@ public class OnDemandAttachBenchmark {
     }
 
     /**
-     * Opens a fresh {@link Handle} per call and attaches against its per-handle configuration — a
-     * one-shot attach source (a new configuration each call) that does <em>not</em> reuse cached
-     * configurations. This mirrors the typical open-handle-per-unit-of-work pattern and confirms there
-     * is no regression on the path the cache cannot help.
+     * Opens a fresh {@link Handle} per call and attaches against its per-handle configuration. This
+     * mirrors the typical open-handle-per-unit-of-work pattern.
      */
     @Benchmark
     public Data handleAttach() {

--- a/core/src/main/java/org/jdbi/v3/core/config/ConfigRegistry.java
+++ b/core/src/main/java/org/jdbi/v3/core/config/ConfigRegistry.java
@@ -13,9 +13,12 @@
  */
 package org.jdbi.v3.core.config;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import org.jdbi.v3.core.argument.Arguments;
@@ -26,9 +29,19 @@ import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.core.mapper.Mappers;
 import org.jdbi.v3.core.mapper.RowMappers;
 import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.meta.Alpha;
 
 /**
  * A registry of {@link JdbiConfig} instances by type.
+ *
+ * <p>A registry returned by {@link #createCopy()} materializes each config object lazily: the first
+ * {@link #get(Class)} for a config type copies the source registry's instance at that moment. Once
+ * materialized, the copy is private to this registry, so changes to it do not modify the source and
+ * vice-versa. If the source does not hold the config type yet, the first access creates a default
+ * instance in the source and then copies it. Configuration is expected to be finalized before Jdbi is
+ * used; a source registry that is reconfigured between {@code createCopy()} and the copy's first access
+ * of the changed config type is observed with the new value. Call {@link #setEagerCopies(boolean)} to
+ * restore copy-at-creation timing instead.
  *
  * @see Configurable
  */
@@ -38,11 +51,14 @@ public final class ConfigRegistry {
 
     private final Map<Class<? extends JdbiConfig<?>>, JdbiConfig<?>> configs = new ConcurrentHashMap<>(32);
     private final Map<Class<? extends JdbiConfig<?>>, Function<ConfigRegistry, JdbiConfig<?>>> configFactories;
+    private final ConfigRegistry source;
+    private final AtomicBoolean eagerCopies = new AtomicBoolean();
 
     /**
      * Creates a new config registry.
      */
     public ConfigRegistry() {
+        source = null;
         configFactories = new ConcurrentHashMap<>();
         get(ConfigCaches.class);
         get(SqlStatements.class);
@@ -55,16 +71,22 @@ public final class ConfigRegistry {
 
     private ConfigRegistry(ConfigRegistry that) {
         configFactories = that.configFactories;
-        that.configs.forEach((type, config) -> {
-            JdbiConfig<?> copy = config.createCopy();
-            configs.put(type, copy);
-        });
-        configs.values().forEach(c -> c.setRegistry(this));
+        final boolean eager = that.eagerCopies.get();
+        eagerCopies.set(eager);
+        if (eager) {
+            source = null;
+            for (Class<? extends JdbiConfig<?>> type : that.knownConfigTypes()) {
+                configs.put(type, that.lookup(type).createCopy());
+            }
+            configs.values().forEach(c -> c.setRegistry(this));
+        } else {
+            source = that;
+        }
     }
 
     /**
      * Returns this registry's instance of the given config class. Creates an instance on-demand if this registry does
-     * not have one of the given type yet.
+     * not have one of the given type yet, copying the source registry's instance if this registry is a copy.
      *
      * @param configClass the config class type.
      * @param <C>         the config class type.
@@ -76,7 +98,13 @@ public final class ConfigRegistry {
         if (lookup != null) {
             return configClass.cast(lookup);
         }
-        C config = configClass.cast(configFactory(configClass).apply(this));
+        final C config;
+        if (source != null) {
+            config = configClass.cast(source.get(configClass).createCopy());
+            config.setRegistry(this);
+        } else {
+            config = configClass.cast(configFactory(configClass).apply(this));
+        }
         return Optional.ofNullable(configClass.cast(configs.putIfAbsent(configClass, config))).orElse(config);
     }
 
@@ -92,6 +120,32 @@ public final class ConfigRegistry {
     }
 
     /**
+     * Returns the config types this registry knows about: its own materialized configs plus, for a lazy
+     * copy, every type known to the registries it copies from.
+     */
+    private Set<Class<? extends JdbiConfig<?>>> knownConfigTypes() {
+        final Set<Class<? extends JdbiConfig<?>>> types = new LinkedHashSet<>();
+        for (ConfigRegistry registry = this; registry != null; registry = registry.source) {
+            types.addAll(registry.configs.keySet());
+        }
+        return types;
+    }
+
+    /**
+     * Returns the effective config instance for the given type without materializing a copy: the nearest
+     * instance along the source chain, or null if no registry in the chain has one.
+     */
+    private JdbiConfig<?> lookup(Class<? extends JdbiConfig<?>> configClass) {
+        for (ConfigRegistry registry = this; registry != null; registry = registry.source) {
+            final JdbiConfig<?> config = registry.configs.get(configClass);
+            if (config != null) {
+                return config;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Returns a copy of this config registry.
      *
      * @return a copy of this config registry
@@ -100,5 +154,31 @@ public final class ConfigRegistry {
      */
     public ConfigRegistry createCopy() {
         return new ConfigRegistry(this);
+    }
+
+    /**
+     * Controls when {@link #createCopy()} copies the config objects. The default (false) materializes each
+     * config object on its first access in the copy. Set true to copy every config object at
+     * {@code createCopy()} time, the behavior of Jdbi releases before 3.55.0. Use this only if code depends
+     * on the exact moment a copy is taken; it restores the old allocation cost on every copy.
+     *
+     * <p>Copies inherit the mode this registry has when {@code createCopy()} runs. Set the flag on the
+     * {@link org.jdbi.v3.core.Jdbi} registry before handles or extensions are created.
+     *
+     * @param eagerCopies true to copy config objects at {@code createCopy()} time
+     */
+    @Alpha
+    public void setEagerCopies(boolean eagerCopies) {
+        this.eagerCopies.set(eagerCopies);
+    }
+
+    /**
+     * Returns true if {@link #createCopy()} copies all config objects immediately.
+     *
+     * @return true if {@link #createCopy()} copies all config objects immediately
+     */
+    @Alpha
+    public boolean isEagerCopies() {
+        return eagerCopies.get();
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
+++ b/core/src/main/java/org/jdbi/v3/core/extension/ExtensionMetadata.java
@@ -80,7 +80,8 @@ public final class ExtensionMetadata {
      * Create an instance specific configuration based on all instance customizers. The instance configuration holds all
      * custom configuration that was applied e.g. through instance annotations.
      *
-     * @param config A configuration object. The object is not changed
+     * @param config The source configuration. Its settings are not changed, but the derived configuration
+     *               creates default config objects in it for config types it does not hold yet
      * @return A new configuration object with all changes applied
      */
     public ConfigRegistry createInstanceConfiguration(ConfigRegistry config) {
@@ -94,7 +95,8 @@ public final class ExtensionMetadata {
      * custom configuration that was applied e.g. through method annotations.
      *
      * @param method The method that is about to be called
-     * @param config A configuration object. The object is not changed
+     * @param config The source configuration. Its settings are not changed, but the derived configuration
+     *               creates default config objects in it for config types it does not hold yet
      * @return A new configuration object with all changes applied
      */
     public ConfigRegistry createMethodConfiguration(Method method, ConfigRegistry config) {

--- a/core/src/test/java/org/jdbi/v3/core/config/TestConfigRegistryCopyTiming.java
+++ b/core/src/test/java/org/jdbi/v3/core/config/TestConfigRegistryCopyTiming.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.jdbi.v3.core.config.TestConfigRegistry.TestConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the timing of {@link ConfigRegistry#createCopy()}: by default a copy materializes each config
+ * object on first access, while {@link ConfigRegistry#setEagerCopies(boolean)} restores the
+ * copy-at-creation timing of releases before 3.55.0.
+ */
+public class TestConfigRegistryCopyTiming {
+
+    @Test
+    public void lazyCopySeesSourceChangeBeforeFirstAccess() {
+        ConfigRegistry parent = new ConfigRegistry();
+        parent.get(TestConfig.class).addList("list1");
+
+        ConfigRegistry copy = parent.createCopy();
+        parent.get(TestConfig.class).addList("list2");
+
+        assertThat(copy.get(TestConfig.class).getList()).containsExactly("list1", "list2");
+    }
+
+    @Test
+    public void lazyCopyIsIsolatedAfterFirstAccess() {
+        ConfigRegistry parent = new ConfigRegistry();
+        parent.get(TestConfig.class).addList("list1");
+
+        ConfigRegistry copy = parent.createCopy();
+        TestConfig copyConfig = copy.get(TestConfig.class);
+
+        parent.get(TestConfig.class).addList("list2");
+        copyConfig.addList("list3");
+
+        assertThat(copyConfig.getList()).containsExactly("list1", "list3");
+        assertThat(parent.get(TestConfig.class).getList()).containsExactly("list1", "list2");
+    }
+
+    @Test
+    public void configCreatedThroughLazyCopyIsIsolated() {
+        ConfigRegistry parent = new ConfigRegistry();
+
+        ConfigRegistry copy = parent.createCopy();
+        copy.get(TestConfig.class).addList("copy-only");
+
+        assertThat(parent.get(TestConfig.class).getList()).isEmpty();
+    }
+
+    @Test
+    public void concurrentFirstAccessMaterializesOneInstance() throws Exception {
+        ConfigRegistry parent = new ConfigRegistry();
+        parent.get(TestConfig.class).addList("list1");
+        ConfigRegistry copy = parent.createCopy();
+
+        int threads = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<TestConfig>> futures = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                futures.add(executor.submit(() -> {
+                    start.await();
+                    return copy.get(TestConfig.class);
+                }));
+            }
+            start.countDown();
+
+            Set<TestConfig> materialized = Collections.newSetFromMap(new IdentityHashMap<>());
+            for (Future<TestConfig> future : futures) {
+                materialized.add(future.get(10, TimeUnit.SECONDS));
+            }
+
+            assertThat(materialized).hasSize(1);
+            TestConfig copyConfig = copy.get(TestConfig.class);
+            assertThat(materialized).containsExactly(copyConfig);
+            assertThat(copyConfig).isNotSameAs(parent.get(TestConfig.class));
+            assertThat(copyConfig.getList()).containsExactly("list1");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void eagerCopyTakesSnapshotAtCopyTime() {
+        ConfigRegistry parent = new ConfigRegistry();
+        parent.setEagerCopies(true);
+        parent.get(TestConfig.class).addList("list1");
+
+        ConfigRegistry copy = parent.createCopy();
+        parent.get(TestConfig.class).addList("list2");
+
+        assertThat(copy.get(TestConfig.class).getList()).containsExactly("list1");
+        assertThat(parent.get(TestConfig.class).getList()).containsExactly("list1", "list2");
+    }
+
+    @Test
+    public void copiesInheritEagerMode() {
+        ConfigRegistry parent = new ConfigRegistry();
+        parent.setEagerCopies(true);
+
+        ConfigRegistry copy = parent.createCopy();
+        assertThat(copy.isEagerCopies()).isTrue();
+
+        ConfigRegistry grandchild = copy.createCopy();
+        assertThat(grandchild.isEagerCopies()).isTrue();
+    }
+
+    @Test
+    public void eagerCopyOfLazyCopyIncludesUnmaterializedConfigs() {
+        ConfigRegistry root = new ConfigRegistry();
+        root.get(TestConfig.class).addList("list1");
+
+        ConfigRegistry lazy = root.createCopy();
+        lazy.setEagerCopies(true);
+        ConfigRegistry eager = lazy.createCopy();
+
+        root.get(TestConfig.class).addList("list2");
+
+        assertThat(eager.get(TestConfig.class).getList()).containsExactly("list1");
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionConfigIsolation.java
+++ b/core/src/test/java/org/jdbi/v3/core/extension/TestExtensionConfigIsolation.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.extension;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
+
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.config.TestConfigRegistry.TestConfig;
+import org.jdbi.v3.core.extension.annotation.UseExtensionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the per-attach isolation contract of {@link ExtensionMetadata#createInstanceConfiguration(ConfigRegistry)}
+ * and {@link ExtensionMetadata#createMethodConfiguration(Method, ConfigRegistry)}: every derivation returns a
+ * private configuration, later derivations observe reconfiguration of the source registry, and mutation of a
+ * derived configuration does not leak into the source or into other derivations.
+ */
+public class TestExtensionConfigIsolation {
+
+    private ConfigRegistry root;
+    private ExtensionMetadata metadata;
+    private Method doThing;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        root = new ConfigRegistry();
+        Extensions extensions = root.get(Extensions.class);
+        extensions.register(new ExtensionFrameworkTestFactory());
+        metadata = extensions.findMetadata(Dao.class, new ExtensionFrameworkTestFactory());
+        doThing = Dao.class.getMethod("doThing");
+    }
+
+    @Test
+    public void everyDerivationIsPrivate() {
+        ConfigRegistry instance1 = metadata.createInstanceConfiguration(root);
+        ConfigRegistry instance2 = metadata.createInstanceConfiguration(root);
+        assertThat(instance2).isNotSameAs(instance1);
+
+        ConfigRegistry method1 = metadata.createMethodConfiguration(doThing, instance1);
+        ConfigRegistry method2 = metadata.createMethodConfiguration(doThing, instance1);
+        assertThat(method2).isNotSameAs(method1);
+    }
+
+    @Test
+    public void laterDerivationObservesSourceReconfiguration() {
+        metadata.createInstanceConfiguration(root).get(TestConfig.class);
+
+        root.get(TestConfig.class).addList("late");
+
+        ConfigRegistry derived = metadata.createInstanceConfiguration(root);
+        assertThat(derived.get(TestConfig.class).getList()).containsExactly("late");
+    }
+
+    @Test
+    public void mutationOfDerivedConfigDoesNotLeak() {
+        ConfigRegistry instance1 = metadata.createInstanceConfiguration(root);
+        instance1.get(TestConfig.class).addList("private");
+
+        assertThat(root.get(TestConfig.class).getList()).isEmpty();
+        ConfigRegistry instance2 = metadata.createInstanceConfiguration(root);
+        assertThat(instance2.get(TestConfig.class).getList()).isEmpty();
+
+        ConfigRegistry method1 = metadata.createMethodConfiguration(doThing, instance1);
+        method1.get(TestConfig.class).addList("method-private");
+        assertThat(instance1.get(TestConfig.class).getList()).containsExactly("private");
+        ConfigRegistry method2 = metadata.createMethodConfiguration(doThing, instance1);
+        assertThat(method2.get(TestConfig.class).getList()).containsExactly("private");
+    }
+
+    public interface Dao {
+        @TestHandler
+        void doThing();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @UseExtensionHandler(id = "test", value = NoOpHandler.class)
+    public @interface TestHandler {}
+
+    public static class NoOpHandler implements ExtensionHandler.Simple {
+        @Override
+        public Object invoke(HandleSupplier handleSupplier, Object... args) {
+            return null;
+        }
+    }
+}

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -558,7 +558,7 @@ Handles are intended to be short-lived and must be closed to release the databas
 A link:{jdbidocs}/core/Handle.html[Handle^] is used to prepare and run SQL statements against the database, and manage database transactions.
 It provides access to fluent statement APIs that can bind arguments, execute the statement, and then map any results into Java objects.
 
-A link:{jdbidocs}/core/Handle.html[Handle^] inherits configuration from the link:{jdbidocs}/core/Jdbi.html[Jdbi^] at the time it is created.
+A link:{jdbidocs}/core/Handle.html[Handle^] inherits configuration from the link:{jdbidocs}/core/Jdbi.html[Jdbi^] that created it.
 See <<Configuration>> for more details.
 
 Handles and all attached query objects such as link:{jdbidocs}/core/statement/Batch.html[Batch^], link:{jdbidocs}/core/statement/Call.html[Call^], link:{jdbidocs}/core/statement/Query.html[Query^], link:{jdbidocs}/core/statement/Script.html[Script^] and link:{jdbidocs}/core/statement/Update.html[Update^] should be used by a single thread and are *not thread-safe*.
@@ -3421,7 +3421,14 @@ Each Jdbi object that represents a distinct database context (for example, link:
 link:{jdbidocs}/core/Handle.html[Handle^] instance, or an attached
 link:{jdbidocs}/sqlobject/SqlObject.html[SqlObject^] class) has a separate config registry instance.
 
-When a new context is created, it inherits a copy of its parent configuration at the time of creation - further modifications to the original will not affect already created configuration contexts.
+When a new context is created, it inherits a copy of its parent configuration.
+Each configuration object is copied when the new context, or a context derived from it, first accesses the object, not when the context is created.
+Once copied, a configuration object is private to its context: changes to the copy do not affect the parent, and changes to the parent do not affect the copy.
+A change to the parent between the creation of the context and its first access of the changed configuration object is visible to the new context.
+Under the documented contract that configuration is set before a context is used, the two moments are equivalent.
+To copy every configuration object when the context is created instead, the behavior of Jdbi releases before 3.55.0, call
+link:{jdbidocs}/core/config/ConfigRegistry.html#setEagerCopies(boolean)[ConfigRegistry#setEagerCopies^]
+on the link:{jdbidocs}/core/Jdbi.html[Jdbi^] configuration before any handle or extension is created.
 Configuration context copies happen when creating a
 link:{jdbidocs}/core/Handle.html[Handle^] from
 link:{jdbidocs}/core/Jdbi.html[Jdbi^], when opening a
@@ -9722,7 +9729,14 @@ link:{jdbidocs}/sqlobject/SqlObject.html[SqlObject^] class) has a separate confi
 A context implements the
 link:{jdbidocs}/core/config/Configurable.html[Configurable^] interface which allows modification of its configuration as well as retrieving the current context's configuration for use by Jdbi core or extensions.
 
-When a new context is created, it inherits a copy of its parent configuration at the time of creation - further modifications to the original will not affect already created configuration contexts.
+When a new context is created, it inherits a copy of its parent configuration.
+Each configuration object is copied when the new context, or a context derived from it, first accesses the object, not when the context is created.
+Once copied, a configuration object is private to its context: changes to the copy do not affect the parent, and changes to the parent do not affect the copy.
+A change to the parent between the creation of the context and its first access of the changed configuration object is visible to the new context.
+Under the documented contract that configuration is set before a context is used, the two moments are equivalent.
+To copy every configuration object when the context is created instead, the behavior of Jdbi releases before 3.55.0, call
+link:{jdbidocs}/core/config/ConfigRegistry.html#setEagerCopies(boolean)[ConfigRegistry#setEagerCopies^]
+on the link:{jdbidocs}/core/Jdbi.html[Jdbi^] configuration before any handle or extension is created.
 Configuration context copies happen when creating a
 link:{jdbidocs}/core/Handle.html[Handle^] from
 link:{jdbidocs}/core/Jdbi.html[Jdbi^], when opening a

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReconfigureAfterAttach.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestReconfigureAfterAttach.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.sqlobject;
+
+import java.util.List;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.Something;
+import org.jdbi.v3.core.mapper.SomethingMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins that configuration added after an extension's first use is observed by later uses: the Jdbi
+ * root configuration for on-demand extensions, and a handle's local configuration for repeated
+ * {@link Handle#attach(Class)} calls on the same handle.
+ */
+public class TestReconfigureAfterAttach {
+
+    @RegisterExtension
+    public JdbiExtension h2Extension = JdbiExtension.h2().withInitializer(TestingInitializers.something()).withPlugin(new SqlObjectPlugin());
+
+    @Test
+    public void onDemandObservesMapperRegisteredAfterFirstUse() {
+        Jdbi jdbi = h2Extension.getJdbi();
+        Dao dao = jdbi.onDemand(Dao.class);
+
+        dao.insert(1, "brian");
+        jdbi.registerRowMapper(new SomethingMapper());
+
+        assertThat(dao.list()).extracting(Something::getName).containsExactly("brian");
+    }
+
+    @Test
+    public void repeatedAttachObservesHandleLocalRegistration() {
+        try (Handle handle = h2Extension.getJdbi().open()) {
+            handle.attach(Dao.class).insert(1, "brian");
+            handle.registerRowMapper(new SomethingMapper());
+
+            assertThat(handle.attach(Dao.class).list()).extracting(Something::getName).containsExactly("brian");
+        }
+    }
+
+    public interface Dao {
+        @SqlUpdate("insert into something (id, name) values (:id, :name)")
+        void insert(@Bind("id") int id, @Bind("name") String name);
+
+        @SqlQuery("select id, name from something")
+        List<Something> list();
+    }
+}

--- a/sqlobject/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-sqlobject/reachability-metadata.json
+++ b/sqlobject/src/test/resources/META-INF/native-image/org.jdbi/jdbi3-sqlobject/reachability-metadata.json
@@ -128,6 +128,7 @@
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestReadOnly$RODao"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestReentrancy$TheBasics"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestReentrancy$TheBasics","org.jdbi.v3.sqlobject.SqlObject"]}},
+    {"type":{"proxy":["org.jdbi.v3.sqlobject.TestReconfigureAfterAttach$Dao"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestRegisterArgumentFactory$ShortStack"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestRegisterArgumentFactory$Waffle"]}},
     {"type":{"proxy":["org.jdbi.v3.sqlobject.TestRegisterConstructorMapper$Dao"]}},


### PR DESCRIPTION
# Materialize ConfigRegistry copies lazily instead of caching derived attach configurations

## Summary

This PR keeps the contribution from #2982 (thanks @ulmetrs!) and reworks the mechanism one level down.

The problem is real and well measured in #2982. Each extension attach performs one full `ConfigRegistry.createCopy()` for the instance configuration, plus one per extension method. `Jdbi#onDemand` re-attaches on every method call, so on-demand-heavy workloads repeat 1 + methodCount registry copies per call (#1103).

#2982 memoized the derived configurations per source registry. The memoization freezes them at first use, and that breaks supported reconfiguration patterns (see below). This PR removes the freeze and makes the copy itself cheap instead: `ConfigRegistry.createCopy()` now records the source registry and copies each `JdbiConfig` on its first access. A copy is O(1) to create, and an attach only pays for the config objects the extension method actually touches.

Every attach still derives a private configuration, so the semantics of #1103's hotspot users stay intact:

- Configuration added to the `Jdbi` after the first on-demand use is observed by later calls.
- Repeated `Handle#attach` on one handle observes registrations made on that handle between attaches.
- Mutation of a derived configuration from inside an extension method stays private to that attach.

The lazy copy applies to all `createCopy()` callers, so it also removes the eager copy cost per `Handle` and per statement, which the cache did not reach.

## What the cache froze

Differential tests fail on the #2982 head and pass on its merge base:

1. `jdbi.onDemand(Dao.class)`, one call, then `jdbi.registerRowMapper(...)`: the next call threw `NoSuchMapperException`. The first attach froze the derived configuration in the root registry with no invalidation.
2. A handle's config registry is created once per handle, not once per attach, so the "one-shot attach source" premise for `Handle#attach` does not hold. Repeated attaches on one handle shared the frozen entry and ignored handle-local registrations made between them.
3. The cached method configuration becomes the handle's live configuration during invocation. A DAO default method that called `getHandle().define(...)` or `registerRowMapper(...)` wrote into a registry shared across threads and across future attaches.

Invalidation is not a fix here: configuration mutations are plain setters on `JdbiConfig` objects, so the registry has no point where it can observe them.

## Semantics and the compatibility flag

A copy now materializes each config object at its first access instead of at `createCopy()` time. If code changes a source registry between `createCopy()` and the copy's first access of the changed config type, the copy observes the new value. Under the documented contract (configuration is finalized before use) the two timings are equivalent. The pre-existing `TestConfigRegistry` suite passes unchanged.

For code that depends on the exact copy moment, `ConfigRegistry#setEagerCopies(true)` (Alpha) restores copy-at-creation timing, at the old allocation cost. Copies inherit the mode their source has at copy time, so set the flag on the `Jdbi` registry before handles or extensions are created. The flag is also a bisect tool: if an upgrade shows a configuration-timing problem, the flag confirms or excludes this change as the cause.

## Changes

- `ConfigRegistry`: lazy copy on read, plus `setEagerCopies`/`isEagerCopies` (Alpha).
- `ExtensionMetadata`: derivation is back to the pre-#2982 form. `ExtensionConfigCache` is removed.
- `OnDemandAttachBenchmark` from #2982 is kept unchanged.
- New tests: `TestConfigRegistryCopyTiming` (lazy and eager timing, mode inheritance, eager copy of a lazy copy), `TestExtensionConfigIsolation` (per-attach isolation, late reconfiguration at the `ExtensionMetadata` level), `TestReconfigureAfterAttach` (end-to-end on-demand and repeated-attach reconfiguration, sqlobject).
- Release notes entry.

## Benchmark

`OnDemandAttachBenchmark` from #2982, unchanged, at its full settings (2 forks, 5x5s warmup, 5x5s measurement), allocation via `-prof gc`. OpenJDK 26.0.2, Linux x86_64, 4 CPUs. The baseline is current master (`6d2422937`) with only the benchmark class added:

| Benchmark | master | this PR | allocation | throughput |
| --- | --- | --- | --- | --- |
| `onDemandAttach` | 92,242 B/op @ 21.1 ops/ms | 54,690 B/op @ 31.9 ops/ms | -41% | 1.51x |
| `handleAttach` (fresh handle per call) | 253,347 B/op @ 6.5 ops/ms | 217,127 B/op @ 7.7 ops/ms | -14% | 1.18x |

The on-demand path keeps most of the win the cache measured in #2982. The `handleAttach` path, which the cache could not improve (#2982 measured +1.3% allocation there), improves as well, because the per-`Handle` and per-statement copies are also lazy now.

## Compatibility

- Public API: two new `@Alpha` methods on `ConfigRegistry`. japicmp and the static analyzers pass.
- The full multi-module suite passes.

Refs #2982, #1103.
