### PR TITLE
Document that Script and @SqlScript do not bind arguments

### DIFF
--- a/core/src/main/java/org/jdbi/v3/core/statement/Script.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/Script.java
@@ -22,6 +22,11 @@ import org.jdbi.v3.core.internal.SqlScriptParser.ScriptTokenHandler;
 
 /**
  * Represents a number of SQL statements delimited by semicolon which will be executed in order in a batch statement.
+ *
+ * <p>A script does not send bound arguments to the database. Each statement is rendered by the template engine
+ * and then passed to the driver as plain text, so a {@code :name} placeholder reaches the database unchanged.
+ * Arguments bound on a script are used only by {@link #defineNamedBindings()}. To bind arguments,
+ * run each statement as its own {@link Update}, or group several updates in one transaction.
  */
 public class Script extends SqlStatement<Script> {
     private final boolean requireSemicolon;

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -4104,6 +4104,8 @@ link:{jdbidocs}/sqlobject/statement/SqlCall.html[@SqlCall^] supports <<sql-call-
 Use link:{jdbidocs}/sqlobject/statement/SqlScript.html[@SqlScript^] to execute one or more statements in a batch.
 
 While link:{jdbidocs}/sqlobject/statement/SqlBatch.html[@SqlBatch^] executes the same SQL statement with different values, the link:{jdbidocs}/sqlobject/statement/SqlScript.html[@SqlScript^] annotation executes different SQL statements without explicit data bound to each statement.
+Method arguments are not bound as statement parameters, only template attributes are substituted.
+To run several statements with bound parameters, declare one `@SqlUpdate` method for each statement and call them from an interface default method.
 
 [source,java,indent=0]
 ----

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlScript.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/statement/SqlScript.java
@@ -25,6 +25,11 @@ import org.jdbi.v3.sqlobject.statement.internal.SqlScriptsHandler;
 
 /**
  * Annotate a method to indicate that it will execute one or more SQL statements.
+ *
+ * <p>Method arguments are not bound as statement parameters. Use
+ * {@link org.jdbi.v3.sqlobject.customizer.Define @Define} to substitute template attributes.
+ * To run several statements with bound parameters, declare one {@link SqlUpdate @SqlUpdate} method
+ * for each statement and call them from a default method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})


### PR DESCRIPTION
Bound arguments on a Script compile but are never sent to the database, because the script runs as a plain Statement batch. State this on Script, @SqlScript, and in the user guide, and point at default methods for several parameterized statements.

Refs #1307