### PR TITLE
mappers: explain prefixed mappers that match no columns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Reflective row mappers (`BeanMapper`, `ConstructorMapper`, `FieldMapper`) that match no columns at all now
+  list the result set columns in the error, and a prefixed mapper explains that `SELECT t.*` yields unprefixed
+  labels and shows how to alias them. Document the same in the mapper and JoinRowMapper sections (#2289)
 - Fix jdbi3-spring excluding spring-jcl from consumers since 3.51.0, which broke Spring Boot 3
   applications at startup with `NoClassDefFoundError: org.apache.commons.logging.LogFactory` (#2990)
 - Fix PreparedBatch NPE when rows bind different runtime types, e.g. mixed bean subclasses (#2974, thanks @arimu1!)

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapper.java
@@ -40,6 +40,7 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.SingleColumnMapper;
 import org.jdbi.v3.core.mapper.reflect.internal.NullDelegatingMapper;
+import org.jdbi.v3.core.mapper.reflect.internal.UnmatchedColumnsHint;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.qualifier.Qualifiers;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -69,7 +70,7 @@ public final class ConstructorMapper<T> implements PrefixedRowMapper<T> {
         "Instance factory '%s' could not match any parameter to any columns in the result set. "
             + "Verify that the Java compiler is configured to emit parameter names, "
             + "that your result set has the columns expected, annotate the "
-            + "parameter names explicitly with @ColumnName, or annotate nullable parameters as @Nullable";
+            + "parameter names explicitly with @ColumnName, or annotate nullable parameters as @Nullable.%s";
 
     @SuppressWarnings("InlineFormatString")
     private static final String UNMATCHED_CONSTRUCTOR_PARAMETER =
@@ -246,7 +247,7 @@ public final class ConstructorMapper<T> implements PrefixedRowMapper<T> {
 
         RowMapper<T> mapper = createSpecializedRowMapper(ctx, columnNames, columnNameMatchers, unmatchedColumns, Function.identity())
             .orElseGet(() -> new UnmatchedConstructorMapper<>(format(
-                UNMATCHED_CONSTRUCTOR_PARAMETERS, factory)));
+                UNMATCHED_CONSTRUCTOR_PARAMETERS, factory, UnmatchedColumnsHint.forColumns(prefix, columnNames))));
 
         if (ctx.getConfig(ReflectionMappers.class).isStrictMatching()
             && anyColumnsStartWithPrefix(unmatchedColumns, prefix, columnNameMatchers)) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/FieldMapper.java
@@ -39,6 +39,7 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.core.mapper.SingleColumnMapper;
 import org.jdbi.v3.core.mapper.reflect.internal.NullDelegatingMapper;
+import org.jdbi.v3.core.mapper.reflect.internal.UnmatchedColumnsHint;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.qualifier.Qualifiers;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -127,7 +128,8 @@ public final class FieldMapper<T> implements PrefixedRowMapper<T> {
         final List<String> unmatchedColumns = new ArrayList<>(columnNames);
 
         RowMapper<T> mapper = createSpecializedRowMapper(ctx, columnNames, columnNameMatchers, unmatchedColumns, Function.identity())
-            .orElseThrow(() -> new IllegalArgumentException(format("Mapping fields for type %s didn't find any matching columns in result set", type)));
+            .orElseThrow(() -> new IllegalArgumentException(format("Mapping fields for type %s didn't find any matching columns in result set.%s",
+                type, UnmatchedColumnsHint.forColumns(prefix, columnNames))));
 
         if (ctx.getConfig(ReflectionMappers.class).isStrictMatching()
             && anyColumnsStartWithPrefix(unmatchedColumns, prefix, columnNameMatchers)) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/PojoMapper.java
@@ -80,7 +80,8 @@ public class PojoMapper<T> implements PrefixedRowMapper<T> {
         final List<String> unmatchedColumns = new ArrayList<>(columnNames);
 
         RowMapper<T> result = createSpecializedRowMapper(ctx, columnNames, columnNameMatchers, unmatchedColumns, Function.identity())
-            .orElseThrow(() -> new IllegalArgumentException(format("Mapping bean %s didn't find any matching columns in result set", type)));
+            .orElseThrow(() -> new IllegalArgumentException(format("Mapping bean %s didn't find any matching columns in result set.%s",
+                type, UnmatchedColumnsHint.forColumns(prefix, columnNames))));
 
         if (ctx.getConfig(ReflectionMappers.class).isStrictMatching()
             && anyColumnsStartWithPrefix(unmatchedColumns, prefix, columnNameMatchers)) {

--- a/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/UnmatchedColumnsHint.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/reflect/internal/UnmatchedColumnsHint.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper.reflect.internal;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+/**
+ * Explains why a reflective row mapper matched no columns at all. Prefixed mappers are the common trap:
+ * the prefix is matched against the column label, so {@code SELECT t.*} yields unprefixed labels that
+ * the mapper cannot see.
+ */
+public final class UnmatchedColumnsHint {
+    private UnmatchedColumnsHint() {}
+
+    /**
+     * Builds the tail of a "no matching columns" message.
+     *
+     * @param prefix      the column name prefix of the mapper, empty for none
+     * @param columnNames the column labels present in the result set
+     * @return a sentence fragment that starts with a space and ends with a period
+     */
+    public static String forColumns(String prefix, List<String> columnNames) {
+        if (prefix.isEmpty()) {
+            return format(" Result set columns: %s.", columnNames);
+        }
+        return format(" Result set columns: %s. The mapper uses prefix '%2$s' and only matches columns whose label"
+                + " starts with it. Alias each selected column with the prefix, for example \"%2$s.id AS %2$s_id\""
+                + " instead of \"%2$s.*\".",
+            columnNames, prefix);
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperTest.java
@@ -16,11 +16,13 @@ package org.jdbi.v3.core.mapper.reflect;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.jdbi.v3.core.statement.Query;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.jdbi.v3.core.junit5.H2DatabaseExtension.SOMETHING_INITIALIZER;
 
 public class BeanMapperTest {
@@ -60,6 +62,43 @@ public class BeanMapperTest {
 
         // annotation on setter
         assertThat(bean.getI()).isOne();
+    }
+
+    @Test
+    public void testPrefixedMapperReportsUnprefixedColumns() {
+        handle.registerRowMapper(BeanMapper.factory(ColumnNameBean.class, "t"));
+
+        assertThatThrownBy(() -> {
+            try (Query query = handle.createQuery("select id, name from something")) {
+                query.mapTo(ColumnNameBean.class).one();
+            }
+        })
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("didn't find any matching columns in result set")
+            .hasMessageContaining("Result set columns: [id, name]")
+            .hasMessageContaining("prefix 't'")
+            .hasMessageContaining("\"t.id AS t_id\" instead of \"t.*\"");
+
+        ColumnNameBean bean = handle.createQuery("select id as t_id, name as t_name from something")
+            .mapTo(ColumnNameBean.class)
+            .one();
+
+        assertThat(bean.getI()).isOne();
+        assertThat(bean.getS()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testUnprefixedMapperReportsColumns() {
+        handle.registerRowMapper(BeanMapper.factory(ColumnNameBean.class));
+
+        assertThatThrownBy(() -> {
+            try (Query query = handle.createQuery("select 1 as other from something")) {
+                query.mapTo(ColumnNameBean.class).one();
+            }
+        })
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("didn't find any matching columns in result set. Result set columns: [other].")
+            .hasMessageNotContaining("prefix");
     }
 
     public static class ColumnNameBean {

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/ConstructorMapperTest.java
@@ -636,6 +636,23 @@ public class ConstructorMapperTest {
             .hasMessageContaining("parameter '[i]' has no matching columns in the result set");
     }
 
+    @Test
+    public void testPrefixedMapperReportsUnprefixedColumns() {
+        handle.registerRowMapper(ConstructorMapper.factory(ConstructorBean.class, "b"));
+
+        assertThatThrownBy(() -> selectOne("select s, i from bean", ConstructorBean.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("could not match any parameter to any columns in the result set")
+            .hasMessageContaining("Result set columns: [s, i]")
+            .hasMessageContaining("prefix 'b'")
+            .hasMessageContaining("\"b.id AS b_id\" instead of \"b.*\"");
+
+        ConstructorBean bean = selectOne("select s as b_s, i as b_i from bean", ConstructorBean.class);
+
+        assertThat(bean.s).isEqualTo("3");
+        assertThat(bean.i).isEqualTo(2);
+    }
+
     static class TypeUseNullableParameterBean {
         private final String s;
         private final int i;

--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/FieldMapperTest.java
@@ -100,6 +100,31 @@ public class FieldMapperTest {
             .hasMessageContaining("could not match fields for columns: [other]");
     }
 
+    @Test
+    public void testPrefixedMapperReportsUnprefixedColumns() {
+        Handle handle = h2Extension.getSharedHandle();
+        handle.execute("insert into something (id, name) values (1, 'foo')");
+        handle.registerRowMapper(FieldMapper.factory(ColumnNameThing.class, "t"));
+
+        assertThatThrownBy(() -> {
+            try (Query query = handle.createQuery("select id, name from something")) {
+                query.mapTo(ColumnNameThing.class).one();
+            }
+        })
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("didn't find any matching columns in result set")
+            .hasMessageContaining("Result set columns: [id, name]")
+            .hasMessageContaining("prefix 't'")
+            .hasMessageContaining("\"t.id AS t_id\" instead of \"t.*\"");
+
+        ColumnNameThing thing = handle.createQuery("select id as t_id, name as t_name from something")
+            .mapTo(ColumnNameThing.class)
+            .one();
+
+        assertThat(thing.i).isOne();
+        assertThat(thing.s).isEqualTo("foo");
+    }
+
     static class NestedThing {
 
         @Nested

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -2357,6 +2357,10 @@ List<JoinRow> contactPhones = handle.select("SELECT " +
     .list();
 ----
 
+NOTE: The prefix is matched against the column label in the result set, not against the table or its alias.
+`SELECT c.*, p.*` produces labels such as `id` and `name` without a prefix, and a prefixed mapper finds no columns to map.
+Alias each column with the prefix, as in the example above.
+
 Typically, the mapped class will have a single constructor.
 If it has multiple constructors, Jdbi will pick one based on these rules:
 
@@ -2492,6 +2496,10 @@ This can help to disambiguate mapping joins, e.g. when two mapped classes have i
 include::{exampledir}/ResultsTest.java[tags=beanMapperPrefix]
 ----
 
+NOTE: The prefix is matched against the column label in the result set, not against the table or its alias.
+`SELECT c.*, p.*` produces labels such as `id` and `name` without a prefix, and a prefixed mapper finds no columns to map.
+Alias each column with the prefix, as in the example above.
+
 For legacy column names that don't match up to property names, use the
 link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] annotation to provide an exact column name.
 
@@ -2612,6 +2620,10 @@ List<JoinRow> contactPhones = handle.select(
     .mapTo(JoinRow.class)
     .list();
 ----
+
+NOTE: The prefix is matched against the column label in the result set, not against the table or its alias.
+`SELECT c.*, p.*` produces labels such as `id` and `name` without a prefix, and a prefixed mapper finds no columns to map.
+Alias each column with the prefix, as in the example above.
 
 For legacy column names that don't match up to field names, use the
 link:{jdbidocs}/core/mapper/reflect/ColumnName.html[@ColumnName^] annotation to provide an exact column name:
@@ -3260,6 +3272,9 @@ List<Contact> contacts = handle.createQuery(SELECT_ALL)
 
 The JoinRowMapper takes a set of types to extract from each row.
 It uses the mapping registry to determine how to map each given type, and presents you with a JoinRow that holds all the resulting values.
+
+When the joined types share column names such as `id`, register each type's mapper with a column name prefix and alias every selected column with that prefix (`c.id AS c_id`).
+The prefix is matched against the column label only, so `SELECT c.*, p.*` leaves the prefixed mappers with no matching columns.
 
 Let's consider two simple types, User and Article, with a join table named Author.
 Guava provides a Multimap class, which is very handy for representing joined tables like this.


### PR DESCRIPTION
A `BeanMapper`, `ConstructorMapper`, or `FieldMapper` registered with a column name prefix matches the prefix against the column label only. `SELECT t.*` yields unprefixed labels, and the mapper failed with "didn't find any matching columns in result set" and no further detail.

The "no matching columns" error now lists the result set columns. When the mapper has a prefix, it also states that the prefix matches on the label and shows the alias form ("t.id AS t_id" instead of "t.*"). The documentation for the three mappers and for JoinRowMapper states the same limitation next to the prefix examples.

Closes #2289