### PR TITLE
Fix commit failure skipping afterRollback callbacks

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
+++ b/core/src/main/java/org/jdbi/v3/core/transaction/LocalTransactionHandler.java
@@ -141,7 +141,7 @@ public class LocalTransactionHandler implements TransactionHandler {
                 restoreAutoCommitState(handle);
             } catch (SQLException e) {
                 try {
-                    rollback(handle);
+                    handle.rollback();
                 } catch (Exception rollbackException) {
                     e.addSuppressed(rollbackException);
                 }

--- a/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
+++ b/core/src/test/java/org/jdbi/v3/core/transaction/TestLocalTransactionHandler.java
@@ -14,6 +14,8 @@
 package org.jdbi.v3.core.transaction;
 
 import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -46,6 +48,23 @@ public class TestLocalTransactionHandler {
             assertThat(e.getSuppressed()).hasSize(1);
             assertThat(e.getSuppressed()[0]).isSameAs(inner);
         }
+    }
+
+    @Test
+    public void testCommitFailureStillFiresAfterRollbackCallback() throws Exception {
+        Mockito.when(c.getAutoCommit()).thenReturn(true);
+        Mockito.doThrow(new SQLException("commit failed")).when(c).commit();
+
+        AtomicBoolean rolledBack = new AtomicBoolean();
+
+        assertThatThrownBy(() ->
+            h.inTransaction(handle -> {
+                handle.afterRollback(() -> rolledBack.set(true));
+                return null;
+            }))
+            .isInstanceOf(TransactionException.class);
+
+        assertThat(rolledBack).isTrue();
     }
 
     @Test


### PR DESCRIPTION
fixes #3021

When `commit()` fails with a `SQLException` (for example SERIALIZABLE conflict), `BoundLocalTransactionHandler.commit()` does a manual rollback (`rollback(handle)`) instead of going through`handle.rollback()`.

That means:
- `afterRollback` hooks never fire (the callback drain only happens inside `Handle.rollback()`)
- internal state gets reset before `inTransaction()` gets a chance to attempt its own fallback rollback, so it doesn't run there either

This bit me with an upsert: the transaction fails, the object is left with an ID that never got cleared (because the `afterRollback` that clears it never ran), and the next attempt mistakes it for an update instead of an insert.

Fix: use `handle.rollback()` instead of the local method. Added a test (`testCommitFailureStillFiresAfterRollbackCallback`) that fails without the fix and passes with it.