### PR TITLE
Load Immutables generated classes through the spec's class loader

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,8 @@
   class loader other than the one that loaded Jdbi, e.g. plugin containers (#3014)
 - Share the extension metadata cache across handles so `handle.attach()`-only workloads no longer
   recompute `ExtensionMetadata` on every handle (#2991)
+- Fix `JdbiImmutables` not finding the generated `Immutable*` and `Modifiable*` classes when the spec
+  is loaded by a class loader other than the one that loaded Jdbi, e.g. plugin containers
 
 # 3.54.0
 

--- a/core/src/main/java/org/jdbi/v3/core/mapper/immutables/JdbiImmutables.java
+++ b/core/src/main/java/org/jdbi/v3/core/mapper/immutables/JdbiImmutables.java
@@ -153,10 +153,15 @@ public class JdbiImmutables implements JdbiConfig<JdbiImmutables> {
         }
     }
 
+    /**
+     * The generated class lives next to the spec, so it must be loaded through the same class loader.
+     * A plain {@code Class.forName(name)} would use the loader of this class, which fails in environments
+     * that isolate application code from Jdbi (plugin containers, application servers).
+     */
     private static <S> Class<? extends S> classByPrefix(String prefix, Class<S> spec) {
         final String implName = spec.getPackage().getName() + '.' + prefix + spec.getSimpleName();
         try {
-            return Class.forName(implName).asSubclass(spec);
+            return Class.forName(implName, true, spec.getClassLoader()).asSubclass(spec);
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException("Couldn't locate default implementation class " + implName, e);
         }

--- a/core/src/test/java/org/jdbi/v3/core/internal/IsolatingClassLoader.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/IsolatingClassLoader.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Defines every class in one package itself from the test class path and delegates all other classes,
+ * including Jdbi, to the parent. This mirrors a plugin loader (Paper, OSGi, application servers): the
+ * parent, which is Jdbi's own loader, can not resolve the isolated classes by name, only the child can.
+ * <p>
+ * Nothing in the isolated package may be referenced from a test directly, or the parent loader would
+ * define it first.
+ */
+public final class IsolatingClassLoader extends ClassLoader {
+
+    private final String isolatedPackagePrefix;
+
+    /**
+     * @param isolatedPackage the package whose classes this loader defines itself, including subpackages
+     */
+    public IsolatingClassLoader(String isolatedPackage) {
+        super(IsolatingClassLoader.class.getClassLoader());
+        this.isolatedPackagePrefix = isolatedPackage + '.';
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (!name.startsWith(isolatedPackagePrefix)) {
+            return super.loadClass(name, resolve);
+        }
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> loaded = findLoadedClass(name);
+            if (loaded == null) {
+                loaded = defineIsolated(name);
+            }
+            if (resolve) {
+                resolveClass(loaded);
+            }
+            return loaded;
+        }
+    }
+
+    private Class<?> defineIsolated(String name) throws ClassNotFoundException {
+        String resource = name.replace('.', '/') + ".class";
+        try (InputStream in = getParent().getResourceAsStream(resource)) {
+            if (in == null) {
+                throw new ClassNotFoundException(name);
+            }
+            byte[] bytes = in.readAllBytes();
+            return defineClass(name, bytes, 0, bytes.length);
+        } catch (IOException e) {
+            throw new ClassNotFoundException(name, e);
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesIsolatedClassLoaderTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesIsolatedClassLoaderTest.java
@@ -13,10 +13,8 @@
  */
 package org.jdbi.v3.core.mapper;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.internal.IsolatingClassLoader;
 import org.jdbi.v3.core.junit5.H2DatabaseExtension;
 import org.jdbi.v3.core.mapper.immutables.JdbiImmutables;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,13 +32,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisabledInNativeImage // a native image can not define classes at run time
 public class ImmutablesIsolatedClassLoaderTest {
 
-    private static final String ISOLATED_PACKAGE = "org.jdbi.v3.core.mapper.isolated.";
-    private static final String SPEC_NAME = ISOLATED_PACKAGE + "IsolatedTrain";
+    private static final String ISOLATED_PACKAGE = "org.jdbi.v3.core.mapper.isolated";
+    private static final String SPEC_NAME = ISOLATED_PACKAGE + ".IsolatedTrain";
 
     @RegisterExtension
     public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
 
-    private final IsolatingClassLoader loader = new IsolatingClassLoader();
+    private final IsolatingClassLoader loader = new IsolatingClassLoader(ISOLATED_PACKAGE);
 
     private Handle handle;
     private Class<?> specType;
@@ -68,7 +66,7 @@ public class ImmutablesIsolatedClassLoaderTest {
     @Test
     public void registerModifiableResolvesGeneratedClassThroughSpecLoader() throws Exception {
         handle.getConfig(JdbiImmutables.class).registerModifiable(specType);
-        Class<?> modifiableType = loader.loadClass(ISOLATED_PACKAGE + "ModifiableIsolatedTrain");
+        Class<?> modifiableType = loader.loadClass(ISOLATED_PACKAGE + ".ModifiableIsolatedTrain");
 
         Object train = handle.createQuery("select * from train").mapTo(modifiableType).one();
 
@@ -79,7 +77,7 @@ public class ImmutablesIsolatedClassLoaderTest {
     private void assertIsolatedTrain(Object train, String prefix) {
         assertThat(train).isInstanceOf(specType);
         assertThat(train.getClass().getClassLoader()).isSameAs(loader);
-        assertThat(train.getClass().getName()).isEqualTo(ISOLATED_PACKAGE + prefix + "IsolatedTrain");
+        assertThat(train.getClass().getName()).isEqualTo(ISOLATED_PACKAGE + "." + prefix + "IsolatedTrain");
         assertThat(train).extracting("name", "carriages").containsExactly("Zephyr", 8);
     }
 
@@ -91,47 +89,5 @@ public class ImmutablesIsolatedClassLoaderTest {
 
         assertThat(handle.createQuery("select count(1) from train where name = 'Zephyr' and carriages = 8").mapTo(int.class).one())
             .isEqualTo(2);
-    }
-
-    /**
-     * Defines every class in the isolated package itself from the test class path and delegates all
-     * other classes, including Jdbi, to the parent. This mirrors a plugin loader: the parent (Jdbi's
-     * loader) can not resolve the isolated classes by name, only the child can.
-     */
-    static final class IsolatingClassLoader extends ClassLoader {
-
-        IsolatingClassLoader() {
-            super(ImmutablesIsolatedClassLoaderTest.class.getClassLoader());
-        }
-
-        @Override
-        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-            if (!name.startsWith(ISOLATED_PACKAGE)) {
-                return super.loadClass(name, resolve);
-            }
-            synchronized (getClassLoadingLock(name)) {
-                Class<?> loaded = findLoadedClass(name);
-                if (loaded == null) {
-                    loaded = defineIsolated(name);
-                }
-                if (resolve) {
-                    resolveClass(loaded);
-                }
-                return loaded;
-            }
-        }
-
-        private Class<?> defineIsolated(String name) throws ClassNotFoundException {
-            String resource = name.replace('.', '/') + ".class";
-            try (InputStream in = getParent().getResourceAsStream(resource)) {
-                if (in == null) {
-                    throw new ClassNotFoundException(name);
-                }
-                byte[] bytes = in.readAllBytes();
-                return defineClass(name, bytes, 0, bytes.length);
-            } catch (IOException e) {
-                throw new ClassNotFoundException(name, e);
-            }
-        }
     }
 }

--- a/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesIsolatedClassLoaderTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/ImmutablesIsolatedClassLoaderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.junit5.H2DatabaseExtension;
+import org.jdbi.v3.core.mapper.immutables.JdbiImmutables;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Immutables generated classes must be resolved through the class loader of the spec, not the class
+ * loader of Jdbi itself. Plugin containers (Paper, OSGi, application servers) load application code in
+ * a child loader that Jdbi's own loader can not see.
+ */
+@DisabledInNativeImage // a native image can not define classes at run time
+public class ImmutablesIsolatedClassLoaderTest {
+
+    private static final String ISOLATED_PACKAGE = "org.jdbi.v3.core.mapper.isolated.";
+    private static final String SPEC_NAME = ISOLATED_PACKAGE + "IsolatedTrain";
+
+    @RegisterExtension
+    public H2DatabaseExtension h2Extension = H2DatabaseExtension.instance();
+
+    private final IsolatingClassLoader loader = new IsolatingClassLoader();
+
+    private Handle handle;
+    private Class<?> specType;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        handle = h2Extension.getSharedHandle();
+        handle.execute("create table train (name varchar, carriages int)");
+        handle.execute("insert into train (name, carriages) values ('Zephyr', 8)");
+
+        specType = loader.loadClass(SPEC_NAME);
+        assertThat(specType.getClassLoader()).isSameAs(loader);
+    }
+
+    @Test
+    public void registerImmutableResolvesGeneratedClassThroughSpecLoader() {
+        handle.getConfig(JdbiImmutables.class).registerImmutable(specType);
+
+        Object train = handle.createQuery("select * from train").mapTo(specType).one();
+
+        assertIsolatedTrain(train, "Immutable");
+        assertRoundTrip(train);
+    }
+
+    @Test
+    public void registerModifiableResolvesGeneratedClassThroughSpecLoader() throws Exception {
+        handle.getConfig(JdbiImmutables.class).registerModifiable(specType);
+        Class<?> modifiableType = loader.loadClass(ISOLATED_PACKAGE + "ModifiableIsolatedTrain");
+
+        Object train = handle.createQuery("select * from train").mapTo(modifiableType).one();
+
+        assertIsolatedTrain(train, "Modifiable");
+        assertRoundTrip(train);
+    }
+
+    private void assertIsolatedTrain(Object train, String prefix) {
+        assertThat(train).isInstanceOf(specType);
+        assertThat(train.getClass().getClassLoader()).isSameAs(loader);
+        assertThat(train.getClass().getName()).isEqualTo(ISOLATED_PACKAGE + prefix + "IsolatedTrain");
+        assertThat(train).extracting("name", "carriages").containsExactly("Zephyr", 8);
+    }
+
+    private void assertRoundTrip(Object train) {
+        assertThat(handle.createUpdate("insert into train (name, carriages) values (:name, :carriages)")
+            .bindPojo(train)
+            .execute())
+            .isOne();
+
+        assertThat(handle.createQuery("select count(1) from train where name = 'Zephyr' and carriages = 8").mapTo(int.class).one())
+            .isEqualTo(2);
+    }
+
+    /**
+     * Defines every class in the isolated package itself from the test class path and delegates all
+     * other classes, including Jdbi, to the parent. This mirrors a plugin loader: the parent (Jdbi's
+     * loader) can not resolve the isolated classes by name, only the child can.
+     */
+    static final class IsolatingClassLoader extends ClassLoader {
+
+        IsolatingClassLoader() {
+            super(ImmutablesIsolatedClassLoaderTest.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (!name.startsWith(ISOLATED_PACKAGE)) {
+                return super.loadClass(name, resolve);
+            }
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null) {
+                    loaded = defineIsolated(name);
+                }
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+        }
+
+        private Class<?> defineIsolated(String name) throws ClassNotFoundException {
+            String resource = name.replace('.', '/') + ".class";
+            try (InputStream in = getParent().getResourceAsStream(resource)) {
+                if (in == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                byte[] bytes = in.readAllBytes();
+                return defineClass(name, bytes, 0, bytes.length);
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/jdbi/v3/core/mapper/isolated/IsolatedTrain.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/isolated/IsolatedTrain.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.mapper.isolated;
+
+import org.immutables.value.Value;
+
+/**
+ * Loaded through a child class loader by {@code ImmutablesIsolatedClassLoaderTest}. Nothing else in this
+ * package may be referenced from the test directly, or the parent loader would define it first.
+ */
+@Value.Immutable
+@Value.Modifiable
+public interface IsolatedTrain {
+
+    String name();
+
+    int carriages();
+}

--- a/generator/src/test/java/org/jdbi/v3/generator/IsolatedClassLoaderTest.java
+++ b/generator/src/test/java/org/jdbi/v3/generator/IsolatedClassLoaderTest.java
@@ -13,14 +13,13 @@
  */
 package org.jdbi.v3.generator;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.util.List;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.extension.Extensions;
 import org.jdbi.v3.core.h2.H2DatabasePlugin;
+import org.jdbi.v3.core.internal.IsolatingClassLoader;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.junit5.JdbiExtension;
 import org.jdbi.v3.testing.junit5.internal.TestingInitializers;
@@ -36,8 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class IsolatedClassLoaderTest {
 
-    private static final String ISOLATED_PACKAGE = "org.jdbi.v3.generator.isolated.";
-    private static final String DAO_NAME = ISOLATED_PACKAGE + "IsolatedDao";
+    private static final String ISOLATED_PACKAGE = "org.jdbi.v3.generator.isolated";
+    private static final String DAO_NAME = ISOLATED_PACKAGE + ".IsolatedDao";
 
     @RegisterExtension
     public JdbiExtension h2Extension = JdbiExtension.h2()
@@ -47,7 +46,7 @@ public class IsolatedClassLoaderTest {
 
     @Test
     public void attachResolvesGeneratedClassThroughExtensionTypeLoader() throws Exception {
-        IsolatingClassLoader loader = new IsolatingClassLoader();
+        IsolatingClassLoader loader = new IsolatingClassLoader(ISOLATED_PACKAGE);
         Class<?> daoType = loader.loadClass(DAO_NAME);
         assertThat(daoType.getClassLoader()).isSameAs(loader);
 
@@ -63,7 +62,7 @@ public class IsolatedClassLoaderTest {
 
     @Test
     public void onDemandResolvesGeneratedClassThroughExtensionTypeLoader() throws Exception {
-        IsolatingClassLoader loader = new IsolatingClassLoader();
+        IsolatingClassLoader loader = new IsolatingClassLoader(ISOLATED_PACKAGE);
         Class<?> daoType = loader.loadClass(DAO_NAME);
 
         Object dao = h2Extension.getJdbi().onDemand(daoType);
@@ -84,47 +83,5 @@ public class IsolatedClassLoaderTest {
         insert.invoke(dao, 2, "Ellie");
 
         assertThat((List<Object>) names.invoke(dao)).containsExactly("Bella", "Ellie");
-    }
-
-    /**
-     * Defines every class in the isolated package itself from the test class path and delegates all
-     * other classes, including Jdbi, to the parent. This mirrors a plugin loader: the parent (Jdbi's
-     * loader) can not resolve the isolated classes by name, only the child can.
-     */
-    static final class IsolatingClassLoader extends ClassLoader {
-
-        IsolatingClassLoader() {
-            super(IsolatedClassLoaderTest.class.getClassLoader());
-        }
-
-        @Override
-        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-            if (!name.startsWith(ISOLATED_PACKAGE)) {
-                return super.loadClass(name, resolve);
-            }
-            synchronized (getClassLoadingLock(name)) {
-                Class<?> loaded = findLoadedClass(name);
-                if (loaded == null) {
-                    loaded = defineIsolated(name);
-                }
-                if (resolve) {
-                    resolveClass(loaded);
-                }
-                return loaded;
-            }
-        }
-
-        private Class<?> defineIsolated(String name) throws ClassNotFoundException {
-            String resource = name.replace('.', '/') + ".class";
-            try (InputStream in = getParent().getResourceAsStream(resource)) {
-                if (in == null) {
-                    throw new ClassNotFoundException(name);
-                }
-                byte[] bytes = in.readAllBytes();
-                return defineClass(name, bytes, 0, bytes.length);
-            } catch (IOException e) {
-                throw new ClassNotFoundException(name, e);
-            }
-        }
     }
 }


### PR DESCRIPTION
JdbiImmutables.classByPrefix resolved the generated Immutable* and Modifiable* classes with Class.forName(name), which uses the class loader of jdbi3-core. In environments that isolate application code from Jdbi (Paper plugins, OSGi, application servers) that loader can not see the generated class and registerImmutable() fails with ClassNotFoundException. Resolve the class through the spec's own loader instead. This is the same defect as #3014 in the generator SQL object factory.

The new test is disabled in native image because GraalVM can not define classes at run time.