### PR TITLE
address CVE-2026-41848 in spring-core

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- update Spring Framework to 6.2.19 due to CVE-2026-41848 (Dependabot alert #45)
 - Fix jdbi3-spring excluding spring-jcl from consumers since 3.51.0, which broke Spring Boot 3
   applications at startup with `NoClassDefFoundError: org.apache.commons.logging.LogFactory` (#2990)
 - Fix PreparedBatch NPE when rows bind different runtime types, e.g. mixed bean subclasses (#2974, thanks @arimu1!)

--- a/internal/build/pom.xml
+++ b/internal/build/pom.xml
@@ -106,7 +106,7 @@
         <dep.postgresql.version>42.7.12</dep.postgresql.version>
         <dep.slf4j.version>2.0.17</dep.slf4j.version>
         <dep.spring.boot.version>3.5.12</dep.spring.boot.version>
-        <dep.spring.version>6.2.17</dep.spring.version>
+        <dep.spring.version>6.2.19</dep.spring.version>
         <dep.sqlite.version>3.51.3.0</dep.sqlite.version>
         <dep.stringtemplate4.version>4.3.4</dep.stringtemplate4.version>
         <dep.testcontainers.version>2.0.5</dep.testcontainers.version>


### PR DESCRIPTION
Update Spring Framework from 6.2.17 to 6.2.19. Spring 6.2.0 through 6.2.18 have a regular expression denial of service in AntPathMatcher (Dependabot alert #45).