### PR TITLE
Add BindListStyle to render bindList elements as VALUES rows

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Add `BindListStyle` to render `bindList` / `@BindList` elements as single-column rows, `(:a),(:b)`, for
+  use with the SQL `VALUES` list constructor. Configure it with `SqlStatements#setBindListStyle` or
+  `@BindList(style = BindListStyle.ROWS)` (#1550, Alpha)
 - update Spring Framework to 6.2.19 due to CVE-2026-41848 (Dependabot alert #45)
 - `ConfigRegistry.createCopy()` now materializes each config object lazily on its first access instead
   of copying every config object eagerly. This removes most of the allocation cost of extension attach

--- a/core/src/main/java/org/jdbi/v3/core/statement/BindListStyle.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/BindListStyle.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.core.statement;
+
+import org.jdbi.v3.meta.Alpha;
+
+/**
+ * Describes how {@link SqlStatement#bindList} renders the bound parameter names into the defined attribute.
+ * The style must match the SQL around the attribute, so it is normally set per statement with
+ * {@code configure(SqlStatements.class, c -> c.setBindListStyle(...))} or {@code @BindList(style = ...)}.
+ *
+ * @see SqlStatements#setBindListStyle(BindListStyle)
+ */
+@Alpha
+public enum BindListStyle {
+    /**
+     * <p>Render each element as a bare parameter.</p>
+     * <p>
+     * {@code select * from things where x in (<ids>)} renders as {@code select * from things where x in (:__ids_0,:__ids_1)}
+     */
+    PLAIN("", ""),
+    /**
+     * <p>Render each element as a single-column row, for use with the SQL {@code VALUES} list constructor.</p>
+     * <p>
+     * {@code select * from (values <ids>) as t(id)} renders as {@code select * from (values (:__ids_0),(:__ids_1)) as t(id)}
+     * <p>
+     * {@link EmptyHandling#NULL_KEYWORD} renders {@code values null}, which is not valid SQL. Handle an empty list with
+     * {@link EmptyHandling#THROW} or {@link EmptyHandling#DEFINE_NULL} and a template conditional instead.
+     */
+    ROWS("(", ")");
+
+    private final String elementPrefix;
+    private final String elementSuffix;
+
+    BindListStyle(String elementPrefix, String elementSuffix) {
+        this.elementPrefix = elementPrefix;
+        this.elementSuffix = elementSuffix;
+    }
+
+    void appendElement(StringBuilder target, String parameterName) {
+        target.append(elementPrefix).append(parameterName).append(elementSuffix);
+    }
+}

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatement.java
@@ -1446,6 +1446,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * @return this
      * @throws IllegalArgumentException if the vararg array is empty.
      * @see #bindList(BiConsumer, String, List)
+     * @see SqlStatements#setBindListStyle(BindListStyle)
      */
     public final This bindList(String key, Object... values) {
         return bindList(EmptyHandling.THROW, key, values);
@@ -1461,6 +1462,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * @throws IllegalArgumentException if the vararg array is empty.
      * @see EmptyHandling
      * @see #bindList(BiConsumer, String, List)
+     * @see SqlStatements#setBindListStyle(BindListStyle)
      */
     public final This bindList(BiConsumer<SqlStatement, String> onEmpty, String key, Object... values) {
         return bindList(onEmpty, key, values == null ? null : Arrays.asList(values));
@@ -1474,6 +1476,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * @return this
      * @throws IllegalArgumentException if the iterable is empty.
      * @see #bindList(BiConsumer, String, List)
+     * @see SqlStatements#setBindListStyle(BindListStyle)
      */
     public final This bindList(String key, Iterable<?> values) {
         return bindList(EmptyHandling.THROW, key, values);
@@ -1489,6 +1492,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * @throws IllegalArgumentException if the iterable is empty.
      * @see EmptyHandling
      * @see #bindList(BiConsumer, String, List)
+     * @see SqlStatements#setBindListStyle(BindListStyle)
      */
     public final This bindList(BiConsumer<SqlStatement, String> onEmpty, String key, Iterable<?> values) {
         return bindList(onEmpty, key, values == null ? null : IterableLike.toList(values));
@@ -1502,6 +1506,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * @return this
      * @throws IllegalArgumentException if the iterator is empty.
      * @see #bindList(BiConsumer, String, List)
+     * @see SqlStatements#setBindListStyle(BindListStyle)
      */
     public final This bindList(String key, Iterator<?> values) {
         return bindList(EmptyHandling.THROW, key, values);
@@ -1517,6 +1522,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * @throws IllegalArgumentException if the iterator is empty.
      * @see EmptyHandling
      * @see #bindList(BiConsumer, String, List)
+     * @see SqlStatements#setBindListStyle(BindListStyle)
      */
     public final This bindList(BiConsumer<SqlStatement, String> onEmpty, String key, Iterator<?> values) {
         return bindList(onEmpty, key, values == null ? null : IterableLike.toList(values));
@@ -1524,7 +1530,8 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
 
     /**
      * Bind a parameter for each value in the given list, and defines an attribute as the comma-separated list of
-     * parameter references (using colon prefix).
+     * parameter references (using colon prefix). The configured {@link BindListStyle} controls how each
+     * parameter reference is rendered, e.g. wrapped in parentheses for a SQL {@code VALUES} list.
      * <p>
      * Examples:
      * <pre>
@@ -1554,6 +1561,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
      * @return this
      * @throws IllegalArgumentException if the list is empty.
      * @see EmptyHandling
+     * @see SqlStatements#setBindListStyle(BindListStyle)
      */
     public final This bindList(BiConsumer<SqlStatement, String> onEmpty, String key, List<?> values) {
         if (values == null || values.isEmpty()) {
@@ -1561,6 +1569,8 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
             return typedThis;
         }
 
+        SqlStatements sqlStatements = getConfig(SqlStatements.class);
+        BindListStyle style = sqlStatements.getBindListStyle();
         StringBuilder names = new StringBuilder();
 
         for (int i = 0; i < values.size(); i++) {
@@ -1569,8 +1579,7 @@ public abstract class SqlStatement<This extends SqlStatement<This>> extends Base
             if (i > 0) {
                 names.append(',');
             }
-            String paramName = getConfig().get(SqlStatements.class).getSqlParser().nameParameter(name, getContext());
-            names.append(paramName);
+            style.appendElement(names, sqlStatements.getSqlParser().nameParameter(name, getContext()));
 
             bind(name, values.get(i));
         }

--- a/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
+++ b/core/src/main/java/org/jdbi/v3/core/statement/SqlStatements.java
@@ -38,6 +38,7 @@ import org.jdbi.v3.core.cache.JdbiCacheBuilder;
 import org.jdbi.v3.core.cache.JdbiCacheLoader;
 import org.jdbi.v3.core.cache.internal.DefaultJdbiCacheBuilder;
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.meta.Alpha;
 import org.jdbi.v3.meta.Beta;
 
 /**
@@ -58,6 +59,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
     private volatile boolean attachAllStatementsForCleanup;
     private volatile boolean attachCallbackStatementsForCleanup = true;
     private volatile boolean scriptStatementsNeedSemicolon = true;
+    private volatile BindListStyle bindListStyle = BindListStyle.PLAIN;
     private final Collection<StatementCustomizer> customizers;
     private final Deque<SqlExceptionHandler> exceptionHandlers;
 
@@ -91,6 +93,7 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
         this.attachAllStatementsForCleanup = that.attachAllStatementsForCleanup;
         this.attachCallbackStatementsForCleanup = that.attachCallbackStatementsForCleanup;
         this.scriptStatementsNeedSemicolon = that.scriptStatementsNeedSemicolon;
+        this.bindListStyle = that.bindListStyle;
         this.customizers = new CopyOnWriteArrayList<>(that.customizers);
         this.contextListeners = new CopyOnWriteArraySet<>(that.contextListeners);
         this.templateCache = that.templateCache;
@@ -379,6 +382,38 @@ public final class SqlStatements implements JdbiConfig<SqlStatements> {
      */
     public void setAttachCallbackStatementsForCleanup(boolean attachCallbackStatementsForCleanup) {
         this.attachCallbackStatementsForCleanup = attachCallbackStatementsForCleanup;
+    }
+
+    /**
+     * Returns how {@link SqlStatement#bindList} renders the bound parameter names. Defaults to {@link BindListStyle#PLAIN}.
+     *
+     * @return the current {@link BindListStyle}
+     */
+    @Alpha
+    public BindListStyle getBindListStyle() {
+        return bindListStyle;
+    }
+
+    /**
+     * Sets how {@link SqlStatement#bindList} renders the bound parameter names into the defined attribute.
+     * {@link BindListStyle#ROWS} wraps each element in parentheses, which is the syntax the SQL {@code VALUES}
+     * list constructor requires:
+     * <pre>
+     * handle.createQuery("select id from (values &lt;ids&gt;) as t(id)")
+     *     .configure(SqlStatements.class, c -&gt; c.setBindListStyle(BindListStyle.ROWS))
+     *     .bindList("ids", 1, 2, 3)
+     * </pre>
+     * The style must match the SQL around each attribute, so set it on the statement as above rather than on the
+     * {@link org.jdbi.v3.core.Jdbi} or {@link org.jdbi.v3.core.Handle}, unless every {@code bindList} attribute
+     * uses the same form.
+     *
+     * @param bindListStyle the {@link BindListStyle} to use
+     * @return this
+     */
+    @Alpha
+    public SqlStatements setBindListStyle(BindListStyle bindListStyle) {
+        this.bindListStyle = Objects.requireNonNull(bindListStyle, "bindListStyle");
+        return this;
     }
 
     /**

--- a/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
+++ b/core/src/test/java/org/jdbi/v3/core/statement/TestBindList.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import static java.util.Collections.emptyList;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
 
@@ -80,6 +81,48 @@ public class TestBindList {
                 .containsExactly(
                         tuple(1, "foo1", null, null),
                         tuple(3, "abc", null, null));
+    }
+
+    @Test
+    public void testBindListRowsStyle() {
+        List<Integer> ids = handle.createQuery("select t.id from (values <ids>) as t(id) order by t.id")
+                .configure(SqlStatements.class, c -> c.setBindListStyle(BindListStyle.ROWS))
+                .bindList("ids", 3, 1, 2)
+                .mapTo(Integer.class)
+                .list();
+
+        assertThat(ids).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    public void testBindListRowsStyleInClause() {
+        List<Thing> list = handle.createQuery("select id, foo from thing where id in (values <ids>)")
+                .configure(SqlStatements.class, c -> c.setBindListStyle(BindListStyle.ROWS))
+                .bindList("ids", 2, 4)
+                .mapTo(Thing.class)
+                .list();
+
+        assertThat(list)
+                .extracting(Thing::getId, Thing::getFoo)
+                .containsExactly(tuple(2, "foo2"));
+    }
+
+    @Test
+    public void testBindListRowsStyleFromHandleConfig() {
+        handle.getConfig(SqlStatements.class).setBindListStyle(BindListStyle.ROWS);
+
+        List<Integer> ids = handle.createQuery("select t.id from (values <ids>) as t(id) order by t.id")
+                .bindList("ids", 2, 1)
+                .mapTo(Integer.class)
+                .list();
+
+        assertThat(ids).containsExactly(1, 2);
+    }
+
+    @Test
+    public void testBindListStyleRejectsNull() {
+        assertThatThrownBy(() -> handle.getConfig(SqlStatements.class).setBindListStyle(null))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/docs/src/adoc/index.adoc
+++ b/docs/src/adoc/index.adoc
@@ -1628,6 +1628,33 @@ handle.createQuery("SELECT value FROM items WHERE kind in (<varargListOfKinds>)"
 Using link:{jdbidocs}/core/statement/SqlStatement.html#bindList(java.lang.String,java.lang.Iterable)[bindList()^] requires writing the SQL with an attribute, not a binding, even though the values are bound.
 The attribute is a placeholder that will be rendered to a comma-separated list of binding placeholders.
 
+By default, the attribute renders as a plain comma-separated list.
+To use the bound values with the SQL `VALUES` list constructor, which requires each value in its own parenthesized row, set the link:{jdbidocs}/core/statement/BindListStyle.html[BindListStyle^] on the statement:
+
+[source,java,indent=0]
+----
+handle.createQuery("SELECT value FROM items WHERE kind in (VALUES <listOfKinds>)")
+    .configure(SqlStatements.class, c -> c.setBindListStyle(BindListStyle.ROWS))
+    .bindList("listOfKinds", keys)
+    .mapTo(String.class)
+    .list();
+// renders as ... in (VALUES (:__listOfKinds_0),(:__listOfKinds_1))
+----
+
+A `VALUES` list can also stand in for a table, which allows a join against the bound values:
+
+[source,java,indent=0]
+----
+handle.createQuery("SELECT link FROM (VALUES <links>) AS candidates (link) EXCEPT SELECT link FROM seen_links")
+    .configure(SqlStatements.class, c -> c.setBindListStyle(BindListStyle.ROWS))
+    .bindList("links", links)
+    .mapTo(String.class)
+    .list();
+----
+
+The style must match the SQL around each attribute, so set it per statement as shown. A style set on the `Jdbi` or `Handle` applies to every `bindList` call made through it.
+`EmptyHandling.NULL_KEYWORD` is not valid with `ROWS`: `VALUES null` is a syntax error. Use `THROW`, or `DEFINE_NULL` with a template conditional, to handle an empty list.
+
 You can bind multiple arguments from properties of a Java Bean:
 
 [source,java,indent=0]
@@ -4290,6 +4317,16 @@ If the database supports array types, it is strongly recommended to use link:{jd
 ----
 @SqlQuery("SELECT name FROM users WHERE id in (<userIds>)")
 List<String> getFromIds(@BindList("userIds") List<Long> userIds)
+----
+
+The `style` attribute selects the link:{jdbidocs}/core/statement/BindListStyle.html[BindListStyle^].
+`ROWS` wraps each element in parentheses for the SQL `VALUES` list constructor.
+The annotation always sets the style for its own parameter, so a style configured on the `Jdbi` or `Handle` does not apply to `@BindList` parameters:
+
+[source,java,indent=0]
+----
+@SqlQuery("SELECT name FROM users WHERE id in (VALUES <userIds>)")
+List<String> getFromIds(@BindList(style = BindListStyle.ROWS) List<Long> userIds)
 ----
 
 ===== Bind map instances with @BindMap

--- a/postgres/src/test/java/org/jdbi/v3/postgres/TestBindListStyle.java
+++ b/postgres/src/test/java/org/jdbi/v3/postgres/TestBindListStyle.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.postgres;
+
+import java.util.List;
+
+import de.softwareforge.testing.postgres.junit5.EmbeddedPgExtension;
+import de.softwareforge.testing.postgres.junit5.MultiDatabaseBuilder;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.BindListStyle;
+import org.jdbi.v3.core.statement.EmptyHandling;
+import org.jdbi.v3.core.statement.SqlStatements;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.jdbi.v3.testing.junit5.JdbiExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestBindListStyle {
+
+    @RegisterExtension
+    public static EmbeddedPgExtension pg = MultiDatabaseBuilder.instanceWithDefaults().build();
+
+    @RegisterExtension
+    public JdbiExtension pgExtension = JdbiExtension.postgres(pg).withPlugins(new PostgresPlugin())
+        .withInitializer((ds, h) -> h.useTransaction(th -> {
+            th.execute("CREATE TABLE links (link TEXT PRIMARY KEY)");
+            th.execute("INSERT INTO links (link) VALUES ('one.com'), ('two.com')");
+        }));
+
+    private Handle handle;
+
+    @BeforeEach
+    public void setUp() {
+        handle = pgExtension.openHandle();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        handle.close();
+    }
+
+    @Test
+    public void testInValuesList() {
+        List<String> links = handle.createQuery("SELECT link FROM links WHERE link IN (VALUES <links>) ORDER BY link")
+            .configure(SqlStatements.class, c -> c.setBindListStyle(BindListStyle.ROWS))
+            .bindList("links", "two.com", "three.com", "one.com")
+            .mapTo(String.class)
+            .list();
+
+        assertThat(links).containsExactly("one.com", "two.com");
+    }
+
+    @Test
+    public void testValuesAsTable() {
+        List<String> newLinks = handle.createQuery(
+                "SELECT link FROM (VALUES <links>) AS newlinks (link) EXCEPT SELECT link FROM links")
+            .configure(SqlStatements.class, c -> c.setBindListStyle(BindListStyle.ROWS))
+            .bindList("links", "one.com", "three.com")
+            .mapTo(String.class)
+            .list();
+
+        assertThat(newLinks).containsExactly("three.com");
+    }
+
+    @Test
+    public void testNullKeywordIsInvalidWithRows() {
+        assertThatThrownBy(() -> handle.createQuery("SELECT link FROM links WHERE link IN (VALUES <links>)")
+                .configure(SqlStatements.class, c -> c.setBindListStyle(BindListStyle.ROWS))
+                .bindList(EmptyHandling.NULL_KEYWORD, "links", List.of())
+                .mapTo(String.class)
+                .list())
+            .isInstanceOf(UnableToExecuteStatementException.class)
+            .hasMessageContaining("syntax error");
+    }
+}

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/BindList.java
@@ -18,7 +18,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.jdbi.v3.core.statement.BindListStyle;
 import org.jdbi.v3.core.statement.SqlStatement;
+import org.jdbi.v3.meta.Alpha;
 import org.jdbi.v3.sqlobject.customizer.internal.BindListFactory;
 
 import static org.jdbi.v3.core.statement.EmptyHandling.BLANK;
@@ -58,6 +60,21 @@ public @interface BindList {
      * @see EmptyHandling
      */
     EmptyHandling onEmpty() default BindList.EmptyHandling.THROW;
+
+    /**
+     * How to render each bound element into the defined attribute. {@link BindListStyle#ROWS} wraps each element
+     * in parentheses for use with the SQL {@code VALUES} list constructor:
+     * <pre>
+     * &#64;SqlQuery("select id from (values &lt;ids&gt;) as t(id)")
+     * List&lt;Integer&gt; ids(@BindList(style = BindListStyle.ROWS) List&lt;Integer&gt; ids)
+     * </pre>
+     * This value replaces any {@link BindListStyle} configured on the statement or handle, so a style set on the
+     * {@link org.jdbi.v3.core.Jdbi} has no effect on {@code @BindList} parameters.
+     *
+     * @return the rendering style. By default, a plain comma-separated list.
+     */
+    @Alpha
+    BindListStyle style() default BindListStyle.PLAIN;
 
     // TODO jdbi4 remove this duplicate of `core` EmptyHandling
     /**

--- a/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
+++ b/sqlobject/src/main/java/org/jdbi/v3/sqlobject/customizer/internal/BindListFactory.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 
 import org.jdbi.v3.core.internal.IterableLike;
+import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
 import org.jdbi.v3.sqlobject.customizer.SqlStatementParameterCustomizer;
@@ -38,6 +39,8 @@ public final class BindListFactory implements SqlStatementCustomizerFactory {
                         + "and parameter name data is not present in the class file, for: "
                         + param.getDeclaringExecutable() + "::" + param));
 
-        return (stmt, arg) -> stmt.bindList(bindList.onEmpty().getCoreImpl(), name, arg == null ? null : IterableLike.toList(arg));
+        return (stmt, arg) -> stmt
+                .configure(SqlStatements.class, c -> c.setBindListStyle(bindList.style()))
+                .bindList(bindList.onEmpty().getCoreImpl(), name, arg == null ? null : IterableLike.toList(arg));
     }
 }

--- a/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindListParameter.java
+++ b/sqlobject/src/test/java/org/jdbi/v3/sqlobject/TestBindListParameter.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 import com.google.common.collect.Lists;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.BindListStyle;
+import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.core.statement.UnableToCreateStatementException;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -69,6 +71,29 @@ public class TestBindListParameter {
         assertThat(result).isZero();
     }
 
+    @Test
+    public void testRowsStyle() {
+        handle.execute("insert into foo (id, bar) values (1, 'one'), (2, 'two'), (3, 'three')");
+
+        assertThat(dao.barsForIds(Lists.newArrayList(3, 1))).containsExactly("one", "three");
+    }
+
+    @Test
+    public void testMixedStylesOnOneMethod() {
+        handle.execute("insert into foo (id, bar) values (1, 'one'), (2, 'two'), (3, 'three')");
+
+        assertThat(dao.barsForIdsExcept(Lists.newArrayList(1, 2, 3), Lists.newArrayList(2))).containsExactly("one", "three");
+    }
+
+    @Test
+    public void testRowsStyleOverridesHandleConfig() {
+        db.getConfig(SqlStatements.class).setBindListStyle(BindListStyle.ROWS);
+        handle.execute("insert into foo (id, bar) values (1, 'one'), (2, 'two')");
+
+        assertThat(dao.ids(Lists.newArrayList(1, 2))).isEqualTo(2);
+        assertThat(dao.barsForIds(Lists.newArrayList(2))).containsExactly("two");
+    }
+
     private interface MyDAO {
         @SqlQuery("select count(*) from foo where bar < 12 and id in (<ids>)")
         int broken();
@@ -78,5 +103,11 @@ public class TestBindListParameter {
 
         @SqlQuery("select count(*) from foo where id in (<ids>)")
         int ids(@BindList List<Integer> ids);
+
+        @SqlQuery("select f.bar from foo f join (values <ids>) as t(id) on f.id = t.id order by f.id")
+        List<String> barsForIds(@BindList(style = BindListStyle.ROWS) List<Integer> ids);
+
+        @SqlQuery("select f.bar from foo f join (values <ids>) as t(id) on f.id = t.id where f.id not in (<excluded>) order by f.id")
+        List<String> barsForIdsExcept(@BindList(style = BindListStyle.ROWS) List<Integer> ids, @BindList List<Integer> excluded);
     }
 }


### PR DESCRIPTION
Closes #1550

`bindList` and `@BindList` always rendered a bound list as a flat comma-separated list, `:a,:b`. The SQL VALUES list constructor needs each element as its own parenthesized row, `(:a),(:b)`. That form is the idiomatic way to write a large IN list on Postgres, and it lets a bound list stand in for a table in a join or EXCEPT, which several people asked for on the issue.

This adds BindListStyle { `PLAIN`, `ROWS` } as a SqlStatements configuration option instead of a new bindList overload, so the bind method family does not grow by another cross product.

    handle.createQuery("select link from (values <links>) as candidates (link)"
            + " except select link from seen_links")
        .configure(SqlStatements.class, c -> c.setBindListStyle(BindListStyle.ROWS))
        .bindList("links", links)
        .mapTo(String.class)
        .list();


`@BindList` gains a style attribute that applies the style to the statement before binding:

    @SqlQuery("select name from users where id in (values <userIds>)")
    List<String> getFromIds(@BindList(style = BindListStyle.ROWS) List<Long> userIds);

Changes:

- core: BindListStyle enum, SqlStatements#getBindListStyle / setBindListStyle, and bindList renders through the style. Default is PLAIN, so existing behavior does not change. The new API is @Alpha.
- sqlobject: @BindList(style = ...), default PLAIN. The annotation value replaces any style configured on the handle, which the javadoc states.
- Tests on H2 in core and sqlobject, and a Postgres test for the IN (VALUES ...) and VALUES-as-table forms from the issue.
- User guide sections for bindList and @BindList, and a release note.