### PR TITLE
QualifiedType: identify member-less qualifiers by type, not a synthesized proxy

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,10 @@
 - Fix PreparedBatch NPE when rows bind different runtime types, e.g. mixed bean subclasses (#2974, thanks @arimu1!)
 - Fix DefaultJdbiCache pinning entries when loader throws an exception (#2995)
 - Fix GraalVM native image missing entries and update metadata to new format, support 25.2 (#2994)
+- `QualifiedType` no longer synthesizes an annotation proxy for a qualifier annotation without
+  members, so `QualifiedType.with(Class)` and the built-in `@Legacy`, `@NVarchar`, `@EnumByName`,
+  and `@EncodedJson` qualifiers work in a GraalVM native image without proxy registration.
+  New `QualifiedType.hasQualifiers(Set)` compares qualifiers without materializing annotations. (#2967)
 - stringtemplate4: `StringTemplateEngine` now caches template compilation through the core statement
   cache instead of recompiling on every render, with compiled templates pooled for thread safety.
   The cached path bypasses `render(String, StatementContext)`: a subclass that overrides `render`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,8 @@
 - `QualifiedType` no longer synthesizes an annotation proxy for a qualifier annotation without
   members, so `QualifiedType.with(Class)` and the built-in `@Legacy`, `@NVarchar`, `@EnumByName`,
   and `@EncodedJson` qualifiers work in a GraalVM native image without proxy registration.
-  New `QualifiedType.hasQualifiers(Set)` compares qualifiers without materializing annotations. (#2967)
+  New `QualifiedType.hasQualifiers(Set)` and `hasNoQualifiers()` compare qualifiers without
+  materializing annotations. (#2967)
 - stringtemplate4: `StringTemplateEngine` now caches template compilation through the core statement
   cache instead of recompiling on every render, with compiled templates pooled for thread safety.
   The cached path bypasses `render(String, StatementContext)`: a subclass that overrides `render`

--- a/benchmark/src/main/java/org/jdbi/v3/benchmark/QualifiedTypeBenchmark.java
+++ b/benchmark/src/main/java/org/jdbi/v3/benchmark/QualifiedTypeBenchmark.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.benchmark;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.jdbi.v3.core.enums.EnumByName;
+import org.jdbi.v3.core.qualifier.NVarchar;
+import org.jdbi.v3.core.qualifier.QualifiedType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Measurement(time = 3)
+@Warmup(time = 2)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+public class QualifiedTypeBenchmark {
+    @NVarchar
+    private static final class Holder {}
+
+    private final QualifiedType<String> plain = QualifiedType.of(String.class);
+    private final QualifiedType<String> nvarchar = QualifiedType.of(String.class).with(NVarchar.class);
+    private final Set<Annotation> none = Set.of();
+    private final Set<Annotation> realNvarchar = Set.of(Holder.class.getAnnotation(NVarchar.class));
+
+    @Benchmark
+    public boolean hasQualifiersEmptyMatch() {
+        return plain.hasQualifiers(none);
+    }
+
+    @Benchmark
+    public boolean hasQualifiersOneMatch() {
+        return nvarchar.hasQualifiers(realNvarchar);
+    }
+
+    @Benchmark
+    public boolean hasQualifiersSizeMismatch() {
+        return nvarchar.hasQualifiers(none);
+    }
+
+    @Benchmark
+    public boolean hasQualifier() {
+        return nvarchar.hasQualifier(EnumByName.class);
+    }
+
+    @Benchmark
+    public QualifiedType<String> withClass() {
+        return QualifiedType.of(String.class).with(NVarchar.class);
+    }
+
+    @Benchmark
+    public QualifiedType<String> withAnnotations() {
+        return QualifiedType.of(String.class).withAnnotations(realNvarchar);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/Arguments.java
@@ -143,8 +143,7 @@ public class Arguments implements JdbiConfig<Arguments> {
         // an actual value is seen and defer when seeing nulls.
         //
         if (value != null && expectedClass == Object.class) {
-            var qualifiers = type.getQualifiers();
-            expectedType = QualifiedType.of(value.getClass()).withAnnotations(qualifiers);
+            expectedType = type.mapType(t -> value.getClass());
         } else {
             expectedType = type;
         }

--- a/core/src/main/java/org/jdbi/v3/core/argument/QualifiedArgumentFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/argument/QualifiedArgumentFactory.java
@@ -66,7 +66,7 @@ public interface QualifiedArgumentFactory {
         }
         Set<Annotation> qualifiers = config.get(Qualifiers.class).findFor(factory.getClass());
         return (type, value, cfg) ->
-            type.getQualifiers().equals(qualifiers)
+            type.hasQualifiers(qualifiers)
                 ? factory.build(type.getType(), value, cfg)
                 : Optional.empty();
     }
@@ -116,14 +116,14 @@ public interface QualifiedArgumentFactory {
 
                 @Override
                 public Optional<Argument> build(QualifiedType<?> type, Object value, ConfigRegistry cfg) {
-                    return type.getQualifiers().equals(qualifiers)
+                    return type.hasQualifiers(qualifiers)
                             ? factory.build(type.getType(), value, cfg)
                             : Optional.empty();
                 }
 
                 @Override
                 public Optional<Function<Object, Argument>> prepare(QualifiedType<?> type, ConfigRegistry cfg) {
-                    return type.getQualifiers().equals(qualifiers)
+                    return type.hasQualifiers(qualifiers)
                             ? factory.prepare(type.getType(), cfg)
                             : Optional.empty();
                 }

--- a/core/src/main/java/org/jdbi/v3/core/mapper/Mappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/Mappers.java
@@ -14,6 +14,7 @@
 package org.jdbi.v3.core.mapper;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -104,7 +105,7 @@ public class Mappers implements JdbiConfig<Mappers> {
      * is registered for the given type.
      */
     public <T> Optional<RowMapper<T>> findFor(QualifiedType<T> type) {
-        if (type.getQualifiers().isEmpty()) {
+        if (type.hasQualifiers(Collections.emptySet())) {
             @SuppressWarnings("unchecked")
             Optional<RowMapper<T>> result = rowMappers.findFor(type.getType()).map(m -> (RowMapper<T>) m);
             if (result.isPresent()) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/Mappers.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/Mappers.java
@@ -14,7 +14,6 @@
 package org.jdbi.v3.core.mapper;
 
 import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -105,7 +104,7 @@ public class Mappers implements JdbiConfig<Mappers> {
      * is registered for the given type.
      */
     public <T> Optional<RowMapper<T>> findFor(QualifiedType<T> type) {
-        if (type.hasQualifiers(Collections.emptySet())) {
+        if (type.hasNoQualifiers()) {
             @SuppressWarnings("unchecked")
             Optional<RowMapper<T>> result = rowMappers.findFor(type.getType()).map(m -> (RowMapper<T>) m);
             if (result.isPresent()) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/QualifiedColumnMapperFactory.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/QualifiedColumnMapperFactory.java
@@ -43,8 +43,7 @@ public interface QualifiedColumnMapperFactory {
      * @param factory the factory to adapt
      */
     static QualifiedColumnMapperFactory adapt(ColumnMapperFactory factory) {
-        return (type, config) -> type.getQualifiers().equals(
-                config.get(Qualifiers.class).findFor(factory.getClass()))
+        return (type, config) -> type.hasQualifiers(config.get(Qualifiers.class).findFor(factory.getClass()))
             ? factory.build(type.getType(), config)
             : Optional.empty();
     }

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
@@ -15,19 +15,18 @@ package org.jdbi.v3.core.qualifier;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.StreamSupport;
 
 import org.jdbi.v3.core.generic.GenericType;
 import org.jdbi.v3.core.internal.AnnotationFactory;
 
 import static java.util.Collections.emptySet;
-
-import static org.jdbi.v3.core.internal.CollectionCollectors.toUnmodifiableSet;
 
 /**
  * A {@link java.lang.reflect.Type} qualified by a set of qualifier annotations. Two qualified types are equal to each other
@@ -37,7 +36,8 @@ import static org.jdbi.v3.core.internal.CollectionCollectors.toUnmodifiableSet;
  */
 public final class QualifiedType<T> {
     private final Type type;
-    private final Set<Annotation> qualifiers;
+    private final Set<QualifierKey> qualifiers;
+    private Set<Annotation> annotations;
     private int hashCode;
 
     /**
@@ -71,7 +71,7 @@ public final class QualifiedType<T> {
         return (QualifiedType<T>) of(type.getType());
     }
 
-    private QualifiedType(Type type, Set<Annotation> qualifiers) {
+    private QualifiedType(Type type, Set<QualifierKey> qualifiers) {
         this.type = type;
         this.qualifiers = qualifiers;
     }
@@ -83,7 +83,7 @@ public final class QualifiedType<T> {
      * @return the QualifiedType
      */
     public QualifiedType<T> with(Annotation... newQualifiers) {
-        return new QualifiedType<>(type, Arrays.stream(newQualifiers).collect(toUnmodifiableSet()));
+        return new QualifiedType<>(type, keysOf(Arrays.asList(newQualifiers)));
     }
 
     /**
@@ -95,10 +95,7 @@ public final class QualifiedType<T> {
      */
     @SafeVarargs
     public final QualifiedType<T> with(Class<? extends Annotation>... newQualifiers) {
-        Set<Annotation> annotations = Arrays.stream(newQualifiers)
-            .map(AnnotationFactory::create)
-            .collect(toUnmodifiableSet());
-        return new QualifiedType<>(type, annotations);
+        return new QualifiedType<>(type, keysOfClasses(Arrays.asList(newQualifiers)));
     }
 
     /**
@@ -109,7 +106,7 @@ public final class QualifiedType<T> {
      * @param newQualifiers the qualifiers for the new qualified type.
      */
     public QualifiedType<T> withAnnotations(Iterable<? extends Annotation> newQualifiers) {
-        return new QualifiedType<>(type, StreamSupport.stream(newQualifiers.spliterator(), false).collect(toUnmodifiableSet()));
+        return new QualifiedType<>(type, keysOf(newQualifiers));
     }
 
     /**
@@ -120,10 +117,23 @@ public final class QualifiedType<T> {
      * @param newQualifiers the qualifiers for the new qualified type.
      */
     public QualifiedType<T> withAnnotationClasses(Iterable<Class<? extends Annotation>> newQualifiers) {
-        Set<Annotation> annotations = StreamSupport.stream(newQualifiers.spliterator(), false)
-            .map(AnnotationFactory::create)
-            .collect(toUnmodifiableSet());
-        return new QualifiedType<>(type, annotations);
+        return new QualifiedType<>(type, keysOfClasses(newQualifiers));
+    }
+
+    private static Set<QualifierKey> keysOf(Iterable<? extends Annotation> annotations) {
+        List<QualifierKey> keys = new ArrayList<>();
+        for (Annotation annotation : annotations) {
+            keys.add(QualifierKey.of(annotation));
+        }
+        return Set.copyOf(keys);
+    }
+
+    private static Set<QualifierKey> keysOfClasses(Iterable<Class<? extends Annotation>> annotationTypes) {
+        List<QualifierKey> keys = new ArrayList<>();
+        for (Class<? extends Annotation> annotationType : annotationTypes) {
+            keys.add(QualifierKey.of(annotationType));
+        }
+        return Set.copyOf(keys);
     }
 
     /**
@@ -136,12 +146,40 @@ public final class QualifiedType<T> {
     }
 
     /**
-     * Returns a set of qualifying annotations.
+     * Returns a set of qualifying annotations. Qualifiers that were given as annotation classes rather than
+     * annotation instances are synthesized on first call.
      *
      * @return the type qualifiers.
      */
     public Set<Annotation> getQualifiers() {
-        return qualifiers;
+        Set<Annotation> result = annotations;
+        if (result == null) {
+            List<Annotation> collected = new ArrayList<>();
+            for (QualifierKey key : qualifiers) {
+                collected.add(key.annotation());
+            }
+            result = Set.copyOf(collected);
+            annotations = result;
+        }
+        return result;
+    }
+
+    /**
+     * Returns true if the qualifiers of this type are exactly the given annotations.
+     *
+     * @param annotations the annotations to compare against.
+     * @return true if this instance has exactly the given qualifiers.
+     */
+    public boolean hasQualifiers(Set<? extends Annotation> annotations) {
+        if (qualifiers.size() != annotations.size()) {
+            return false;
+        }
+        for (Annotation annotation : annotations) {
+            if (!qualifiers.contains(QualifierKey.of(annotation))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -175,7 +213,12 @@ public final class QualifiedType<T> {
      * @return true if this instance contains the given qualifier.
      */
     public boolean hasQualifier(Class<? extends Annotation> qualifier) {
-        return qualifiers.stream().anyMatch(qualifier::isInstance);
+        for (QualifierKey key : qualifiers) {
+            if (key.type() == qualifier) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -207,5 +250,37 @@ public final class QualifiedType<T> {
         qualifiers.forEach(qualifier -> builder.append(qualifier).append(' '));
         builder.append(type.getTypeName());
         return builder.toString();
+    }
+
+    /**
+     * Identity of one qualifier. A qualifier annotation that declares no members is identified by its type alone,
+     * so it never needs an annotation instance. A qualifier with members is identified by an instance, and relies
+     * on the {@link Annotation#equals(Object)} contract.
+     */
+    private record QualifierKey(Class<? extends Annotation> type, Annotation instance) {
+        private static final ClassValue<Boolean> HAS_MEMBERS = new ClassValue<>() {
+            @Override
+            protected Boolean computeValue(Class<?> annotationType) {
+                return annotationType.getDeclaredMethods().length > 0;
+            }
+        };
+
+        static QualifierKey of(Annotation annotation) {
+            Class<? extends Annotation> annotationType = annotation.annotationType();
+            return new QualifierKey(annotationType, HAS_MEMBERS.get(annotationType) ? annotation : null);
+        }
+
+        static QualifierKey of(Class<? extends Annotation> annotationType) {
+            return new QualifierKey(annotationType, HAS_MEMBERS.get(annotationType) ? AnnotationFactory.create(annotationType) : null);
+        }
+
+        Annotation annotation() {
+            return instance != null ? instance : AnnotationFactory.create(type);
+        }
+
+        @Override
+        public String toString() {
+            return instance != null ? instance.toString() : "@" + type.getName() + "()";
+        }
     }
 }

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
@@ -167,19 +167,28 @@ public final class QualifiedType<T> {
     /**
      * Returns true if the qualifiers of this type are exactly the given annotations.
      *
-     * @param annotations the annotations to compare against.
+     * @param expected the annotations to compare against.
      * @return true if this instance has exactly the given qualifiers.
      */
-    public boolean hasQualifiers(Set<? extends Annotation> annotations) {
-        if (qualifiers.size() != annotations.size()) {
+    public boolean hasQualifiers(Set<? extends Annotation> expected) {
+        if (qualifiers.size() != expected.size()) {
             return false;
         }
-        for (Annotation annotation : annotations) {
+        for (Annotation annotation : expected) {
             if (!qualifiers.contains(QualifierKey.of(annotation))) {
                 return false;
             }
         }
         return true;
+    }
+
+    /**
+     * Returns true if this type has no qualifiers.
+     *
+     * @return true if this instance is an unqualified type.
+     */
+    public boolean hasNoQualifiers() {
+        return qualifiers.isEmpty();
     }
 
     /**

--- a/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
+++ b/core/src/main/java/org/jdbi/v3/core/qualifier/QualifiedType.java
@@ -267,11 +267,15 @@ public final class QualifiedType<T> {
 
         static QualifierKey of(Annotation annotation) {
             Class<? extends Annotation> annotationType = annotation.annotationType();
-            return new QualifierKey(annotationType, HAS_MEMBERS.get(annotationType) ? annotation : null);
+            return new QualifierKey(annotationType, hasMembers(annotationType) ? annotation : null);
         }
 
         static QualifierKey of(Class<? extends Annotation> annotationType) {
-            return new QualifierKey(annotationType, HAS_MEMBERS.get(annotationType) ? AnnotationFactory.create(annotationType) : null);
+            return new QualifierKey(annotationType, hasMembers(annotationType) ? AnnotationFactory.create(annotationType) : null);
+        }
+
+        private static boolean hasMembers(Class<? extends Annotation> annotationType) {
+            return HAS_MEMBERS.get(annotationType);
         }
 
         Annotation annotation() {

--- a/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/ArgumentBinder.java
@@ -208,7 +208,7 @@ class ArgumentBinder {
                 final TypeVariable<?>[] typeVars = clazz.getTypeParameters();
                 if (typeVars.length > 0) {
                     return new UnableToCreateStatementException("No type parameters found for erased type '" + type + Arrays.toString(typeVars)
-                        + "' with qualifiers '" + qualifiedType.getQualifiers()
+                        + "' of qualified type '" + qualifiedType
                         + "'. To bind a generic type, prefer using bindByType.");
                 }
             }

--- a/core/src/main/resources/META-INF/native-image/org.jdbi/jdbi3-core/reachability-metadata.json
+++ b/core/src/main/resources/META-INF/native-image/org.jdbi/jdbi3-core/reachability-metadata.json
@@ -1,6 +1,5 @@
 {
   "reflection": [
-    {"type":{"proxy":["org.jdbi.v3.meta.Legacy"]}},
     {"type":"org.jdbi.v3.meta.Legacy"},
     {"type":"org.jdbi.v3.core.Handles","methods":[{"name":"<init>"}]},
     {"type":"org.jdbi.v3.core.argument.Arguments","methods":[{"name":"<init>","parameterTypes":["org.jdbi.v3.core.config.ConfigRegistry"]}]},

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
@@ -13,12 +13,22 @@
  */
 package org.jdbi.v3.core.qualifier;
 
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.jdbi.v3.core.generic.GenericType;
+import org.jdbi.v3.core.internal.AnnotationFactory;
+import org.jdbi.v3.meta.Legacy;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.jdbi.v3.core.qualifier.SampleQualifiers.bar;
 import static org.jdbi.v3.core.qualifier.SampleQualifiers.foo;
 
@@ -51,4 +61,76 @@ public class TestQualifiedType {
             .isNotEqualTo(QualifiedType.of(String.class).with(foo(1)))
             .isNotEqualTo(QualifiedType.of(String.class).with(bar("1")));
     }
+
+    @Test
+    public void memberlessQualifierClassEqualsRealAnnotation() {
+        Annotation real = Holder.class.getAnnotation(Legacy.class);
+        QualifiedType<String> fromClass = QualifiedType.of(String.class).with(Legacy.class);
+        QualifiedType<String> fromInstance = QualifiedType.of(String.class).with(real);
+
+        assertThat(fromClass)
+            .isEqualTo(fromInstance)
+            .hasSameHashCodeAs(fromInstance)
+            .hasToString("@org.jdbi.v3.meta.Legacy() java.lang.String");
+        assertThat(fromClass.hasQualifier(Legacy.class)).isTrue();
+        assertThat(fromClass.hasQualifier(NVarchar.class)).isFalse();
+        assertThat(fromClass.hasQualifiers(Set.of(real))).isTrue();
+        assertThat(fromInstance.hasQualifiers(Set.of(real))).isTrue();
+        assertThat(fromClass.hasQualifiers(Set.of())).isFalse();
+        assertThat(QualifiedType.of(String.class).hasQualifiers(Set.of())).isTrue();
+        assertThat(QualifiedType.of(String.class).hasQualifiers(Set.of(real))).isFalse();
+    }
+
+    @Test
+    public void getQualifiersSynthesizesMemberlessAnnotations() {
+        Set<Annotation> qualifiers = QualifiedType.of(String.class).with(Legacy.class).getQualifiers();
+
+        assertThat(qualifiers).hasSize(1);
+        Annotation synthesized = qualifiers.iterator().next();
+        assertThat(synthesized).isInstanceOf(Legacy.class);
+        assertThat(synthesized).isEqualTo(Holder.class.getAnnotation(Legacy.class));
+        assertThat(qualifiers).isEqualTo(Set.of(Holder.class.getAnnotation(Legacy.class)));
+    }
+
+    @Test
+    public void qualifierWithMembersComparesByValue() {
+        Annotation real = DefaultedHolder.class.getAnnotation(Defaulted.class);
+        Annotation synthesized = AnnotationFactory.create(Defaulted.class, Map.of("value", 7));
+        Annotation other = AnnotationFactory.create(Defaulted.class, Map.of("value", 8));
+
+        assertThat(QualifiedType.of(String.class).with(real))
+            .isEqualTo(QualifiedType.of(String.class).with(synthesized))
+            .hasSameHashCodeAs(QualifiedType.of(String.class).with(synthesized))
+            .isNotEqualTo(QualifiedType.of(String.class).with(other));
+        assertThat(QualifiedType.of(String.class).with(real).getQualifiers()).containsExactly(real);
+        assertThat(QualifiedType.of(String.class).with(real).hasQualifiers(Set.of(synthesized))).isTrue();
+        assertThat(QualifiedType.of(String.class).with(real).hasQualifiers(Set.of(other))).isFalse();
+    }
+
+    @Test
+    public void qualifierClassWithRequiredMemberIsRejected() {
+        assertThatThrownBy(() -> QualifiedType.of(String.class).with(SampleQualifiers.Foo.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot synthesize annotation @Foo");
+    }
+
+    @Test
+    public void qualifierClassWithDefaultedMembersIsSynthesized() {
+        assertThat(QualifiedType.of(String.class).with(Defaulted.class))
+            .isEqualTo(QualifiedType.of(String.class).with(DefaultedHolder.class.getAnnotation(Defaulted.class)))
+            .isEqualTo(QualifiedType.of(String.class).with(Defaulted.class));
+    }
+
+    @Legacy
+    private static final class Holder {}
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Qualifier
+    public @interface Defaulted {
+        int value() default 7;
+    }
+
+    @Defaulted
+    private static final class DefaultedHolder {}
 }

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
@@ -77,7 +77,9 @@ public class TestQualifiedType {
         assertThat(fromClass.hasQualifiers(Set.of(real))).isTrue();
         assertThat(fromInstance.hasQualifiers(Set.of(real))).isTrue();
         assertThat(fromClass.hasQualifiers(Set.of())).isFalse();
+        assertThat(fromClass.hasNoQualifiers()).isFalse();
         assertThat(QualifiedType.of(String.class).hasQualifiers(Set.of())).isTrue();
+        assertThat(QualifiedType.of(String.class).hasNoQualifiers()).isTrue();
         assertThat(QualifiedType.of(String.class).hasQualifiers(Set.of(real))).isFalse();
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifiedType.java
@@ -87,8 +87,9 @@ public class TestQualifiedType {
 
         assertThat(qualifiers).hasSize(1);
         Annotation synthesized = qualifiers.iterator().next();
-        assertThat(synthesized).isInstanceOf(Legacy.class);
-        assertThat(synthesized).isEqualTo(Holder.class.getAnnotation(Legacy.class));
+        assertThat(synthesized)
+            .isInstanceOf(Legacy.class)
+            .isEqualTo(Holder.class.getAnnotation(Legacy.class));
         assertThat(qualifiers).isEqualTo(Set.of(Holder.class.getAnnotation(Legacy.class)));
     }
 

--- a/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifierWithMembers.java
+++ b/core/src/test/java/org/jdbi/v3/core/qualifier/TestQualifierWithMembers.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.qualifier;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.qualifier.SampleQualifiers.Foo;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jdbi.v3.core.qualifier.SampleQualifiers.foo;
+
+/**
+ * A qualifier annotation with members is matched by value, so two factories that differ only in the
+ * member value stay distinct. The factory annotations come from reflection and the lookup keys are
+ * built by hand, which also exercises the member check under a native image, where the whole core
+ * suite runs.
+ */
+public class TestQualifierWithMembers {
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance().withInitializer(H2DatabaseExtension.SOMETHING_INITIALIZER);
+
+    private static final QualifiedType<String> FOO_ONE = QualifiedType.of(String.class).with(foo(1));
+    private static final QualifiedType<String> FOO_TWO = QualifiedType.of(String.class).with(foo(2));
+
+    @Test
+    public void argumentFactoriesAreMatchedByMemberValue() {
+        Handle handle = h2Extension.getSharedHandle();
+        handle.registerArgument(new SuffixOneArgumentFactory());
+        handle.registerArgument(new SuffixTwoArgumentFactory());
+
+        handle.createUpdate("INSERT INTO something (id, name) VALUES (1, :name)")
+            .bindByType("name", "abc", FOO_ONE)
+            .execute();
+        handle.createUpdate("INSERT INTO something (id, name) VALUES (2, :name)")
+            .bindByType("name", "abc", FOO_TWO)
+            .execute();
+
+        assertThat(handle.select("SELECT name FROM something ORDER BY id").mapTo(String.class).list())
+            .containsExactly("abc-1", "abc-2");
+    }
+
+    @Test
+    public void columnMappersAreMatchedByMemberValue() {
+        Handle handle = h2Extension.getSharedHandle();
+        handle.registerColumnMapper(new SuffixOneMapper());
+        handle.registerColumnMapper(new SuffixTwoMapper());
+        handle.execute("INSERT INTO something (id, name) VALUES (1, 'abc')");
+
+        assertThat(handle.select("SELECT name FROM something").mapTo(FOO_ONE).one()).isEqualTo("abc-1");
+        assertThat(handle.select("SELECT name FROM something").mapTo(FOO_TWO).one()).isEqualTo("abc-2");
+        assertThat(handle.select("SELECT name FROM something").mapTo(String.class).one()).isEqualTo("abc");
+    }
+
+    @Foo(1)
+    static class SuffixOneArgumentFactory extends SuffixArgumentFactory {
+        SuffixOneArgumentFactory() {
+            super("-1");
+        }
+    }
+
+    @Foo(2)
+    static class SuffixTwoArgumentFactory extends SuffixArgumentFactory {
+        SuffixTwoArgumentFactory() {
+            super("-2");
+        }
+    }
+
+    abstract static class SuffixArgumentFactory extends AbstractArgumentFactory<String> {
+        private final String suffix;
+
+        SuffixArgumentFactory(String suffix) {
+            super(Types.VARCHAR);
+            this.suffix = suffix;
+        }
+
+        @Override
+        protected Argument build(String value, ConfigRegistry config) {
+            return (pos, stmt, ctx) -> stmt.setString(pos, value + suffix);
+        }
+    }
+
+    @Foo(1)
+    static class SuffixOneMapper implements ColumnMapper<String> {
+        @Override
+        public String map(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+            return r.getString(columnNumber) + "-1";
+        }
+    }
+
+    @Foo(2)
+    static class SuffixTwoMapper implements ColumnMapper<String> {
+        @Override
+        public String map(ResultSet r, int columnNumber, StatementContext ctx) throws SQLException {
+            return r.getString(columnNumber) + "-2";
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2967

`QualifiedType.with(Class)` used to synthesize a `java.lang.reflect.Proxy` for every qualifier so that `Set<Annotation>` equality worked against real annotations read from reflection. GraalVM needs a registration for each proxy, and the eager @Legacy synthesis in Arguments broke native images (#2965). The same gap existed for @NVarchar, @EnumByName and @EncodedJson.

QualifiedType now stores an internal QualifierKey per qualifier. An annotation with no members is keyed by its type alone. An annotation with members is keyed by a real instance and keeps the Annotation.equals contract, so with(Class) on such a type still uses AnnotationFactory. getQualifiers() materializes annotation instances lazily, and only that path can still create a proxy.

Internal comparison sites use the new hasQualifiers(Set) instead of getQualifiers().equals(...), so binding and mapping never synthesize. The Legacy proxy registration is removed from the core reachability metadata. Verified with native-tests on GraalVM CE 25.0.2.